### PR TITLE
CSS fix for markdowneditor/textarea

### DIFF
--- a/lib/res.css
+++ b/lib/res.css
@@ -887,7 +887,7 @@ div + #BigText {
 	font-family: Webdings;
 }
 
-.markdownEditor + div textarea {
+.usertext-edit div textarea {
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 }


### PR DESCRIPTION
CSS wouldn't apply if a user had disabled the comment tools. Made it
more generic.
