### PR TITLE
Save/unsave doesn't work in multi-reddits

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -6985,9 +6985,6 @@ modules['betteReddit'] = {
 			}
 			// var params = 'id='+linkid+'&executed='+executed+'&uh='+modhash[1]+'&renderstyle=html';
 			var params = 'id='+linkid+'&executed='+executed+'&uh='+modules['betteReddit'].modhash+'&renderstyle=html';
-			if (RESUtils.currentSubreddit()) {
-				params += '&r='+RESUtils.currentSubreddit();
-			}
 			GM_xmlhttpRequest({
 				method:	"POST",
 				url:	apiURL,


### PR DESCRIPTION
When trying to save/unsave a submission in a multi-reddit (like http://www.reddit.com/r/gifs+gif) an error is shown saying that saving failed. This happens because the subreddit is posted alongside the other parameter if it is present, and, in case of a multi-reddit, reddit seems to choke on the "+" in it.
From my point of view, there is no need to post the subreddit when saving/unsaving, as the normal reddit function (with res disabled) doesn't do this.
