### PR TITLE
Fix RES option buttons not showing in Firefox.

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -3447,7 +3447,7 @@ var RESConsole = {
 				thisOptionFormEle = createElementWithID('button', optionName);
 				thisOptionFormEle.classList.add('RESConsoleButton');
 				thisOptionFormEle.setAttribute('moduleID',moduleID);
-				thisOptionFormEle.innerText = optionObject.text;
+				thisOptionFormEle.textContent = optionObject.text;
 				thisOptionFormEle.addEventListener('click', optionObject.callback, false);
 				break;
 			case 'list':


### PR DESCRIPTION
This was caused by an outdated use of innerText property, instead of textContent.
