### PR TITLE
Bump minimum Chrome version to 26.0 (as mentioned in #586)

### DIFF
--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -2,7 +2,7 @@
 	"name": "Reddit Enhancement Suite",
 	"version": "4.3.0.4",
 	"manifest_version": 2,
-	"minimum_chrome_version": "20.0",
+	"minimum_chrome_version": "26.0",
 	"description": "Reddit Enhancement Suite - a group of enhancements for browsing Reddit",
 	"background": {
 		"scripts": ["background.js"]

--- a/OperaBlink/manifest.json
+++ b/OperaBlink/manifest.json
@@ -2,7 +2,7 @@
 	"name": "Reddit Enhancement Suite",
 	"version": "4.3.0",
 	"manifest_version": 2,
-	"minimum_chrome_version": "20.0",
+	"minimum_chrome_version": "26.0",
 	"description": "Reddit Enhancement Suite - a group of enhancements for browsing Reddit",
 	"background": {
 		"scripts": ["background.js"]


### PR DESCRIPTION
Again, so we can ensure that `chrome.runtime` will work.
