### PR TITLE
Cleanup from the showImages rewrite.

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -10990,14 +10990,14 @@ modules['showImages'] = {
 				elem.src = info.image.links.original;
 				elem.type = 'IMAGE';
 				if (info.image.image.caption) elem.caption = info.image.image.caption;
-				this.createImageExpando(elem);
+				modules['showImages'].createImageExpando(elem);
 			},
 			handleGallery: function(elem, info) {
 				elem.src = info.album.images.map(function(e) {
 					return e.links.original;
 				});
 				elem.type = 'GALLERY';
-				this.createImageExpando(elem);
+				modules['showImages'].createImageExpando(elem);
 			}
 		},
 		ehost: {
@@ -11018,7 +11018,7 @@ modules['showImages'] = {
 			handleInfo: function(elem, info) {
 				elem.type = 'IMAGE';
 				elem.src = info.src;
-				this.createImageExpando(elem);
+				modules['showImages'].createImageExpando(elem);
 			}
 		},
 		snaggy: {
@@ -11036,7 +11036,7 @@ modules['showImages'] = {
 			handleInfo: function(elem, info) {
 				elem.type = 'IMAGE';
 				elem.src = info.src;
-				this.createImageExpando(elem);
+				modules['showImages'].createImageExpando(elem);
 			}
 		},
 		minus: {


### PR DESCRIPTION
Remove picsarus because it does not appear to be used on reddit. (I could not locate a single use of it)
The call to creatImageExpando has been moved to `handleInfo` to allow for conditions where the embed can't take place.
Alters the flickr and imgclean to conform to the `siteModule` system.
Fixes a typo in `findImages`.
