### PR TITLE
Safari bug where shift+enter on link opens tab at end of tab bar

### DIFF
--- a/RES.safariextension/background-safari.html
+++ b/RES.safariextension/background-safari.html
@@ -158,6 +158,7 @@
 				// chrome.tabs.create({url: thisLinkURL});
 				// opens tab next to current, instead of at end of tab bar
 				var linkTab = safari.application.activeBrowserWindow.openTab(button, safari.application.activeBrowserWindow.tabs.indexOf(safari.application.activeBrowserWindow.activeTab)+1);
+				linkTab.url = thisLinkURL;
 				sendResponse({status: "success"}, msgEvent);
 				break;
 			case 'openLinkInNewTab':


### PR DESCRIPTION
Fixed a bug where shift+enter or shift+c will open up the new tab at the end of the tab bar, instead of next to the current. I just inserted the proper index for where to open the tab in the openTab method, instead of letting it default to the end of the tab bar. 

The Safari default behavior is to open new tabs next to the current tab when you command-click a link, but openTab doesn't seem to do that by default, you need to specify the index in the tab array of where to open the new tab. 
