### PR TITLE
Use strict (in)equality comparison operators, other various cleanup

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -3586,7 +3586,7 @@ var RESConsole = {
 	},
 	enableModule: function(moduleID, onOrOff) {
 		var prefs = this.getAllModulePrefs(true);
-		prefs[moduleID] = onOrOff;
+		prefs[moduleID] = !!onOrOff;
 		this.setModulePrefs(prefs);
 	},
 	showConfigOptions: function(moduleID) {


### PR DESCRIPTION
I stripped the parentheses from the `typeof` calls, as that seemed cleaner to me, though I can easily modify all of them to use parentheses instead. I've also made some other cleanup/fixes, such as whitespace fixing and using Regex literals.
