### PR TITLE
Quick MediaCrush fix

### DIFF
--- a/lib/mediacrush.js
+++ b/lib/mediacrush.js
@@ -92,7 +92,7 @@ window.MediaCrush = (function() {
 		image.style.maxWidth = modules['showImages'].options.maxWidth.value + 'px';
 		image.style.maxHeight = modules['showImages'].options.maxHeight.value + 'px';
 
-		image.src = self.domain + media.files[0].file;
+		image.src = media.files[0].url;
 		modules['showImages'].makeImageZoomable(image);
 		link.appendChild(image);
 		target.appendChild(link);
@@ -115,7 +115,7 @@ window.MediaCrush = (function() {
 					continue;
 				}
 				var source = document.createElement('source');
-				source.src = self.domain + media.files[i].file;
+				source.src = media.files[i].url;
 				video.appendChild(source);
 			}
 			modules['showImages'].makeImageZoomable(video);
@@ -128,7 +128,7 @@ window.MediaCrush = (function() {
 					continue;
 				}
 				var source = document.createElement('source');
-				source.src = self.domain + media.files[i].file;
+				source.src = media.files[i].url;
 				audio.appendChild(source);
 			}
 			target.appendChild(audio);


### PR DESCRIPTION
`url` will use the link from the CDN, `file` uses the link on MediaCrush directly. CDN is faster.
