### PR TITLE
Update lib/reddit_enhancement_suite.user.js

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -9947,7 +9947,7 @@ modules['showImages'] = {
 			}
 		},
 		quickmeme: {
-			hashRe: /^http:\/\/(?:(?:www.)?quickmeme.com\/meme|qkme.me|i.qkme.me)\/([\w]+)\/?/i,
+			hashRe: /^http:\/\/(?:(?:www.|m.)?quickmeme.com\/meme|qkme.me|i.qkme.me)\/([\w]+)\/?/i,
 			go: function() {},
 			detect: function(elem) {
 				var href = elem.href.toLowerCase();
@@ -9956,7 +9956,7 @@ modules['showImages'] = {
 			handleLink: function(elem) {
 				var groups = this.hashRe.exec(elem.href);
 				if (groups) {
-					this.handleInfo(elem, 'http://i.qkme.me/'+groups[1]+'.jpg');
+					this.handleInfo(elem, 'http://resme.me/'+groups[1]+'.jpg');
 				}
 			},
 			handleInfo: function(elem, info) {


### PR DESCRIPTION
- Added image expando support for quickmeme's mobile domain
- Also added an "add captions" feature for quickmeme links

A nuisance for people with RES who are interested in participating in communities such as the AdviceAnimals subreddit is that there is no straightforward way to add captions to anything they see, because links modified by RES point straight to an image rather than a page with a captioning ability. Consequently, RES users have a somewhat crippled experience in these communities.

This modification removes that problem by using a middleman domain with nuanced HTTP header detection which determines whether the URL was loaded in an expando or in its own window/tab.

When determined to be expando/inline, it directs straight to the quickmeme image (which is the current behavior of RES). When determined to be its own window/tab, it instead serves an HTML page containing the image and a small and unobtrusive "add captions" button which dynamically embeds an HTML5-friendly, no-Flash-required image captioning script when clicked.

The server errs on the side of caution by only serving HTML if it is 100% certain the image link was loaded in its own window/tab. Otherwise it falls back on normal image loading.

It has been tested in Opera, Firefox, Chrome, Safari, and IE 7/8/9.

The modification is barely noticeable to people who don't care about adding their own captions to anything, while giving the captioning ability back to people who do care.

It is hosted on a dedicated softlayer server with a 2 Gbps uplink and 10 TB/month bandwidth allotment. I think it would be cool to make this eventually work with other meme sites too, but I started with quickmeme because it's the most popular. Let me know what you guys think!
