### PR TITLE
CSS patch for rank widths

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -13574,13 +13574,20 @@ modules['neverEndingReddit'] = {
 					var newHTML = tempDiv.querySelector('#siteTable');
 					// did we find anything?
 					if (newHTML !== null) {
-						var stMultiCheck = tempDiv.querySelectorAll('#siteTable');
+						var firstLen, lastLen,
+							stMultiCheck = tempDiv.querySelectorAll('#siteTable');
 						// stupid sponsored links create a second div with ID of sitetable (bad reddit! you should never have 2 IDs with the same name! naughty, naughty reddit!)
 						if (stMultiCheck.length === 2) {
 							// console.log('skipped first sitetable, stupid reddit.');
 							newHTML = stMultiCheck[1];
 						}
 						newHTML.setAttribute('ID', 'siteTable-' + modules['neverEndingReddit'].currPage + 1);
+						firstLen = $(newHTML).find('.link:first .rank').text().length;
+						lastLen = $(newHTML).find('.link:last .rank').text().length;
+						if (lastLen > firstLen) {
+							lastLen = (lastLen * 1.1).toFixed(1);
+							RESUtils.addCSS('body.res > .content .link .rank { width: ' + lastLen + 'ex; }');
+						}
 						modules['neverEndingReddit'].duplicateCheck(newHTML);
 						// check for new mail
 						var hasNewMail = tempDiv.querySelector('#mail');


### PR DESCRIPTION
Users with <100 links per page set would have the third (and later
fourth) digits hidden when NER loaded in a new page that took them over
100(0) links. Necessary since reddit now applies the width of the rank
container per page, not per link.
