### PR TITLE
Fix/hack for Firefox 'Open l+c in background tabs'

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -764,6 +764,11 @@ var RESUtils = {
 		var evt = document.createEvent('MouseEvents');
 		evt.initMouseEvent('mousedown', true, true, window, 0, 1, 1, 1, 1, false, false, false, false, button, null); obj.dispatchEvent(evt); 
 	},
+	ctrlclick: function(obj) {
+		var evt = document.createEvent('MouseEvents');
+		evt.initMouseEvent('mousedown', true, true, window, 0, 1, 1, 1, 1, true, false, false, false, 0, null);
+		obj.dispatchEvent(evt);
+	},
 	loggedInUser: function() {
 		if (typeof(this.loggedInUserCached) == 'undefined') {
 			var userLink = document.querySelector('#header-bottom-right > span.user > a');
@@ -5800,7 +5805,11 @@ modules['keyboardNav'] = {
 	followLinkAndComments: function(background) {
 		// find the [l+c] link and click it...
 		var lcLink = this.keyboardLinks[this.activeIndex].querySelector('.redditSingleClick');
+		if ((typeof(self.on) == 'function')&&(background)) {
+			RESUtils.ctrlclick(lcLink);
+		} else {
 		RESUtils.mousedown(lcLink, background);
+		}
 	},
 	upVote: function() {
 		if (typeof(this.keyboardLinks[this.activeIndex]) == 'undefined') return false;


### PR DESCRIPTION
Pursuant to this - http://www.reddit.com/r/Enhancement/comments/mgr6e/bug_view_lc_in_background_tab_with_keyboard/

Middle-click was persisting in FF causing scroll to be 'on' after using Shift-L. The hack (emphasis on hack) substitutes in a Ctrl+Left click which works around the problem.
