### PR TITLE
See a comment's context without navigating away.

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -7813,6 +7813,51 @@ modules['singleClick'] = {
 	}
 };
 
+modules['commentIsolator'] = {
+	moduleID: 'commentIsolator',
+	moduleName: 'Comment Branch Isolator',
+	category: 'Comments',
+	options: {
+	},
+	description: 'Toggles display of sibling comments so you can see a comment\'s context',
+	isEnabled: function() {
+		return RESConsole.getModulePrefs(this.moduleID);
+	},
+	include: Array(
+		/^[^/]+\/+[^\/]+\/r\/[^?\/]+\/comments\/[^?\/]+/i
+	),
+	isMatchURL: function() {
+		return RESUtils.isMatchURL(this.moduleID);
+	},
+	go: function() {
+		if (!this.isEnabled() || !this.isMatchURL())
+			return;
+		document.body.addEventListener('DOMNodeInserted', function(evt) {
+			if (evt.target.tagName != 'DIV' || !hasClass(evt.target, 'comment'))
+				return;
+			modules['commentIsolator'].addIsolateLinks(evt.target);
+		}, true);
+		this.addIsolateLinks();
+	},
+	addIsolateLinks: function(el) {
+		el = el || document.body;
+		var $li = $('<li><a href="#">isolate</a></li>');
+		$li.children().click(function(evt) {
+			evt.preventDefault();
+			var $l = $(this), d = $l.data();
+			if (d.commentIsolated)
+				delete d.commentIsolated;
+			else
+				d.commentIsolated = true;
+			$l.parentsUntil('.nestedlisting').siblings('.comment').toggle(!d.commentIsolated);
+			$l.css('color', d.commentIsolated ? 'orangered' : '').text(d.commentIsolated ? 'show all' : 'isolate').closest('.comment')[0].scrollIntoView();
+		});
+		$('> .entry .buttons, .comment .entry .buttons', el).not(function() {
+			return $(this).closest('.morechildren').length > 0;
+		}).append($li);
+	}
+};
+
 modules['commentPreview'] = {
 	moduleID: 'commentPreview',
 	moduleName: 'Live Comment Preview',


### PR DESCRIPTION
I hate it when you read a good comment, but its parent comment(s) are way above and out of view. This toggles sibling comments' visibility so you can see the context without ever leaving the page, nor loading anything more from reddit's servers.
