### PR TITLE
Force HTTPS on all images

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -7005,7 +7005,7 @@ modules['userTagger'] = {
 
 			css += '#benefits { width: 200px; margin-left: 0; }';
 			css += '#userTaggerToolTip #userTaggerVoteWeight { width: 30px; }';
-			css += '.RESUserTagImage { display: inline-block; width: 16px; height: 8px; background-image: url(\'' + (location.protocol == "http:" ? 'http://' : 'https://s3.amazonaws.com/') + 'e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png\'); background-repeat: no-repeat; background-position: -16px -137px; }';
+			css += '.RESUserTagImage { display: inline-block; width: 16px; height: 8px; background-image: url("https://s3.amazonaws.com/e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png"); background-repeat: no-repeat; background-position: -16px -137px; }';
 			css += '.userTagLink { display: inline-block; }';
 			css += '.hoverHelp { margin-left: 3px; cursor: pointer; color: #369; text-decoration: underline; }';
 			css += '.userTagLink.hasTag, #userTaggerPreview { display: inline-block; padding: 0 4px; border: 1px solid #c7c7c7; border-radius: 3px; }';
@@ -7874,7 +7874,7 @@ modules['userTagger'] = {
 			userHTML += '<div class="authorFieldPair"><div class="authorLabel">Link:</div> <div class="authorDetail"><a target="_blank" href="' + escapeHTML(modules['userTagger'].tags[jsonData.data.name].link) + '">website link</a></div></div>';
 		}
 		userHTML += '<div class="clear"></div><div class="bottomButtons">';
-		userHTML += '<a target="_blank" class="blueButton" href="http://www.reddit.com/message/compose/?to=' + escapeHTML(jsonData.data.name) + '"><img src="//redditstatic.s3.amazonaws.com/mailgray.png"> send message</a>';
+		userHTML += '<a target="_blank" class="blueButton" href="http://www.reddit.com/message/compose/?to=' + escapeHTML(jsonData.data.name) + '"><img src="https://redditstatic.s3.amazonaws.com/mailgray.png"> send message</a>';
 		if (jsonData.data.is_gold) {
 			userHTML += '<a target="_blank" class="blueButton" href="http://www.reddit.com/gold/about">User has Reddit Gold</a>';
 		} else {
@@ -13328,7 +13328,7 @@ modules['neverEndingReddit'] = {
 			RESUtils.addCSS('#progressIndicator h2 { margin-bottom: .5em; }');
 			RESUtils.addCSS('#progressIndicator .gearIcon { margin-left: 1em; }');
 			RESUtils.addCSS('#NREMailCount { margin-left: 0; float: left; margin-top: 3px;}');
-			RESUtils.addCSS('#NREPause { margin-left: 2px; width: 16px; height: 16px; float: left; background-image: url("' + (location.protocol == "http:" ? 'http://' : 'https://s3.amazonaws.com/') + 'e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png"); cursor: pointer; }');
+			RESUtils.addCSS('#NREPause { margin-left: 2px; width: 16px; height: 16px; float: left; background-image: url("https://s3.amazonaws.com/e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png"); cursor: pointer; }');
 			RESUtils.addCSS('#NREPause, #NREPause.paused.reversePause { background-position: -16px -192px; }');
 			RESUtils.addCSS('#NREPause.paused, #NREPause.reversePause {  background-position: 0 -192px; }');
 		}
@@ -13417,8 +13417,8 @@ modules['neverEndingReddit'] = {
 					RESUtils.addCSS('#NREFloat { position: fixed; top: 10px; right: 10px; display: none; }');
 				}
 				RESUtils.addCSS('#NREMail { width: 16px; height: 12px; float: left; margin-top: 4px; background: center center no-repeat; }');
-				RESUtils.addCSS('#NREMail.nohavemail { background-image: url(//redditstatic.s3.amazonaws.com/mailgray.png); }');
-				RESUtils.addCSS('#NREMail.havemail { background-image: url(//redditstatic.s3.amazonaws.com/mail.png); }');
+				RESUtils.addCSS('#NREMail.nohavemail { background-image: url(https://redditstatic.s3.amazonaws.com/mailgray.png); }');
+				RESUtils.addCSS('#NREMail.havemail { background-image: url(https://redditstatic.s3.amazonaws.com/mail.png); }');
 				RESUtils.addCSS('.res-colorblind #NREMail.havemail { background-image: url(http://thumbs.reddit.com/t5_2s10b_5.png); }');
 				this.NREFloat.appendChild(this.NREMail);
 				this.NREMailCount = createElementWithID('a', 'NREMailCount');
@@ -15106,9 +15106,9 @@ modules['accountSwitcher'] = {
 				RESUtils.addCSS('#RESAccountSwitcherIconOverlay { cursor: pointer; position: absolute; display: none; width: 11px; height: 22px; background-position: 2px 3px; padding-left: 2px; padding-right: 2px; padding-top: 3px; border: 1px solid #369; border-bottom: 1px solid #5f99cf; background-color: #5f99cf; border-radius: 3px 3px 0 0; z-index: 100; background-repeat: no-repeat; background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAPCAYAAAAyPTUwAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyBpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBXaW5kb3dzIiB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOkQ3NTExRkExOEYzNTExRTFBNjgzQzhEOUY2QzU2MUNFIiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOkQ3NTExRkEyOEYzNTExRTFBNjgzQzhEOUY2QzU2MUNFIj4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6RDc1MTFGOUY4RjM1MTFFMUE2ODNDOEQ5RjZDNTYxQ0UiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6RDc1MTFGQTA4RjM1MTFFMUE2ODNDOEQ5RjZDNTYxQ0UiLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz6W3fJJAAAB4ElEQVR42mJgwA4YgdgSiJUUFRXDW1tbL7Kzswsw4VDMBcRXgfgeMzPzJx4eHn4gG0MtSICPjY3NF0jLoCtglJWV1eDm5rZmZWX9k5ZbWGFmYqwhwM3B8Pn7T4bzl6/enzNlQsfrV68+srKxPWHMz89/ZmJiIunn58fA9+YKAwMHHwODlA4Dw4fHDAzPbzD8VLRhWLNuPcOzp0//MEhJSaU/f/HyPxhkyf//3xsEYa+s/f8/nOn//19f/n/98fO/jo5ONwMfH5/S27dvwfL/nt/5//8rhP3/z7f//55cgzD//PkPdK4F2N3x8fFLv3///v/d56//l69a83///v3/V65e8//+k+f///79+7+4uPgAUB0zIywUgNZEZmVlzRMTE2P78OEDA9DTDN++ffs3c+bMglOnTk0HqvkDC5p/L168+P7582cmaWlpBhUVFQZ5eXkGoPUMDx8+BMn/QQ5C1vb29r+HDx/+jwwuXLjwv7e39z8wWHkYkAOdk5OT4cePHygx9OXLF7BzgPpQo05NTS2mp6fnO7LJc+bM+a2np1eKNUFISEg0gEIFHIz//v3X1dWdDU1UYMAMYzg7O8eUlpYmXLly5dtfFm6h40cO3DU2NhYBphOea9euHQOpAQgwAKMW+Z5mJFvIAAAAAElFTkSuQmCC); }');
 			} else {
 				RESUtils.addCSS('#RESAccountSwitcherIcon { display: inline-block; vertical-align: middle; margin-left: 3px; }');
-				RESUtils.addCSS('#RESAccountSwitcherIcon .downArrow { cursor: pointer; margin-top: 2px; display: block; width: 16px; height: 10px; background-image: url("' + (location.protocol == "http:" ? 'http://' : 'https://s3.amazonaws.com/') + 'e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png"); background-position: 0 -106px; }');
+				RESUtils.addCSS('#RESAccountSwitcherIcon .downArrow { cursor: pointer; margin-top: 2px; display: block; width: 16px; height: 10px; background-image: url("https://s3.amazonaws.com/e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png"); background-position: 0 -106px; }');
 				RESUtils.addCSS('#RESAccountSwitcherIconOverlay { cursor: pointer; position: absolute; display: none; width: 20px; height: 22px; z-index: 100; border: 1px solid #369; border-bottom: 1px solid #5f99cf; background-color: #5f99cf; border-radius: 3px 3px 0 0; }');
-				RESUtils.addCSS('#RESAccountSwitcherIconOverlay .downArrow { margin-top: 6px; margin-left: 3px; display: inline-block; width: 18px; height: 10px; background-image: url("' + (location.protocol == "http:" ? 'http://' : 'https://s3.amazonaws.com/') + 'e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png"); background-position: 0 -96px; }');
+				RESUtils.addCSS('#RESAccountSwitcherIconOverlay .downArrow { margin-top: 6px; margin-left: 3px; display: inline-block; width: 18px; height: 10px; background-image: url("https://s3.amazonaws.com/e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png"); background-position: 0 -96px; }');
 				// this.alienIMG = '<span class="downArrow"></span>';
 			}
 			// RESUtils.addCSS('#RESAccountSwitcherIconOverlay { display: none; position: absolute; }');
@@ -15604,8 +15604,8 @@ modules['filteReddit'] = {
 	},
 	beforeLoad: function() {
 		if (this.isEnabled()) {
-			RESUtils.addCSS('.RESFilterToggle { margin-right: 5px; color: white; background-image: url(//redditstatic.s3.amazonaws.com/bg-button-add.png); cursor: pointer; text-align: center; width: 68px; font-weight: bold; font-size: 10px; border: 1px solid #444; padding: 1px 6px; border-radius: 3px 3px 3px 3px;  }');
-			RESUtils.addCSS('.RESFilterToggle.remove { background-image: url(//redditstatic.s3.amazonaws.com/bg-button-remove.png) }');
+			RESUtils.addCSS('.RESFilterToggle { margin-right: 5px; color: white; background-image: url(https://redditstatic.s3.amazonaws.com/bg-button-add.png); cursor: pointer; text-align: center; width: 68px; font-weight: bold; font-size: 10px; border: 1px solid #444; padding: 1px 6px; border-radius: 3px 3px 3px 3px;  }');
+			RESUtils.addCSS('.RESFilterToggle.remove { background-image: url(https://redditstatic.s3.amazonaws.com/bg-button-remove.png) }');
 			RESUtils.addCSS('.RESFiltered { display: none !important; }');
 			if (this.options.NSFWfilter.value && this.isEnabled() && this.isMatchURL()) {
 				this.addNSFWFilterStyle();
@@ -16377,8 +16377,8 @@ modules['commentNavigator'] = {
 			RESUtils.addCSS('.commentarea .menuarea { margin-right: 0; }');
 			RESUtils.addCSS('.menuarea > .spacer { margin-right: 0; }');
 			RESUtils.addCSS('#commentNavButtons { margin: auto; }');
-			RESUtils.addCSS('#commentNavUp { margin: auto; cursor: pointer; background-image: url("' + (location.protocol == "http:" ? 'http://' : 'https://s3.amazonaws.com/') + 'e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png"); width: 32px; height: 20px; background-position: 0 -224px; }');
-			RESUtils.addCSS('#commentNavDown { margin: auto; cursor: pointer; background-image: url("' + (location.protocol == "http:" ? 'http://' : 'https://s3.amazonaws.com/') + 'e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png"); width: 32px; height: 20px; background-position: 0 -244px; }');
+			RESUtils.addCSS('#commentNavUp { margin: auto; cursor: pointer; background-image: url("https://s3.amazonaws.com/e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png"); width: 32px; height: 20px; background-position: 0 -224px; }');
+			RESUtils.addCSS('#commentNavDown { margin: auto; cursor: pointer; background-image: url("https://s3.amazonaws.com/e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png"); width: 32px; height: 20px; background-position: 0 -244px; }');
 			RESUtils.addCSS('#commentNavUp.noNav { background-position: 0 -264px; }');
 			RESUtils.addCSS('#commentNavDown.noNav { background-position: 0 -284px; }');
 			RESUtils.addCSS('#commentNavButtons { display: none; margin-left: 12px; text-align: center; user-select: none; -webkit-user-select: none; -moz-user-select: none; }');
@@ -16896,12 +16896,12 @@ modules['subredditManager'] = {
 			RESUtils.addCSS('#RESShortcutsSort { font-size: 14px; }')
 			RESUtils.addCSS('#RESShortcutsTrash { display: none; font-size: 17px; width: 16px; cursor: pointer; right: 15px; height: 16px; position: absolute; top: 0; z-index: 1000; user-select: none; -webkit-user-select: none; -moz-user-select: none; }');
 			RESUtils.addCSS('.srSep { margin-left: 6px; }');
-			RESUtils.addCSS('.RESshortcutside { margin-right: 5px; margin-top: 2px; color: white; background-image: url(//redditstatic.s3.amazonaws.com/bg-button-add.png); cursor: pointer; text-align: center; width: 68px; font-weight: bold; font-size: 10px; border: 1px solid #444; padding: 1px 6px; border-radius: 3px 3px 3px 3px; }');
-			RESUtils.addCSS('.RESshortcutside.remove { background-image: url(//redditstatic.s3.amazonaws.com/bg-button-remove.png) }');
+			RESUtils.addCSS('.RESshortcutside { margin-right: 5px; margin-top: 2px; color: white; background-image: url(https://redditstatic.s3.amazonaws.com/bg-button-add.png); cursor: pointer; text-align: center; width: 68px; font-weight: bold; font-size: 10px; border: 1px solid #444; padding: 1px 6px; border-radius: 3px 3px 3px 3px; }');
+			RESUtils.addCSS('.RESshortcutside.remove { background-image: url(https://redditstatic.s3.amazonaws.com/bg-button-remove.png) }');
 			RESUtils.addCSS('.RESshortcutside:hover { background-color: #f0f0ff; }');
 			// RESUtils.addCSS('h1.redditname > a { float: left; }');
 			RESUtils.addCSS('h1.redditname { overflow: auto; }');
-			RESUtils.addCSS('.sortAsc, .sortDesc { float: right; background-image: url("' + (location.protocol == "http:" ? 'http://' : 'https://s3.amazonaws.com/') + 'e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png"); width: 12px; height: 12px; background-repeat: no-repeat; }');
+			RESUtils.addCSS('.sortAsc, .sortDesc { float: right; background-image: url("https://s3.amazonaws.com/e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png"); width: 12px; height: 12px; background-repeat: no-repeat; }');
 			RESUtils.addCSS('.sortAsc { background-position: 0 -149px; }');
 			RESUtils.addCSS('.sortDesc { background-position: -12px -149px; }');
 			RESUtils.addCSS('#RESShortcutsAddFormContainer { display: none; position: absolute; width: 290px; padding: 2px; right: 0; top: 21px; z-index: 10000; background-color: #f0f3fc; border: 1px solid #c7c7c7; border-radius: 3px; font-size: 12px; color: #000; }');
@@ -19542,8 +19542,8 @@ modules['dashboard'] = {
 	go: function() {
 		if (this.isEnabled()) {
 			this.getLatestWidgets();
-			RESUtils.addCSS('.RESDashboardToggle { margin-right: 5px; color: white; background-image: url(//redditstatic.s3.amazonaws.com/bg-button-add.png); cursor: pointer; text-align: center; width: 68px; font-weight: bold; font-size: 10px; border: 1px solid #444; padding: 1px 6px; border-radius: 3px 3px 3px 3px;  }');
-			RESUtils.addCSS('.RESDashboardToggle.remove { background-image: url(//redditstatic.s3.amazonaws.com/bg-button-remove.png) }');
+			RESUtils.addCSS('.RESDashboardToggle { margin-right: 5px; color: white; background-image: url(https://redditstatic.s3.amazonaws.com/bg-button-add.png); cursor: pointer; text-align: center; width: 68px; font-weight: bold; font-size: 10px; border: 1px solid #444; padding: 1px 6px; border-radius: 3px 3px 3px 3px;  }');
+			RESUtils.addCSS('.RESDashboardToggle.remove { background-image: url(https://redditstatic.s3.amazonaws.com/bg-button-remove.png) }');
 			if (this.isMatchURL()) {
 				$('#RESDropdownOptions').prepend('<li id="DashboardLink"><a href="/r/Dashboard">my dashboard</a></li>');
 				if (RESUtils.currentSubreddit()) {
@@ -19615,7 +19615,7 @@ modules['dashboard'] = {
 		RESUtils.addCSS('ul.widgetStateButtons li.minimize, ul.widgetStateButtons li.close { font-size: 24px; }');
 		RESUtils.addCSS('.minimized ul.widgetStateButtons li.minimize { font-size: 14px; }');
 		RESUtils.addCSS('ul.widgetStateButtons li.refresh { margin-left: 3px; width: 24px; position:relative; padding: 0; }');
-		RESUtils.addCSS('ul.widgetStateButtons li.refresh div { height: 16px; width: 16px; position: absolute; left: 4px; top: 4px; background-image: url(\'' + (location.protocol == "http:" ? 'http://' : 'https://s3.amazonaws.com/') + 'e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png\'); background-repeat: no-repeat; background-position: -16px -209px; }');
+		RESUtils.addCSS('ul.widgetStateButtons li.refresh div { height: 16px; width: 16px; position: absolute; left: 4px; top: 4px; background-image: url("https://s3.amazonaws.com/e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png"); background-repeat: no-repeat; background-position: -16px -209px; }');
 		RESUtils.addCSS('#userTaggerContents .show { display: inline-block; }');
 		RESUtils.addCSS('#tagPageControls { display: inline-block; position: relative; top: 9px;}');
 
@@ -21720,7 +21720,7 @@ modules['snoonet'] = {
 	beforeLoad: function() {
 		// TODO: maybe don't depend on their sprite sheet?
 		var css = '.icon-menu #enableSnoonet:before {';
-		css += 'background-image: url(//redditstatic.s3.amazonaws.com/sprite-reddit.hV9obzo72Pc.png);';
+		css += 'background-image: url(https://redditstatic.s3.amazonaws.com/sprite-reddit.hV9obzo72Pc.png);';
 		css += 'background-position: 0px -708px;';
 		css += 'background-repeat: no-repeat;';
 		css += 'height: 16px;';

--- a/lib/res.css
+++ b/lib/res.css
@@ -77,7 +77,7 @@
 	display: inline-block;
 	width: 15px;
 	height: 15px;
-	background-image: url('//s3.amazonaws.com/e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png');
+	background-image: url('https://s3.amazonaws.com/e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png');
 	background-repeat: no-repeat;
 	background-position: 0 -209px;
 }
@@ -264,7 +264,7 @@
 	background-color: white !important;
 }
 #RESHelp {
-	background-image: url("//s3.amazonaws.com/e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png");
+	background-image: url("https://s3.amazonaws.com/e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png");
 	background-position: -16px -120px;
 	margin-right: 8px;
 	width: 16px;
@@ -982,7 +982,7 @@ img {
 	max-width: 23px;
 	max-height: 23px;
 	display: inline-block;
-	background-image: url('//s3.amazonaws.com/e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png');
+	background-image: url('https://s3.amazonaws.com/e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png');
 	margin-right: 6px;
 	cursor: pointer; 
 	padding: 0;
@@ -1011,7 +1011,7 @@ img {
 .RESdupeimg { color: #000; font-size: 10px;  }
 .RESClear { clear: both; margin-bottom: 10px;  }
 
-.RESGalleryControls a { cursor: pointer; display: inline-block; background-image: url("//s3.amazonaws.com/e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png"); width: 16px; height: 16px; margin: 5px; }
+.RESGalleryControls a { cursor: pointer; display: inline-block; background-image: url("https://s3.amazonaws.com/e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png"); width: 16px; height: 16px; margin: 5px; }
 .RESGalleryControls span { position: relative; top: -9px; }
 .RESGalleryControls .previous { background-position: 0 -352px; }
 .RESGalleryControls .next { background-position: 16px -352px; }


### PR DESCRIPTION
`//` on Firefox translates into `resource://`, not `http(s)://`. This is why the expando button is not showing up on the latest repo version of RES.

Some of these are not strictly necessary (mainly the `img src` URLs and the CSS that we insert in res_user.js), but there's no harm in using all HTTPS.
