### PR TITLE
Images load synchronously and fixes memory leak

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -10473,7 +10473,7 @@ modules['showImages'] = {
 			imgDiv.sources = imageLink.src;
 
 			// Also preload images for an album
-			this.preloadImages(imageLink.src);
+			this.preloadImages(imageLink.src, 0);
 		} else {
 			// Only the image is left to display, pack it like a single-image album with no caption or title
 			singleImage = {src:imageLink.src,href:imageLink.href};
@@ -10661,11 +10661,23 @@ modules['showImages'] = {
 		expandoButton.classList.remove('collapsedExpando');
 		expandoButton.classList.add('expanded');
 	},
-	preloadImages: function(srcs) {
-		for (var i = 0; i < srcs.length; i++) {
-			var img = new Image();
-			img.src = srcs[i].src;
+	/**
+	 * Recursively loads the images synchronously.
+	 */
+	preloadImages: function(srcs, i) {
+		var _this = this,
+		_i = i,
+		img = new Image();
+		img.onload = img.onerror = function(){
+			_i++;
+			if(typeof srcs[_i] == 'undefined'){
+				return;
+			}
+			_this.preloadImages(srcs, _i);
+
+			delete img; // Delete the image element from the DOM to stop the RAM usage getting to high.
 		}
+		img.src = srcs[i].src;
 	},
 	generateTextExpando: function(expandoButton) {
 		var imageLink = expandoButton.imageLink;


### PR DESCRIPTION
Currently galleries load all images asynchronously, this isn't a big issue on small galleries but on 50+ images it can make weaker internet connections struggle. 

This makes the images load synchronously and then deletes the element that preloaded the image out of the DOM which reduces the plugins memory usage.
