### PR TITLE
add node_modules/ directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@
 *.cachefile
 
 ## General
+/node_modules
 Chrome.pem
 /XPI/reddit_res.xpi
 


### PR DESCRIPTION
Not sure why node_modules isn't ignored, but I believe it should be
