### PR TITLE
Upgrade markdown parser to newer version

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -9325,7 +9325,7 @@ modules['commentPreview'] = {
 							});
 							var body = '<tbody>'+tableRows.join('')+'</tbody>';
 							return '<table>'+head+body+'</table>';
-						}
+						} else return str;
 					} else return str;
 				}).join('');
 				return text;


### PR DESCRIPTION
I replaced the existing markdown parser with a later version of sundown from [here](http://code.google.com/p/pagedown/source/browse/Markdown.Converter.js)

This seems to have fixed a many of the outstanding bugs in the current comment previews including #68.

Tables and autolinking _have_ been reimplemented.
