### PR TITLE
Fixes to fav.me links.

### DIFF
--- a/Chrome/reddit_enhancement_suite.user.js
+++ b/Chrome/reddit_enhancement_suite.user.js
@@ -10198,8 +10198,16 @@ modules['showImages'] = {
 								}
 							});
 						} else {
-							ele.setAttribute('src', this.deviantArtCalls[apiURL].getAttribute('src'));
-							modules['showImages'].createImageExpando(ele);
+							function linkRecheckFunc(context) {
+								var src = modules['showImages'].deviantArtCalls[apiURL].getAttribute('src');
+								if (src != null) {
+									context.elem.setAttribute('src', src);
+									modules['showImages'].createImageExpando(context.ele);
+								} else {
+									setTimeout(linkRecheckFunc, 1000, context);
+								}
+							};
+							linkRecheckFunc({elem:ele, api:apiURL});
 						}
 					} else if (/\.(png|jpe?g|gif)$/.test(href)) {
 						//correctly handle direct links

--- a/Opera/includes/reddit_enhancement_suite.user.js
+++ b/Opera/includes/reddit_enhancement_suite.user.js
@@ -10198,8 +10198,16 @@ modules['showImages'] = {
 								}
 							});
 						} else {
-							ele.setAttribute('src', this.deviantArtCalls[apiURL].getAttribute('src'));
-							modules['showImages'].createImageExpando(ele);
+							function linkRecheckFunc(context) {
+								var src = modules['showImages'].deviantArtCalls[apiURL].getAttribute('src');
+								if (src != null) {
+									context.elem.setAttribute('src', src);
+									modules['showImages'].createImageExpando(context.ele);
+								} else {
+									setTimeout(linkRecheckFunc, 1000, context);
+								}
+							};
+							linkRecheckFunc({elem:ele, api:apiURL});
 						}
 					} else if (/\.(png|jpe?g|gif)$/.test(href)) {
 						//correctly handle direct links

--- a/RES.safariextension/reddit_enhancement_suite.user.js
+++ b/RES.safariextension/reddit_enhancement_suite.user.js
@@ -10198,8 +10198,16 @@ modules['showImages'] = {
 								}
 							});
 						} else {
-							ele.setAttribute('src', this.deviantArtCalls[apiURL].getAttribute('src'));
-							modules['showImages'].createImageExpando(ele);
+							function linkRecheckFunc(context) {
+								var src = modules['showImages'].deviantArtCalls[apiURL].getAttribute('src');
+								if (src != null) {
+									context.elem.setAttribute('src', src);
+									modules['showImages'].createImageExpando(context.ele);
+								} else {
+									setTimeout(linkRecheckFunc, 1000, context);
+								}
+							};
+							linkRecheckFunc({elem:ele, api:apiURL});
 						}
 					} else if (/\.(png|jpe?g|gif)$/.test(href)) {
 						//correctly handle direct links

--- a/XPI/data/reddit_enhancement_suite.user.js
+++ b/XPI/data/reddit_enhancement_suite.user.js
@@ -10198,8 +10198,16 @@ modules['showImages'] = {
 								}
 							});
 						} else {
-							ele.setAttribute('src', this.deviantArtCalls[apiURL].getAttribute('src'));
-							modules['showImages'].createImageExpando(ele);
+							function linkRecheckFunc(context) {
+								var src = modules['showImages'].deviantArtCalls[apiURL].getAttribute('src');
+								if (src != null) {
+									context.elem.setAttribute('src', src);
+									modules['showImages'].createImageExpando(context.ele);
+								} else {
+									setTimeout(linkRecheckFunc, 1000, context);
+								}
+							};
+							linkRecheckFunc({elem:ele, api:apiURL});
 						}
 					} else if (/\.(png|jpe?g|gif)$/.test(href)) {
 						//correctly handle direct links

--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -10198,8 +10198,16 @@ modules['showImages'] = {
 								}
 							});
 						} else {
-							ele.setAttribute('src', this.deviantArtCalls[apiURL].getAttribute('src'));
-							modules['showImages'].createImageExpando(ele);
+							function linkRecheckFunc(context) {
+								var src = modules['showImages'].deviantArtCalls[apiURL].getAttribute('src');
+								if (src != null) {
+									context.elem.setAttribute('src', src);
+									modules['showImages'].createImageExpando(context.ele);
+								} else {
+									setTimeout(linkRecheckFunc, 1000, context);
+								}
+							};
+							linkRecheckFunc({elem:ele, api:apiURL});
 						}
 					} else if (/\.(png|jpe?g|gif)$/.test(href)) {
 						//correctly handle direct links


### PR DESCRIPTION
Fixes for most of the problems involved with issue #39.
- Detection method for unembeddable links changed to simple file extension detection.
- The expandos are now properly added for multiple instances of the same link on a page.
