### PR TITLE
Adds hide/show comments for all comments, fixes those links for 'load more comments' comments

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -12682,37 +12682,56 @@ modules['hideChildComments'] = {
 			var commentMenu = document.querySelector('ul.buttons');
 			if (commentMenu) {
 				commentMenu.appendChild(toggleButton);
-				var rootComments = document.querySelectorAll('div.commentarea > div.sitetable > div.thing > div.child > div.listing');
-				for (var i = 0, len = rootComments.length; i < len; i++) {
-					var toggleButton = document.createElement('li');
-					var toggleLink = document.createElement('a');
-					toggleLink.textContent = 'hide child comments';
-					toggleLink.setAttribute('action', 'hide');
-					toggleLink.setAttribute('href', 'javascript:void(0);');
-					toggleLink.setAttribute('class', 'toggleChildren');
-					// toggleLink.setAttribute('title','Hide child comments.');
-					toggleLink.addEventListener('click', function(e) {
-						modules['hideChildComments'].toggleComments(this.getAttribute('action'), this);
-						if (this.getAttribute('action') === 'hide') {
-							this.setAttribute('action', 'show');
-							// this.setAttribute('title','show child comments.');
-							this.textContent = 'show child comments';
-						} else {
-							this.setAttribute('action', 'hide');
-							// this.setAttribute('title','hide child comments.');
-							this.textContent = 'hide child comments';
-						}
-					}, true);
-					toggleButton.appendChild(toggleLink);
-					var sib = rootComments[i].parentNode.previousSibling;
-					if (typeof sib !== 'undefined') {
-						var sibMenu = sib.querySelector('ul.buttons');
-						if (sibMenu) sibMenu.appendChild(toggleButton);
-					}
-				}
 				if (this.options.automatic.value) {
 					RESUtils.click(this.toggleAllLink);
 				}
+			}
+			this.addToggleCommentsLinks();
+			RESUtils.watchForElement('newComments', modules['hideChildComments'].addToggleCommentsLinks);
+		}
+	},
+	addToggleCommentsLinks: function(comment) {
+		var commentContainers;
+		if (comment) {
+			//There are other comments that were already in this listing, no need to add link to the container
+			if(comment.parentNode.parentNode.classList.contains('listing')) {
+				return;
+			} else {
+				comment.parentNode.parentNode.classList.add('listing');
+			}
+			commentContainers = [comment.parentNode.parentNode];
+		} else {
+			commentContainers = document.querySelectorAll('div.commentarea > div.sitetable div.listing');
+		}
+		for (var i=0, len=commentContainers.length; i<len; i++) {
+			//The only child this comment container has is the 'more comments' link, suppress link
+			if(commentContainers[i].firstChild.classList.contains('morechildren')) {
+				//Removing the listing class isn't detrimental, new comments that get loaded in from 'load more comments' didn't even have the listing class before I fixed it.
+				//This also makes it consistent that a sitetable with listing has actual comments shown, not just a 'load more comments' link. It also makes it easier to know when to add a hide comments link =)
+				commentContainers[i].classList.remove('listing');
+				continue;
+			}
+			var toggleButton = document.createElement('li');
+			var toggleLink = document.createElement('a');
+			toggleLink.textContent = 'hide comments';
+			toggleLink.setAttribute('action', 'hide');
+			toggleLink.setAttribute('href', 'javascript:void(0);');
+			toggleLink.setAttribute('class', 'toggleChildren');
+			toggleLink.addEventListener('click', function(e) {
+				modules['hideChildComments'].toggleComments(this.getAttribute('action'), this);
+				if (this.getAttribute('action') === 'hide') {
+					this.setAttribute('action','show');
+					this.textContent = 'show comments';
+				} else {
+					this.setAttribute('action','hide');
+					this.textContent = 'hide comments';
+				}
+			}, true);
+			toggleButton.appendChild(toggleLink);
+			var sib = commentContainers[i].parentNode.previousSibling;
+			if (typeof sib !== 'undefined') {
+				var sibMenu = sib.querySelector('ul.buttons');
+				if (sibMenu) sibMenu.appendChild(toggleButton);
 			}
 		}
 	},
@@ -12731,15 +12750,13 @@ modules['hideChildComments'] = {
 						if (thisChildren !== null) {
 							thisChildren.style.display = 'none';
 						}
-						thisToggleLink.textContent = 'show child comments';
-						// thisToggleLink.setAttribute('title', 'show child comments');
+						thisToggleLink.textContent = 'show comments';
 						thisToggleLink.setAttribute('action', 'show');
 					} else {
 						if (thisChildren !== null) {
 							thisChildren.style.display = 'block';
 						}
-						thisToggleLink.textContent = 'hide child comments';
-						// thisToggleLink.setAttribute('title', 'hide child comments');
+						thisToggleLink.textContent = 'hide comments';
 						thisToggleLink.setAttribute('action', 'hide');
 					}
 				}


### PR DESCRIPTION
There was an issue with comments loaded from 'load more comments' not having the show/hide child comment links which has been resolved.

I added show/hide comment links to all comments with children which I find is a very handy feature.

I also changed the link text. I can revert that portion, it's not a big deal, but it just felt better.

First pull request woohoo!
