### PR TITLE
Added imgflip.com support for inline image viewer

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -2367,6 +2367,34 @@ modules['showImages'] = {
 				modules['showImages'].createImageExpando(elem);
 			}
 		},
+		imgflip: {
+			options: {
+				'display imgflip': {
+					description: 'Display expander for imgflip',
+					value: true,
+					type: 'boolean'
+				}
+			},
+			go: function() {},
+			detect: function(elem) {
+				return /^https?:\/\/imgflip\.com\/(i|gif)\/[a-z0-9]+/.test(elem.href);
+			},
+			handleLink: function(elem) {
+				var def = $.Deferred();
+				var groups = /^https?:\/\/imgflip\.com\/(i|gif)\/([a-z0-9]+)/.exec(elem.href);
+				def.resolve(elem, '//i.imgflip.com/' + groups[2] + '.' + (groups[1] === 'gif' ? 'gif' : 'jpg'));
+				return def.promise();
+			},
+			handleInfo: function(elem, info) {
+				elem.type = 'IMAGE';
+				elem.src = info;
+				elem.href = elem.src;
+				if (RESUtils.pageType() === 'linklist') {
+					$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
+				}
+				return $.Deferred().resolve(elem).promise();
+			}
+		},
 		mediacrush: {
 			options: {
 				'display mediacrush': {


### PR DESCRIPTION
disclaimer: I run imgflip.com

Thanks in advance for reviewing this! I tried to make this as minimal as possible. It appears that adding support for new sites still adds processing time at O(n), but I tested this regex speed in chrome, and it looks like you'd have to run it on 1000 URLs before hitting 1ms added time, regardless of URL length.

This was a good excuse to change imgflip GIF pages to use /gif/ instead of /i/, so they can be identified easier. I didn't want to add any API calls or image.onerror handlers to RES just to determine what extension the image had.
