### PR TITLE
Fix for image viewer compatibility with other extensions

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -8740,6 +8740,7 @@ modules['showImages'] = {
 		elem.name = 'img'+this.imagesRevealed[href];
 		this.imageList.push(elem);
 
+		//expandLink aka the expando button
 		var expandLink = document.createElement('a');
 		expandLink.className = 'toggleImage expando-button collapsed';
 		if (elem.type == 'IMAGE') expandLink.className += ' image';
@@ -8759,6 +8760,13 @@ modules['showImages'] = {
 			addClass(expandLink, 'commentImg');
 		}
 		insertAfter(preNode, expandLink);
+		/*
+		 * save the link element for later use since some extensions
+		 * like web of trust can place other elements in places that
+		 * confuse the old method
+		 */
+		expandLink.imageLink = elem;
+
 		if (this.scanningSelfText && this.options.autoExpandSelfText.value) {
 			this.revealImage(expandLink, true);
 		} else if (this.allImagesVisible) {
@@ -8784,13 +8792,7 @@ modules['showImages'] = {
 		if (!expandoButton) return false;
 		// showhide = false means hide, true means show!
 
-		if (hasClass(expandoButton, 'commentImg')) {
-			var imageLink = expandoButton.previousSibling;
-			var expandoBox = expandoButton.nextSibling;
-		} else {
-			var imageLink = expandoButton.parentNode.firstChild.querySelector('a.title');
-			var expandoBox = expandoButton.parentNode.lastChild;
-		}
+		var imageLink = expandoButton.imageLink;
 		if (typeof(this.siteModules[imageLink.site]) == 'undefined') {
 			console.log('something went wrong scanning image from site: ' + imageLink.site);
 			return;
@@ -8799,34 +8801,35 @@ modules['showImages'] = {
 			this.siteModules[imageLink.site].deferredHandleLink(imageLink);
 			return;
 		}
-		if (typeof(expandoBox) != 'undefined' && expandoBox != null
-		&&  typeof(expandoBox.tagName) != 'undefined' && hasClass(expandoBox, 'madeVisible')) {
+
+		if (expandoButton.expandoBox && hasClass(expandoButton.expandoBox, 'madeVisible')) {
 			if (!showHide) {
 				removeClass(expandoButton, 'expanded');
 				addClass(expandoButton, 'collapsed');
-				expandoBox.style.display = 'none';
+				expandoButton.expandoBox.style.display = 'none';
 				$('div.side').fadeIn();
 			} else {
 				removeClass(expandoButton, 'collapsed');
 				addClass(expandoButton, 'expanded');
-				expandoBox.style.display = 'block';
+				expandoButton.expandoBox.style.display = 'block';
 			}
 		} else {
-			//TODO: text, flash, custom
+			//TODO: flash, custom
 			switch (imageLink.type) {
 				case 'IMAGE':
-					this.generateImageExpando(expandoButton, imageLink);
+					this.generateImageExpando(expandoButton);
 					break;
 				case 'GALLERY':
-					this.generateGalleryExpando(expandoButton, imageLink);
+					this.generateGalleryExpando(expandoButton);
 					break;
 				case 'TEXT':
-					this.generateTextExpando(expandoButton, imageLink);
+					this.generateTextExpando(expandoButton);
 					break;
 			}
 		}
 	},
-	generateImageExpando: function(expandoButton, imageLink) {
+	generateImageExpando: function(expandoButton) {
+		var imageLink = expandoButton.imageLink;
 		var imgDiv = document.createElement('div');
 		addClass(imgDiv, 'madeVisible');
 
@@ -8888,13 +8891,16 @@ modules['showImages'] = {
 		} else {
 			expandoButton.parentNode.appendChild(imgDiv);
 		}
+		expandoButton.expandoBox = imgDiv;
+
 		removeClass(expandoButton, 'collapsed');
 		addClass(expandoButton, 'expanded');
 
 		this.trackImageLoad(imageLink, image);
 		this.makeImageZoomable(image);
 	},
-	generateGalleryExpando: function(expandoButton, imageLink) {
+	generateGalleryExpando: function(expandoButton) {
+		var imageLink = expandoButton.imageLink;
 		var which = 0;
 		if (imageLink.hash) {
 			var hash = imageLink.hash.replace('#','');
@@ -9027,13 +9033,16 @@ modules['showImages'] = {
 		} else {
 			expandoButton.parentNode.appendChild(imgDiv);
 		}
+		expandoButton.expandoBox = imgDiv;
+
 		removeClass(expandoButton, 'collapsed');
 		addClass(expandoButton, 'expanded');
 
 		this.trackImageLoad(imageLink, image);
 		this.makeImageZoomable(image);
 	},
-	generateTextExpando: function(expandoButton, imageLink) {
+	generateTextExpando: function(expandoButton) {
+		var imageLink = expandoButton.imageLink;
 		var wrapperDiv = document.createElement('div');
 		wrapperDiv.className = 'usertext';
 
@@ -9067,6 +9076,7 @@ modules['showImages'] = {
 		} else {
 			expandoButton.parentNode.appendChild(wrapperDiv);
 		}
+		expandoButton.expandoBox = imageDiv;
 
 		removeClass(expandoButton, 'collapsed');
 		addClass(expandoButton, 'expanded');


### PR DESCRIPTION
Fixes a bug where other extensions such as web of trust could insert
DOM elements near the original link causing `revealImage` to be unable
to locate the correct element.
