### PR TITLE
subredditInfo hover in comments

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -11224,7 +11224,7 @@ modules['showImages'] = {
 				elem.src = info.src;
 				elem.href = info.src;
 
-				if (RESUtils.pageType() === 'linklist') {
+				if (RESUtils.pageType() === 'linklist' && elem.classList.contains('title')) {
 					$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
 				}
 


### PR DESCRIPTION
Change to href to avoid instances in comments where the user creates a
link with a different name than the target subreddit, eg [RES
issues](/r/RESissues), instead of just /r/RESissues.

Also strips the trailing slash so that cached subreddit names are always
SR_NAME and not SR_NAME/
