### PR TITLE
New Module: Persist Hidden Comments across Page Loads

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -16200,13 +16200,7 @@ m_chp = modules['commentHidePersistor'] = {
     maxKeys: 100,
     pruneKeysTo: 50,
 
-    options: {
-        showByDefault: {
-            type: 'boolean',
-            value: false,
-            description: 'Persist hidden comments by default'
-        }
-    },
+    options: {},
     isEnabled: function () {
         return RESConsole.getModulePrefs(this.moduleID);
     },


### PR DESCRIPTION
This is a little module that stores a list of hidden comments in localStorage, and then re-hides them on the page load.

Tricky bits:
1. It uses an array of keys to prune if the object gets too large. Right now it prunes at 500.
2. There was a little rendering issue with the comment navigator that I worked around with a setTimeout. I assume it was interacting poorly with another module. Feel free to play around with that if you want to see what I'm talking about, otherwise it works well.

Any thoughts appreciated!
