### PR TITLE
orangered-inbox - fixed bug where not-orangered points to /unread

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -6917,7 +6917,6 @@ modules['betteReddit'] = {
 		if (typeof(this.mail) == 'undefined') {
 			this.mail = document.querySelector('#mail');
 			if (this.mail) {
-				this.mail.setAttribute('href', this.getInboxLink(true));
 				this.mailCount = createElementWithID('a','mailCount');
 				this.mailCount.display = 'none';
 				this.mailCount.setAttribute('href', this.getInboxLink(true));


### PR DESCRIPTION
if orangeredToInbox option isn't enabled

Sorry I didn't notice this bug before it was released.
