### PR TITLE
fixHideLink works on multi-subreddits now

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -7832,9 +7832,7 @@ modules['betteReddit'] = {
 				var apiURL = 'http://'+location.hostname+'/api/hide';
 			}
 			var params = 'id='+linkid+'&executed='+executed+'&uh='+modules['betteReddit'].modhash+'&renderstyle=html';
-			if (RESUtils.currentSubreddit()) {
-				params += '&r='+RESUtils.currentSubreddit();
-			}
+			
 			GM_xmlhttpRequest({
 				method:	"POST",
 				url:	apiURL,


### PR DESCRIPTION
http://www.reddit.com/dev/api#POST_api_hide currently only requires post ID and modhash.  it appeared to be breaking on feeding a multi-sub into the (obsolete) subreddit parameter, which isn't surprising.  but since it doesn't look necessary now, just chuck it.

fixes #377 
