### PR TITLE
Livememe regex update

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -9988,7 +9988,7 @@ modules['showImages'] = {
 			}
 		},
 		livememe: {
-			hashRe: /^http:\/\/(?:www.livememe.com|lvme.me)\/([\w]+)\/?/i,
+			hashRe: /^http:\/\/(?:www.livememe.com|lvme.me)\/(?!edit)([\w]+)\/?/i,
 			go: function() { },
 			detect: function(elem) {
 				return elem.href.toLowerCase().indexOf('livememe.com') >= 0;


### PR DESCRIPTION
Added exclusion for livememe URLs containing 'edit' since they point to a live editor rather than an image.

[RESissues thread](http://www.reddit.com/r/RESissues/comments/10hvsq/bug_links_to_edit_in_livememe_and_possibly_other/).
