### PR TITLE
Switch the arrows in the parentHover to be more widely compaible.

### DIFF
--- a/lib/res.css
+++ b/lib/res.css
@@ -1020,15 +1020,16 @@ button.RESBigEditorPop:hover {
 }
 .parentArrow {
 	text-align: center;
-	margin-top: -5px
+	margin-top: -5px;
+	margin-bottom: 5px;
 }
 .res-parents-down .parentArrow::before, .res-parents-down .parentArrow::after {
 	padding: 1ex;
-	content: "\\02b07";
+	content: "↓";
 }
 .res-parents-up .parentArrow::before, .res-parents-up .parentArrow::after {
 	padding: 1ex;
-	content: "\\02b06";
+	content: "↑";
 }
 a.bylink.parentlink {
 	float: right; 


### PR DESCRIPTION
- The old arrows looked nicer, but weren't viewable on all computers.
- The literals should not have been double escaped.
- Tweaked spacing a bit.
