### PR TITLE
Add option to disable display of image captions.

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -8377,7 +8377,7 @@ modules['showImages'] = {
 		displayImageCaptions: {
 			type: 'boolean',
 			value: true,
-			description: 'Retrieve image captions/attribution information (Does not apply.'
+			description: 'Retrieve image captions/attribution information.'
 		}
 	},
 	description: 'Opens images inline in your browser with the click of a button. Also has configuration options, check it out!',


### PR DESCRIPTION
Switch toggles titles, captions, and credits on images.

If captions are disabled, skip the API for single image imgur links
because we can guess those.
