### PR TITLE
Fire "neverEndingLoad" event for use by other userscripts.

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -10843,6 +10843,9 @@ modules['neverEndingReddit'] = {
 							var noresultsfound = (noresults) ? true : false;
 							modules['neverEndingReddit'].NERFail(noresultsfound);
 						}
+						var e = document.createEvent("Events");
+						e.initEvent("neverEndingLoad", true, true);
+						window.dispatchEvent(e);					
 					}
 				},
 				onerror: function(err) {


### PR DESCRIPTION
This patch introduces an event that fires when Never-Ending Reddit loads new entries. It allows third-party userscripts to cooperate with RES much more efficiently.
