### PR TITLE
Handle comma separated impromptu albums.

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -9348,7 +9348,7 @@ modules['showImages'] = {
 		},
 		imgur: {
 			APIKey: 'fe266bc9466fe69aa1cf0904e7298eda',
-			hashRe:/^https?:\/\/(?:[i.]|[edge.]|[www.])*imgur.com\/(?:r\/[\w]+\/)?([\w]{5,}(?:&[\w]{5,})?)(\..+)?(?:#(\d*))?$/i,
+			hashRe:/^https?:\/\/(?:[i.]|[edge.]|[www.])*imgur.com\/(?:r\/[\w]+\/)?([\w]{5,}(?:[&,][\w]{5,})?)(\..+)?(?:#(\d*))?$/i,
 			albumHashRe: /^https?:\/\/(?:i\.)?imgur.com\/a\/([\w]+)(\..+)?(?:\/)?(?:#\d*)?$/i,
 			apiPrefix: 'http://api.imgur.com/2/',
 			calls: {},
@@ -9361,8 +9361,8 @@ modules['showImages'] = {
 				var groups = this.hashRe.exec(href);
 				if (!groups) var albumGroups = this.albumHashRe.exec(href);
 				if (groups && !groups[2]) {
-					if (groups[1].indexOf('&') > -1) {
-						var hashes = groups[1].split('&');
+					if (groups[1].search(/[&,]/) > -1) {
+						var hashes = groups[1].split(/[&,]/);
 						modules['showImages'].siteModules['imgur'].handleInfo(elem, {
 							album: {images: hashes.map(function(hash) {
 								return {


### PR DESCRIPTION
It turns out that Imgur's impromptu albums can have the hashes either ampersand _or_ **comma** separated.
