### PR TITLE
Permit custom macro definitions in the commentPreview module.

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -9640,7 +9640,7 @@ modules['commentPreview'] = {
 				controlBox.appendChild( promoteRES.create() );
 
 
-				modules['commentPreview'].options['macros'].value.forEach(function(elem, index, array) {
+				Array.prototype.slice.call(modules['commentPreview'].options['macros'].value).forEach(function(elem, index, array) {
 					controlBox.appendChild(new EditControl(elem[0], function(){
 						prefixSelectionLines( targetTextArea, elem[1] );
 						refreshPreview( preview, targetTextArea );


### PR DESCRIPTION
I added an options setting to the comment preview module that allows the user to define additional shortcut buttons.
