### PR TITLE
Correctly encode unicode login password

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -2127,59 +2127,6 @@ var RESUtils = {
 			}
 		}
 	},
-	urlencode: function(string) {
-		return encodeURIComponent(this._utf8_encode(string));
-	},
-	urldecode: function(string) {
-		return this._utf8_decode(decodeURIComponent(string));
-	},
-	// private method for UTF-8 encoding
-	_utf8_encode: function (string) {
-		string = string.replace(/\r\n/g,"\n");
-		var utftext = "";
-		for (var n = 0; n < string.length; n++) {
-			var c = string.charCodeAt(n);
-			if (c < 128) {
-				utftext += String.fromCharCode(c);
-			}
-			else if((c > 127) && (c < 2048)) {
-				utftext += String.fromCharCode((c >> 6) | 192);
-				utftext += String.fromCharCode((c & 63) | 128);
-			}
-			else {
-				utftext += String.fromCharCode((c >> 12) | 224);
-				utftext += String.fromCharCode(((c >> 6) & 63) | 128);
-				utftext += String.fromCharCode((c & 63) | 128);
-			}
-		}
-		return utftext;
-	},
-	// private method for UTF-8 decoding
-	_utf8_decode: function (utftext) {
-		var c,c1,c2;
-		var string = "";
-		var i = 0;
-		c = c1 = c2 = 0;
-		while ( i < utftext.length ) {
-			c = utftext.charCodeAt(i);
-			if (c < 128) {
-				string += String.fromCharCode(c);
-				i++;
-			}
-			else if((c > 191) && (c < 224)) {
-				c2 = utftext.charCodeAt(i+1);
-				string += String.fromCharCode(((c & 31) << 6) | (c2 & 63));
-				i += 2;
-			}
-			else {
-				c2 = utftext.charCodeAt(i+1);
-				c3 = utftext.charCodeAt(i+2);
-				string += String.fromCharCode(((c & 15) << 12) | ((c2 & 63) << 6) | (c3 & 63));
-				i += 3;
-			}
-		}
-		return string;
-	},
 	isEmpty: function(obj) {
 		for(var prop in obj) {
 			if(obj.hasOwnProperty(prop))
@@ -14460,7 +14407,7 @@ modules['accountSwitcher'] = {
 		GM_xmlhttpRequest({
 			method:	"POST",
 			url:	loginUrl,
-			data: 'user='+RESUtils.urlencode(username)+'&passwd='+RESUtils.urlencode(password)+rem,
+			data: 'user='+encodeURIComponent(username)+'&passwd='+encodeURIComponent(password)+rem,
 			headers: {
 				"Content-Type": "application/x-www-form-urlencoded"
 			},


### PR DESCRIPTION
Intended to address honestbleeps/Reddit-Enhancement-Suite#502.

We shouldn't be utf8 encoding the JS string, encodeURIComponent will do all that. I don't know why the urlencode/decode functions originally existed, they've been there since the first github commit - maybe some input needs to be made to see if anyone remembers their original purpose?

Anyway, I've tested that the problem exists on firefox and chrome, and that this resolves it in chrome.
I've not tested it in firefox.
