### PR TITLE
Exclude comment codes from annotations

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -298,6 +298,24 @@ function keyArrayCompare(fromArr, toArr) {
 	return true;
 }
 
+// A link is a comment code if all these conditions are true:
+// * It has no content (i.e. content.length == 0)
+// * Its href is of the form "/code"
+//
+// In case it's not clear, here is a list of some common comment
+// codes on a specific subreddit:
+// http://www.reddit.com/r/metarage/comments/p3eqe/full_updated_list_of_comment_faces_wcodes/
+var COMMENT_CODE_REGEX = /^\/\w+$/;
+function isCommentCode(link) {
+	var content = link.innerHTML;
+
+	// Note that link.href will return the full href (which includes the
+	// reddit.com domain). We don't want that.
+	var href = link.getAttribute("href");
+	
+	return !content && COMMENT_CODE_REGEX.test(href);
+}
+
 function operaUpdateCallback(obj) {
 	RESUtils.compareVersion(obj);
 }
@@ -4451,12 +4469,10 @@ modules['keyboardNav'] = {
 				var links = obj.querySelectorAll('div.md a');
 				var annotationCount = 0;
 				for (var i=0, len=links.length; i<len; i++) {
-                    var content = links[i].innerHTML;
-                    var link_href = links[i].href;
-                    if (!(hasClass(links[i], 'madeVisible') ||
-                          hasClass(links[i], 'toggleImage') ||
-                          hasClass(links[i], 'noKeyNav') ||
-                          content.length == 0)) {
+					if (!(hasClass(links[i], 'madeVisible') ||
+					      hasClass(links[i], 'toggleImage') ||
+					      hasClass(links[i], 'noKeyNav') ||
+					      isCommentCode(links[i]))) {
 						var annotation = document.createElement('span');
 						annotationCount++;
 						annotation.innerHTML = '['+annotationCount+'] ';


### PR DESCRIPTION
Currently, comment codes are detected as ordinary links, and are thus annotated. This unfortunately results in issues like this: http://www.reddit.com/r/Minecraft/comments/wk47e/sheep_art/c5e1frh. If you click on the comment, the two nice image arrays of sheep and cloth suddenly explode into this mess of annotations. Of course, we don't need these annotations because these images are not links; they're simply placeholders (comment codes) so that the subreddit's custom CSS can set the link's background image.

This pull request adds a function that checks whether a link is a comment code (`isCommentCode`). This function is used in the method `keyFocus`, which adds annotations to links found in a comment.

Let me know if you think this should be added as an additional option that can be tweaked as opposed to a default.
