### PR TITLE
Issue with new messages count

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -6451,6 +6451,8 @@ modules['betteReddit'] = {
 				}
 			}
 		} else {
+			var newTitle = document.title.replace(/^\[[\d]+\]\s/,'');
+			document.title = newTitle;
 			modules['betteReddit'].mailCount.display = 'none'
 			modules['betteReddit'].mailCount.innerHTML = '';
 			if (modules['neverEndingReddit'].NREMailCount) {
@@ -10008,6 +10010,7 @@ modules['neverEndingReddit'] = {
 			this.NREMail.setAttribute('href','http://www.reddit.com/message/inbox/');
 			this.NREMail.setAttribute('title','no new mail');
 			removeClass(this.NREMail, 'havemail');
+			modules['betteReddit'].setUnreadCount(0);
 			// this.NREMail.innerHTML = '<img src="/static/mailgray.png" alt="messages">';
 		}
 	},


### PR DESCRIPTION
New message count is removed if there are no new messages after having messages on initial load.

Steps to reproduce in current version:
- Load reddit when you have a new message
- Open message in new tab (marking messages as read)
- Scroll to bottom so that NER loads new page
- New mail icon goes away, but count in title and next to icon remain

This fix removes the count both in the title and next to the icon.
