### PR TITLE
Switch to HTTPS for Google APIs

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -14,7 +14,7 @@
 // @version       4.0.3
 // @updateURL     http://redditenhancementsuite.com/latest/reddit_enhamcement_suite.meta.js
 // @installURL    http://redditenhancementsuite.com/test/reddit_enhancement_suite.user.js
-// @require       http://ajax.googleapis.com/ajax/libs/jquery/1.7.0/jquery.min.js
+// @require       https://ajax.googleapis.com/ajax/libs/jquery/1.7.0/jquery.min.js
 // ==/UserScript==
 
 var RESVersion = "4.0.3";


### PR DESCRIPTION
Pure JS version (Scriptish/Greasemonkey) of RES cannot be installed on Firefox if HTTPS-Everywhere is also installed, a default ruleset of which redirects GoogleAPIs to HTTPS.  Doing so results in the following error:

<pre>
Error loading dependency: http://ajax.googleapis.com/ajax/libs/jquery/1.7.0/jquery.min.js
Error! Server returned: nothing (timed out)
</pre>
