### PR TITLE
Added a module to configure behavior when clicking an entry (EntryTitleAction)

### DIFF
--- a/Chrome/background.js
+++ b/Chrome/background.js
@@ -144,11 +144,11 @@ chrome.extension.onMessage.addListener(
 				}
 				sendResponse({status: "success"});
 				break;
-			case 'mainLinkConfigure':
+			case 'entryTitleAction':
 				var focus = !(request.isBackground);
 				// Get the selected tab so we can get the index of it.  This allows us to open our new tab as the "next" tab.
 				var newIndex = sender.tab.index+1;
-				// handle requests from mainLinkConfigure module
+				// handle requests from entryTitleAction module
 				chrome.tabs.create({url: request.linkURL, selected: focus, index: newIndex, openerTabId: sender.tab.id});
 				sendResponse({status: "success"});
 				break;

--- a/Chrome/background.js
+++ b/Chrome/background.js
@@ -144,6 +144,14 @@ chrome.extension.onMessage.addListener(
 				}
 				sendResponse({status: "success"});
 				break;
+			case 'mainLinkConfigure':
+				var focus = !(request.isBackground);
+				// Get the selected tab so we can get the index of it.  This allows us to open our new tab as the "next" tab.
+				var newIndex = sender.tab.index+1;
+				// handle requests from mainLinkConfigure module
+				chrome.tabs.create({url: request.linkURL, selected: focus, index: newIndex, openerTabId: sender.tab.id});
+				sendResponse({status: "success"});
+				break;
 			case 'keyboardNav':
 				var button = !(request.button == 1);
 				// handle requests from keyboardNav module

--- a/Opera/index.html
+++ b/Opera/index.html
@@ -163,6 +163,18 @@ opera.extension.addEventListener( "message", function( event ) {
 				}
 				event.source.postMessage(passBack);
 				break;
+			case 'mainLinkConfigure':
+				var focus = !(request.isBackground);
+
+				// handle requests from mainLinkConfigure module
+				opera.extension.tabs.create({url: request.linkURL, focused: focus});
+
+				var passBack = {
+					msgType: 'mainLinkConfigure',
+					data: { status: 'success' }
+				}
+				event.source.postMessage(passBack);
+				break;
 			case 'keyboardNav':
 				var button = !(request.button == 1);
 				// handle requests from keyboardNav module

--- a/Opera/index.html
+++ b/Opera/index.html
@@ -163,14 +163,14 @@ opera.extension.addEventListener( "message", function( event ) {
 				}
 				event.source.postMessage(passBack);
 				break;
-			case 'mainLinkConfigure':
+			case 'entryTitleAction':
 				var focus = !(request.isBackground);
 
-				// handle requests from mainLinkConfigure module
+				// handle requests from entryTitleAction module
 				opera.extension.tabs.create({url: request.linkURL, focused: focus});
 
 				var passBack = {
-					msgType: 'mainLinkConfigure',
+					msgType: 'entryTitleAction',
 					data: { status: 'success' }
 				}
 				event.source.postMessage(passBack);

--- a/OperaBlink/background.js
+++ b/OperaBlink/background.js
@@ -144,12 +144,12 @@ chrome.extension.onMessage.addListener(
 				}
 				sendResponse({status: "success"});
 				break;
-			case 'mainLinkConfigure':
+			case 'entryTitleAction':
 				var focus = !(request.isBackground);
 				// Get the selected tab so we can get the index of it.  This allows us to open our new tab as the "next" tab.
 				var newIndex = sender.tab.index+1;
 
-				// handle requests from mainLinkConfigure module
+				// handle requests from entryTitleAction module
 				opera.extension.tabs.create({url: request.linkURL, selected: focus, index: newIndex, openerTabId: sender.tab.id});
 
 				sendResponse({status: "success"});

--- a/OperaBlink/background.js
+++ b/OperaBlink/background.js
@@ -144,6 +144,16 @@ chrome.extension.onMessage.addListener(
 				}
 				sendResponse({status: "success"});
 				break;
+			case 'mainLinkConfigure':
+				var focus = !(request.isBackground);
+				// Get the selected tab so we can get the index of it.  This allows us to open our new tab as the "next" tab.
+				var newIndex = sender.tab.index+1;
+
+				// handle requests from mainLinkConfigure module
+				opera.extension.tabs.create({url: request.linkURL, selected: focus, index: newIndex, openerTabId: sender.tab.id});
+
+				sendResponse({status: "success"});
+				break;
 			case 'keyboardNav':
 				var button = !(request.button == 1);
 				// handle requests from keyboardNav module

--- a/RES.safariextension/background-safari.html
+++ b/RES.safariextension/background-safari.html
@@ -148,10 +148,10 @@
 				}
 				sendResponse({status: "success"}, msgEvent);
 				break;
-			case 'mainLinkConfigure':
+			case 'entryTitleAction':
 				(request.isBackground) ? focus = 'background' : focus = 'foreground';
 
-				// handle requests from mainLinkConfigure module
+				// handle requests from entryTitleAction module
 				var linkTab = safari.application.activeBrowserWindow.openTab(focus);
 				linkTab.url = request.linkURL;
 

--- a/RES.safariextension/background-safari.html
+++ b/RES.safariextension/background-safari.html
@@ -148,6 +148,15 @@
 				}
 				sendResponse({status: "success"}, msgEvent);
 				break;
