### PR TITLE
UsernameHider doesn't reveal username in edited post-comment 

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -9600,10 +9600,11 @@ modules['showImages'] = {
 			deferred: true,
 			go: function() {},
 			detect: function(elem) {
-				return ((elem.href.indexOf('flickr.com')>=0) && (elem.href.indexOf('/sets/') == -1) && (elem.href.split('/').length > 5));
+				return ((elem.href.indexOf('flickr.com')>=0) && (elem.href.indexOf('/sets/') == -1) && (elem.href.indexOf('reddit.com/domain') == -1) && (elem.href.split('/').length > 5));
 			},
 			handleLink: function(elem) {
 				//Only do this here if deferred
+				elem.type = 'IMAGE';
 				modules['showImages'].createImageExpando(elem);
 			},
 			deferredHandleLink: function(elem) {


### PR DESCRIPTION
Fix for #111 defect.

Recreate defect:
1. Turn on username hiding.
2. Edit and save an existing comment.
Username has not been set to the default hidden value. ("~anonymous~")

Reason for defect:
After editing a comment, a new element with the edited comment is inserted into the page. The inserted element didn't hide the username since the username hiding module only runs if it the inserted element  is the siteTable Div-element. 

Fix:
This commit simply adds to the username hiding module that it run username hiding if an inserted element is either siteTable or a comment.
