### PR TITLE
Alternative Flickr image expand, without the API

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -9908,7 +9908,6 @@ modules['showImages'] = {
 		}
 	},
 	// this function is only ever used by imgclean, which currently is being removed from RES, so this function is being commented out.
-	/*
 	scrapeHTML: function(elem, url, selector, handler) {
 		GM_xmlhttpRequest({
 			method:	"GET",
@@ -9936,9 +9935,7 @@ modules['showImages'] = {
 				}
 			}
 		});
-
 	},
-	*/
 	siteModules: {
 		'default': {
 			acceptRegex: /\.(gif|jpe?g|png)(?:[?&#_].*|$)/i,
@@ -10239,63 +10236,34 @@ modules['showImages'] = {
 				}
 			}
 		},
-		/* flickr has disabled the RES API key - it's just too many hits.
 		flickr: {
 			hashRe: /^http:\/\/(?:\w+).?flickr.com\/(?:.*)\/([\d]{10})\/?(?:.*)?$/i,
-			calls: {},
 			go: function() {},
+			deferred: true,
 			detect: function(elem) {
 				var href = elem.href;
 				return this.hashRe.test(href);
 			},
 			handleLink: function(elem) {
-				var href = elem.href;
-				var groups = this.hashRe.exec(href);
-				if (groups && !groups[2]) {
-					var photoID = groups[1];
-					var apiURL = 'http://api.flickr.com/services/rest/?method=flickr.photos.getSizes&api_key=0414c8799c8baa02c83cf14c219e5b46&photo_id='+photoID+'&format=json&nojsoncallback=1';
-					if (apiURL in this.calls) {
-						this.handleInfo(elem, this.calls[apiURL]);
-					} else {
-						GM_xmlhttpRequest({
-							method: 'GET',
-							url: apiURL,
-							onload: function(response) {
-								try {
-									var json = JSON.parse(response.responseText);
-								} catch (e) {
-									var json = {};
-								}
-								modules['showImages'].siteModules['flickr'].calls[apiURL] = json;
-								modules['showImages'].siteModules['flickr'].handleInfo(elem, json);
-							}
-						});
-					}
+				modules['showImages'].createImageExpando(elem);
+			},
+			deferredHandleLink: function(elem) {
+				var selector = '#allsizes-photo > IMG';
+				if (elem.href.indexOf('/sizes') == -1) {
+					elem.href += '/sizes/c';
 				}
+
+				modules['showImages'].scrapeHTML(elem, elem.href, selector)
 			},
 			handleInfo: function(elem, info) {
-				if (typeof(info.sizes) == 'undefined') {
-					return false;
-				}
-				var biggest = 0;
-				var source = '';
-				for (i in info.sizes['size']) {
-					var thisObj = info.sizes['size'][i];
-					if (thisObj['width'] > biggest) {
-						biggest = thisObj['width'];
-						source = thisObj['source'];
-					}
-				}
 				elem.type = 'IMAGE';
-				elem.href = source;
-				if (RESUtils.pageType() == 'linklist') {
-					$(elem).closest('.thing').find('.thumbnail').attr('href',elem.href);
-				}
-				elem.src = source;
-				modules['showImages'].createImageExpando(elem);
+				elem.src = info.src;
+				// we don't overwrite the URL here since this is a deferred/scraped call.
+				// elem.href = info.src;
+				$(elem).closest('.thing').find('.thumbnail').attr('href',elem.href);
+				modules['showImages'].revealImageDeferred(elem);
 			}
 		},
-		*/
 		/*
 		// imgclean hasn't been used on reddit in a couple of months, removing support for now.
 		imgclean: {


### PR DESCRIPTION
This change actually reverts back to some much older code, and changes the URL to point to /sizes/c if there is no /sizes already in the URL. RES is then able to scrape that page for the image just fine.
