### PR TITLE
Exclude MediaCrush from default showImage expando

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1429,7 +1429,7 @@ modules['showImages'] = {
 	siteModules: {
 		'default': {
 			acceptRegex: /^[^#]+?\.(gif|jpe?g|png)(?:[?&#_].*|$)/i,
-			rejectRegex: /(wikipedia\.org\/wiki|photobucket\.com|gifsound\.com|\/wiki\/File:.*)/i,
+			rejectRegex: /(wikipedia\.org\/wiki|photobucket\.com|gifsound\.com|mediacru\.sh|\/wiki\/File:.*)/i,
 			go: function() {},
 			detect: function(elem) {
 				var siteMod = modules['showImages'].siteModules['default'];


### PR DESCRIPTION
Prevents the default from taking over MediaCrush URLs that end in ".gif" or whatever.
