### PR TITLE
Reverse bg/fg for vote weight in night mode

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -7490,7 +7490,7 @@ modules['userTagger'] = {
 					obj.style.display = 'none';
 				} else {
 					obj.style.display = 'inline';
-					document.querySelector('.res-nightmode') ? obj.style.color = rgb : obj.style.backgroundColor = rgb;
+					(modules['styleTweaks'].options.lightOrDark.value === 'dark') ? obj.style.color = rgb : obj.style.backgroundColor = rgb;
 					if (this.options.vwNumber.value) obj.textContent = '[' + voteString + ']';
 					if (this.options.vwTooltip.value) obj.setAttribute('title','your votes for '+escapeHTML(author)+': '+escapeHTML(voteString));
 				}


### PR DESCRIPTION
To tone down the white/green/red background on the vote weight in night
mode, switch to setting the foreground colour, rather than the default
background colour.
