### PR TITLE
Expando support for soundCloud

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -2721,6 +2721,53 @@ modules['showImages'] = {
 				return $.Deferred().resolve(elem).promise();
 			}
 		},
+		soundcloud: {
+			options: {
+				'display soundcloud': {
+					description: 'Display expander for soundcloud',
+					value: true,
+					type: 'boolean'
+				}
+			},
+			go: function() {},
+			detect: function(elem) {
+				var href = elem.href.toLowerCase();
+				if (href.indexOf('soundcloud.com') !== -1) {
+					if (elem.className.indexOf("title") === -1) return true;
+				}
+				return false ;
+			},
+			handleLink: function(elem) {
+				var def = $.Deferred();
+				var apiURL = 'http://soundcloud.com/oembed?url=' +encodeURIComponent(elem.href)+ '&format=json&iframe=true';
+				GM_xmlhttpRequest({
+					method: 'GET',
+					url: apiURL,
+					// aggressiveCache: true,
+					onload: function(response) {
+						try {
+							def.resolve(elem, JSON.parse(response.responseText) );
+						} catch (error) {
+							def.reject();
+						}
+					},
+					onerror: function(response) {
+						def.reject();
+					}
+				});
+
+				return def.promise();
+			},
+			handleInfo: function(elem, info) {
+				// Get src from iframe html returned
+				var src = $(info.html).attr("src");
+				elem.type = 'IFRAME';
+				elem.setAttribute("data-embed", src);
+				elem.setAttribute("data-pause", '{"method":"pause"}');
+				elem.setAttribute("data-play", '{"method":"play"}');
+				return $.Deferred().resolve(elem).promise();
+			}
+		},
 	}
 };
 


### PR DESCRIPTION
Hello,

A first pass at adding expando support for soundcloud.
Since the embed iframe url can't be calculated from the URL alone, I've used the oembed API in order to extract it.

Added on the basis of its position in this listing (11th most popular linked domain)
http://www.reddit.com/r/TheoryOfReddit/comments/1by2yv/top_100_external_domains_submitted_to_reddit_as/

Thanks,
Carl
