### PR TITLE
expanding/zooming images toggles srstyle visibility

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -1037,6 +1037,47 @@ var RESUtils = {
 			return false;
 		}
 	},
+	doElementsCollide: function (ele1, ele2, margin) {
+		margin = margin || 0;
+		var ele1 = $(ele1);
+		var ele2 = $(ele2);
+
+		var dims1 = ele1.offset();
+		dims1.right = dims1.left + ele1.width();
+		dims1.bottom = dims1.top + ele1.height();
+
+		dims1.left -= margin;
+		dims1.top -= margin;
+		dims1.right += margin;
+		dims1.bottom += margin;
+
+
+		var dims2 = ele2.offset();
+		dims2.right = dims2.left + ele2.width();
+		dims2.bottom = dims2.top + ele2.height();
+
+		if (	(	(dims1.left < dims2.left  && dims2.left < dims1.right)
+			 	||	(dims1.left < dims2.right && dims2.right < dims1.right)
+			 	||	(dims2.left < dims1.left  && dims1.left < dims2.right)
+			 	||	(dims2.left < dims1.right && dims1.right < dims2.right)
+			 	)
+		    &&
+				(	(dims1.top  < dims2.top    && dims2.top    < dims1.bottom)
+			 	||	(dims1.top  < dims2.bottom && dims2.bottom < dims1.bottom)
+		    	||	(dims2.top  < dims1.top    && dims1.top    < dims2.bottom)
+			 	||	(dims2.top  < dims1.bottom && dims1.bottom < dims2.bottom))
+		    ) {
+			// In layman's terms:
+			// If one of the box's left/right borders is between the other box's left/right
+			// and same with top/bottom,
+			// then they collide.  
+			// This could probably be logicked into a more compact form.
+
+			return true;
+		}
+
+		return false;
+	},
 	scrollTo: function(x,y) {
 		var headerOffset = this.getHeaderOffset();
 		window.scrollTo(x,y-headerOffset);
@@ -9328,6 +9369,7 @@ modules['showImages'] = {
 				}, 100);
 				expandoButton.expandoBox.style.display = 'block';
 			}
+			this.handleSRStyleToggleVisibility();
 		} else if (showHide) {
 			//TODO: flash, custom
 			switch (imageLink.type) {
@@ -9468,6 +9510,7 @@ modules['showImages'] = {
 
 			var image = document.createElement('img');
 			addClass(image, 'RESImage');
+			image.id = 'RESImage-' + RESUtils.randomHash();
 			image.src = sourceImage.src;
 			image.title = 'drag to resize';
 			image.style.maxWidth = thisHandle.options.maxWidth.value + 'px';
@@ -9593,10 +9636,15 @@ modules['showImages'] = {
 				}, false);
 			}
 		}
+
+		image.addEventListener('load', function(e) {
+			modules['showImages'].handleSRStyleToggleVisibility(e.target);
+		}, false);
 	},
 	imageTrackShift: function() {
 		var url = modules['showImages'].imageTrackStack.shift();
 		if (typeof(url) == 'undefined') {
+			modules['showImages'].handleSRStyleToggleVisibility();
 			return;
 		}
 		if (BrowserDetect.isChrome()) {
@@ -9632,6 +9680,23 @@ modules['showImages'] = {
 		var p = Math.pow;
 		var dragSize = p(p(e.clientX-rc.left, 2)+p(e.clientY-rc.top, 2), .5);
 		return Math.round(dragSize);
+	},
+	handleSRStyleToggleVisibility: function(image) {
+		RESUtils.debounce('handleSRStyleToggleVisibility', 50, function() {
+			var toggleEle = modules['styleTweaks'].styleToggleContainer;
+			var imageElems = image ? [ image ] : document.querySelectorAll('.RESImage');
+
+			for (var i = 0 ; i < imageElems.length; i++) {
+				var imageEle = imageElems[i];
+				var imageID = imageEle.getAttribute('id');
+
+				if (RESUtils.doElementsCollide(toggleEle, imageEle, 15)) {
+					modules['styleTweaks'].setSRStyleToggleVisibility(false, 'imageZoom-' + imageID);
+				} else {
+					modules['styleTweaks'].setSRStyleToggleVisibility(true, 'imageZoom-' + imageID);
+				}
+			}
+		});
 	},
 	setPlaceholder: function(imageTag) {
 		if (!($(imageTag).data('imagePlaceholder'))) {
@@ -9670,10 +9735,13 @@ modules['showImages'] = {
 
 					e.target.style.maxHeight='';
 					e.target.style.height='auto';
+					modules['showImages'].handleSRStyleToggleVisibility(e.target);
 
 					var thisPH = $(imageTag).data('imagePlaceholder');
 					$(thisPH).width($(e.target).width() + 'px');
-					$(thisPH).height($(e.target).height() + 'px');
+					$(thisPH).height($(e.target).height() + 'px');					
+
+					modules['showImages'].handleSRStyleToggleVisibility(imageTag);
 
 					modules['showImages'].dragTargetData.dragging = true;
 				}
@@ -9694,6 +9762,7 @@ modules['showImages'] = {
 
 				}
 
+				modules['showImages'].handleSRStyleToggleVisibility(e.target);
 				modules['showImages'].dragTargetData.diagonal = 0;
 			}, false);
 			imageTag.addEventListener('click', function(e) {
@@ -11992,6 +12061,7 @@ modules['styleTweaks'] = {
 	},
 	srstyleHideLock: RESUtils.createMultiLock(),
 	setSRStyleToggleVisibility: function (visible, source) {
+		window.console.log("toggling visibility.", visible, source);
 		/// When showing/hiding popups which could overlay the "Use subreddit style" checkbox,
 		/// set the checkbox's styling to "less visible" or "more visible"
 		/// @param 	visible 		bool	make checkbox "more visible" (true) or less (false)


### PR DESCRIPTION
in lieu of handleSidebarHiding (7fa7f24847e888f0b1b31324a45487869ad6d143)

Small bug: window resizing should trigger .handleSRStyleToggleVisibility.  That should get fixed, but I'm being lazy about it right now.
