### PR TITLE
Fix two issues with case sensitive comparisson in the account switcher module.

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -12161,7 +12161,7 @@ modules['accountSwitcher'] = {
 					var accountCount = 0;
 					for (var i=0, len=accounts.length; i<len; i++) {
 						var thisPair = accounts[i];
-						if (thisPair[0] != this.loggedInUser || this.options.showCurrentUserName.value){
+						if (thisPair[0].toUpperCase() !== this.loggedInUser.toUpperCase() || this.options.showCurrentUserName.value){
 							accountCount++;
 							var thisLI = document.createElement('LI');
 							addClass(thisLI, 'accountName');
@@ -12240,8 +12240,9 @@ modules['accountSwitcher'] = {
 		}
 		for (var i=0, len=accounts.length; i<len; i++) {
 			var thisPair = accounts[i];
-			if (thisPair[0] == username) {
+			if (thisPair[0].toUpperCase() === username.toUpperCase()) {
 				password = thisPair[1];
+				break;
 			}
 		}
 		// console.log('request with user: ' +username+ ' -- passwd: ' + password);


### PR DESCRIPTION
I've fixed two issues with case sensitive comparisson in the account switcher module. Reddit accounts are case insensitive, but the account switcher was comparing them case-sensitively which was causing some problems.

The two fixes are:
1. If you have selected to not have your current account show up in the user list, but you didn't enter it in the same case that reddit reports, it still won't show up.
2. If you somehow select to switch to an account that is in the database but specify the wrong case, you will still be switched correctly. I think this is possible using the command line.
