### PR TITLE
UserTagger HoverInfo "give gold" button opens "gild comment" form when applicable

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -7230,7 +7230,7 @@ modules['userTagger'] = {
 		}, 1000);
 		obj.addEventListener('mouseout', modules['userTagger'].delayedHideAuthorInfo);
 		if (typeof(this.authorInfoCache[thisUserName]) != 'undefined') {
-			this.writeAuthorInfo(this.authorInfoCache[thisUserName]);
+			this.writeAuthorInfo(this.authorInfoCache[thisUserName], obj);
 		} else {
 			GM_xmlhttpRequest({
 				method:	"GET",
@@ -7238,7 +7238,7 @@ modules['userTagger'] = {
 				onload:	function(response) {
 					var thisResponse = JSON.parse(response.responseText);
 					modules['userTagger'].authorInfoCache[thisUserName] = thisResponse;
-					modules['userTagger'].writeAuthorInfo(thisResponse);
+					modules['userTagger'].writeAuthorInfo(thisResponse, obj);
 				}
 			});
 		}
@@ -7249,7 +7249,7 @@ modules['userTagger'] = {
 			modules['userTagger'].hideAuthorInfo();
 		}, modules['userTagger'].options.fadeDelay.value);
 	},
-	writeAuthorInfo: function(jsonData) {
+	writeAuthorInfo: function(jsonData, authorLink) {
 		var utctime = jsonData.data.created_utc;
 		var d = new Date(utctime * 1000);
 		// var userHTML = '<a class="hoverAuthor" href="/user/'+jsonData.data.name+'">'+jsonData.data.name+'</a>:';
@@ -7264,7 +7264,7 @@ modules['userTagger'] = {
 		if (jsonData.data.is_gold) {
 			userHTML += '<a target="_blank" class="blueButton" href="http://www.reddit.com/gold/about">User has Reddit Gold</a>';
 		} else {
-			userHTML += '<a target="_blank" class="blueButton" href="http://www.reddit.com/gold?goldtype=gift&recipient='+escapeHTML(jsonData.data.name)+'">Gift Reddit Gold</a>';
+			userHTML += '<a target="_blank" id="gildUser" class="blueButton" href="http://www.reddit.com/gold?goldtype=gift&recipient='+escapeHTML(jsonData.data.name)+'">Gift Reddit Gold</a>';
 		}
 
 		if (this.options.highlightButton.value) {
@@ -7292,6 +7292,20 @@ modules['userTagger'] = {
 					modules['userTagger'].toggleUserHighlight(username);
 				}, false);
 			}
+		}
+		if (modules['userTagger'].options.gildComments.value && RESUtils.pageType() == 'comments') {
+			var giveGold = this.authorInfoToolTipContents.querySelector('#gildUser');
+			giveGold && giveGold.addEventListener('click', function(e) {
+				if (e.ctrlKey || e.cmdKey || e.shiftKey) return;
+
+				var comment = $(authorLink).closest('.comment');
+				if (!comment) return;
+
+				modules['userTagger'].hideAuthorInfo();
+				var giveGold = comment.find('.give-gold')[0];
+				RESUtils.click(giveGold);
+				e.preventDefault();
+			});
 		}
 	},
 	toggleUserHighlight: function(username) {


### PR DESCRIPTION
If the user tagger hover info appears on a username inside of a comment, and the user is not gold, and the comment has a give gold button, then clicking the "give gold" button activates the "give gold for this comment" form on that comment.  Otherwise, use the old behavior (open either the 'give gold to this user' or the 'about gold' page).

This can be disabled in options: userTagger > gildComment in favor of always using the old behavior.
