### PR TITLE
Enforce user tag fg text colour in Night Mode + CSS tweaks

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -5509,7 +5509,7 @@ modules['userTagger'] = {
 			for (var color in this.bgToTextColorMap) {
 				var thisValue = color;
 				if (thisValue == 'none') thisValue = '';
-				thisHTML += '<option style="background-color: '+color+'; color: '+this.bgToTextColorMap[color]+'" value="'+thisValue+'">'+color+'</option>';
+				thisHTML += '<option style="background-color: '+color+'; color: '+this.bgToTextColorMap[color]+'!important" value="'+thisValue+'">'+color+'</option>';
 			}
 			thisHTML += '</select>';
 			thisHTML += '<label for="userTaggerPreview">Preview</label> <span id="userTaggerPreview"></span>';
@@ -5809,7 +5809,7 @@ modules['userTagger'] = {
 			}
 			userTagLink.innerHTML = thisTag;
 			if (thisColor) {
-				userTagLink.setAttribute('style','background-color: '+thisColor+'; color: '+this.bgToTextColorMap[thisColor]);
+				userTagLink.setAttribute('style','background-color: '+thisColor+'; color: '+this.bgToTextColorMap[thisColor]+'!important');
 			}
 			userTagLink.setAttribute('username',thisUser);
 			userTagLink.setAttribute('title','set a tag');
@@ -5952,7 +5952,7 @@ modules['userTagger'] = {
 			}
 			if (!noclick) {
 				this.clickedTag.setAttribute('class','userTagLink hasTag');
-				this.clickedTag.setAttribute('style', 'background-color: '+color+'; color: ' + this.bgToTextColorMap[color]);
+				this.clickedTag.setAttribute('style', 'background-color: '+color+'; color: ' + this.bgToTextColorMap[color]+'!important');
 				this.clickedTag.innerHTML = tag;
 			}
 		} else {
@@ -6063,7 +6063,7 @@ modules['userTagger'] = {
 				}
 				userTagLink.innerHTML = thisTag;
 				if (thisColor) {
-					userTagLink.setAttribute('style','background-color: '+thisColor+'; color: '+this.bgToTextColorMap[thisColor]);
+					userTagLink.setAttribute('style','background-color: '+thisColor+'; color: '+this.bgToTextColorMap[thisColor]+'!important');
 				}
 				userTagLink.setAttribute('username',thisAuthor);
 				userTagLink.setAttribute('title','set a tag');
@@ -11655,7 +11655,7 @@ modules['styleTweaks'] = {
 			css += " .usertable tr .user .userkarma {color:#aa9 !important;}";
 			css += " .thing.spam {background-color:salmon !important;}";
 			css += " .wikipage h1 {color:#ddd !important;}";
-			css += " .titlebox .usertext-body .md h3 {color:black !important;}";
+			css += " .titlebox .usertext-body .md h3, #userTaggerTable th, #newCommentsTable th {color:#000;}";
 			css += " .new-comment .usertext-body .md {border:0.1em #aaa dashed;}";
 			css += " .sitetable .moderator {background-color:#282!important;}";
 			css += " .sitetable .admin {background-color:#F01!important;}";


### PR DESCRIPTION
Use !important to ensure the colormap colour is applied.

Header colour changed to #000 for tables in the tags/subs pages in the
dashboard.
