### PR TITLE
Update to batch css icons, fix hotlink case

### DIFF
--- a/lib/gfycat.js
+++ b/lib/gfycat.js
@@ -93,20 +93,16 @@
         function pauseClick() {
             if (vid.paused) {
                 vid.play();
-                ctrlPausePlay.style.backgroundPosition = '-95px 0';
-                ctrlSlower.style.backgroundPosition = '-165px 0';
-                ctrlFaster.style.backgroundPosition = '-20px 0';
-                ctrlFaster.style.width = "14px";
-                ctrlSlower.style.marginLeft = "0px";
+		ctrlPausePlay.innerHTML="&#xf16c;";
+                ctrlSlower.innerHTML="&#xf14d;";
+                ctrlFaster.innerHTML="&#xf14c;"
                 ctrlSlower.onclick = slower;
                 ctrlFaster.onclick = faster;
             } else {
                 vid.pause();
-                ctrlPausePlay.style.backgroundPosition = '-71px 0';
-                ctrlSlower.style.backgroundPosition = '0 0';
-                ctrlSlower.style.marginLeft = "6px";
-                ctrlFaster.style.backgroundPosition = '-192px 0';
-                ctrlFaster.style.width = "8px";
+		ctrlPausePlay.innerHTML="&#xf16b;";
+                ctrlSlower.innerHTML="&#xf168;";
+                ctrlFaster.innerHTML="&#xf16e;"
                 ctrlSlower.onclick = stepBackward;
                 ctrlFaster.onclick = stepForward;
             }
@@ -131,12 +127,12 @@
             if (isReverse) {
                 mp4src.src = mp4src.src.replace(/-reverse\.mp4/g, ".mp4");
                 webmsrc.src = webmsrc.src.replace(/-reverse\.webm/g, ".webm");
-                ctrlReverse.style.backgroundPosition = '-46px 0';
+		ctrlReverse.innerHTML="&#xf169;";
                 isReverse = false;
             } else {
                 mp4src.src = mp4src.src.replace(/\.mp4/g, "-reverse.mp4");
                 webmsrc.src = webmsrc.src.replace(/\.webm/g, "-reverse.webm");
-                ctrlReverse.style.backgroundPosition = '-141px 0';
+		ctrlReverse.innerHTML="&#xf16d;";
                 isReverse = true;
             }
             vid.load();

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1046,10 +1046,6 @@ modules['showImages'] = {
 		imgDiv.appendChild(element);
 		wrapperDiv.appendChild(imgDiv);
 
-		if (options.media.blob_type === 'video') {
-			element.addEventListener('click', modules['showImages'].handleVideoClick);
-		}
-
 		expandoButton.addEventListener('click', function(e) {
 			if (options.media.blob_type === 'video' || options.media.blob_type === 'audio') {
 				var media = wrapperDiv.querySelector('video, audio');
@@ -1086,16 +1082,12 @@ modules['showImages'] = {
 		// video, but e.target and e.currentTarget still point to the video
 		// and not the controls... yuck.
 		// 
-		var video = (e.target.tagName === 'VIDEO') ? e.target : e.target.querySelector('video');
-		if (!video || modules['showImages'].dragTargetData.hasChangedWidth) {
-			return;
-		}
-
-		if (video.paused) {
-			video.play();
-		} else {
-			video.pause();
-		}
+		// if (e.target.paused) {
+		//     e.target.play();
+		// }
+		// else {
+		//     e.target.pause();
+		// }
 	},
 	generateNoEmbedExpando: function(expandoButton) {
 		var imageLink = expandoButton.imageLink,
@@ -1611,11 +1603,8 @@ modules['showImages'] = {
 				if (!groups) return def.reject();
 				var href = elem.href.toLowerCase();
 				var hotLink = false;
-				if (href.indexOf('giant.gfycat') !== -1 ||
-					href.indexOf('fat.gfycat') !== -1 ||
-					href.indexOf('zippy.gfycat') !== -1)
-					hotLink = true;
-
+				if(href.match(/(giant|fat|zippy)*.gif/g))
+				        hotLink = true;
 				var siteMod = modules['showImages'].siteModules['gfycat'];
 				var apiURL = 'http://gfycat.com/cajax/get/' + groups[1];
 
@@ -1681,9 +1670,8 @@ modules['showImages'] = {
 						autoplay: true,
 						muted: true,
 						directurl: elem.href,
-						placeholder: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==	',
-						controlimg: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAAAMCAQAAACNKDq3AAAAAmJLR0QAAKqNIzIAAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQfeAgsFLjEVM8hjAAAAHWlUWHRDb21tZW50AAAAAABDcmVhdGVkIHdpdGggR0lNUGQuZQcAAALsSURBVFjDzVY/TBNRGP9dr4dIU66WdPhY0ITBQdvidSJYjs3RxAWn0wFXIXEzRhcHY4yE4CKDODgaiZMbbdIRW8DF5C4hLtfBBCH8USPkObSPe17oe4+oKd8bvi/N9/1+7/1+fS8HYsQAACCbGpAGgQCQR8u0Qd9omTz+myoibBULbdA4TklQg+x4pdbnT4XU+nBsGiJGzHAY8NEAyDar2cK6IRt1ENqo9BX7YMLAAfaxvwo3t72utINjq1mKbAs/lzDd/KIpGgOApsGzXr8YnWfybHPtcLy5LVayyGMTh8coJJ/j2Ky39B1IiJJZyuOb1Vwxgx6YSKAHGeSKZtXSssPSZDExgOx1a40e6hkyiEEMClmvX1ydw0K2YFbJFivI+49VSDlVMKtkGz+AtiG6doQe71qZWJngYKH37+xoRS8G7PQjanT/8TqpJV+9+AktZAvk6bK0DdEV6twd3lWqlCocbGBSxw59lta20sgVz1Tolc7b/f8ticumVkhEkCkUZ0kCgK5Q1uXW7QBKPC8DVl4yMZc5wta34+gg2L+1M4Hz3bckqrbm4OkoxEOlUJwlCQCZYG9YZ2tn936lAX43xit7rX9zf+eJN/P3Rzm2LosYwx8eP8t3+90Sdp4JXsxfVSrElQFSSoXiLAkAmJ1KBTojPSEAhCxkAOC3c9rvPDHWiLB1WXikgsnp9zOXK922IxXMTkXVWEOtkM/C9vKVCsVZEgAwUtMT68IS/04R89C7zhPGQYStywIA5u6V+erNe6+Nz8ZB9+0YqUWVfD+RQuI3nEyhOEsiLpssFhd4D78lQCpYXJDNRNi6LECu9uD2yyfGirF1Gm5HywQdO0SFRAy5QjFshzkMAFiy7pYVV8tB3S37DotW2a+7ZeWxWthk67CMNp/eZZdYr65kzGUuc6Os1y+uzr1lv+6yJEA2r+RRRv1YhRRTR9gOc5hxsn8MS6I4c+PTtZ3h5G5/cLH2/C1Wu/2onK74W4V+AwA0aeG8nbMTAAAAAElFTkSuQmCC'
 					};
+					video.poster = 'http://thumbs.gfycat.com/'+info.gfyName+'-poster.jpg';
 					video.sources = [
 						{
 							'source': info.webmUrl,
@@ -1701,7 +1689,6 @@ modules['showImages'] = {
 					modules['showImages'].makeImageZoomable(element.querySelector('video'));
 					return element;
 				};
-
 				elem.type = 'GENERIC_EXPANDO';
 				elem.expandoClass = ' video collapsed';
 				elem.expandoOptions = {

--- a/lib/players.css
+++ b/lib/players.css
@@ -294,3 +294,14 @@
 		.res-player { position: relative; display: inline-block; width: auto; max-width: 100%; }
 		.res-player video { max-width: 100%; }
 		.res-player.fullscreen, .res-player.fullscreen video { max-width: none; }
+
+
+	.res-lightweight-player-controls {
+		cursor: default;
+		float: right;
+		font-size: 12px;
+		margin-right: 5px;
+		-webkit-user-select: none;
+		-moz-user-select: none;
+		user-select: none;
+	}

--- a/lib/templates.html
+++ b/lib/templates.html
@@ -168,7 +168,7 @@
 		<script id="GfycatUI" type="application/x-template">
 			<div class="res-player video gfycatR">
 				<a class="madeVisible" href="{{ directurl }}" target="_blank">
-				<video autoplay loop muted preload title="Drag to Resize" class="gfyRVid" >
+				<video autoplay loop muted preload title="Drag to Resize" class="gfyRVid" poster="{{ poster }}"">
 					{{#sources}}
 					<source src="{{ source }}" {{#type}}type="{{ type }}"{{/type}} class="{{ class }}">
 					{{/sources}}
@@ -176,10 +176,10 @@
 				</a>
 				<div style="height: 35px;" class="ctrlContainer">
 					<div style="width: 90px; height: 25px; float: right; padding: 5px; display: none;" class="ctrlBox">
-						<img src="{{ placeholder }}"  class="gfyRCtrlFaster" style="float: right; margin-right: 5px; width: 14px; height: 12px; background:url('{{ controlimg }}') -20px 0; border: none;"/>
-						<img src="{{ placeholder }}"  class="gfyRCtrlSlower" style="float: right; margin-right: 5px; width: 14px; height: 12px; background:url('{{ controlimg }}') -165px 0; border: none;"/>
-						<img src="{{ placeholder }}"  class="gfyRCtrlReverse" style="float: right; margin-right: 5px; width: 14px; height: 12px; background:url('{{ controlimg }}') -46px 0; border: none;"/>					
-						<img src="{{ placeholder }}"  class="gfyRCtrlPause" style="float: right; margin-right: 5px; width: 12px; height: 12px; background:url('{{ controlimg }}') -95px 0; border: none;"/>
+						<div  class="res-icon res-lightweight-player-controls gfyRCtrlFaster" >&#xf14c;</div>
+						<div  class="res-icon res-lightweight-player-controls gfyRCtrlSlower" >&#xf14d;</div>
+						<div  class="res-icon res-lightweight-player-controls gfyRCtrlReverse" style="margin-right: 6px;">&#xf169;</div>					
+						<div  class="res-icon res-lightweight-player-controls gfyRCtrlPause" style="marginright: 4px;">&#xf16c;</div>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Updated player to use Batch css icons for controls.  

Fixed issue where hotlinks to video files were put in img tags (this replaced PR #794 which I will now delete).  

This looks great to me.  But let me know if any changes will help it live in the RES ecosystem better and I can update the code.  
