### PR TITLE
Handle Flickr links with /in/<what> in the URL

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -10250,7 +10250,14 @@ modules['showImages'] = {
 			deferredHandleLink: function(elem) {
 				var selector = '#allsizes-photo > IMG';
 				if (elem.href.indexOf('/sizes') == -1) {
-					elem.href += '/sizes/c';
+					var inPosition = elem.href.indexOf('/in/');
+					var inFragment = '';
+					if (inPosition != -1) {
+						inFragment = elem.href.substring(inPosition);
+						elem.href = elem.href.substring(0, inPosition);
+					}
+
+					elem.href += '/sizes/c' + inFragment;
 				}
 
 				modules['showImages'].scrapeHTML(elem, elem.href, selector)


### PR DESCRIPTION
Now handles flickr.com
- `/user/photoid` (links to size 'c' - medium 800px width)
- `/user/photoid/in/<something>` (/in/<something> is kept)
- `/user/photoid/sizes/<size>/in/<something>` (unchanged)
