### PR TITLE
Add user karma for alternate accounts

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -1085,13 +1085,16 @@ var RESUtils = {
 		this.loggedInUser();
 		return this.loggedInUserHashCached;
 	},
-	getUserInfo: function(callback, username) {
+	getUserInfo: function(callback, username, live) {
 		// Default to currently logged-in user, for backwards compatibility
 		username = (typeof username !== "undefined" ? username : RESUtils.loggedInUser());
 		if (username === null) return false;
 
+		// Default to getting live data (i.e. from reddit's server)
+		live = (typeof live === "boolean" ? live : true);
+
 		if (!(username in RESUtils.userInfoCallbacks)) {
-			userInfoCallbacks[username] = [];
+			RESUtils.userInfoCallbacks[username] = [];
 		}
 		RESUtils.userInfoCallbacks[username].push(callback);
 		var cacheData = RESStorage.getItem('RESUtils.userInfoCache.' + username) || '{}';
@@ -1099,7 +1102,7 @@ var RESUtils = {
 		var lastCheck = (userInfoCache !== null) ? parseInt(userInfoCache.lastCheck, 10) || 0 : 0;
 		var now = new Date();
 		// 300000 = 5 minutes
-		if ((now.getTime() - lastCheck) > 300000) {
+		if (live && (now.getTime() - lastCheck) > 300000) {
 			if (!RESUtils.userInfoRunning) {
 				RESUtils.userInfoRunning = true;
 				GM_xmlhttpRequest({
@@ -14269,15 +14272,16 @@ modules['accountSwitcher'] = {
 					this.downArrowOverlay = $('<span id="RESAccountSwitcherIconOverlay"><span class="downArrow"></span></span>');
 					this.downArrow = $('<span id="RESAccountSwitcherIcon"><span class="downArrow"></span></span>');
 				}
-				$(this.downArrowOverlay).click(function() {
+				this.downArrowOverlay.on('click', function() {
 					modules['accountSwitcher'].toggleAccountMenu(false);
 					modules['accountSwitcher'].manageAccounts();
-				})
-				$(document.body).append(this.downArrowOverlay);
-				$(this.downArrow).click(function() {
+				}).appendTo(document.body);
+
+				this.downArrow.on('click', function() {
+					modules['accountSwitcher'].updateUserDetails();
 					modules['accountSwitcher'].toggleAccountMenu(true);
 				});
-				$(this.downArrowOverlay).mouseleave(function() {
+				this.downArrowOverlay.on('mouseleave', function() {
 					modules['accountSwitcher'].dropdownTimer = setTimeout(function() {
 						modules['accountSwitcher'].toggleAccountMenu(false);
 					}, 1000);
@@ -14287,13 +14291,11 @@ modules['accountSwitcher'] = {
 				$(this.userLink).after(this.downArrow);
 
 				this.accountMenu = $('<ul id="RESAccountSwitcherDropdown" class="RESDropdownList"></ul>')
-				$(this.accountMenu).mouseenter(function() {
+				this.accountMenu.on('mouseenter', function() {
 					clearTimeout(modules['accountSwitcher'].dropdownTimer);
 				});
-				$(this.accountMenu).mouseleave(function() {
-					modules['accountSwitcher'].dropdownTimer = setTimeout(function() {
-						modules['accountSwitcher'].toggleAccountMenu(false);
-					}, 1000);
+				this.accountMenu.on('mouseleave', function() {
+					modules['accountSwitcher'].toggleAccountMenu(false);
 				});
 				// GM_addStyle(css);
 				var accounts = this.options.accounts.value;
@@ -14309,9 +14311,10 @@ modules['accountSwitcher'] = {
 							if (this.loggedInUser && username.toUpperCase() === this.loggedInUser.toUpperCase()) {
 								$accountLink.addClass('active');
 							}
+
 							$accountLink
 								.data('username', username)
-								.text(username)
+								.html(username)
 								.css('cursor', 'pointer')
 								.on('click', function(e) {
 									e.preventDefault();
@@ -14319,15 +14322,16 @@ modules['accountSwitcher'] = {
 								})
 								.appendTo(this.accountMenu);
 
-							// Fetch the user's karma
-							// The variables *must* be bound in a closure for this to work
-							// with multiple users
-							(function(username, $accountLink) {
-								$.getJSON('/user/'+encodeURIComponent(username)+'/about.json?app=res')
-									.done(function(data) {
-										$accountLink.html(username + ' (' + data.data.link_karma + ' &middot; ' + data.data.comment_karma + ')');
-									});
-							}(username, $accountLink));
+							RESUtils.getUserInfo(function (userInfo) {
+								var userDetails = username;
+								
+								// Display the karma of the user, if it is already pre-fetched
+								if (userInfo && !userInfo.error && userInfo.data) {
+									userDetails = username + ' (' + userInfo.data.link_karma + ' &middot; ' + userInfo.data.comment_karma + ')';
+								}
+
+								$accountLink.html(userDetails);
+							}, username, false);
 						}
 					}
 					$('<li>', { 'class': 'accountName' })
@@ -14343,6 +14347,26 @@ modules['accountSwitcher'] = {
 				$(document.body).append(this.accountMenu);
 			}
 		}
+	},
+	updateUserDetails: function() {
+		this.accountMenu.find('.accountName').each(function (index) {
+			var username = $(this).data('username'),
+				that = this;
+
+			// Leave a 500 ms delay between requests
+			setTimeout(function () {
+				RESUtils.getUserInfo(function (userInfo) {
+					// Fail if retrieving the user's info results in an error (such as a 404)
+					if (!userInfo || userInfo.error || !userInfo.data) {
+						return;
+					}
+
+					// Display the karma of the user
+					var userDetails = username + ' (' + userInfo.data.link_karma + ' &middot; ' + userInfo.data.comment_karma + ')';
+					$(that).html(userDetails);
+				}, username);
+			}, 500 * index);
+		});
 	},
 	toggleAccountMenu: function(open) {
 		if ((open) || (! $(modules['accountSwitcher'].accountMenu).is(':visible'))) {
@@ -14382,7 +14406,7 @@ modules['accountSwitcher'] = {
 	},
 	closeAccountMenu: function() {
 		// this function basically just exists for other modules to call.
-		$(this.accountMenu).hide();
+		this.accountMenu.hide();
 	},
 	switchTo: function(username) {
 		var accounts = this.options.accounts.value;


### PR DESCRIPTION
Implemented part of a [desired feature request](http://www.reddit.com/r/Enhancement/comments/1ki5ve/feature_request_show_linkcomment_karma_and/). However, although this feature is functional, it still needs some work. In particular, caching and over-calling the API is still a major issue here--`$.get` caches calls (so karma isn't always up-to-date), and excessive calls are made, especially if the user does not use the account switcher. Would there be a way to perhaps cache karma and a time into `localStorage`, and trigger this whenever some clicks on the account switcher (rather than on page load)? (I'm not too familiar with using RES's storage.)
