### PR TITLE
Add trailing slash support for imgur galleries

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -9000,7 +9000,7 @@ modules['showImages'] = {
 		imgur: {
 			APIKey: 'fe266bc9466fe69aa1cf0904e7298eda',
 			hashRe:/^https?:\/\/(?:[i.]|[edge.]|[www.])*imgur.com\/(?:r\/[\w]+\/)?([\w]{5,})(\..+)?$/i,
-			albumHashRe: /^https?:\/\/(?:i\.)?imgur.com\/a\/([\w]+)(\..+)?(?:#\d*)?$/i,
+			albumHashRe: /^https?:\/\/(?:i\.)?imgur.com\/a\/([\w]+)(\..+)?(?:\/)?(?:#\d*)?$/i,
 			apiPrefix: 'http://api.imgur.com/2/',
 			calls: {},
 			go: function(){},


### PR DESCRIPTION
Some users end up adding trailing slashes to imgur gallery URLs, which causes RES to not identify them.
