### PR TITLE
Fix highlighting of current sub in subreddit manager/Enable tagging/hoverInfo for mod box

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -6397,7 +6397,7 @@ modules['userTagger'] = {
 	},
 	applyTags: function(ele) {
 		if (ele == null) ele = document;
-		this.authors = ele.querySelectorAll('.noncollapsed a.author, p.tagline a.author, #friend-table span.user a');
+		this.authors = ele.querySelectorAll('.noncollapsed a.author, p.tagline a.author, #friend-table span.user a, .sidecontentbox .author');
 		this.authorCount = this.authors.length;
 		this.authori = 0;
 		(function(){
@@ -6588,7 +6588,11 @@ modules['userTagger'] = {
 			modules['userTagger'].authorInfoToolTipHeader.innerHTML += friendButton;
 		});
 		this.authorInfoToolTipContents.innerHTML = '<a class="hoverAuthor" href="/user/'+obj.textContent+'">'+obj.textContent+'</a>:<br><img src="'+RESConsole.loader+'"> loading...';
-		this.authorInfoToolTip.setAttribute('style', 'top: ' + (thisXY.y - 14) + 'px; left: ' + (thisXY.x - 10) + 'px;');
+		if((window.innerWidth-thisXY.x)<=412){
+			this.authorInfoToolTip.setAttribute('style', 'top: ' + (thisXY.y - 14) + 'px; left: ' + (thisXY.x - 180) + 'px;');
+		} else {
+			this.authorInfoToolTip.setAttribute('style', 'top: ' + (thisXY.y - 14) + 'px; left: ' + (thisXY.x - 10) + 'px;');
+		}
 		RESUtils.fadeElementIn(this.authorInfoToolTip, 0.3);
 		var thisUserName = obj.textContent;
 		setTimeout(function() {


### PR DESCRIPTION
Previous indexOf was matching subreddits with the same word in the title, such as apple/applehelp. Whichever was the first match was being highlighted, so if applehelp appeared before apple in the list of shortcuts then it would be highlighted, even when the current subreddit was r/apple.

Also added a class for the matched subreddit to enable styling.