+			case 'mainLinkConfigure':
+				(request.isBackground) ? focus = 'background' : focus = 'foreground';
+
+				// handle requests from mainLinkConfigure module
+				var linkTab = safari.application.activeBrowserWindow.openTab(focus);
+				linkTab.url = request.linkURL;
+
+				sendResponse({status: "success"}, msgEvent);
+				break;
 			case 'keyboardNav':
 				(request.button == 1) ? button = 'background' : button = 'foreground';
 				// handle requests from keyboardNav module

--- a/XPI/lib/main.js
+++ b/XPI/lib/main.js
@@ -242,11 +242,11 @@ pageMod.PageMod({
 				}
 				worker.postMessage({status: "success"});
 				break;
-			case 'mainLinkConfigure':
+			case 'entryTitleAction':
 				var isBackground = request.isBackground;
 				var isPrivate = priv.isPrivate(windows.activeWindow);
 
-				// handle requests from mainLinkConfigure module
+				// handle requests from entryTitleAction module
 				tabs.open({url: request.linkURL, inBackground: isBackground, isPrivate: isPrivate });
 
 				worker.postMessage({status: "success"});

--- a/XPI/lib/main.js
+++ b/XPI/lib/main.js
@@ -242,6 +242,15 @@ pageMod.PageMod({
 				}
 				worker.postMessage({status: "success"});
 				break;
+			case 'mainLinkConfigure':
+				var isBackground = request.isBackground;
+				var isPrivate = priv.isPrivate(windows.activeWindow);
+
+				// handle requests from mainLinkConfigure module
+				tabs.open({url: request.linkURL, inBackground: isBackground, isPrivate: isPrivate });
+
+				worker.postMessage({status: "success"});
+				break;
 			case 'keyboardNav':
 				var button = (request.button == 1);
 				var isPrivate = priv.isPrivate(windows.activeWindow);

--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -8762,23 +8762,23 @@ modules['entryTitleAction'] = {
 		actionBehavior: {
 			type: 'enum',
 			values: [
-				{ name: 'Main link opens the link.', value: 'link' },
-				{ name: 'Main link opens the comments.', value: 'comments' }
+				{ name: 'Open the content (reddit\'s default action).', value: 'link' },
+				{ name: 'Open the comments.', value: 'comments' }
 			],
 			value: 'comments',
-			description: 'What action should take place when the main link is clicked.'
+			description: 'What action should take place when the entry is clicked.'
 		},
 		focusBehavior: {
 			type: 'enum',
 			values: [
-				{ name: 'foreground', value: 'foreground' },
-				{ name: 'background', value: 'background' }
+				{ name: 'Open in new tab and switch to that tab.', value: 'foreground' },
+				{ name: 'Open in new tab and don\'t switch tabs.', value: 'background' }
 			],
 			value: 'background',
-			description: 'Where the links open.'
+			description: 'Where the link opens.'
 		}
 	},
-	description: 'Configures how the main link works.',
+	description: 'Adds the ability to modify the behavior when clicking the entry\'s title.<br /><br />Note: <b>This changes reddit\'s default behavior.</b>',
 	isEnabled: function() {
 		return RESConsole.getModulePrefs(this.moduleID);
 	},

--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -3185,7 +3185,7 @@ var RESConsole = {
 			'betteReddit': true,
 			'singleClick': true,
 			'subRedditTagger': true,
-			'mainLinkConfigure': false,
+			'entryTitleAction': false,
 			'uppersAndDowners': true,
 			'keyboardNav': true,
 			'commentPreview': true,
@@ -8754,9 +8754,9 @@ modules['singleClick'] = {
 };
 
 
-modules['mainLinkConfigure'] = {
-	moduleID: 'mainLinkConfigure',
-	moduleName: 'Main Link Configure',
+modules['entryTitleAction'] = {
+	moduleID: 'entryTitleAction',
+	moduleName: 'Entry Title Action',
 	category: 'UI',
 	options: {
 		actionBehavior: {
@@ -8798,7 +8798,7 @@ modules['mainLinkConfigure'] = {
 		if ((this.isEnabled()) && (this.isMatchURL())) {
 			this.applyLinks();
 			// listen for new DOM nodes so that modules like autopager, river of reddit, etc still get affected.
-			RESUtils.watchForElement('siteTable', modules['mainLinkConfigure'].applyLinks);
+			RESUtils.watchForElement('siteTable', modules['entryTitleAction'].applyLinks);
 		}
 	},
 	applyLinks: function(ele) {
@@ -8808,8 +8808,8 @@ modules['mainLinkConfigure'] = {
 		var entries = ele.querySelectorAll(selector);
 
 		for (var i=0, len=entries.length; i<len; i++) {
-			if ((typeof entries[i] !== 'undefined') && (!entries[i].classList.contains('mlcTagged'))) {
-				entries[i].classList.add('mlcTagged')
+			if ((typeof entries[i] !== 'undefined') && (!entries[i].classList.contains('entryTitleActionTagged'))) {
+				entries[i].classList.add('entryTitleActionTagged')
 				var thisLA = entries[i].querySelector('A.title');
 				if (thisLA !== null) {
 					var thisLink = thisLA.getAttribute('href');
@@ -8819,8 +8819,8 @@ modules['mainLinkConfigure'] = {
 					}
 
 					// Set attributes for retrieval later based on settings.
-					thisLA.setAttribute('mlcLink', thisLA.href)
-					thisLA.setAttribute('mlcComment', thisComments.href)
+					thisLA.setAttribute('entryTitleActionLink', thisLA.href)
+					thisLA.setAttribute('entryTitleActionComments', thisComments.href)
 
 					// TODO: Webkit won't trigger click events on middle click using the 'click' event.  
 					// ?? We should still preventDefault on a click though, maybe?
@@ -8830,11 +8830,11 @@ modules['mainLinkConfigure'] = {
 						if (e.button !== 2) {
 							// Retrieve attributes based on settings.
 							var thisLink = ''
-							if (modules['mainLinkConfigure'].options.actionBehavior.value == 'link') {
-								thisLink = $(this).parent().parent().parent().find('a.title').attr('mlcLink');
+							if (modules['entryTitleAction'].options.actionBehavior.value == 'link') {
+								thisLink = $(this).parent().parent().parent().find('a.title').attr('entryTitleActionLink');
 							}
-							else if (modules['mainLinkConfigure'].options.actionBehavior.value == 'comments') {
-								thisLink = $(this).parent().parent().parent().find('a.title').attr('mlcComment');
+							else if (modules['entryTitleAction'].options.actionBehavior.value == 'comments') {
+								thisLink = $(this).parent().parent().parent().find('a.title').attr('entryTitleActionComments');
 							}
 
 							// check if it's a relative link (no http://domain) because chrome barfs on these when creating a new tab...
@@ -8843,14 +8843,14 @@ modules['mainLinkConfigure'] = {
 							}
 
 							var thisJSON = {
-								requestType: 'mainLinkConfigure',
+								requestType: 'entryTitleAction',
 								linkURL: thisLink,
-								isBackground: (modules['mainLinkConfigure'].options.focusBehavior.value === 'background') ? true : false,
+								isBackground: (modules['entryTitleAction'].options.focusBehavior.value === 'background') ? true : false,
 								ctrl: e.ctrlKey
 							};
 
 							// Post the action.
-							var foundBrowserType = modules['mainLinkConfigure'].postMessageJSON(thisJSON);
+							var foundBrowserType = modules['entryTitleAction'].postMessageJSON(thisJSON);
 
 							// If can't find browser type, just try to open the url.
 							if (!foundBrowserType) {
@@ -8868,7 +8868,7 @@ modules['mainLinkConfigure'] = {
 			chrome.extension.sendMessage(aJSON);
 		}
 		else if (BrowserDetect.isSafari()) {
-			safari.self.tab.dispatchMessage("mainLinkConfigure", aJSON);
+			safari.self.tab.dispatchMessage("entryTitleAction", aJSON);
 		}
 		else if (BrowserDetect.isOpera()) {
 			opera.extension.postMessage(JSON.stringify(aJSON));

--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -3185,6 +3185,7 @@ var RESConsole = {
 			'betteReddit': true,
 			'singleClick': true,
 			'subRedditTagger': true,
+			'mainLinkConfigure': false,
 			'uppersAndDowners': true,
 			'keyboardNav': true,
 			'commentPreview': true,
@@ -8749,6 +8750,137 @@ modules['singleClick'] = {
 				}
 			}
 		}
+	}
+};
+
+
+modules['mainLinkConfigure'] = {
+	moduleID: 'mainLinkConfigure',
+	moduleName: 'Main Link Configure',
+	category: 'UI',
+	options: {
+		actionBehavior: {
+			type: 'enum',
+			values: [
+				{ name: 'Main link opens the link.', value: 'link' },
+				{ name: 'Main link opens the comments.', value: 'comments' }
+			],
+			value: 'comments',
+			description: 'What action should take place when the main link is clicked.'
+		},
+		focusBehavior: {
+			type: 'enum',
+			values: [
+				{ name: 'foreground', value: 'foreground' },
+				{ name: 'background', value: 'background' }
+			],
+			value: 'background',
+			description: 'Where the links open.'
+		}
+	},
+	description: 'Configures how the main link works.',
+	isEnabled: function() {
+		return RESConsole.getModulePrefs(this.moduleID);
+	},
+	isMatchURL: function() {
+		return RESUtils.isMatchURL(this.moduleID);
+	},
+	include: [
+		/^https?:\/\/([a-z]+)\.reddit\.com\/[\?]*/i,
+		/^https?:\/\/([a-z]+)\.reddit\.com\/r\/[-\w\._]*\//i
+	],
+	exclude: [
+		/^https?:\/\/([a-z]+)\.reddit\.com\/r\/[-\w\._\/\?]*\/comments[-\w\._\/\?=]*/i
+	],
+	beforeLoad: function() {
+	},
+	go: function() {
+		if ((this.isEnabled()) && (this.isMatchURL())) {
+			this.applyLinks();
+			// listen for new DOM nodes so that modules like autopager, river of reddit, etc still get affected.
+			RESUtils.watchForElement('siteTable', modules['mainLinkConfigure'].applyLinks);
+		}
+	},
+	applyLinks: function(ele) {
+		selector = '#siteTable .entry, #siteTable_organic .entry';
+
+		var ele = ele || document;
+		var entries = ele.querySelectorAll(selector);
+
+		for (var i=0, len=entries.length; i<len; i++) {
+			if ((typeof entries[i] !== 'undefined') && (!entries[i].classList.contains('mlcTagged'))) {
+				entries[i].classList.add('mlcTagged')
+				var thisLA = entries[i].querySelector('A.title');
+				if (thisLA !== null) {
+					var thisLink = thisLA.getAttribute('href');
+					var thisComments = entries[i].querySelector('.comments');
+					if (!(thisLink.match(/^https?/i))) {
+						thisLink = location.protocol + '//' + document.domain + thisLink;
+					}
+
+					// Set attributes for retrieval later based on settings.
+					thisLA.setAttribute('mlcLink', thisLA.href)
+					thisLA.setAttribute('mlcComment', thisComments.href)
+
+					// TODO: Webkit won't trigger click events on middle click using the 'click' event.  
+					// ?? We should still preventDefault on a click though, maybe?
+					thisLA.addEventListener('click', function(e) {
+						e.preventDefault();
+
+						if (e.button !== 2) {
+							// Retrieve attributes based on settings.
+							var thisLink = ''
+							if (modules['mainLinkConfigure'].options.actionBehavior.value == 'link') {
+								thisLink = $(this).parent().parent().parent().find('a.title').attr('mlcLink');
+							}
+							else if (modules['mainLinkConfigure'].options.actionBehavior.value == 'comments') {
+								thisLink = $(this).parent().parent().parent().find('a.title').attr('mlcComment');
+							}
+
+							// check if it's a relative link (no http://domain) because chrome barfs on these when creating a new tab...
+							if (!(thisLink.match(/^http/i))) {
+								thisLink = 'http://' + document.domain + thisLink;
+							}
+
+							var thisJSON = {
+								requestType: 'mainLinkConfigure',
+								linkURL: thisLink,
+								isBackground: (modules['mainLinkConfigure'].options.focusBehavior.value === 'background') ? true : false,
+								ctrl: e.ctrlKey
+							};
+
+							// Post the action.
+							var foundBrowserType = modules['mainLinkConfigure'].postMessageJSON(thisJSON);
+
+							// If can't find browser type, just try to open the url.
+							if (!foundBrowserType) {
+								// Foreground/background setting doesn't matter here.
+								window.open(thisLink);
+							}
+						}
+					}, false);
+				}
+			}
+		}
+	},
+	postMessageJSON: function(aJSON) {
+		if (BrowserDetect.isChrome()) {
+			chrome.extension.sendMessage(aJSON);
+		}
+		else if (BrowserDetect.isSafari()) {
+			safari.self.tab.dispatchMessage("mainLinkConfigure", aJSON);
+		}
+		else if (BrowserDetect.isOpera()) {
+			opera.extension.postMessage(JSON.stringify(aJSON));
+		}
+		else if (BrowserDetect.isFirefox()) {
+			self.postMessage(aJSON);
+		}
+		else {
+			return false;
+		}
+
+		return true;
 	}
 };
 


### PR DESCRIPTION
Configure the behavior when clicking the entry's title.

### Options
* Action
  - open the content (reddit's default action)
  - open the comments
* Focus
  - open in foreground
  - open in background

### Testing
Fully tested on Firefox and Chrome. I appreciate any feedback for about its behavior on other browsers.

### Other
* This is similar to the SingleClickOpener module, but I felt it was different enough to warrant its own module.
* The module is disabled by default because **it changes reddit's default behavior**.
* My motivation for making this is the desire to only open the comments (since I can get to the content from there) and to have interaction remain as close to the normal flow as possible (left-clicking on the main link).

### Disclaimer
I am not a web developer and did a lot of copy-pasting based on the existing SingleClickOpener module.