### PR TITLE
Image viewer tweaks

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -10275,7 +10275,7 @@ modules['showImages'] = {
 			// the modified regex below fixes detection of "edited" imgur images, but imgur's edited images are broken right now actually, falling into
 			// a redirect loop.  preserving the old one just in case.  however it also fixes detection of the extension (.jpg, for example) which
 			// was too greedy a search...
-			hashRe:/^https?:\/\/(?:[i.]|[edge.]|[www.])*imgur.com\/(?:r\/[\w]+\/)?([\w]{5,}(?:[&,][\w]{5,})?)(\.[\w]{3,4})?(?:#(\d*))?(?:\?(?:\d*))?$/i,
+			hashRe:/^https?:\/\/(?:[i.]|[edge.]|[www.])*imgur.com\/(?:r\/[\w]+\/)?([\w]{5,}(?:[&,][\w]{5,})*)(\.[\w]{3,4})?(?:#(\d*))?(?:\?(?:\d*))?$/i,
 			albumHashRe: /^https?:\/\/(?:i\.)?imgur.com\/a\/([\w]+)(\..+)?(?:\/)?(?:#\d*)?$/i,
 			apiPrefix: 'http://api.imgur.com/2/',
 			calls: {},


### PR DESCRIPTION
- Made the image viewer ignore generic wiki `File:...` urls since we cannot reliably
  derive an image URL locally.
- Display an error message in place of images that failed to load.
- Ad-hoc imgur albums with more than 2 pages are now properly detected.
