### PR TITLE
Fixed steam domain detection

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -11729,7 +11729,7 @@ modules['showImages'] = {
 		steam: {
 			go: function() {},
 			detect: function(elem) {
-				return /cloud(?:-\d)?.steampowered.com/i.test(elem.host);
+				return /^cloud(?:-\d)?.steampowered.com$/i.test(elem.host);
 			},
 			handleLink: function(elem) {
 				return $.Deferred().resolve(elem, elem.href).promise();


### PR DESCRIPTION
Fixed detection of steam urls to include `cloud-*.steampowered.com` and not just `cloud.steampowered.com`
