### PR TITLE
showParent fixed with better selector

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -10486,7 +10486,9 @@ modules['showParent'] = {
 			addClass(div, 'comment parentComment');
 			var bgFix = '';
 			if ((!(modules['styleTweaks'].options.commentBoxes.value)) || (!(modules['styleTweaks'].isEnabled())))  {
-				(modules['styleTweaks'].options.lightOrDark.value == 'dark') ? bgFix = 'border: 1px solid #666666; padding: 4px; background-color: #333333;' : bgFix = 'border: 1px solid #666666; padding: 4px; background-color: #FFFFFF;';
+				bgFix = (modules['styleTweaks'].options.lightOrDark.value == 'dark')
+					? 'border: 1px solid #666666; padding: 4px; background-color: #333333;' 
+					: 'border: 1px solid #666666; padding: 4px; background-color: #FFFFFF;';
 			}
 			div.setAttribute('style','width:auto;position:absolute; top:'+top+'px; left:'+left+'px; '+bgFix+';');
 			var parentDiv = document.querySelector('div.id-t1_'+id);


### PR DESCRIPTION
showParent module, which shows the parent comment to the current comment, now uses a better selector for the comment's `parent` button.  This should fix Opera and Safari and not break Chrome and Firefox's "show parent" behavior.

Only the first commit is necessary for this fix. The rest is just code cleanup.
