### PR TITLE
Add settings links and keyboard shortcuts to Tips 'n' Tricks

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -4169,7 +4169,7 @@ modules['keyboardNav'] = {
 		toggleHelp: {
 			type: 'keycode',
 			value: [191,false,false,true], // ? (note the true in the shift slot)
-			description: 'Show help'
+			description: 'Show help for keyboard shortcuts'
 		},
 		toggleCmdLine: {
 			type: 'keycode',


### PR DESCRIPTION
RES Tips 'n' Tricks now lists links to relevant settings (or plaintext if user has modules.settingsNavigation.watchUrl disabled) and keyboard shortcuts.  Some tips and option descriptions may be slightly improved (copy and URLs).

@honestbleeps, you may want to exercise some artistic and editorial oversight on the new content in the Tips 'n' Tricks blocks.

I apologize about all the contextual-help commits in the gitlog, but I didn't want to waste time and effort rebasing out the hover-help components when it was easier to just rebranch and strip out the code we don't want.
