### PR TITLE
betteReddit - option for orangered to point to /message/inbox, not /unread

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -6612,6 +6612,11 @@ modules['betteReddit'] = {
 			value: true,
 			description: 'Show unread message count in favicon?'
 		},
+		unreadLinksToInbox: {
+			type: 'boolean',
+			value: false,
+			description: 'Always go to the inbox, not unread messages, when clicking on orangered'
+		},
 		videoTimes: {
 			type: 'boolean',
 			value: true,
@@ -6820,19 +6825,28 @@ modules['betteReddit'] = {
 			modules['betteReddit'].selfTextHash[thisID] = linkList[i].data.selftext_html;
 		}
 	},
+	getInboxLink: function (havemail) {
+		if (havemail && !modules['betteReddit'].options.unreadLinksToInbox.value) { 
+			return '/message/unread/';
+		}
+
+		return '/message/inbox/';
+	},
 	showUnreadCount: function() {
 		if (typeof(this.mail) == 'undefined') {
 			this.mail = document.querySelector('#mail');
 			if (this.mail) {
+				this.mail.setAttribute('href', this.getInboxLink(true));
 				this.mailCount = createElementWithID('a','mailCount');
 				this.mailCount.display = 'none';
-				this.mailCount.setAttribute('href','/message/unread');
+				this.mailCount.setAttribute('href', this.getInboxLink(true));
 				insertAfter(this.mail, this.mailCount);
 			}
 		}
 		if (this.mail) {
 			$(modules['betteReddit'].mail).html('');
 			if (hasClass(this.mail, 'havemail')) {
+				this.mail.setAttribute('href', this.getInboxLink(true));
 				var lastCheck = parseInt(RESStorage.getItem('RESmodules.betteReddit.msgCount.lastCheck.'+RESUtils.loggedInUser())) || 0;
 				var now = new Date();
 				// 300000 = 5 minutes... we don't want to annoy Reddit's servers too much with this query...
@@ -10531,7 +10545,7 @@ modules['neverEndingReddit'] = {
 				this.NREFloat.appendChild(this.NREMail);
 				this.NREMailCount = createElementWithID('a','NREMailCount');
 				this.NREMailCount.display = 'none';
-				this.NREMailCount.setAttribute('href','/message/unread');
+				this.NREMailCount.setAttribute('href',modules['betteReddit'].getInboxLink(true));
 				this.NREFloat.appendChild(this.NREMailCount);
 				var hasNew = false;
 				if ((typeof(this.navMail) != 'undefined') && (this.navMail != null)) {
@@ -10641,7 +10655,7 @@ modules['neverEndingReddit'] = {
 		if (newmail) {
 			modules['neverEndingReddit'].hasNewMail = true;
 			removeClass(this.NREMail, 'nohavemail');
-			this.NREMail.setAttribute('href','http://www.reddit.com/message/unread/');
+			this.NREMail.setAttribute('href', modules['betteReddit'].getInboxLink(true));
 			this.NREMail.setAttribute('title','new mail!');
 			var newMailImg = '/static/mail.png';
 			if (modules['styleTweaks'].options.colorBlindFriendly.value) {
@@ -10652,7 +10666,7 @@ modules['neverEndingReddit'] = {
 		} else {
 			modules['neverEndingReddit'].hasNewMail = false;
 			addClass(this.NREMail, 'nohavemail');
-			this.NREMail.setAttribute('href','http://www.reddit.com/message/inbox/');
+			this.NREMail.setAttribute('href',modules['betteReddit'].getInboxLink(false));
 			this.NREMail.setAttribute('title','no new mail');
 			removeClass(this.NREMail, 'havemail');
 			modules['betteReddit'].setUnreadCount(0);


### PR DESCRIPTION
Setting this new betteReddit `unreadLinksToInbox` option to true sets the "unread mail" links (navbar/NRE envelope and count) to point to /message/inbox instead of /message/unread.

If the option or the betteReddit module is disabled, the links follow the normal unread/inbox behavior.

_per [CircumcisedSpine's request](http://www.reddit.com/r/Enhancement/comments/12oyif/feature_request_option_to_have_clicking_on/)_
