### PR TITLE
Add gold highlight to reddit's save comment button

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -7318,6 +7318,7 @@ modules['betteReddit'] = {
 	highlightGoldSaveLinks: function (ele) {
 		if (!modules['betteReddit'].highlightGoldSaveLinksInit) {
 			RESUtils.addCSS('.comment .buttons a.gold { color: #9a7d2e; }');
+			RESUtils.addCSS('.res-nightmode .comment .buttons a.gold { color: #9a7d2e; }');
 			modules['betteReddit'].highlightGoldSaveLinksInit = true;
 		}
 


### PR DESCRIPTION
This is to help visually distinguish the reddit gold-only "save comment" button from RES's.  

This is just a band-aid to help out gold members, until @honestbleeps can figure out what to do about reddit saved comments vs RES saved comments.  Hopefully that'll happen before saving comments becomes a non-gold feature and the highlighting is less relevant.
