### PR TITLE
The urlencode method breaks accountswitcher for certain passwords

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -2099,12 +2099,10 @@ var RESUtils = {
 		}
 	},
 	urlencode: function(string) {
-		// Javascript's escape function is stupid, and ignores the + character. Why? I have no idea.
-		// string = string.replace('+', '%2B');
-		return escape(this._utf8_encode(string)).replace('+', '%2B');
+	    return encodeURIComponent(this._utf8_encode(string));
 	},
 	urldecode: function(string) {
-		return this._utf8_decode(unescape(string));
+		return this._utf8_decode(decodeURIComponent(string));
 	},
 	// private method for UTF-8 encoding
 	_utf8_encode: function (string) {


### PR DESCRIPTION
Reported [here](http://www.reddit.com/r/RESissues/comments/1hza18/bug_incorrect_login_andor_password_please_check/).
## Replicate
- Create a password that contains `++`
- Can not use `accountswitcher` module to login
## Cause

[L2101:](https://github.com/honestbleeps/Reddit-EnhancementSuite/blob/master/lib/reddit_enhancement_suite.user.js#L2101)

```
urlencode: function(string) {
    // Javascript's escape function is stupid, and ignores the + character. Why? I have no idea.
    // string = string.replace('+', '%2B');
    return escape(this._utf8_encode(string)).replace('+', '%2B');
}
```

That'll do it.
## Potential Fix

Use Javascript's inbuilt `encodeURIComponent` method for passwords?
