### PR TITLE
[feature request] Display *all* usernames in popdown, and don't remove the current username

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -12608,6 +12608,11 @@ modules['accountSwitcher'] = {
 			type: 'boolean',
 			value: false,
 			description: 'Keep me logged in when I restart my browser.'
+		},
+		showCurrentUserName: {
+			type: 'boolean',
+			value: false,
+			description: 'Show my current user name in the Account Switcher.'
 		}
 	},
 	description: 'Store username/password pairs and switch accounts instantly while browsing Reddit!',
@@ -12655,7 +12660,7 @@ modules['accountSwitcher'] = {
 					var accountCount = 0;
 					for (var i=0, len=accounts.length; i<len; i++) {
 						thisPair = accounts[i];
-						if (thisPair[0] != this.loggedInUser) {
+						if (thisPair[0] != this.loggedInUser || this.options.showCurrentUserName.value){
 							accountCount++;
 							var thisLI = document.createElement('LI');
 							addClass(thisLI, 'accountName');


### PR DESCRIPTION
From this thread: http://www.reddit.com/r/Enhancement/comments/sfxcm/feature_request_display_all_usernames_in_popdown/

It's been a feature I've kind of wanted too. So I decided to try and get it done. Let me know if there's some kind of format or convention I missed out on, but it was a quick thing to add.

There's a new item in the Account Switcher options to show the current user name, it defaults to false. I was only able to test in chrome (that's all that's available to me right now), so it might be worth running through one of the other browsers in one of your other tests.

Let me know if there are any problems.
