### PR TITLE
Store the current NER page in sessionStorage instead of the URL.

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -11399,22 +11399,22 @@ modules['neverEndingReddit'] = {
 				var nextLink = nextPrevLinks[nextPrevLinks.length-1];
 				if (nextLink) {
 					this.nextPageURL = nextLink.getAttribute('href');
-					// remove NERpage parameter, no sense sending it to reddit.
-					this.nextPageURL = this.nextPageURL.replace(/\&NERpage=([\d]+)/,'');
 					var nextXY=RESUtils.getXYpos(nextLink);
 					this.nextPageScrollY = nextXY.y;
 				}
 				this.attachLoaderWidget();
 				
+				//Reset this info if the page is in a new tab
+				if (window.history.length) {
+					delete sessionStorage['NERpage'];
+				}
 				if (this.options.returnToPrevPage.value) {
 					this.attachModalWidget();
 					// Set the current page to page 1...
 					this.currPage = 1;
-					// If there's a page=# value in location.hash, then update the currPage...
-					var currPageRe = /NERpage=([0-9]+)/i;
-					var backButtonPageNumber = currPageRe.exec(location.href);
-					if ((backButtonPageNumber) && (backButtonPageNumber[1] > 1)) {
-						this.currPage = backButtonPageNumber[1];
+					var backButtonPageNumber = sessionStorage.getItem('NERpage') || 1;
+					if (backButtonPageNumber > 1) {
+						this.currPage = backButtonPageNumber;
 						this.loadNewPage(true);
 					}
 				}
@@ -11500,32 +11500,12 @@ modules['neverEndingReddit'] = {
 		}
 		var thisPageType = RESUtils.pageType()+'.'+RESUtils.currentSubreddit();
 		RESStorage.setItem('RESmodules.neverEndingReddit.lastPage.'+thisPageType, modules['neverEndingReddit'].pageURLs[thisPageNum]);
-		// this needed to be replaced to avoid a chrome bug where hash changes screw up searching and middle-click scrolling..
-		//		if ((thisPageNum > 1) || (location.hash != '')) location.hash = 'page='+thisPageNum;
-		var urlParams = RESUtils.getUrlParams();
-		if (thisPageNum != urlParams.NERpage) {
+		if (thisPageNum != sessionStorage.getItem(NERpage)) {
 			if (thisPageNum > 1) {
-				urlParams.NERpage = thisPageNum;
+				sessionStorage.NERpage = thisPageNum;
 				modules['neverEndingReddit'].pastFirstPage = true;
 			} else {
-				urlParams.NERpage = null;
-			}
-			if (modules['neverEndingReddit'].pastFirstPage) {
-				var qs = '?';
-				var count = 0;
-				var and = '';
-				for (i in urlParams) {
-					count++;
-					if (urlParams[i] != null) {
-						if (count == 2) and = '&';
-						qs += and+i+'='+urlParams[i];
-					}
-				}
-				// delete query parameters if there are none to display so we don't just show a ?
-				if (qs == '?') {
-					qs = location.pathname;
-				}
-				window.history.replaceState(thisPageNum, "thepage="+thisPageNum, qs);
+				delete sessionStorage['NERpage'];
 			}
 		}
 		if ((modules['neverEndingReddit'].fromBackButton != true) && (modules['neverEndingReddit'].options.returnToPrevPage.value)) {


### PR DESCRIPTION
A patch to store the NER page information in `sessionStorage` instead of the URL to fix Chrome's in page search.
