### PR TITLE
Subreddit shortcuts do not save changes if pre v4.1.5 format

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -16825,7 +16825,9 @@ modules['subredditManager'] = {
 	// JSON specification doesn't specify what to do with dates - so unstringify here
 	parseDates: function () {
 	    for (var i = 0, len = this.mySubredditShortcuts.length; i < len; i++) {
-	        this.mySubredditShortcuts[i].addedDate = new Date(this.mySubredditShortcuts[i].addedDate);
+	        this.mySubredditShortcuts[i].addedDate = this.mySubredditShortcuts[i].addedDate
+	        	? new Date(this.mySubredditShortcuts[i].addedDate)
+	        	: new Date(0);
 	    }
 	},
 	saveLatestShortcuts: function() {


### PR DESCRIPTION
If RESStorage RESmodules.subredditManagers.subredditShortcut.username shortcuts don't have .addedDate properties on all the shortcuts (RES v4.1.2 format, presumably), then RES v4.3.x loads them in with .addedDate = Date[invalid date].  Then, when you go to save them, JSON.stringify breaks on the invalid dates (in Safari, at least - Firefox might be more tolerant) and the user can't save any changes to their subreddit shortcuts.
