### PR TITLE
"Use subreddit style" toggle - don't show on top of menus/popups

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -11823,6 +11823,8 @@ modules['styleTweaks'] = {
 		this.setStyleToggleCss(true);
 	},
 	setStyleToggleCss: function (visible) {
+		// When showing a popup which could overlay the "Use subreddit style" checkbox,
+		// when showing popup, call this function with visible=false; when hiding, visible=true
 		var self = modules['styleTweaks']; 
 		if (!self.styleToggleContainer) return;
 


### PR DESCRIPTION
Ensure that the "Use subreddit styling" toggle doesn't overstep its bounds by temporarily disabling the  [new and improved z-index](https://github.com/honestbleeps/Reddit-Enhancement-Suite/commit/9f70f63e84275a41b4a6ba3e1b44cdc8db5500d0) when RES pop-up/drop-down elements are showing.
