### PR TITLE
do not override reddit gold comment save button behavior [#219]

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -7061,7 +7061,7 @@ modules['betteReddit'] = {
 	},
 	fixSaveLinks: function(ele) {
 		var root = ele || document;
-		var saveLinks = root.querySelectorAll('FORM.save-button > SPAN > A');
+		var saveLinks = root.querySelectorAll('li:not(.comment-save-button) > FORM.save-button > SPAN > A');
 		for (var i=0, len=saveLinks.length; i<len; i++) {
 			saveLinks[i].removeAttribute('onclick');
 			saveLinks[i].setAttribute('action','save');


### PR DESCRIPTION
It allows the Reddit Gold comment save button to work when the Reddit Enhancement Suite is installed and enabled.  This fixes issue #219. I'm happy to enhance this patch if needed, just let me know if there are related issues to address.
