### PR TITLE
Set openerTabId in chrome.tabs.create()

### DIFF
--- a/Chrome/background.html
+++ b/Chrome/background.html
@@ -129,14 +129,14 @@
 					if (request.openOrder == 'commentsfirst') {
 						// only open a second tab if the link is different...
 						if (request.linkURL != request.commentsURL) {
-							chrome.tabs.create({url: request.commentsURL, selected: button, index: newIndex});
+							chrome.tabs.create({url: request.commentsURL, selected: button, index: newIndex, openerTabId: sender.tab.id});
 						}
-						chrome.tabs.create({url: request.linkURL, selected: button, index: newIndex+1});
+						chrome.tabs.create({url: request.linkURL, selected: button, index: newIndex+1, openerTabId: sender.tab.id});
 					} else {
-						chrome.tabs.create({url: request.linkURL, selected: button, index: newIndex});
+						chrome.tabs.create({url: request.linkURL, selected: button, index: newIndex, openerTabId: sender.tab.id});
 						// only open a second tab if the link is different...
 						if (request.linkURL != request.commentsURL) {
-							chrome.tabs.create({url: request.commentsURL, selected: button, index: newIndex+1});
+							chrome.tabs.create({url: request.commentsURL, selected: button, index: newIndex+1, openerTabId: sender.tab.id});
 						}
 					}
 					sendResponse({status: "success"});
@@ -151,7 +151,7 @@
 					}
 					// Get the selected tab so we can get the index of it.  This allows us to open our new tab as the "next" tab.
 					var newIndex = sender.tab.index+1;
-					chrome.tabs.create({url: thisLinkURL, selected: button, index: newIndex});
+					chrome.tabs.create({url: thisLinkURL, selected: button, index: newIndex, openerTabId: sender.tab.id});
 					sendResponse({status: "success"});
 					break;
 				case 'openLinkInNewTab':
@@ -164,7 +164,7 @@
 					}
 					// Get the selected tab so we can get the index of it.  This allows us to open our new tab as the "next" tab.
 					var newIndex = sender.tab.index+1;
-					chrome.tabs.create({url: thisLinkURL, selected: focus, index: newIndex});
+					chrome.tabs.create({url: thisLinkURL, selected: focus, index: newIndex, openerTabId: sender.tab.id});
 					sendResponse({status: "success"});
 					break;
 				case 'compareVersion':


### PR DESCRIPTION
Set openerTabId in chrome.tabs.create() calls so that other extensions can see opener-opened tab relationships. Implements Issue #151
