### PR TITLE
Fix a bug with the night-mode toggle in the Settings panel

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -14513,7 +14513,7 @@ modules['styleTweaks'] = {
 				this.lightSwitch();
 			}
 			if (this.options.colorBlindFriendly.value) {
-				var orangered = document.body.querySelector('#mail');
+				var orangered = document.getElementById('mail');
 				if ((orangered) && (orangered.classList.contains('havemail'))) {
 					orangered.setAttribute('style', 'background-image: url(http://thumbs.reddit.com/t5_2s10b_5.png); background-position: 0 0;');
 				}


### PR DESCRIPTION
I've seen a few reports in /r/RESissues where the night mode radio buttons seem to do nothing after switching to Dark; switching to Light would not work. This fixes the issue.
