### PR TITLE
Escaping quotes correctly

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -97,7 +97,7 @@ guidersCSS += '.guider_arrow_left { display: block; background-position: 0px -84
 
 
 // DOM utility functions
-var escapeLookups = { "&": "&amp;", '"': "&quot", "<": "&lt;", ">": "&gt;" };
+var escapeLookups = { "&": "&amp;", '"': "&quot;", "<": "&lt;", ">": "&gt;" };
 function escapeHTML(str) { return (str == null) ? null : str.toString().replace(/[&"<>]/g, function(m) { return escapeLookups[m] }) };
 
 // set up MutationObserver variable to take whichever is supported / existing...


### PR DESCRIPTION
Previously, the escaped double quote lacked the ending semi-colon. 

Previous: &quot
Now: &quot ;    (have to insert a space so that GitHub doesn't format it as ")
