### PR TITLE
showLastEditedTimestamp fix 

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -7418,7 +7418,7 @@ modules['betteReddit'] = {
 			}
 
 			if ((modules['betteReddit'].options.showLastEditedTimestamp.value) && (RESUtils.pageType() == 'linklist') || (RESUtils.pageType() == 'comments')) {
-				RESUtils.addCSS('.edited-timestamp:after{content:" (" attr(title) ")";font-size: 90%;}');
+				RESUtils.addCSS('.edited-timestamp[title]:after{content:" (" attr(title) ")";font-size: 90%;}');
 			}
 			
 			if ((modules['betteReddit'].options.toolbarFix.value) && (RESUtils.pageType() == 'linklist')) {


### PR DESCRIPTION
In my haste I forgot that a small number of recently edited comments/posts do not get the title attribute applied immediately. To the user this appears as a barren
brace of brackets. Added a simple attribute selector as a workaround.
