### PR TITLE
Update MediaCrush support

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -12709,7 +12709,7 @@ modules['showImages'] = {
 					return div;
 				};
 				var def = $.Deferred();
-				if (info.type == 'application/album') {
+				if (info.type === 'application/album') {
 					elem.type = 'MEDIACRUSH';
 					elem.expandoOptions = {
 						generate: generate,
@@ -12717,7 +12717,7 @@ modules['showImages'] = {
 						settings: info.settings,
 						media: info
 					};
-				} else if (info.blob_type == "video") {
+				} else if (info.blob_type === "video") {
 					elem.type = 'MEDIACRUSH';
 					elem.expandoOptions = {
 						generate: generate,
@@ -12725,7 +12725,7 @@ modules['showImages'] = {
 						settings: info.settings,
 						media: info
 					};
-				} else if (info.blob_type == "audio") {
+				} else if (info.blob_type === "audio") {
 					elem.type = 'MEDIACRUSH';
 					elem.expandoOptions = {
 						generate: generate,
@@ -12733,7 +12733,7 @@ modules['showImages'] = {
 						settings: info.settings,
 						media: info
 					};
-				} else if (info.blob_type == "image") {
+				} else if (info.blob_type === "image") {
 					elem.type = 'IMAGE';
 					elem.src = MediaCrush.domain + info.original;
 				}
@@ -23008,10 +23008,10 @@ window.MediaCrush = (function() {
 	}
 
 	var renderMedia = function(target, media, options, callback) {
-		if (media.blob_type == "video") {
+		if (media.blob_type === "video") {
 			var video = document.createElement('video');
-			video.loop = media.type == 'image/gif';
-			video.autoplay = media.type == 'image/gif';
+			video.loop = media.type === 'image/gif';
+			video.autoplay = media.type === 'image/gif';
 			video.controls = true;
 			// Set flags
 			if (media.flags) {
@@ -23020,20 +23020,22 @@ window.MediaCrush = (function() {
 				if (media.flags.mute) video.muted = media.flags.mute;
 			}
 			for (var i = 0; i < media.files.length; i++) {
-				if (media.files[i].type.indexOf('video/') != 0)
+				if (media.files[i].type.indexOf('video/') != 0) {
 					continue;
+				}
 				var source = document.createElement('source');
 				source.src = self.domain + media.files[i].file;
 				video.appendChild(source);
 			}
 			modules['showImages'].makeImageZoomable(video);
 			target.appendChild(video);
-		} else if (media.blob_type == "audio") {
+		} else if (media.blob_type === "audio") {
 			var audio = document.createElement('audio');
 			audio.controls = true;
 			for (var i = 0; i < media.files.length; i++) {
-				if (media.files[i].type.indexOf('audio/') != 0)
+				if (media.files[i].type.indexOf('audio/') != 0) {
 					continue;
+				}
 				var source = document.createElement('source');
 				source.src = self.domain + media.files[i].file;
 				audio.appendChild(source);


### PR DESCRIPTION
This makes a few changes:
- Rely on blob_type instead of user-supplied mimetype to figure out media type (i.e. video/audio/image)
- Set flags (like autoplay/loop) according to user-specified values. This is valuable, for example, if someone uploads an actual video and sets the flags so that it behaves like a GIF (autoplay+loop+mute).
- Fix issue with link on branding for albums
