### PR TITLE
Fixes bug where you haven't got anything in the NSFW list

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -12915,7 +12915,7 @@ modules['filteReddit'] = {
 		return this.arrayContainsSubstring(this.options.flair.value, flair.toLowerCase(), reddit);
 	},
 	allowNSFW: function (subreddit) {
-		if (!subreddit) return false;
+		if (!subreddit || !this.options.allowNSFW.value) return false;
 		var whiteList = this.options.allowNSFW.value.split(',');
 		return this.arrayContainsSubstring(whiteList, subreddit.toLowerCase(), null, true);
 	},


### PR DESCRIPTION
Therefore, `allowNSFW.value` is `undefined` so we can't call `split`
