### PR TITLE
Tinycon shouldn't clobber page title if it can't set the favicon

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -6974,6 +6974,9 @@ modules['betteReddit'] = {
 		}
 	},
 	setUnreadCount: function(count) {
+		if (this.options.showUnreadCountInFavicon.value) {
+			window.Tinycon.setOptions({ fallback: false });
+		}
 		if (count>0) {
 			if (this.options.showUnreadCountInTitle.value) {
 				var newTitle = '[' + count + '] ' + document.title.replace(/^\[[\d]+\]\s/,'');


### PR DESCRIPTION
That's just being a sore loser.  Besides, RES has a different option for adding unread count to title.

Fixes issue [#265](https://github.com/honestbleeps/Reddit-Enhancement-Suite/issues/265).
