### PR TITLE
Fix for elementUnderMouse in the dash

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -1125,14 +1125,14 @@ var RESUtils = {
 		RESUtils.mouseX = cursor.x;
 		RESUtils.mouseY = cursor.y;
 	},
-	elementUnderMouse: function ( obj ) {
-		var $obj = $(obj),
-			top = $obj.offset().top,
-			left = $obj.offset().left,
-			width = $obj.outerWidth(),
-			height = $obj.outerHeight(),
-			right = left + width,
-			bottom = top + height;
+	elementUnderMouse: function (obj) {
+		var $obj = $(obj);
+		var top = $obj.offset().top;
+		var left = $obj.offset().left;
+		var width = $obj.outerWidth();
+		var height = $obj.outerHeight();
+		var right = left + width;
+		var bottom = top + height;
 		if ((RESUtils.mouseX >= left) && (RESUtils.mouseX <= right) && (RESUtils.mouseY >= top) && (RESUtils.mouseY <= bottom)) {
 			return true;
 		} else {


### PR DESCRIPTION
Slipped into the last commit by mistake. Fixed up the formatting/vars.
This works around the offset issues with dashboard modules and hoverInfo. jQuery
offset uses the document as the base, rather than the nearest parent,
which bypasses the relatively positioned `RESDashboardComponents` and
gives us the desired x/y values.
