### PR TITLE
Allow the "view images" tab to be hidden without having to turn off the inline image viewer

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -10121,6 +10121,11 @@ modules['showImages'] = {
 			type: 'boolean',
 			value: false,
 			description: 'Display all images at once in a \'filmstrip\' layout, rather than the default navigable \'slideshow\' style.'
+		},
+		showViewImagesTab: {
+			type: 'boolean',
+			value: true,
+			description: 'Show a \'view images\' tab at the top of each subreddit, to easily toggle showing all images at once.'
 		}
 	},
 	description: 'Opens images inline in your browser with the click of a button. Also has configuration options, check it out!',
@@ -10219,6 +10224,9 @@ modules['showImages'] = {
 			}, true);
 			a.appendChild(text);
 			li.appendChild(a);
+			if (!this.options.showViewImagesTab.value) {
+				li.style.display = 'none';
+			}
 			mainMenuUL.appendChild(li);
 			this.viewImageButton = a;
 			/*


### PR DESCRIPTION
The "view images" tab in the header is big and sometimes gets in the way.  I've had it clip through the user bar quite a few times, and it's only gotten worse as reddit has added the "gilded" and "wiki" tabs.  Since I never use the thing, I thought I'd look through the code and add the option to hide it myself.

It doesn't change anything for the default user, and since it only hides the element, things that refer to it still work (like the keyboard shortcut to toggle all images).
