### PR TITLE
after inserting macro, put cursor/selection somewhere logical

### DIFF
--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -706,7 +706,7 @@ modules['commentTools'] = {
 
 		box.value = beforeSelection + prefix + selectedText + suffix + trailingSpace + afterSelection;
 
-		box.selectionEnd = box.value.length - afterSelection.length;
+		box.selectionEnd = beforeSelection.length + prefix.length + selectedText.length;
 		if (selectionStart === selectionEnd) {
 			box.selectionStart = box.selectionEnd;
 		} else {


### PR DESCRIPTION
It looks like I broke this when I upgraded macros, so I think this restores it to something sane.

If the user selected text before inserting a macro, then highlight the inserted macro text.  
If the user had not selected text, put the cursor after the inserted macro text.  
If the user had not selected text and used a comment formatter like **bold**, put the cursor inside the formatting marks.
