### PR TITLE
Prevent autoload of next page with 'j' when autoLoad is disabled.

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -5668,7 +5668,7 @@ modules['keyboardNav'] = {
 					RESUtils.scrollTo(0,thisXY.y - window.innerHeight + thisHeight + 5);
 				}
 			}
-			if (this.activeIndex == (this.keyboardLinks.length-1) && && modules['neverEndingReddit'].options.autoLoad.value) {
+			if (this.activeIndex == (this.keyboardLinks.length-1) && modules['neverEndingReddit'].options.autoLoad.value) {
 				this.nextPage();
 			}
 			modules['keyboardNav'].recentKey();


### PR DESCRIPTION
Scrolling down to the last link with 'j' triggered the next page to load, even when autoLoad was disabled.
