### PR TITLE
Fix issue with loading top level comments

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -3898,8 +3898,10 @@ modules['uppersAndDowners'] = {
 	showUppersAndDownersOnComment: function(commentEle) {
 		// if this is not a valid comment (e.g. a load more comments div, which has the same classes for some reason)
 		if ((commentEle.getAttribute('data-votesvisible') == 'true') 
-			|| (hasClass(commentEle,'morechildren')))
+			|| (hasClass(commentEle,'morechildren')) 
+			|| (hasClass(commentEle,'morerecursion'))) {
 			return;
+		}
 		commentEle.setAttribute('data-votesvisible', 'true');
 		var tagline = commentEle.querySelector('p.tagline');
 		var ups = commentEle.getAttribute('data-ups');


### PR DESCRIPTION
**Fix issue with not connecting to the immediate child of an expanded set of comments. In particular loading top level comments was not firing `newCommentForms`**

_Before this fix:_
1. Load more top level comments
2. Reply to a newly loaded comment
3. No comment preview

**Now applies RES settings to newly added comments**

**`Continue this thread` links were receiving uppers and downers**
