### PR TITLE
Restore subredditFrontPage keyboard shortcut, add to other pages

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -6079,6 +6079,10 @@ modules['keyboardNav'] = {
 							e.preventDefault();
 							this.frontPage();
 							break;
+						case checkKeysForEvent(e, this.options.subredditFrontPage.value):
+							e.preventDefault();
+							this.frontPage(true);
+							break;
 						case checkKeysForEvent(e, this.options.nextPage.value):
 							e.preventDefault();
 							this.nextPage();
@@ -6217,6 +6221,10 @@ modules['keyboardNav'] = {
 							e.preventDefault();
 							this.frontPage();
 							break;
+						case checkKeysForEvent(e, this.options.subredditFrontPage.value):
+							e.preventDefault();
+							this.frontPage(true);
+							break;
 						case checkKeysForEvent(e, this.options.nextPage.value):
 							e.preventDefault();
 							this.nextPage();
@@ -6320,6 +6328,10 @@ modules['keyboardNav'] = {
 						case checkKeysForEvent(e, this.options.frontPage.value):
 							e.preventDefault();
 							this.frontPage();
+							break;
+						case checkKeysForEvent(e, this.options.subredditFrontPage.value):
+							e.preventDefault();
+							this.frontPage(true);
 							break;
 						case checkKeysForEvent(e, this.options.nextPage.value):
 							e.preventDefault();


### PR DESCRIPTION
http://www.reddit.com/r/RESissues/comments/1rik2h/shiftf_not_taking_me_to_front_page_of_the/

Looks like the subredditFrontPage keyboard shortcut accidentally got nixed with the goMode change (afb1778).  This restores it and makes it functional on comments pages in addition to linklisting pages.
