### PR TITLE
Try to prevent subreddits from hiding the style toggle button.

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -11574,14 +11574,14 @@ modules['styleTweaks'] = {
 		// great, now people are still finding ways to hide this.. these extra declarations are to try and fight that.
 		// Sorry, subreddit moderators, but users can disable all subreddit stylesheets if they want - this is a convenience 
 		// for them and I think taking this functionality away from them is unacceptable.
-		styleToggle.setAttribute('style','display: block !important; position: relative !important; left: 0px !important; top: 0px !important; height: auto !important; width: auto !important;');
+		styleToggle.setAttribute('style','display: block !important; position: relative !important; left: 0px !important; top: 0px !important; height: auto !important; width: auto !important; visibility: visible !important;');
 		var thisLabel = document.createElement('label');
 		addClass(styleToggle,'styleToggle');
 		this.styleToggleCheckbox = document.createElement('input');
 		this.styleToggleCheckbox.setAttribute('type','checkbox');
 		this.styleToggleCheckbox.setAttribute('name','subRedditStyleCheckbox');
 		this.styleToggleCheckbox.setAttribute('name','subRedditStyleCheckbox');
-		this.styleToggleCheckbox.setAttribute('style','display: inline-block !important; height: auto !important; width: auto !important;');
+		this.styleToggleCheckbox.setAttribute('style','display: inline-block !important; height: auto !important; width: auto !important; visibility: visible !important;');
 		if (RESUtils.currentSubreddit()) {
 			this.curSubReddit = RESUtils.currentSubreddit().toLowerCase();
 		}
@@ -11599,7 +11599,7 @@ modules['styleTweaks'] = {
 			insertAfter(subredditTitle, styleToggle);
 		}
 		thisLabel.setAttribute('for','subRedditStyleCheckbox');
-		thisLabel.setAttribute('style','display: inline-block !important; margin-left: 5px !important;');
+		thisLabel.setAttribute('style','display: inline-block !important; margin-left: 5px !important; visibility: visible !important;');
 		thisLabel.innerHTML = 'Use subreddit style ';
 		styleToggle.appendChild(thisLabel);
 	},


### PR DESCRIPTION
This commit attempts to further prevent subreddits from hiding the toggle button. [QueueNX pointed me to /r/lds](http://www.reddit.com/r/Enhancement/comments/w5iug/use_subreddit_style_not_showing_up_on_some/) which is disabling it by setting visibility: hidden. Therefore I've added visibility: visible !important.
