### PR TITLE
Allow selecting a comment by clicking anywhere in the comment box.

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -5195,14 +5195,14 @@ modules['keyboardNav'] = {
 		if ((typeof(this.keyboardLinks) != 'undefined') && (this.options.clickFocus.value)) {
 			for (var i=0, len=this.keyboardLinks.length;i<len;i++) {
 				this.keyboardLinks[i].setAttribute('keyIndex', i);
-				this.keyboardLinks[i].addEventListener('click', function(e) {
+				this.keyboardLinks[i].parentElement.addEventListener('click', (function(e) {
 					var thisIndex = parseInt(this.getAttribute('keyIndex'));
 					if (modules['keyboardNav'].activeIndex != thisIndex) {
 						modules['keyboardNav'].keyUnfocus(modules['keyboardNav'].keyboardLinks[modules['keyboardNav'].activeIndex]);
 						modules['keyboardNav'].activeIndex = thisIndex;
 						modules['keyboardNav'].keyFocus(modules['keyboardNav'].keyboardLinks[modules['keyboardNav'].activeIndex]);
 					}
-				}, true);
+				}).bind(this.keyboardLinks[i]), true);
 			}
 			this.keyFocus(this.keyboardLinks[this.activeIndex]);
 		}


### PR DESCRIPTION
Move the `onclick` handler from the `.entry` `div` to the `.comment` `div`. The effect is to allow selection by clicking to the left of the child comments. This is useful when browsing large deeply nested comment threads.
