### PR TITLE
CSS fix for edited comments

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -5234,7 +5234,8 @@ modules['userTagger'] = {
 	),
 	beforeLoad: function() {
 		if ((this.isEnabled()) && (this.isMatchURL())) {
-			var css = '#userTaggerToolTip { display: none; position: absolute; width: 334px; height: 248px; }';
+			var css = '.comment .tagline { display: inline; }';
+			css += '#userTaggerToolTip { display: none; position: absolute; width: 334px; height: 248px; }';
 			css += '#userTaggerToolTip label { margin-top: 5px; clear: both; float: left; width: 110px; }';
 			css += '#userTaggerToolTip input[type=text], #userTaggerToolTip select { margin-top: 5px; float: left; width: 195px; border: 1px solid #c7c7c7; border-radius: 3px 3px 3px 3px; -moz-border-radius: 3px 3px 3px 3px; -webkit-border-radius: 3px 3px 3px 3px; margin-bottom: 6px; }';
 			css += '#userTaggerToolTip input[type=checkbox] { margin-top: 5px; float: left; }';


### PR DESCRIPTION
Per [this](http://www.reddit.com/r/RESissues/comments/tft5j/bug_saving_an_edited_comment_breaks_css/) thread.

Pre-emptively setting the 'p.tagline' in comments to inline/inline-block fixes this.
