### PR TITLE
Remove shell declaration

### DIFF
--- a/makelinks.sh
+++ b/makelinks.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 files=("reddit_enhancement_suite.user.js" "res.css" "nightmode.css" "commentBoxes.css")
 paths=("./Chrome/" "./XPI/data/" "./Opera/includes/" "./RES.safariextension/")
 


### PR DESCRIPTION
Breaks on Linux machines using bash - removing the declaration should allow any shell to interpret it as a script. 

/bin/sh doesn't allow for declaring variables as lists.
