### PR TITLE
Adding moveUp/DownThread and moveToTopComment

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -5260,16 +5260,14 @@ modules['keyboardNav'] = {
 	moveUpThread: function() {
 		if ((this.activeIndex < this.keyboardLinks.length-1) && (this.activeIndex > 1)) {
 			this.moveToTopComment();
-
-			this.moveUpSibling();
 		}
+		this.moveUpSibling();
 	},
 	moveDownThread: function() {
 		if ((this.activeIndex < this.keyboardLinks.length-1) && (this.activeIndex > 1)) {
 			this.moveToTopComment();
-
-			this.moveDownSibling();
 		}
+		this.moveDownSibling();
 	},
 	moveToTopComment: function() {
 		if ((this.activeIndex < this.keyboardLinks.length-1) && (this.activeIndex > 1)) {


### PR DESCRIPTION
Adds the following functionalities and keyboard shortcuts

moveToTopComment: t Select the topmost comment in the current comment thread.

moveUpThread: shift-alt-k Select the topmost comment of the comment thread above current thread. It just calls [moveToTopComment], then [moveUpSibling].

moveDownThread: shift-alt-j Same as above, but for the comment thread below.

Spawned from [this thread on r/enhancements](http://www.reddit.com/r/Enhancement/comments/12o6ze/is_there_any_way_to_collapse_to_a_comments_root/)
