### PR TITLE
Clean newCommentCache every 6 hours instead of 24

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -13165,8 +13165,8 @@ modules['newCommentCount'] = {
 			lastClean = now.getTime();
 			RESStorage.setItem('RESmodules.newCommentCount.lastClean', now.getTime());
 		}
-		// Clean cache once a day
-		if ((now.getTime() - lastClean) > 86400000) {
+		// Clean cache every six hours
+		if ((now.getTime() - lastClean) > 21600000) {
 			this.cleanCache();
 		}
 		var IDre = /\/r\/[\w]+\/comments\/([\w]+)\//i;


### PR DESCRIPTION
Clean newCommentCache every six hours instead of every 24. Just for paranoia.
