### PR TITLE
Memegen image inlining

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -11067,9 +11067,9 @@ modules['showImages'] = {
 				if (groups) {
 					// Animated vs static meme images.
 					if (groups[2]) {
-                        this.handleInfo(elem, 'http://a.memegen.com/' + groups[3] + '.gif');
+						this.handleInfo(elem, 'http://a.memegen.com/' + groups[3] + '.gif');
 					} else {
-					    this.handleInfo(elem, 'http://m.memegen.com/' + groups[3] + '.jpg');
+						this.handleInfo(elem, 'http://m.memegen.com/' + groups[3] + '.jpg');
 					}
 				}
 			},


### PR DESCRIPTION
Hey Steve,

we'd like to add image inline support for our new meme generator.

We have a series of sites for different languages, like www.memegen.com, www.memegen.de, ru.memegen.com etc. So the regex I implemented reflects that.

Here's a test post: http://www.reddit.com/user/Hakayati/
With the locally built RES, it seems to pull the image inline correctly.

We're automatically detecting content type and set the header accordingly.

Please let me know if I missed anything. Thanks for your work on this awesome extension!
