### PR TITLE
Fixes #212 - replacing r/ is bad practise

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -14387,7 +14387,10 @@ modules['subredditManager'] = {
 				var subreddit = modules['subredditManager'].shortCutsAddFormField.value;
 				var displayname = modules['subredditManager'].shortCutsAddFormFieldDisplayName.value;
 				if (displayname == '') displayname = subreddit;
-				subreddit = subreddit.replace('/r/','').replace('r/','');
+				var r_match_regex = /^(\/r\/|r\/)(.*)/i;
+				if(r_match_regex.test(subreddit)) {
+					subreddit = subreddit.match(r_match_regex)[2];
+				}
 				modules['subredditManager'].shortCutsAddFormField.value = '';
 				modules['subredditManager'].shortCutsAddFormFieldDisplayName.value = '';
 				modules['subredditManager'].shortCutsAddFormContainer.style.display = 'none';


### PR DESCRIPTION
Replacing r/ can and will match comment strings and isn't as strict/safe
as /r/. Perhaps when adding shortcuts we should have a full regex match
so we can reject incorrect shortcuts? However, this fixes #212 and makes
this bit of script more robust.
