### PR TITLE
Imageviewer enhancements

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -9221,6 +9221,7 @@ modules['showImages'] = {
 			// Add listeners for drag to resize functionality...
 			imageTag.addEventListener('mousedown', function(e) {
 				if (e.button == 0) {
+					if (!imageTag.minWidth) imageTag.minWidth = Math.max(1, Math.min(imageTag.width, 100));
 					modules['showImages'].dragTargetData.imageWidth = e.target.width;
 					modules['showImages'].dragTargetData.diagonal = modules['showImages'].getDragSize(e);
 					modules['showImages'].dragTargetData.dragging = false;
@@ -9232,7 +9233,7 @@ modules['showImages'] = {
 					var newDiagonal = modules['showImages'].getDragSize(e);
 					var oldDiagonal = modules['showImages'].dragTargetData.diagonal;
 					var imageWidth = modules['showImages'].dragTargetData.imageWidth;
-					e.target.style.maxWidth=e.target.style.width=(newDiagonal/oldDiagonal*imageWidth)+'px';
+					e.target.style.maxWidth=e.target.style.width=Math.max(e.target.minWidth, newDiagonal/oldDiagonal*imageWidth)+'px';
 
 					e.target.style.maxHeight='';
 					e.target.style.height='auto';
@@ -9248,7 +9249,7 @@ modules['showImages'] = {
 					var newDiagonal = modules['showImages'].getDragSize(e);
 					var oldDiagonal = modules['showImages'].dragTargetData.diagonal;
 					var imageWidth = modules['showImages'].dragTargetData.imageWidth;
-					e.target.style.maxWidth=e.target.style.width=(newDiagonal/oldDiagonal*imageWidth)+'px';
+					e.target.style.maxWidth=e.target.style.width=Math.max(e.target.minWidth, newDiagonal/oldDiagonal*imageWidth)+'px';
 				}
 
 				modules['showImages'].handleSidbarHiding();


### PR DESCRIPTION
- Added support for imgur mulit-image links. Note: It just occured to me that we should ask the imgur guys for a batch api for image info. We could cover an entire link page with 1 request.
- Established a minimum width that an image will zoom to: the smaller of 100 pixels, or the image's initial width.
- I cleaned up the image scaling, and improved the automatic sidebar hiding so it is better behaved.
- I redesigned the gonewild feature so that subreddit moderators can enable and customize the feature for their own subreddits. If you do not want to extend it to other subs then would be really easy to remove the check for the enable link.
- Added an optional filter to prevent the IIV from adding URLs for NSFW links to the browser history. (Behavior is not altered by default, to do otherwise would cause a support nightmare)

GoneWild mode documentation:

> To enable go gonewild mode for a subreddit add `[](/RESGoneWildEnable)` to the markdown code for the sidebar.
> This should not have any visible effect on the HTML.
> When gonewild mode is enabled, by default tabs 'm' and 'f' will be displayed.
> If the default choices are not desired, then use `[](/RESGoneWildEnable-nodefault)` instead.
> If custom tabs are desired append `?` to the link followed by up to 8 label/taglist pairs separated by `&`
> A label/taglist pair takes the form `label=taglist`
> A taglist has can contain up to 8 tags separated by `,`
> Labels and tags can be up to 32 characters long and may contain upper and lowercase letters, numbers, underscores, hyphens, and spaces.
> Labels appear to the right of the "view images" button and are surrounded by `[]` brackets.
> Post titles are searched for any place that an entry in the tag list appears surrounded by any kind of bracket `<>`, `[]`, `()`, `{}`.
> Tags are not case sensitive.
> 
> Example:
> To duplicate the behavior originally used for /r/gonewild you would use `[](/RESGoneWildEnable-nodefault?m=m,man,male&f=f,fem,female)`
