### PR TITLE
Default CSS3 image-orientation to from-image

### DIFF
--- a/lib/res.css
+++ b/lib/res.css
@@ -958,6 +958,9 @@ button.RESBigEditorPop:hover {
 
 
 /* Image Viewer */
+img {
+	image-orientation: from-image;
+}
 .commentarea .thing .usertext-body .expando-button, .listing-page .thing .expando-button {
 	padding: 0;
 }


### PR DESCRIPTION
With this change, [`image-orientation`](https://developer.mozilla.org/en-US/docs/Web/CSS/image-orientation) will now rotate an image based on its EXIF information in Firefox.
