### PR TITLE
show the π server / debug info in top right corner with NeverEndingReddit

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -13096,10 +13096,11 @@ modules['neverEndingReddit'] = {
 			document.body.appendChild(this.NREFloat);
 
 			if (this.options.showServerInfo.value) {
-				RESUtils.addCSS('.debuginfo { position: fixed; top: 5px; right: 5px; }');
+				RESUtils.addCSS('.debuginfo { position: fixed; bottom: 5px; right: 5px; }');
 				RESUtils.addCSS('.debuginfo { background: rgba(255,255,255,0.3); }');
-				RESUtils.addCSS('.res-nightmode .debuginfo { background: rgba(30,30,30,0.3); color: #ccc; }');
-				RESUtils.addCSS('.listing-page .debuginfo { top: 25px; }');
+				RESUtils.addCSS('.debuginfo:hover { background: rgba(255,255,255,0.8); }');
+				RESUtils.addCSS('.res-nightmode .debuginfo { background: rgba(30,30,30,0.5); color: #ccc; }');
+				RESUtils.addCSS('.res-nightmode .debuginfo:hover { background: rgba(30,30,30,0.8); }');
 			}
 		}
 	},


### PR DESCRIPTION
neverEndingReddit option (default false) to show the server/debug info for a page render in the top right corner (since NER makes it impossible to find)

![screen shot 2013-11-09 at 3 00 56 pm](https://f.cloud.github.com/assets/455632/1507451/3d97906c-4982-11e3-9c6f-ea692966ae90.png)
![screen shot 2013-11-09 at 3 01 15 pm](https://f.cloud.github.com/assets/455632/1507452/3da3efb0-4982-11e3-8ce0-fee8d71fe460.png)
