### PR TITLE
Highlight current subreddit in subreddit bar/'Continue this thread' links

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -5666,6 +5666,11 @@ modules['keyboardNav'] = {
 				} else {
 					thisToggle = thisNonCollapsed.querySelector('a.expand');
 				}
+				// 'continue this thread' links
+				contThread = thisNonCollapsed.querySelector('span.deepthread > a');
+				if(contThread){
+					thisToggle = contThread;
+				}
 			}
 			RESUtils.click(thisToggle);
 		}


### PR DESCRIPTION
Restore the default reddit behaviour of highlighting the subreddit bar shortcut if it matches the current URL.
