### PR TITLE
Search RES settings, navigate to settings via URL hash

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -15480,7 +15480,7 @@ modules['settingsNavigation'] =
 		setUrl: {
 			type: 'boolean',
 			value: false,
-			description: 'When navigating settings, update URL with pointer to settings page'
+			description: 'When navigating settings, update URL and browser history with pointer to settings page'
 		}
 	},
 	isEnabled: function() {
@@ -15506,27 +15506,36 @@ modules['settingsNavigation'] =
 
 		if (this.options.watchUrl.value) {
 			window.addEventListener('hashchange', function(e) { modules['settingsNavigation'].onHashChange(e); });
+			window.addEventListener('popstate', function(e) { modules['settingsNavigation'].onPopState(e); });
 			setTimeout(function() { modules['settingsNavigation'].onHashChange(); }, 300); // for initial pageload; wait until after RES has completed loading
 		}
 	},
 	setUrlHash: function(moduleID, optionKey) {
-		var components = ['#!settings']
-		if (moduleID) components.push(moduleID);
-		if (moduleID && optionKey) components.push(optionKey);
+		var titleComponents = ['RES Settings'];
+		var hashComponents = ['#!settings']
+		
+		if (moduleID) {
+			hashComponents.push(moduleID);
 
-		var hash = components.join('/');
-
-		modules['settingsNavigation'].urlHashLock.lock(hash);
-		window.location.hash = hash;
-	},
-	urlHashLock: RESUtils.createMultiLock(),
-	onHashChange: function (event) {
-		var hash = window.location.hash;
-		if (modules['settingsNavigation'].urlHashLock.locked()) {
-			modules['settingsNavigation'].urlHashLock.unlock(hash);
-			return;
+			var module = modules[moduleID];
+			var moduleName = module && module.moduleName || moduleID;
+			titleComponents.push(moduleName);
 		}
 
+		if (moduleID && optionKey) {
+			hashComponents.push(optionKey);
+			titleComponents.push(optionKey);
+		}
+
+		var hash = hashComponents.join('/');
+		var title = titleComponents.join(' - ');
+
+		if (window.location.hash != hash) {
+			window.history.pushState(hashComponents, title, hash);
+		}
+	},
+	onHashChange: function (event) {
+		var hash = window.location.hash;
 		if (hash.substring(0, 10) != '#!settings') return;
 
 		var params = hash.match(/\/\w+/g);
@@ -15538,6 +15547,15 @@ modules['settingsNavigation'] =
 		}
 
 		modules['settingsNavigation'].loadSettingsPage(moduleID, optionKey);
+	},
+	onPopState: function (event) {
+		var state = event.state;
+		if (!(state && state[0] != '#!settings')) return;
+
+		var moduleID = state[1];
+		var optionKey = state[2];
+
+		modules['settingsNavigation'].loadSettingsPage(moduleID, opionKey);
 	},
 	loadSettingsPage: function(moduleID, optionKey) {
 		if (moduleID && modules.hasOwnProperty(moduleID)) {


### PR DESCRIPTION
Search the RES settings or click on links to navigate directly to settings for specific modules and options
## Search settings
- from console> Press `.` to open console > type in `search your search terms` > press enter
- from gear dropdown menu> Hover over gear to open menu > click "search settings" > search box automatically gets focus > type in `your search terms` > press enter or click the `[>>]` button.
- from RES settings console> click on search box in settings console's title bar> type in `your search terms`> press enter or click the `[>>]` button

Any of these actions will open the RES settings Console> About> Search panel and display a list of search results for RES options, which list breadcrumb path and a description of the option.  Click a search result to navigate directly to that option.
## Navigate to option from URL

If `modules['settingsNavigation'].options['watchUrl']` is enabled (true by default), then visiting a `reddit.com/.../#!settings...` URL will open the RES settings console and navigate to the specified module/option.

http://www.reddit.com/anywhere#!settings opens the RES settings console.
http://www.reddit.com/anywhere/#!settings/accountSwitcher opens the RES settings console and navigates to the Account Switcher module settings.
http://www.reddit.com/anywhere/#!settings/betteReddit/showUnreadCount opens the RES settings console, navigates to the betteReddit module settings, and scrolls down to the showUnreadCount option.
## Update URL when navigating settings console

If `modules['settingsNavigation'].options['setUrl']` is enabled (false by default), then navigating to a module's settings in the RES settings console changes the page's URL hash to `#!settings/moduleID` (clicking around) or `#!settings/moduleID/optionKey`  (clicking a search result).
