### PR TITLE
Ignore ".png" after a # in the URL

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -11193,7 +11193,7 @@ modules['showImages'] = {
 	},
 	siteModules: {
 		'default': {
-			acceptRegex: /\.(gif|jpe?g|png)(?:[?&#_].*|$)/i,
+			acceptRegex: /^[^#]+?\.(gif|jpe?g|png)(?:[?&#_].*|$)/i,
 			rejectRegex: /(wikipedia\.org\/wiki|photobucket\.com|gifsound\.com|\/wiki\/File:.*)/i,
 			go: function(){},
 			detect: function(elem) {


### PR DESCRIPTION
This prevents a link like http://www.reddit.com/r/science/comments/1kf4q1/for_the_first_time_in_35_years_a_new_carnivorous/ from being treated as an image.
