### PR TITLE
Ignore SRS stylesheet

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -11759,6 +11759,10 @@ modules['styleTweaks'] = {
 		if (getIgnored) {
 			this.ignoredSubReddits = safeJSON.parse(getIgnored, 'RESmodules.styleTweaks.ignoredSubredditStyles');
 		}
+		if ($.inArray('shitredditsays', this.ignoredSubReddits) == -1) {
+			this.ignoredSubReddits.push('shitredditsays'); // ShitRedditSays is ignored regardless of user preferences until they stop abusing CSS to hide RES features and confuse users.
+			// Other subreddits who do this should also be added here.
+		}
 		this.head = document.getElementsByTagName("head")[0];
 		var subredditTitle = document.querySelector('.titlebox h1');
 		var styleToggle = document.createElement('div');


### PR DESCRIPTION
So I did another check and found SRS was evading my previous work in stopping subreddits from hiding the style toggle button.

Instead of playing a stupid game of cat-and-mouse, let's just have their style completely disabled in RES, regardless of whether the user has added them to his/her style ignore list already or not.
