### PR TITLE
Choose when to not filter selected NSFW posts

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -12920,7 +12920,6 @@ modules['filteReddit'] = {
 			this.nsfwSwitch.setAttribute('title',"Toggle NSFW Filter");
 			this.nsfwSwitch.addEventListener('click',function(e) {
 				e.preventDefault();
-				this.addNSFWFilterStyle();
 				if (modules['filteReddit'].options.NSFWfilter.value == true) {
 					modules['filteReddit'].filterNSFW(false);
 					RESUtils.setOption('filteReddit','NSFWfilter',false);
@@ -12994,6 +12993,7 @@ modules['filteReddit'] = {
 		RESUtils.addCSS('.thing.over18.allowOver18 { display: block !important; }');
 	},
 	filterNSFW: function(filterOn) {
+		this.addNSFWFilterStyle();
 		$(document.body).toggleClass('allowOver18');
 	},
 	filterTitle: function(title, reddit) {


### PR DESCRIPTION
Follow-up to #301

Rather than simply showing posts from whitelisted subreddits everywhere, the user can now specify that posts from a list of subreddits should only be whitelisted when visiting a subreddit or multi-subreddit containing a subreddit from that list.

This now supports [this use case](https://github.com/honestbleeps/Reddit-Enhancement-Suite/pull/301#issuecomment-14889817) in addition to [the other use case](https://github.com/honestbleeps/Reddit-Enhancement-Suite/pull/301#issuecomment-14889920).
