### PR TITLE
Tips'n'Tricks appears on top of settings console

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -17327,7 +17327,7 @@ RESUtils.addCSS(' \
 	visibility: hidden; \
 	color: #000; \
 	font-size: 12px; \
-	z-index: 1000; \
+	z-index: 100000100; \
 	position: fixed; \
 	margin: auto; \
 	top: -1500px; \


### PR DESCRIPTION
This is annoying, mostly when I'm testing in Firefox =p

Either the Tips 'n' Tricks guider should be closed when the settings console is opened or the guider should have a lower z-index than the settings console.
