### PR TITLE
Prevent autoload of next page with 'j' when autoLoad is disabled.

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -5668,7 +5668,7 @@ modules['keyboardNav'] = {
 					RESUtils.scrollTo(0,thisXY.y - window.innerHeight + thisHeight + 5);
 				}
 			}
-			if (this.activeIndex == (this.keyboardLinks.length-1)) {
+			if (this.activeIndex == (this.keyboardLinks.length-1) && && modules['neverEndingReddit'].options.autoLoad.value) {
 				this.nextPage();
 			}
 			modules['keyboardNav'].recentKey();


### PR DESCRIPTION
When navigating the page with Keyboard Nav, scrolling down with 'j' to the last link in the index triggers NER to load the next page, even when autoLoad is off.
