### PR TITLE
Fully remove Greasemonkey support

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -612,46 +612,9 @@ if (BrowserDetect.isOpera()) {
 
 
 
-// GreaseMonkey API compatibility for non-GM browsers (Chrome, Safari, Firefox)
-// @copyright      2009, 2010 James Campos
-// @modified		2010 Steve Sobel - added some missing gm_* functions
-// @license        cc-by-3.0; http://creativecommons.org/licenses/by/3.0/
-if ((typeof GM_deleteValue === 'undefined') || (typeof GM_addStyle === 'undefined')) {
-	GM_addStyle = function(css) {
-		var style = document.createElement('style');
-		style.textContent = css;
-		var head = document.getElementsByTagName('head')[0];
-		if (head) {
-			head.appendChild(style);
-		}
-	};
-
-	GM_deleteValue = function(name) {
-		localStorage.removeItem(name);
-	};
-
-	GM_getValue = function(name, defaultValue) {
-		var value = localStorage.getItem(name);
-		if (!value)
-			return defaultValue;
-		var type = value[0];
-		value = value.substring(1);
-		switch (type) {
-			case 'b':
-				return value === 'true';
-			case 'n':
-				return Number(value);
-			default:
-				return value;
-		}
-	};
-
-	GM_setValue = function(name, value) {
-		value = (typeof value)[0] + value;
-		localStorage.setItem(name, value);
-	};
-
-	if (BrowserDetect.browser === "Explorer") {
+// GM_xmlhttpRequest for non-GM browsers
+if (typeof GM_xmlhttpRequest === 'undefined') {
+	if (BrowserDetect.browser === 'Explorer') {
 		GM_xmlhttpRequest = function(obj) {
 			var request,
 				crossDomain = (obj.url.indexOf(location.hostname) === -1);
@@ -1440,6 +1403,14 @@ var RESUtils = {
 			if ((obj[i]) && (obj[i].value == value)) {
 				obj[i].selected = true;
 			}
+		}
+	},
+	addStyle: function(css) {
+		var style = document.createElement('style');
+		style.textContent = css;
+		var head = document.getElementsByTagName('head')[0];
+		if (head) {
+			head.appendChild(style);
 		}
 	},
 	stripHTML: function(str) {
@@ -2817,10 +2788,9 @@ var gdAlert = {
 			'background-color: #333333; z-index: 100000200;' +
 			'}';
 
-		GM_addStyle(alertCSS);
+		RESUtils.addStyle(alertCSS);
 
 		gdAlert.populateContainer(callback);
-
 	},
 
 	populateContainer: function(callback) {
@@ -10228,7 +10198,7 @@ modules['usernameHider'] = {
 		if ((this.isEnabled()) && (this.isMatchURL())) {
 			if (this.tryAgain && RESUtils.loggedInUser()) {
 				this.hideUsername();
-				GM_addStyle(RESUtils.css);
+				RESUtils.addStyle(RESUtils.css);
 			}
 		}
 	},
@@ -15214,7 +15184,7 @@ modules['accountSwitcher'] = {
 				this.accountMenu.on('mouseleave', function() {
 					modules['accountSwitcher'].toggleAccountMenu(false);
 				});
-				// GM_addStyle(css);
+				// RESUtils.addStyle(css);
 				var accounts = this.options.accounts.value;
 				if (accounts !== null) {
 					var accountCount = 0;
@@ -21978,7 +21948,7 @@ function RESdoBeforeLoad() {
 		}
 	}
 	// apply style...
-	GM_addStyle(RESUtils.css);
+	RESUtils.addStyle(RESUtils.css);
 	// clear out css cache...
 	RESUtils.css = '';
 }
@@ -22085,7 +22055,7 @@ function RESInit() {
 					// console.log(thisModuleID + ' end: ' + Date());
 				}
 			}
-			GM_addStyle(RESUtils.css);
+			RESUtils.addStyle(RESUtils.css);
 			//	console.log('end: ' + Date());
 		}
 		if ((location.href.indexOf('reddit.honestbleeps.com/download') !== -1)


### PR DESCRIPTION
This is a complete pull request for fully removing Greasemonkey support from RES.

**TODO:**
- <del>Replace/rename the Greasemonkey API functions with standard functions, likely under `RESUtils`.</del>
- <del>Refactor the `postMessage`-related functions into a standard function under `RESUtils`.</del>
