### PR TITLE
"highlight first commenter" overrides "submitter" background from userHighlighter

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -14026,11 +14026,6 @@ modules['userHighlight'] = {
 				author = entry.querySelector('.author');
 			if (!author) return;
 
-			if (modules['userHighlight'].options.highlightOP.value) {
-				var authorIsOP = entry.querySelector('.userattrs .submitter');
-				if (authorIsOP) return;
-			}
-
 			var authorClass;
 			for (var i = 0, length = author.classList.length; i < length; i++) {
 				authorClass = author.classList[i];


### PR DESCRIPTION
How about "if userHighlighter is highlighting submitter and firstCommenter, don't apply 'first commenter' highlight to comments from submitter'"?  

or do y'all think it's better that to get username with firstCommenter highlight + [S] userattr?
