### PR TITLE
Sticky notifications

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -20361,13 +20361,9 @@ modules['dashboard'] = {
 
 addModule('notifications', function (module, moduleID) {
 	$.extend(module, {
-	
 		moduleName: 'RES Notifications',
 		category: 'UI',
 		description: 'Manage pop-up notifications for RES functions',
-		isEnabled: function() {
-			return RESConsole.getModulePrefs(this.moduleID);
-		},
 		include: [
 			/.*/i
 		]
@@ -20499,13 +20495,13 @@ addModule('notifications', function (module, moduleID) {
 		var isSticky = modules['notifications'].options.sticky.value == 'all'
 			|| (modules['notifications'].options.sticky.value == 'notificationType' && notificationType.sticky);
 		if (!isSticky) {
-			this.setCloseNotificationTimer(thisNotification, delay);
+			module.setCloseNotificationTimer(thisNotification, delay);
 		} 
-		this.RESNotifications.style.display = 'block';
-		this.RESNotifications.appendChild(thisNotification);
+		module.RESNotifications.style.display = 'block';
+		module.RESNotifications.appendChild(thisNotification);
 		modules['styleTweaks'].setSRStyleToggleVisibility(false, 'notification');
 		RESUtils.fadeElementIn(thisNotification, 0.2, 1);
-		this.notificationCount++;
+		module.notificationCount++;
 
 		return {
 			element: thisNotification,
@@ -20546,8 +20542,8 @@ addModule('notifications', function (module, moduleID) {
 	function setupNotificationsContainer() {
 		if (typeof module.notificationCount === 'undefined') {
 			module.adFrame = document.body.querySelector('#ad-frame');
-			if (this.adFrame) {
-				this.adFrame.style.display = 'none';
+			if (module.adFrame) {
+				module.adFrame.style.display = 'none';
 			}
 			module.notificationCount = 0;
 			module.notificationTimers = [];
@@ -20559,7 +20555,7 @@ addModule('notifications', function (module, moduleID) {
 	function createNotificationElement(contentObj, notificationType) {
 		var thisNotification = document.createElement('div');
 		thisNotification.classList.add('RESNotification');
-		thisNotification.setAttribute('id', 'RESNotification-' + this.notificationCount);
+		thisNotification.setAttribute('id', 'RESNotification-' + module.notificationCount);
 		$(thisNotification).html('<div class="RESNotificationHeader"><h3>' + contentObj.renderedHeader + '</h3><div class="RESNotificationClose RESCloseButton">&times;</div></div><div class="RESNotificationContent">' + contentObj.message + '</div>');
 		thisNotification.querySelector('.RESNotificationToggle').setAttribute('title', 'Show notifications from ' + notificationType.moduleID + ' - ' + notificationType.notificationID);
 		return thisNotification;


### PR DESCRIPTION
Notifications can stick around now, requiring the user to manually dismiss them.

The user can choose to allow notifications to be sticky based on their notification type (default), always, or never.

Notifications are not sticky by default.

`modules['notifications'].showNotification({ sticky: true })` makes that notification and its notification type sticky.  After a notification has shown once and created a notification type, the user can disable sticky on that notification type and resultant notifications will not be sticky.
