### PR TITLE
userHighlight autoColorUsernames: apply unique color to usernames

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -13366,6 +13366,11 @@ modules['userHighlight'] = {
 			type: 'text',
 			value: 'white',
 			description: 'Color for highlighted text.'
+		},
+		autoColorUsernames: {
+			type: 'boolean',
+			value: false,
+			description: 'Set a unique color for each username'
 		}
 	},
 	isEnabled: function() {
@@ -13384,6 +13389,12 @@ modules['userHighlight'] = {
 			if (this.options.highlightFriend.value)	this.doHighlight('friend');
 			if (this.options.highlightMod.value)	this.doHighlight('moderator');
 			if (this.options.highlightAdmin.value)	this.doHighlight('admin');
+
+			if (this.options.autoColorUsernames.value) {
+				RESUtils.watchForElement('newComments', this.scanPageForNewUsernames);
+				RESUtils.watchForElement('siteTable', this.scanPageForNewUsernames);
+				this.scanPageForNewUsernames();
+			}
 		}
 	},
 	findDefaults: function() {
@@ -13423,6 +13434,35 @@ modules['userHighlight'] = {
 		};
 		$('#dummy').detach();
 	},
+	scanPageForNewUsernames: function (ele) {
+		ele = ele || document.body;
+		var authors = ele.querySelectorAll('.author');
+		RESUtils.forEachChunked(authors, 15, 1000, function(element, i, array) {
+			// Get identifiers
+			var idClass;
+			for (var i = 0, length = element.classList.length; i < length; i++) {
+				idClass = element.classList[i];
+				if (idClass.substring(0, 6) == 'id-t2_') break;
+			}
+
+			if (modules['userHighlight'].coloredUsernames[idClass]) return;
+
+			// Choose color
+			var hash = 5381, str = idClass;
+			for (var i = 0; i < str.length; i++) {
+				hash = ((hash << 5) + hash) + str.charCodeAt(i); /* hash * 33 + c */
+			}
+
+			var r = (hash & 0xFF0000) >> 16;
+			var g = (hash & 0x00FF00) >> 8;
+			var b = hash & 0x0000FF;
+ 			var color = "rgb(" + [ r, g, b ].join(',') + ")";
+
+			// Apply color
+			modules['userHighlight'].doTextColor('.' + idClass, color);
+		});
+	},
+	coloredUsernames: {},
 	highlightUser: function (username) {
 		var name = 'author[href$="/' + username + '"]';  // yucky, but it'll do
 		return this.doHighlight('user', name);
@@ -13454,6 +13494,14 @@ modules['userHighlight'] = {
 				text-decoration: none !important; \
 			}';
 			return RESUtils.addCSS(css);
+	},
+	doTextColor: function (selector, color) {
+		var css = '	\
+			.tagline .author' + selector + ' {	\
+				color: ' + color + ' !important;	\
+			}	\
+			';
+		return RESUtils.addCSS(css);
 	}
 }; 
 


### PR DESCRIPTION
Sets a text color for all author usernames if modules['userHighlight'].options.autoColorUsernames is enabled.  The color is selected by hashing the user's ID.

This should fulfill a whole bunch of "highlight the comment thread OP" requests.
