### PR TITLE
Preload images in inline gallery.

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -9160,9 +9160,17 @@ modules['showImages'] = {
 		this.trackImageLoad(imageLink, image);
 		this.makeImageZoomable(image);
 	},
+	preloadImages: function(srcs) {
+		for (var i = 0; i < srcs.length; i++) {
+			var img = new Image();
+			img.src = srcs[i].src;
+		}
+	},
 	generateGalleryExpando: function(expandoButton) {
 		var imageLink = expandoButton.imageLink;
 		var which = imageLink.galleryStart || 0;
+
+		this.preloadImages(imageLink.src);
 
 		var imgDiv = document.createElement('div');
 		addClass(imgDiv, 'madeVisible');


### PR DESCRIPTION
Instead of loading each image individually in a gallery as you click through them, all of them are preloaded from the beginning.  This way, you don't have to wait for large images to load while you flip through the inline image gallery.  
