### PR TITLE
NeverEndingReddit inbox icon - use /static/ images instead of stylesheet; use colorblind-friendly icon

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -10556,8 +10556,8 @@ modules['neverEndingReddit'] = {
 					RESUtils.addCSS('#NREFloat { position: fixed; top: 10px; right: 10px; display: none; }');
 				}
 				RESUtils.addCSS('#NREMail { width: 16px; height: 12px; float: left; margin-top: 4px; background: center center no-repeat; }');
-				RESUtils.addCSS('#NREMail.nohavemail { background-image: url(/static/mailgray.png); }');
-				RESUtils.addCSS('#NREMail.havemail { background-image: url(/static/mail.png); }');
+				RESUtils.addCSS('#NREMail.nohavemail { background-image: url(http://www.redditstatic.com/mailgray.png); }');
+				RESUtils.addCSS('#NREMail.havemail { background-image: url(http://www.redditstatic.com/mail.png); }');
 				RESUtils.addCSS('.res-colorblind #NREMail.havemail { background-image: url(http://thumbs.reddit.com/t5_2s10b_5.png); }');
 				this.NREFloat.appendChild(this.NREMail);
 				this.NREMailCount = createElementWithID('a','NREMailCount');


### PR DESCRIPTION
reddit's spritesheet's URL appears to change periodically (due to CSS changes, presumably). Because the  Never-Ending Reddit inbox icon, `#NREMail`, sourced an old URL for the reddit spritesheet, the icon has not been displaying. To fix this issue and prevent it from reoccuring in the future,  I set `#NREMail` to use the static images. 

I also set up `#NREMail` to use the color-blind friendly icon  (again?).  As part of this fix, RES now adds a `.res-colorblind` class to the body, in case subreddit moderators want to take advantage of it.

[Relevant bug report](http://www.reddit.com/r/RESissues/comments/14b3ym/bug_never_ending_orangered_envelope_is_invisible/)
