### PR TITLE
Address issue in c747295

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -19853,7 +19853,7 @@ modules['dashboard'] = {
 
 				// $widgetContent will contain HTML from Reddit's page load. No XSS here or you'd already be hit, can't call escapeHTML on this either and wouldn't help anyhow.
 				try {
-					$thisWidgetContents.html($widgetContent);
+					$thisWidgetContents.empty().append($widgetContent);
 				} catch (e) {
 					// console.log(e);
 				}


### PR DESCRIPTION
The issue mentioned in c747295b3246f03e6f97c2a479b735dc37d79b50 is due to the fact that I changed `$thisWidgetContents.html($widgetContent);` to use `$thisWidgetContents.html($widgetContent.html());` (essentially) instead, when they are not equivalent. I've reimplemented the minor changes, ensuring that the dashboard widget doesn't break.
