### PR TITLE
bitcoinTip's "tip publicly" does not open comment form

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -19510,7 +19510,8 @@ modules['bitcointip'] = {
         if ($target.closest('.link').length > 0) { /* Post */
             form = $('.commentarea .usertext:first');
         } else { /* Comment */
-            $target.closest('ul').find('a[onclick*="reply"]').click();
+            var replyButton = $target.closest('ul').find('a[onclick*="reply"]');
+            RESUtils.click(replyButton[0]);
             form = $target.closest('.thing').find('FORM.usertext.cloneable:first');
         }
         var textarea = form.find('textarea');


### PR DESCRIPTION
This is currently just a Chrome Canary issue, but 1) it might persist into released Chrome and 2) it won't hurt to fix it.

http://www.reddit.com/r/RESissues/comments/1k18w9/bug_clicking_bitcointip_inserts_the_wrong_text/
