### PR TITLE
Added slash to the link in the MediaCrush branding

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -11325,7 +11325,7 @@ modules['showImages'] = {
 
 		if (options.media.type != 'application/album') {
 			var brand = document.createElement('a');
-			brand.href = MediaCrush.domain + options.media.hash;
+			brand.href = MediaCrush.domain + '/' + options.media.hash;
 			brand.target = '_blank';
 			brand.className = 'mediacrush-brand';
 			var image = document.createElement('img');


### PR DESCRIPTION
Hi. This fixes links in the branding &lt;a&gt;.
