### PR TITLE
keyNav moveToParent tweaks

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -5753,7 +5753,9 @@ modules['keyboardNav'] = {
 		// wire up keyboard links for mouse clicky selecty goodness...
 		if ((typeof this.keyboardLinks !== 'undefined') && (this.options.clickFocus.value)) {
 			for (var i = 0, len = this.keyboardLinks.length; i < len; i++) {
-				$(this.keyboardLinks[i]).parent().data('keyIndex', i)
+				$(this.keyboardLinks[i])
+					.data('keyIndex', i)
+					.parent()
 					.on('click', modules['keyboardNav'].updateKeyFocus);
 			}
 			this.keyFocus(this.keyboardLinks[this.activeIndex]);
@@ -5762,7 +5764,7 @@ modules['keyboardNav'] = {
 	updateKeyFocus: function(event) {
 		event.stopPropagation();
 
-		var thisIndex = parseInt($(this).data('keyIndex'), 10);
+		var thisIndex = parseInt($(this).find('.entry:first').data('keyIndex'), 10);
 		if (modules['keyboardNav'].activeIndex !== thisIndex) {
 			modules['keyboardNav'].keyUnfocus(modules['keyboardNav'].keyboardLinks[modules['keyboardNav'].activeIndex]);
 			modules['keyboardNav'].activeIndex = thisIndex;
@@ -6453,7 +6455,7 @@ modules['keyboardNav'] = {
 				if (firstParent !== null) {
 					this.keyUnfocus(this.keyboardLinks[this.activeIndex]);
 					var thisParent = firstParent.parentNode.parentNode.previousSibling;
-					var newKeyIndex = parseInt(thisParent.getAttribute('keyindex'), 10);
+					var newKeyIndex = parseInt($(thisParent).data('keyIndex'), 10);
 					this.activeIndex = newKeyIndex;
 					this.keyFocus(this.keyboardLinks[this.activeIndex]);
 					var thisXY = RESUtils.getXYpos(this.keyboardLinks[this.activeIndex]);


### PR DESCRIPTION
Add the data to the `.entry` instead of the parent `.comment` / adjust
the `thisIndex` to match / replace legacy reference to attr with data
