### PR TITLE
Enable drag resizing for HTML5 video elements

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -11349,11 +11349,8 @@ modules['showImages'] = {
 			sourceEle.type = source.type;
 			$(video).append(sourceEle);
 		}
-		// store width to allow existing zoomable functionalty to work correcty.
-		video.addEventListener("loadedmetadata", function(){ video.width = video.videoWidth; });
-		imgDiv.appendChild(video);
 
-		modules['showImages'].makeImageZoomable(video);
+		imgDiv.appendChild(video);
 
 		if ('credits' in imageLink) {
 			var credits = document.createElement('div');
@@ -11686,7 +11683,11 @@ modules['showImages'] = {
 			imageTag.addEventListener('mouseup', modules['showImages'].dragImage, false);
 			imageTag.addEventListener('mousemove', modules['showImages'].dragImage, false);
 			imageTag.addEventListener('mouseout', modules['showImages'].mouseoutImage, false);
-			imageTag.addEventListener('click', modules['showImages'].clickImage, false);
+
+			// click event is unneeded for HTML5 video
+			if(imageTag.tagName !== 'VIDEO'){
+				imageTag.addEventListener('click', modules['showImages'].clickImage, false);
+			}
 		}
 	},
 	mousedownImage: function(e) {
@@ -11727,9 +11728,6 @@ modules['showImages'] = {
 		}
 	},
 	clickImage: function(e) {
-		// Click is not needed for HTML5 video
-		if(e.target.tagName === 'VIDEO') return;
-
 		modules['showImages'].dragTargetData.diagonal = 0;
 		if (modules['showImages'].dragTargetData.hasChangedWidth) {
 			modules['showImages'].dragTargetData.dragging = false;
@@ -11743,7 +11741,6 @@ modules['showImages'] = {
 		if (newWidth !== currWidth) {
 			modules['showImages'].dragTargetData.hasChangedWidth = true;
 
-			image.width = newWidth;
 			image.style.width = newWidth + 'px';
 			image.style.maxWidth = newWidth + 'px';
 			image.style.maxHeight = '';


### PR DESCRIPTION
Hello,

With the rise of things like gfycat, I've seen a number of people on reddit noting that RES's standard drag re-size feature doesn't work with HTML5 video. Given how much i tend to use the drag resize feature myself, i thought i may as well have a go at adding it to RES.

I've attempted to keep my additional code to a minimum, so have reused the standard `makeImageZoomable` method, just making a couple of tweaks in order to get it to behave correctly with the HTML5 video (primary just down to video elements not making heights/widths available in the standard ways). The one bit I'm not too happy with (as its a bit of a workaround) is my method of keeping the standard video controls working as expected, since i couldn't find a better way to achieve this (without having to add custom controls) other than simply making the drag script ignore events fired from the bottom 40px of the video element (enough to fit the controls in chrome and firefox ).

I'm hoping others beside myself will find this feature useful, and I'm open to any feedback / ideas on how to improve this functionality. 

Thanks,
Carl
