### PR TITLE
Display the keyNav annotations using CSS generated content.

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -4868,7 +4868,10 @@ modules['keyboardNav'] = {
 				#keyCommandInputTip ul { font-size: 11px; list-style-type: disc; }  \
 				#keyCommandInputTip li { margin-left: 15px; }  \
 				#keyCommandInputError { margin-top: 5px; color: red; font-weight: bold; } \
-				.keyNavAnnotation { font-size: 9px; position: relative; top: -6px; } \
+				.keyNavAnnotation::after { \
+					content: "[" attr(data-index) "]"; \
+					font-size: 9px; position: relative; top: -6px; \
+				} \
 			');
 		}
 	},
@@ -5433,7 +5436,7 @@ modules['keyboardNav'] = {
 					      RESUtils.isCommentCode(links[i]))) {
 						var annotation = document.createElement('span');
 						annotationCount++;
-						$(annotation).text('['+annotationCount+'] ');
+						annotation.dataset.index = annotationCount;
 						annotation.title = 'press '+annotationCount+' to open link';
 						annotation.classList.add('keyNavAnnotation');
 						/*


### PR DESCRIPTION
The purpose of the change is to keep the annotations from being
selected, so the numbers don't end up being copied and pasted.
