### PR TITLE
Make button locations more consistent

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -13875,7 +13875,7 @@ modules['saveComments'] = {
 						href: href,
 						username: username,
 						comment: commentHTML,
-						timeSaved: new Date()
+						timeSaved: Date()
 					};
 				this.storedComments[id] = savedComment;
 


### PR DESCRIPTION
Here's how it currently looks (with these changes) without the Reddit Gold "save":

![Screenshot](http://i.minus.com/iuB6OGoPlE41e.png)

and with the Reddit Gold "save":

![Screenshot](http://i.minus.com/ibpXXCVA4I5cBB.png)

Note that the "save-RES" button HAS shifted to the left, but I personally think it makes more sense if it's next to Reddit's own "save" button. Thoughts?
