### PR TITLE
Added polyfill for Function.bind() in Safari.

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -122,6 +122,16 @@ function createElementWithID(elementType, id, classname) {
 // sigh.. opera just has to be a pain in the ass... check for navigator object...
 if (typeof(navigator) == 'undefined') navigator = window.navigator;
 
+//Because Safari 5.1 doesn't have Function.bind
+if (typeof(Function.prototype.bind) == 'undefined') {
+	Function.prototype.bind = function(context) {
+		var oldRef = this;
+		return function() {
+			return oldRef.apply(context || null, Array.prototype.slice.call(arguments));
+		};
+	}
+}
+
 var BrowserDetect = {
 	init: function () {
 		this.browser = this.searchString(this.dataBrowser) || "An unknown browser";


### PR DESCRIPTION
The comment macro feature was broken in Safari because Safari doesn't have Function.prototype.bind
