### PR TITLE
Fixes for saving option tables

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -3675,14 +3675,14 @@ var RESConsole = {
 										optionValue = inputs[l].value;
 									}
 								}
-								if ((optionValue !== '') && (inputs[l].getAttribute('type') != 'radio')) {
+								if ((optionValue !== '') && (inputs[l].getAttribute('type') != 'radio')
+									//If no keyCode is set, then discard the value
+									&& !(Array.isArray(optionValue) && isNaN(optionValue[0]))) {
 									notAllBlank = true;
 								}
 								// optionRow[k] = optionValue;
 							}
-							if (optionValue || notAllBlank) {
-								optionRow.push(optionValue);
-							}
+							optionRow.push(optionValue);
 						}
 						// just to be safe, added a check for optionRow !== null...
 						if ((notAllBlank) && (optionRow !== null)) {


### PR DESCRIPTION
- Blank fields in tables no longer dissappear and shift everything over.
- Keycode fields with no keyCode set now count as blank.
