### PR TITLE
Work around Chrome bug 161028

### DIFF
--- a/Chrome/background.js
+++ b/Chrome/background.js
@@ -87,6 +87,13 @@ XHRCache = {
 	}
 };
 
+function copyLocalStorage() {
+	var s = {};
+	for (var key in localStorage)
+		s[key] = localStorage[key];
+	return s;
+}
+
 chrome.extension.onMessage.addListener(
 	function(request, sender, sendResponse) {
 		switch(request.requestType) {
@@ -192,14 +199,14 @@ chrome.extension.onMessage.addListener(
 				return true;
 				break;
 			case 'getLocalStorage':
-				sendResponse(localStorage);
+				sendResponse(copyLocalStorage());
 				break;
 			case 'saveLocalStorage':
 				for (var key in request.data) {
 					localStorage.setItem(key,request.data[key]);
 				}
 				localStorage.setItem('importedFromForeground',true);
-				sendResponse(localStorage);
+				sendResponse(copyLocalStorage());
 				break;
 			case 'localStorage':
 				switch (request.operation) {


### PR DESCRIPTION
Copy localStorage before sending to requesting page, since JSON.stringify is currently broken for localStorage on the Chrome dev channel.

See http://crbug.com/161028
