### PR TITLE
RESUtils.initObservers watches the real #siteTable for changes

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -1969,6 +1969,11 @@ var RESUtils = {
 		} else {
 			// initialize sitetable observer...
 			var siteTable = document.querySelector('#siteTable');
+			var stMultiCheck = document.querySelectorAll('#siteTable');
+			if (stMultiCheck.length == 2) {
+			    siteTable = stMultiCheck[1];
+			}
+
 			if (MutationObserver && siteTable) {
 				var observer = new MutationObserver(function(mutations) {  
 					mutations.forEach(function(mutation) {


### PR DESCRIPTION
The "sponsored link" on /r/all and large subs is currently wrapped in a `#siteTable` element. RES's siteTable watcher is listening for changes on that, rather than the actual link listings.

This change adds a guard against the advert #siteTable so that the MutationObserver/DOMNodeInserted listens to the link listings container.

Fixes #272 
