### PR TITLE
Change gfycat siteModule behaviour to show video instead of gif.

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -11335,13 +11335,12 @@ modules['showImages'] = {
                 
                 if (!groups) return def.reject();
                 var href = elem.href.toLowerCase();
+                var hotLink = false;
                 if(href.indexOf('giant.gfycat') >= 0 ||
                     href.indexOf('fat.gfycat') >= 0 ||
                     href.indexOf('zippy.gfycat') >= 0)
-                        return def.resolve(elem, {
-                                    direct: true,
-                                    src: href
-                                });
+                        hotLink = true;
+                
                 var siteMod = modules['showImages'].siteModules['gfycat'];
                 var apiURL = 'http://gfycat.com/cajax/get/' + groups[1];
 
@@ -11360,6 +11359,8 @@ modules['showImages'] = {
                         onload: function(response) {
                             try {
                                 var json = JSON.parse(response.responseText);
+                                json.gfyItem.src = elem.href;
+                                json.gfyItem.hotLink = hotLink
                                 siteMod.calls[apiURL] = json;
                                 def.resolve(elem, json.gfyItem);
                             } catch(error) {
@@ -11375,8 +11376,6 @@ modules['showImages'] = {
                 return def.promise();
             },
             handleInfo: function(elem, info) {
-                elem.type = 'IMAGE';
-                
                 function humanSize(bytes) {
                     var byteUnits = [' kB', ' MB'];
                     for(var i=-1; bytes > 1024; i++) {
@@ -11384,17 +11383,35 @@ modules['showImages'] = {
                     } 
                     return Math.max(bytes, 0.1).toFixed(1) + byteUnits[i];
                 }
-                if("direct" in info && info.direct) {
+                if(info.hotLink) {
+                    elem.type="IMAGE";
                     elem.src = info.src;
+                    elem.imageTitle = humanSize(info.gifSize);
+                    if(((info.gifSize   > 524288 && (info.gifSize / info.mp4Size) > 5)
+                        || (info.gifSize    > 1048576 && (info.gifSize / info.mp4Size) > 2))
+                        && document.createElement('video').canPlayType)
+                        elem.imageTitle += ' (' + humanSize(info.mp4Size)  + " for <a href='http://gfycat.com/" + info.gfyName + "'>HTML5 version.</a>)";
+
+                    if (RESUtils.pageType() == 'linklist') {
+                    $(elem).closest('.thing').find('.thumbnail').attr('href',elem.href);
+                    }
                     return $.Deferred().resolve(elem).promise();
                 }
-                elem.src = info.gifUrl;
-                elem.imageTitle = humanSize(info.gifSize);
-                if(info.gifSize > 1048576 && (info.gifSize / info.mp4Size) > 2)
-                    elem.imageTitle += ' (' + humanSize(info.mp4Size) + ' via direct link)';
+
+                elem.mediaOptions = {
+                        autoplay: true,
+                        loop: true
+                }
+
+                sources = [];
+                sources[0] = {'file': info.mp4Url,'type':'video/mp4'};
+                sources[1] = {'file': info.webmUrl,'type':'video/webm'};
+                elem.type = 'VIDEO';        
+                $(elem).data('sources', sources);
+            
                 if (RESUtils.pageType() == 'linklist') {
                     $(elem).closest('.thing').find('.thumbnail').attr('href',elem.href);
-                }
+                    }
 
                 return $.Deferred().resolve(elem).promise();
             }


### PR DESCRIPTION
As you point out, all RES users have html5 so we've re-thought this.

It can be the submitters choice what type of link they submit.  For an html5 video link, RES users should see video.

If someone submits a direct link to a gif from gfycat, then the preview should show gif (we wrote in a test for this, but notice RES already catches .gif and handles).
