### PR TITLE
(Re)fix unwanted page autoloading with 'j' when NER is disabled.

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -5011,7 +5011,7 @@ modules['keyboardNav'] = {
 					RESUtils.scrollTo(0,thisXY.y - window.innerHeight + thisHeight + 5);
 				}
 			}
-			if (this.activeIndex == (this.keyboardLinks.length-1) && modules['neverEndingReddit'].options.autoLoad.value) {
+			if (this.activeIndex == (this.keyboardLinks.length-1) && (modules['neverEndingReddit'].isEnabled()&&modules['neverEndingReddit'].options.autoLoad.value)) {
 				this.nextPage();
 			}
 			modules['keyboardNav'].recentKey();


### PR DESCRIPTION
Had to add an extra check to see if NER was active. In my older 'fix' I only checked for 'autoLoad' being true (neglecting to check if NER was enabled in the first place).
