### PR TITLE
Inline image viewer - show # of images in album before expando'd

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -10462,6 +10462,8 @@ modules['showImages'] = {
 		if (elem.type == 'VIDEO') expandLink.className += ' video collapsed';
 		if (elem.type == 'AUDIO') expandLink.className += ' video collapsed'; // yes, still class "video", that's what reddit uses.
 		if (elem.type == 'NOEMBED') expandLink.className += ' '+elem.expandoClass;
+
+		if (elem.type == 'GALLERY' && elem.src && elem.src.length) expandLink.setAttribute('title', elem.src.length + ' items in gallery');
 		$(expandLink).html('&nbsp;');
 		expandLink.addEventListener('click', function(e) {
 			e.preventDefault();


### PR DESCRIPTION
First idea - add it as a tooltip on the expando button

as a warning to low-bandiwdth users like http://www.reddit.com/r/RESissues/comments/1kep84/bug_loadallinalbum_still_loading_albums_even_when/
