### PR TITLE
Firefox fix for collapsed image expandos

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -9591,7 +9591,7 @@ modules['showImages'] = {
 		if ((this.isEnabled()) && (this.isMatchURL())) {
 			RESUtils.addCSS(".expando-button.image { vertical-align:top !important; float: left; width: 23px; height: 23px; max-width: 23px; max-height: 23px; display: inline-block; background-image: url('http://e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png'); margin-right: 6px; cursor: pointer;  padding: 0; }");
 			RESUtils.addCSS(".expando-button.image.commentImg { float: none; margin-left: 4px; } ");
-			RESUtils.addCSS(".expando-button.image.collapsedExpando { background-position: 0 0; } ");
+			RESUtils.addCSS(".expando-button.image.collapsedExpando { background-position: 0 0; padding: 0; } ");
 			RESUtils.addCSS(".expando-button.image.collapsedExpando:hover { background-position: 0 -24px; } ");
 			RESUtils.addCSS(".expando-button.image.expanded { background-position: 0 -48px; } ");
 			RESUtils.addCSS(".expando-button.image.expanded:hover { background-position: 0 -72px; } ");


### PR DESCRIPTION
Long-standing issue with Firefox whereby image expandos in comments that
have been opened and then collapsed are broken. This is due to Firefox
prioritising CSS from reddit over RES (reason unknown).
