### PR TITLE
Settings nav - remove hash from url when closing settings panel

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -3571,6 +3571,8 @@ var RESConsole = {
 			RESConsole.keyCodeModal.style.display = 'none';
 			RESConsole.captureKey = false;
 		}
+
+		modules['settingsNavigation'].resetUrlHash();
 	},
 	menuClick: function(obj) {
 		if (obj) var objID = obj.getAttribute('id');
@@ -15735,6 +15737,9 @@ modules['settingsNavigation'] =
 		if (window.location.hash != hash) {
 			window.history.pushState(hashComponents, title, hash);
 		}
+	},
+	resetUrlHash: function() {
+		window.location.hash = "";
 	},
 	onHashChange: function (event) {
 		var hash = window.location.hash;


### PR DESCRIPTION
 It's annoying when you reload the page and get sent back to the settings.
