### PR TITLE
more bitcointip module cleanup

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -17954,12 +17954,12 @@ modules['bitcoinTip'] = {
             description: 'Mapping of usernames to bitcoin addresses'
         },
         fetchWalletAddress: {
-        	text: 'Search private messages',
-        	description: "Search private messages for bitcoin wallet associated with the current username." +
-        	"<p>You must be logged in to search.</p>" +
-        	"<p>After clicking the button, you must reload the page to see newly-found addresses.</p>",
-        	type: 'button',
-        	callback: null // populated when module loads
+            text: 'Search private messages',
+            description: "Search private messages for bitcoin wallet associated with the current username." +
+            "<p>You must be logged in to search.</p>" +
+            "<p>After clicking the button, you must reload the page to see newly-found addresses.</p>",
+            type: 'button',
+            callback: null // populated when module loads
         }
     },
     isEnabled: function() {
@@ -17975,7 +17975,7 @@ modules['bitcoinTip'] = {
         return RESUtils.isMatchURL(this.moduleID);
     },
     beforeLoad: function() {
-    	this.options.fetchWalletAddress.callback = this.fetchAddressForCurrentUser.bind(this);
+        this.options.fetchWalletAddress.callback = this.fetchAddressForCurrentUser.bind(this);
 
         RESUtils.addCSS('.tip-bitcoins { cursor: pointer; }');
         RESUtils.addCSS('.tips-enabled-icon { cursor: help; }');
@@ -17992,32 +17992,35 @@ modules['bitcoinTip'] = {
             this.icons.reversed = this.icons.completed;
         }
 
-        if (this.options.attachButtons.value) {
-            this.attachTipButtons();
-            RESUtils.watchForElement('newComments', modules['bitcoinTip'].attachTipButtons.bind(this));
-            this.attachTipMenu();
-        }
-
         if (this.options.subreddit.value) {
             this.attachSubredditIndicator();
-        }
-
-        if (this.options.hide.value) {
-            this.hideVerifications();
-            RESUtils.watchForElement('newComments', modules['bitcoinTip'].hideVerifications.bind(this));
         }
 
         if (this.options.balance.value) {
             this.attachBalance();
         }
 
-        if (this.options.status.value !== 'none') {
-            this.scanForTips();
-            RESUtils.watchForElement('newComments', this.scanForTips.bind(this));
-        }
-
         if (RESUtils.currentSubreddit() === 'bitcointip') {
             this.injectBotStatus();
+        }
+
+        if (RESUtils.pageType() == 'comments') {
+            if (this.options.attachButtons.value) {
+                this.attachTipButtons();
+                RESUtils.watchForElement('newComments', modules['bitcoinTip'].attachTipButtons.bind(this));
+                this.attachTipMenu();
+            }
+
+            if (this.options.hide.value) {
+                this.hideVerifications();
+                RESUtils.watchForElement('newComments', modules['bitcoinTip'].hideVerifications.bind(this));
+            }
+
+
+            if (this.options.status.value !== 'none') {
+                this.scanForTips();
+                RESUtils.watchForElement('newComments', this.scanForTips.bind(this));
+            }
         }
     },
 
@@ -18140,30 +18143,39 @@ modules['bitcoinTip'] = {
             });
         }
 
