### PR TITLE
module.include/exclude can be pagetypes, not just URL regexps

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -4612,11 +4612,9 @@ modules['uppersAndDowners'] = {
 		return RESConsole.getModulePrefs(this.moduleID);
 	},
 	include: [
-		/^https?:\/\/([a-z]+)\.reddit\.com\/?(?:\??[\w]+=[\w]+&?)*/i,
-		/^https?:\/\/([a-z]+)\.reddit\.com\/r\/[\w]+\/?(?:\??[\w]+=[\w]+&?)*$/i,
-		/^https?:\/\/([a-z]+)\.reddit\.com\/user\/[-\w\.]+/i,
-		/^https?:\/\/([a-z]+)\.reddit\.com\/[-\w\.\/]+\/comments\/?[-\w\.]*/i,
-		/^https?:\/\/([a-z]+)\.reddit\.com\/comments\/[-\w\.]+/i
+		'linklist',
+		'profile',
+		'comments'
 	],
 	isMatchURL: function() {
 		return RESUtils.isMatchURL(this.moduleID);


### PR DESCRIPTION
A module's include/exclude list can now be pagetypes ("comments", "linklisting", "profile", etc. -- see `RESutils.pageType()`) in addition to regular expressions for URLs.

If this approach looks good, @honestbleeps, I can go through all the modules and switch out regexps for pagetypes.  
