### PR TITLE
viewSource gets correct source for replies to PMs

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -8428,14 +8428,13 @@ modules['commentPreview'] = {
 								var sourceText = null;
 								if (typeof(thisResponse[1]) != 'undefined') {
 									sourceText = thisResponse[1].data.children[0].data.body;
-								} else if (location.href.match(/message\/(moderator|messages)/)) {
-									// since we're in modmail, we have to parse the tree.
-									// this is a bit odd, and maybe a reddit API bug, but
-									// whatever the case, it's the only way to get the right item.
+								} else {
 									var thisData = thisResponse.data.children[0].data;
 									if (thisData.id == postID) {
 										sourceText = thisData.body;
 									} else {
+										// The message we want is a reply to a PM/modmail, but reddit returns the whole thread.
+										// So, we have to dig into the replies to find the message we want.
 										for (var i=0, len=thisData.replies.data.children.length; i<len; i++) {
 											var replyData = thisData.replies.data.children[i].data;
 											if (replyData.id == postID) {
@@ -8444,8 +8443,6 @@ modules['commentPreview'] = {
 											}
 										}
 									}
-								} else {
-									sourceText = thisResponse.data.children[0].data.body;
 								}
 								// sourceText in this case is reddit markdown. escaping it would screw it up.
 								$(userTextForm).html('<div><textarea rows="1" cols="1" name="text">' + sourceText + '</textarea></div><div class="bottom-area"><div class="usertext-buttons"><button type="button" class="cancel">hide</button></div></div>');


### PR DESCRIPTION
`modules['commentPreview'].viewSource`, when attempting to view source for a PM/modmail message which is a reply, was grabbing the source for the first comment in that thread. Generally speaking, `viewSource` should check post IDs and replies against what the user asked for to find the correct comment.

http://www.reddit.com/r/RESissues/comments/1949rr/bug_found_an_obscure_and_weird_bug_regarding_the/
