### PR TITLE
Macro dropdown list unusable in "big editor"

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -7898,8 +7898,8 @@ modules['commentPreview'] = {
 			RESUtils.addCSS('.RESDialogSmall.livePreview .RESDialogContents h3 { font-weight: bold; }');
 			RESUtils.addCSS('.RESMacroDropdownTitle, .RESMacroDropdownTitleOverlay { cursor: pointer; display: inline-block; font-size: 11px; text-decoration: underline; color: gray; padding-left: 2px; padding-right: 21px; background-image: url(http://www.redditstatic.com/droparrowgray.gif); background-position: 100% 50%; background-repeat: no-repeat; }');
 			RESUtils.addCSS('.RESMacroDropdownTitleOverlay { cursor: pointer; }');
-			RESUtils.addCSS('#RESMacroDropdown { display: none; }');
 			RESUtils.addCSS('#RESMacroDropdownContainer { display: none; position: absolute; }');
+			RESUtils.addCSS('#RESMacroDropdown { display: none; position: absolute; z-index: 2001; }');
 			RESUtils.addCSS('#RESMacroDropdownList { margin-top: 0; width: auto; max-width: 300px; }');
 			RESUtils.addCSS('#RESMacroDropdown li { padding-right: 10px; height: 25px; line-height: 24px; }');
 
@@ -8583,8 +8583,6 @@ modules['commentPreview'] = {
 		var top = (pos.top) + "px";
 		//show the dropdown directly over the placeholder  
 		$(modules['commentPreview'].macroDropdownContainer).css( { 
-			position: 'absolute',
-			zIndex: 50,
 			left: left, 
 			top: top
 		}).show();


### PR DESCRIPTION
macro dropdown menu is hidden behind big editor.
# BigEditor { z-index: 2000; }

macro dropdown: { z-index: 50 }
