### PR TITLE
Comment source can be loaded multiple times in succession if double-clicked

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -9075,10 +9075,9 @@ modules['commentTools'] = {
 	},
 	viewSource: function(button) {
 		var buttonList = $(button).parent().parent();
-		var usertext = buttonList.siblings("form.usertext");
-		var sourceDiv = usertext.find(".viewSource");
+		var sourceDiv = $(button).closest('.thing').find(".usertext-edit.viewSource:first");
 		if (sourceDiv.length != 0) {
-			sourceDiv.show();
+			sourceDiv.toggle();
 		} else {
 			var permaLink = buttonList.find(".first a");
 			var jsonURL = permaLink.attr("href");
@@ -9126,7 +9125,7 @@ modules['commentTools'] = {
 						userTextForm.find("textarea[name=text]").html(sourceText);
 					} else {
 						var sourceText = thisResponse[0].data.children[0].data.selftext;
-						console.log(sourceText);
+//						console.log(sourceText);
 						// sourceText in this case is reddit markdown. escaping it would screw it up.
 						userTextForm.find("textarea[name=text]").html(sourceText);
 					}


### PR DESCRIPTION
http://www.reddit.com/r/RESissues/comments/1gezs6/bug_the_source_textbox_can_appear_multiple_times/

This could be solved either with a "do not load source for a comment if I am already loading source for that comment" check or a "don't let the user double-click" check.

... but honestly it's a non-issue because why are you double-clicking links?
