### PR TITLE
Add missing 'nextTip' reference in Tips/Tricks

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -12669,7 +12669,8 @@ modules['RESTips'] = {
 								onclick: modules['RESTips'].prevTip
 							},
 							{
-								name: "Next"
+								name: "Next",
+								onclick: modules['RESTips'].nextTip
 							}],
 				  description: this.tips[i].message,
 				  id: thisID,


### PR DESCRIPTION
Fixes the next/prev button functionality on the Tips and Tricks popup.
