### PR TITLE
Add highlight to user via [highlight] button on user tagger hover info

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -7066,6 +7066,8 @@ modules['userTagger'] = {
 		if (this.options.highlightButton.value) {
 			if (!this.highlightedUsers || !this.highlightedUsers[jsonData.data.name]) {
 				userHTML += '<div class="blueButton" id="highlightUser" user="'+escapeHTML(jsonData.data.name)+'">Highlight</div>';
+			} else {
+				userHTML += '<div class="redButton" id="highlightUser" user="'+escapeHTML(jsonData.data.name)+'">Unhighlight</div>';
 			}
 		}
 		
@@ -7083,24 +7085,34 @@ modules['userTagger'] = {
 			if (this.authorInfoToolTipHighlight) {
 				this.authorInfoToolTipHighlight.addEventListener('click', function(e) {
 					var username = e.target.getAttribute('user');
+					modules['userTagger'].toggleUserHighlight(username);
 				}, false);
 			}
 		}
 	},
-	highlightUser: function(username) {
+	toggleUserHighlight: function(username) {
 		if (!this.highlightedUsers) this.highlightedUsers = {};
-		if (this.highlightedUsers[username]) return;
 
-		var name = 'author[href$="/' + username + '"]';  // yucky, but it'll do
-		var color = this.options.highlightColor.value;
-		var hoverColor = this.options.highlightColorHover.value;
+		if (this.highlightedUsers[username]) {
+			this.highlightedUsers[username].remove();
+			delete this.highlightedUsers[username];
+			this.toggleUserHighlightButton(true);
+		} else {
 
-		modules['userHighlight'].doHighlight(name, color, hoverColor, true);
 
-		if (this.authorInfoToolTipHighlight) {
-			$(this.authorInfoToolTipHighlight).fadeOut(300);
+			var color = this.options.highlightColor.value;
+			var hoverColor = this.options.highlightColorHover.value;
+			
+			this.highlightedUsers[username] = 
+				modules['userHighlight'].highlightUser(username, color, hoverColor);
+			this.toggleUserHighlightButton(false);
 		}
-		this.highlightedUsers[username] = true;
+	},
+	toggleUserHighlightButton: function(canHighlight) {	
+		$(this.authorInfoToolTipHighlight)
+			.toggleClass('blueButton', canHighlight)
+			.toggleClass('redButton', !canHighlight)
+			.text(canHighlight ? 'Highlight' : 'Unhighlight');
 	},
 	ignoreUser: function(e) {
 		if (e.target.classList.contains('blueButton')) {


### PR DESCRIPTION
Adds a "highlight" button to the user tagger's hover info which, when clicked, highlights the hovered user with colors set in preferences, blue-purple by default.

Partially addresses #343 
P.S. Don't mind my blatant cross-module dependency.
