### PR TITLE
Never-Ending Reddit's autoLoad pause enhancements

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -11407,6 +11407,11 @@ modules['neverEndingReddit'] = {
 			value: true,
 			description: 'Automatically load new page on scroll (if off, you click to load)'
 		},
+		notifyWhenPaused: {
+			type: 'boolean',
+			value: true,
+			description: 'Show a reminder to unpause Never-Ending Reddit after pausing'
+		},
 		reversePauseIcon: {
 			type: 'boolean',
 			value: false,
@@ -11579,6 +11584,13 @@ modules['neverEndingReddit'] = {
 		RESStorage.setItem('RESmodules.neverEndingReddit.isPaused', modules['neverEndingReddit'].isPaused);
 		if (modules['neverEndingReddit'].isPaused) {
 			modules['neverEndingReddit'].NREPause.classList.add('paused');
+			if (modules['neverEndingReddit'].options.notifyWhenPaused.value) {
+				var notification = [];
+				notification.push('Never-Ending Reddit has been paused. Click the play/pause button to unpause it.');
+				notification.push('To hide this message, disable Never-Ending Reddit\'s ' + modules['settingsNavigation'].makeUrlHashLink('neverEndingReddit', 'notifyWhenPaused', 'notifyWhenPaused option <span class="gearIcon" />') + '.');
+				notification = notification.join('<br><br>');
+				RESUtils.notification(notification);
+			}
 		} else {
 			modules['neverEndingReddit'].NREPause.classList.remove('paused');
 			modules['neverEndingReddit'].handleScroll();


### PR DESCRIPTION
- Automatically pause NER every X pages (per preferences, default don't do pause)
- Notification when auto-pausing
- Notification when pausing at all, to remind user to unpause. (Can be disabled in options)
- "Scroll to load" text improved to reflect paused state
