### PR TITLE
Move MutationObserver into BrowserDetect out of global scope

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -100,14 +100,6 @@ guidersCSS += '.guider_arrow_left { display: block; background-position: 0 -84px
 var escapeLookups = { "&": "&amp;", '"': "&quot;", "<": "&lt;", ">": "&gt;" };
 function escapeHTML(str) { return (str == null) ? null : str.toString().replace(/[&"<>]/g, function(m) { return escapeLookups[m] }) };
 
-// set up MutationObserver variable to take whichever is supported / existing...
-// unfortunately, this doesn't (currently) exist in Opera.
-// var MutationObserver = window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver || null;
-// At the time of writing WebKit's mutation oberver leaks entire pages on refresh so it needs to be disabled.
-var MutationObserver = window.MutationObserver || /* window.WebKitMutationObserver || */ window.MozMutationObserver || null;
-// null out MutationObserver to test legacy DOMNodeInserted
-// MutationObserver = null;
-
 function insertAfter( referenceNode, newNode ) {
 	if ((typeof(referenceNode) == 'undefined') || (referenceNode == null)) {
 		console.log(arguments.callee.caller);
@@ -150,6 +142,14 @@ var BrowserDetect = {
 			|| this.searchVersion(navigator.appVersion)
 			|| "an unknown version";
 		this.OS = this.searchString(this.dataOS) || "an unknown OS";
+
+		// set up MutationObserver variable to take whichever is supported / existing...
+		// unfortunately, this doesn't (currently) exist in Opera.
+		// this.MutationObserver = window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver || null;
+		// At the time of writing WebKit's mutation oberver leaks entire pages on refresh so it needs to be disabled.
+		this.MutationObserver = window.MutationObserver || /* window.WebKitMutationObserver || */ window.MozMutationObserver || null;
+		// null out MutationObserver to test legacy DOMNodeInserted
+		// this.MutationObserver = null;
 	},
 	searchString: function (data) {
 		for (var i=0;i<data.length;i++)	{
@@ -1969,8 +1969,8 @@ var RESUtils = {
 		if (RESUtils.pageType() == 'comments') {
 			// initialize comments page based sitetable observer...
 			var siteTable = document.querySelector('.commentarea > div.sitetable');
-			if (MutationObserver && siteTable) {
-				var observer = new MutationObserver(function(mutations) {  
+			if (BrowserDetect.MutationObserver && siteTable) {
+				var observer = new BrowserDetect.MutationObserver(function(mutations) {
 					mutations.forEach(function(mutation) {
 						// when a node is added on a comments page, check if it's a new self comment.
 						if ($(mutation.addedNodes[0]).hasClass('comment')) {
@@ -2006,8 +2006,8 @@ var RESUtils = {
 			    siteTable = stMultiCheck[1];
 			}
 
-			if (MutationObserver && siteTable) {
-				var observer = new MutationObserver(function(mutations) {  
+			if (BrowserDetect.MutationObserver && siteTable) {
+				var observer = new BrowserDetect.MutationObserver(function(mutations) {
 					mutations.forEach(function(mutation) {
 						if (mutation.addedNodes[0].id.indexOf('siteTable') != -1) {
 							// when a new sitetable is loaded, we need to add new observers for selftexts within that sitetable...
@@ -2066,10 +2066,10 @@ var RESUtils = {
 	},
 	addNewCommentObserver: function(ele) {
 		var mutationNodeToObserve = ele;
-		if (MutationObserver) {
+		if (BrowserDetect.MutationObserver) {
 			// console.log('node to observe:');
 			// console.log(mutationNodeToObserve);
-			var observer = new MutationObserver(function(mutations) {  
+			var observer = new BrowserDetect.MutationObserver(function(mutations) {
 				RESUtils.watchers.newComments.forEach(function(callback) {
 					// add form observers to these new comments we've found...
 					$(mutations[0].target).find('.thing .child').each(function() {
@@ -2102,9 +2102,9 @@ var RESUtils = {
 	},
 	addNewCommentFormObserver: function(ele) {
 		var commentsFormParent = ele;
-		if (MutationObserver) {
+		if (BrowserDetect.MutationObserver) {
 			// var mutationNodeToObserve = moreCommentsParent.parentNode.parentNode.parentNode.parentNode;
-			var observer = new MutationObserver(function(mutations) {  
+			var observer = new BrowserDetect.MutationObserver(function(mutations) {
 				var form = $(mutations[0].target).children('form');
 				if ((form) && (form.length == 1)) {
 					RESUtils.watchers.newCommentsForms.forEach(function(callback) {
@@ -2140,9 +2140,9 @@ var RESUtils = {
 	},
 	addSelfTextObserver: function(ele) {
 		var selfTextParent = ele;
-		if (MutationObserver) {
+		if (BrowserDetect.MutationObserver) {
 			// var mutationNodeToObserve = moreCommentsParent.parentNode.parentNode.parentNode.parentNode;
-			var observer = new MutationObserver(function(mutations) {  
+			var observer = new BrowserDetect.MutationObserver(function(mutations) {
 				var form = $(mutations[0].target).find('form');
 				if ((form) && (form.length > 0)) {
 					RESUtils.watchers.selfText.forEach(function(callback) {
@@ -8394,9 +8394,9 @@ modules['commentPreview'] = {
 	/*
 	addParentListener: function (event) {
 		var moreCommentsParent = event.currentTarget;
-		if (MutationObserver) {
+		if (BrowserDetect.MutationObserver) {
 			var mutationNodeToObserve = $(moreCommentsParent).closest('div.sitetable')[0];
-			var observer = new MutationObserver(function(mutations) {  
+			var observer = new BrowserDetect.MutationObserver(function(mutations) {
 //				mutations.forEach(function(mutation) {
 					$(mutations[0].target).find('form').each(function() {
 						modules['commentPreview'].wireupCommentEditors( this );


### PR DESCRIPTION
var MutationObserver = window.MutationObserver doesn't work in FF19 because scoping.  Therefore, let's avoid the scoping issue by storing RES's pointer to MutationObserver in an object (BrowserDetect).

Fixes #259 for Firefox.
