### PR TITLE
Add Firefox-specific function to followComments

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -5355,6 +5355,12 @@ modules['keyboardNav'] = {
 					linkURL: thisHREF
 				}
 				opera.extension.postMessage(JSON.stringify(thisJSON));
+			} else if (typeof(self.on) == 'function') {
+				var thisJSON = {
+					requestType: 'keyboardNav',
+					linkURL: thisHREF
+				}
+				self.postMessage(thisJSON);
 			} else {
 				window.open(thisHREF);
 			}


### PR DESCRIPTION
followComments was missing the equivalent function from followLink. 

Seems `window.open` triggers the native popup blocker.