-        if (/^\/r\//.test(document.location.pathname)) {
-            /* Add the "tip bitcoins" button after "give gold". */
-            var allGiveGoldLinks = ele.querySelectorAll('a.give-gold');
-            RESUtils.forEachChunked(allGiveGoldLinks, 15, 1000, function(giveGold, i, array) {
-                $(giveGold).parent().after($('<li/>')
-                    .append(modules['bitcoinTip'].tipButton.clone(true)));
-            });
+    
+        /* Add the "tip bitcoins" button after "give gold". */
+        var allGiveGoldLinks = ele.querySelectorAll('a.give-gold');
+        RESUtils.forEachChunked(allGiveGoldLinks, 15, 1000, function(giveGold, i, array) {
+            $(giveGold).parent().after($('<li/>')
+                .append(modules['bitcoinTip'].tipButton.clone(true)));
+        });
 
+        if (!module.attachedPostTipButton) {
+            module.attachedPostTipButton = true; // signifies either "attached button" or "decided not to attach button"
+         
+            if (!RESUtils.isCommentPermalinkPage() && $('.link').length === 1) { 
+                // Viewing full comments on a submission, so user can comment on post
                 $('.link ul.buttons .share').after($('<li/>')
                     .append(modules['bitcoinTip'].tipButton.clone(true)));
-                module.attachedPostTipButton = true;
             }
-         }
-        if (!module.attachedPostTipButton && $('.link').length === 1) { // Viewing a submission?
+        }
+
     },
 
     attachTipMenu: function() {
-        this.tipMenu = 
+        this.tipMenu =
             $('<div id="tip-menu" class="drop-choices">' +
                 '<a class="choice tip-publicly" href="javascript:void(0);">tip publicly</a>' +
                 '<a class="choice tip-privately" href="javascript:void(0);">tip privately</a>' +
-                modules['settingsNavigation'].makeUrlHashLink('bitcoinTip', null, 
-                    '<img src="' + this.icons.tipped + '"> bitcointip', 'choice') +
                '</div>');
+
+        if (modules['settingsNavigation']) { // affordance for userscript mode
+            this.tipMenu.append(
+                modules['settingsNavigation'].makeUrlHashLink('bitcoinTip', null,
+                '<img src="' + this.icons.tipped + '"> bitcointip', 'choice')
+            );
+        }
          $(document.body).append(this.tipMenu);
 
         this.tipMenu.find('a').click(function(event) {
@@ -18298,27 +18310,27 @@ modules['bitcoinTip'] = {
     },
 
     fetchAddressForCurrentUser: function () {
-		var user = RESUtils.loggedInUser();
-		if (!user) {
-			RESUtils.notification('Log in, then try again.');
-			return;
-		}
-    	this.fetchAddress(user, function(address) { 
-    		if (address) {
-    			modules['bitcoinTip'].setAddress(user, address);
-    			RESUtils.notification(
-    				'Found address ' + address + ' for user ' + user +
-    				'<br><br>Address appear RES settings after you refresh the page.'
-    				);
-    		} else {
-    			RESUtils.notification('Could not find address for user ' + user);
-    		}
+        var user = RESUtils.loggedInUser();
+        if (!user) {
+            RESUtils.notification('Log in, then try again.');
+            return;
+        }
+        this.fetchAddress(user, function(address) { 
+            if (address) {
+                modules['bitcoinTip'].setAddress(user, address);
+                RESUtils.notification(
+                    'Found address ' + address + ' for user ' + user +
+                    '<br><br>Address appear RES settings after you refresh the page.'
+                    );
+            } else {
+                RESUtils.notification('Could not find address for user ' + user);
+            }
 
-    	});
-    	RESUtils.notification(
-    		'Searching your private messages for a bitcoin wallet address. ' +
-    		'Reload the page to see if a wallet was found.'
-    		);
+        });
+        RESUtils.notification(
+            'Searching your private messages for a bitcoin wallet address. ' +
+            'Reload the page to see if a wallet was found.'
+            );
     },
 
     fetchAddress: function fetchAddress(user, callback) {
@@ -18363,9 +18375,9 @@ modules['bitcoinTip'] = {
         var tips = {};
         var items = $(ele);
         if (items.is('.entry')) {
-        	items = items.closest('div.comment, div.self, div.link');
+            items = items.closest('div.comment, div.self, div.link');
         } else {
-        	items = items.find('div.comment, div.self, div.link');
+            items = items.find('div.comment, div.self, div.link');
         }
         items.each(function() {
             var $this = $(this);


### PR DESCRIPTION
show bitcoinTip button after share button for posts instead of at the end, after [l+c]
adding tip button to post is more efficient
don't show tip button on post listings
don't show tip button on posts when viewing comment permalink page
only show bitcoin pref menu link in tip menu when using RES (i.e. not bitcointip userscript)
