### PR TITLE
Add CSS to fix truncated rank counter

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -12902,6 +12902,12 @@ modules['neverEndingReddit'] = {
 							// console.log('skipped first sitetable, stupid reddit.');
 							newHTML = stMultiCheck[1];
 						}
+						// compare first and last links in the listing to determine rank counter length. Moving from 2 to 3 digits requires RES to inject its own CSS
+						if (newHTML.firstChild.classList.contains('link')) {
+							if (newHTML.children[newHTML.children.length-3].children[1].textContent.length > newHTML.firstChild.children[1].textContent.length) {
+								RESUtils.addCSS('.res .content .link .rank { width: 3.3ex; }');
+							}
+						}
 						newHTML.setAttribute('ID','siteTable-'+modules['neverEndingReddit'].currPage+1);
 						modules['neverEndingReddit'].duplicateCheck(newHTML);
 						// check for new mail


### PR DESCRIPTION
Compare the first/last link in a NER page to determine transition from 2
to 3 digits.
