### PR TITLE
Notify user when posts are filtered

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -13363,6 +13363,7 @@ modules['filteReddit'] = {
 			if (numNsfwHidden) notification.push ( numNsfwHidden + ' post(s) hidden by the ' + modules['settingsNavigation'].makeUrlHashLink('filteReddit', 'NSFWfilter', 'NSFW filter') + '.');
 			if (numNsfwHidden && modules['filteReddit'].options.NSFWQuickToggle.value) notification.push('You can toggle the nsfw filter in the <span class="gearIcon"></span> menu.');
 
+			notification.push("To hide this message, disable the " + modules['settingsNavigation'].makeUrlHashLink('filteReddit', 'notification', 'filteReddit notification') + '.');
 			var notification = notification.join('<br><br>');
 			RESUtils.notification(notification);
 		}


### PR DESCRIPTION
If filteReddit's custom filters (keyword, subreddit, domain, etc.) or nsfw filter hide any posts, then a notification tells the user how many posts were removed by what kind of filter and provide quick links and directions to editing/toggling filters.

Fixes #314 
