### PR TITLE
Replace html entities with < > & " ' in imgur/tumblr expandos

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -9180,7 +9180,7 @@ modules['showImages'] = {
 
 		var header = document.createElement('h3');
 		addClass(header, 'imgTitle');
-		header.textContent = imageLink.imageTitle || '';
+		header.textContent = RESUtils.htmlEntitiesToText(imageLink.imageTitle);
 		imgDiv.appendChild(header);
 
 		var imageAnchor = document.createElement('a');
@@ -9242,14 +9242,14 @@ modules['showImages'] = {
 
 		var imageTitle = document.createElement('h4');
 		imageTitle.className = 'imgCaptions';
-		imageTitle.textContent = imgDiv.sources[which].title || '';
+		imageTitle.textContent = RESUtils.htmlEntitiesToText(imgDiv.sources[which].title);
 		imageWrapper.appendChild(imageTitle);
 
 		imageWrapper.appendChild(imageAnchor);
 
 		var imageCaptions = document.createElement('div');
 		imageCaptions.className = 'imgCaptions';
-		imageCaptions.textContent = imgDiv.sources[which].caption || '';
+		imageCaptions.textContent = RESUtils.htmlEntitiesToText(imgDiv.sources[which].caption);
 		imageWrapper.appendChild(imageCaptions);
 
 		imgDiv.appendChild(imageWrapper);
@@ -9272,13 +9272,13 @@ modules['showImages'] = {
 				leftButton.classList.remove('end');
 				rightButton.classList.remove('end');
 			}
-			imageTitle.textContent = source.title || '';
-			imageCaptions.textContent = source.caption || '';
+			imageTitle.textContent = RESUtils.htmlEntitiesToText(source.title);
+			imageCaptions.textContent = RESUtils.htmlEntitiesToText(source.caption);
 		}
 
 		var captions = document.createElement('div');
 		captions.className = 'imgCaptions';
-		captions.textContent = imageLink.caption || '';
+		captions.textContent = RESUtils.htmlEntitiesToText(imageLink.caption);
 		imgDiv.appendChild(captions);
 
 		if ('credits' in imageLink) {
@@ -9315,7 +9315,7 @@ modules['showImages'] = {
 
 		var header = document.createElement('h3');
 		header.className = 'imgTitle';
-		header.textContent = imageLink.imageTitle || '';
+		header.textContent = RESUtils.htmlEntitiesToText(imageLink.imageTitle);
 		imgDiv.appendChild(header);
 
 		var text = document.createElement('div');
@@ -9337,7 +9337,7 @@ modules['showImages'] = {
 
 		var captions = document.createElement('div');
 		captions.className = 'imgCaptions';
-		captions.textContent = imageLink.caption || '';
+		captions.textContent = RESUtils.htmlEntitiesToText(imageLink.caption);
 		imgDiv.appendChild(captions);
 
 		if ('credits' in imageLink) {


### PR DESCRIPTION
imgur and tumblr post expandos have been showing HTML entities in the titles and captions since [`innerHTML` was phased out in favor of `textContent`](https://github.com/honestbleeps/Reddit-Enhancement-Suite/commit/7f8949f6b36e2f075890cdc0f5854d439e48ab2f). This change replaces the most common HTML entities with their text equivalents: `< > & " '`

[relevant post](http://www.reddit.com/r/RESissues/comments/13pad3/bug_ampersands_in_imgur_album_picture_titles_are/)
