### PR TITLE
No Comment-Tools in share page

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -9740,7 +9740,7 @@ modules['commentTools'] = {
 	},
 	attachCommentTools: function(elem) {
 		if (elem == null) elem = document.body;
-		$(elem).find("textarea[name]").each(modules["commentTools"].attachEditorToUsertext);
+		$(elem).find("textarea[name][name!=share_to][name!=message]").each(modules["commentTools"].attachEditorToUsertext);
 	},
 	getFieldLimit: function(name) {
 		switch (name) {


### PR DESCRIPTION
Don't attach comment tools when the name of the text area is
"share_to"(used for email or username) or "message"(used for message).
This prevents the comment tools from being displayed on the share page.
This fixes #638.
