### PR TITLE
Youtube expando module (comments only)

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -2652,7 +2652,7 @@ modules['showImages'] = {
 				if (!groups) groups = altHashRe.exec(elem.href);
 
 				if (groups) {
-					def.resolve(elem, '//www.youtube.com/embed/' + groups[1]);
+					def.resolve(elem, '//www.youtube.com/embed/' + groups[1] + '?autoplay=1&enablecastapi=1');
 				} else {
 					def.reject();
 				}


### PR DESCRIPTION
Hello,

Was playing around with creating a youtube (possibly other flash video site) expando for reddit comments. 
Looking around it seems most of the big video sites offer their embeds via iframe, so for i opted for that rather than creating a true flash embed.

Whats everyones thoughts on this? useful/not useful 

Edit: Have added support for "m.youtube" and "youtu.be" links + matched the iframe size to reddits own.
