### PR TITLE
CSS tweaks/fixes/night mode

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -12094,7 +12094,6 @@ modules['styleTweaks'] = {
 			css += '.thing .expando-button{background-color:transparent}';
 			css += '.RESdupeimg{color:#eee;font-size:10px;}';
 			css += '.keyHighlight,.keyHighlight .md{background-color:#666}.keyHighlight .title.loggedin:visited, .keyHighlight .title:visited{color:#dfdfdf}';
-			css += '.side .titlebox{padding-left:5px}';
 			css += '.user .userkarma{color:#444}';
 			css += '.drop-choices{background-color:#C2D2E2}';
 			css += '.drop-choices a{color:#000}';


### PR DESCRIPTION
Night mode styling/colours is open to change as ever. Minor changes for the most part though some pages/states of reddit may have been missed. Mainly removal of !important in favour of (sometimes) more specific selectors.

General CSS clean up, nothing major, mainly small stuff. 0 instead of 0px, merging multiples into shorthand, removal of moz/webkit prefixes for border-radius since they're obsolete.

Fix for the notifications being partially overlapped by the header.
