### PR TITLE
Settings console search should show a result for modules

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -17914,6 +17914,18 @@ modules['settingsNavigation'] =
 		for (var moduleKey in modules) {
 			if (!modules.hasOwnProperty(moduleKey)) continue;
 			var module = modules[moduleKey];
+
+
+			var searchString = module.moduleID + module.moduleName + module.category + module.description;
+			searchString = modules['settingsNavigation'].prepareSearchText(searchString, false);
+			var matches = modules['settingsNavigation'].searchMatches(queryTerms, searchString);
+			if (matches) {
+				var result = modules['settingsNavigation'].makeModuleSearchResult(moduleKey);
+				result.rank = matches;
+				results.push(result);
+			}
+			
+
 			var options = module.options;
 
 			for (var optionKey in options) {
@@ -17995,11 +18007,29 @@ modules['settingsNavigation'] =
 
 		return result;
 	},
+	makeModuleSearchResult: function (moduleKey) {
+		var module = modules[moduleKey];
+		
+		var result = {};
+		result.type = 'module';
+		result.breadcrumb = ['Settings', 
+			module.category,
+			'(' + module.moduleID + ')'
+			].join(' > ');
+		result.title = module.moduleName;
+		result.description = module.description;
+		result.moduleID = moduleKey;
+
+		return result;
+	},
 
 	onSearchResultSelected: function(result) {
 		if (!result) return;
 
 		switch (result.type) {
+			case 'module':
+				modules['settingsNavigation'].loadSettingsPage(result.moduleID);
+				break;
 			case 'option':
 				modules['settingsNavigation'].loadSettingsPage(result.moduleID, result.optionKey);
 				break;


### PR DESCRIPTION
e.g. if I search for "bitcointip" I want to see a line item that's simply a pointer to #!settings/bitcoinTip in addition to all of its options
