### PR TITLE
Never Ending Reddit fixes

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -12786,7 +12786,6 @@ modules['neverEndingReddit'] = {
 		modules['neverEndingReddit'].fromBackButton = false;
 	},
 	NERFail: function(noresults) {
-		console.log('NERFAIL');
 		modules['neverEndingReddit'].isLoading = false;
 		var newHTML = createElementWithID('div','NERFail');
 		if (noresults) {


### PR DESCRIPTION
Reverted to the old way of using #page=n in the URL to determine if the user has come back from the back button.  This is OK to do now that both Firefox and Chrome can handle hashchanges without canceling the ctrl-f dialog, which was the main reason for switching away from this method.

The session storage only method was hopelessly inaccurate because it's just damn near impossible (without running RES or at least some small bit of code on every single page a user browses) to tell if they've really come from the back button or not.

In addition, a timeout has been added to delay RES's attempt to scroll you back to the last post you were looking at. It's not perfect, but it is markedly better.  The problem is that browsers often try to autoscroll you down however far you were on the last page -- which becomes irrelevant and almost 100% incorrect with Never Ending Reddit, because the page length is different upon return from the back button, etc...

I would prefer a smarter solution than a setTimeout, but the only conceivable options right now are either a bit more involved (later release?) or are simply untested and may not work great:
- Waiting until specific and/or all modules report some sort of "DOM modifications complete" event
- Doing some sort of re-check after the scroll happens to ensure the last scrolled element remains in view, perhaps polling every xxx milliseconds and once it has held in view for a specified time, then letting things go?
- Coming up with some other sort of crazy wizardry...
