### PR TITLE
Add image move support

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -219,6 +219,26 @@ modules['keyboardNav'] = {
 			value: [189, false, false, true], // shift--
 			description: 'Increase the size of image(s) in the highlighted post area (finer control)'
 		},
+		imageMoveUp: {
+			type: 'keycode',
+			value: [38, false, false, true], // shift-up
+			description: 'Move the image(s) in the highlighted post area up'
+		},
+		imageMoveDown: {
+			type: 'keycode',
+			value: [40, false, false, true], // shift-down
+			description: 'Move the image(s) in the highlighted post area down'
+		},
+		imageMoveLeft: {
+			type: 'keycode',
+			value: [37, false, false, true], // shift-left
+			description: 'Move the image(s) in the highlighted post area left'
+		},
+		imageMoveRight: {
+			type: 'keycode',
+			value: [39, false, false, true], // shift-right
+			description: 'Move the image(s) in the highlighted post area right'
+		},
 		previousGalleryImage: {
 			type: 'keycode',
 			value: [219, false, false, false], // [
@@ -844,6 +864,18 @@ modules['keyboardNav'] = {
 						case RESUtils.checkKeysForEvent(e, this.options.imageSizeDownFine.value):
 							this.imageSizeDown(true);
 							break;
+						case RESUtils.checkKeysForEvent(e, this.options.imageMoveUp.value):
+							this.imageMoveUp();
+							break;
+						case RESUtils.checkKeysForEvent(e, this.options.imageMoveDown.value):
+							this.imageMoveDown();
+							break;
+						case RESUtils.checkKeysForEvent(e, this.options.imageMoveLeft.value):
+							this.imageMoveLeft();
+							break;
+						case RESUtils.checkKeysForEvent(e, this.options.imageMoveRight.value):
+							this.imageMoveRight();
+							break;
 						case RESUtils.checkKeysForEvent(e, this.options.previousGalleryImage.value):
 							this.previousGalleryImage();
 							break;
@@ -995,6 +1027,18 @@ modules['keyboardNav'] = {
 							break;
 						case RESUtils.checkKeysForEvent(e, this.options.imageSizeDownFine.value):
 							this.imageSizeDown(true);
+							break;
+						case RESUtils.checkKeysForEvent(e, this.options.imageMoveUp.value):
+							this.imageMoveUp();
+							break;
+						case RESUtils.checkKeysForEvent(e, this.options.imageMoveDown.value):
+							this.imageMoveDown();
+							break;
+						case RESUtils.checkKeysForEvent(e, this.options.imageMoveLeft.value):
+							this.imageMoveLeft();
+							break;
+						case RESUtils.checkKeysForEvent(e, this.options.imageMoveRight.value):
+							this.imageMoveRight();
 							break;
 						case RESUtils.checkKeysForEvent(e, this.options.nextGalleryImage.value):
 							this.nextGalleryImage();
@@ -1450,6 +1494,38 @@ modules['keyboardNav'] = {
 	imageSizeDown: function(fineControl) {
 		var factor = (fineControl) ? -50 : -150;
 		this.imageResize(factor);
+	},
+	imageMoveUp: function() {
+		this.imageMove(0, -50);
+	},
+	imageMoveDown: function() {
+		this.imageMove(0, 50);
+	},
+	imageMoveLeft: function() {
+		this.imageMove(-50, 0);
+	},
+	imageMoveRight: function() {
+		this.imageMove(50, 0);
+	},
+	imageMove: function(deltaX, deltaY) {
+		var images = $(document).find('.RESImage.loaded');
+		if(images.length == 0) {
+			return;
+		}
+		var mostVisible = -1;
+		var mostVisiblePercentage = 0;
+		for(var i = 0; i < images.length; i++) {
+			var percentageVisible = RESUtils.getPercentageVisibleYAxis(images[i]);
+			if(percentageVisible > mostVisiblePercentage) {
+				mostVisible = i;
+				mostVisiblePercentage = percentageVisible;
+			}
+		}
+        // Don't move any images if none are visible
+        if(mostVisible == -1) {
+            return false;
+        }
+		modules['showImages'].moveImage(images[mostVisible], deltaX, deltaY);
 	},
 	previousGalleryImage: function() {
 		var previousButton = this.keyboardLinks[this.activeIndex].querySelector('.RESGalleryControls .previous');

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -84,6 +84,11 @@ modules['showImages'] = {
 			value: true,
 			description: 'Allow dragging to resize/zoom images.'
 		},
+		imageMove: {
+			type: 'boolean',
+			value: true,
+			description: 'Allow dragging while holding shift to move images.'
+		},
 		markVisited: {
 			type: 'boolean',
 			value: true,
@@ -773,12 +778,13 @@ modules['showImages'] = {
 			image.classList.add('RESImage');
 			image.id = 'RESImage-' + RESUtils.randomHash();
 			image.src = sourceImage.src;
-			image.title = 'drag to resize';
+			image.title = 'drag to resize or shift+drag to move';
 			image.style.maxWidth = thisHandle.options.maxWidth.value + 'px';
 			image.style.maxHeight = thisHandle.options.maxHeight.value + 'px';
 			imageAnchor.appendChild(image);
 			modules['showImages'].setPlaceholder(image);
 			thisHandle.makeImageZoomable(image);
+			thisHandle.makeImageMovable(image);
 			thisHandle.trackImageLoad(imageLink, image);
 			paragraph.appendChild(imageAnchor);
 
@@ -1279,6 +1285,11 @@ modules['showImages'] = {
 		diagonal: 0, //zero to represent the state where no the mouse button is not down
 		dragging: false
 	},
+	moveTargetData: {
+		moving: false, // Whether the image should move with the mouse or not
+		mouseLastPos: [0, 0], // Last position of the mouse. Used to calculate deltaX and deltaY for our move.
+		hasMoved: false // If true we will stop click events on the image
+	},
 	getDragSize: function(e) {
 		var rc = e.target.getBoundingClientRect(),
 			p = Math.pow,
@@ -1334,20 +1345,50 @@ modules['showImages'] = {
 			}
 		}
 	},
+	makeImageMovable: function(imageTag) {
+		if (this.options.imageMove.value) {
+			// We can add duplicates safely without checking if makeImageZoomable already added them
+			// because duplicate EventListeners are discarded
+			// See: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget.addEventListener
+			imageTag.addEventListener('mousedown', modules['showImages'].mousedownImage, false);
+			// The click event fires after the mouseup event, and it is the click event that triggers link following.
+			// Therefore preventing this event and not mouseup.
+			// If we haven't moved we should not prevent the default behaviour
+			imageTag.addEventListener('click', function(e) {
+				if(modules['showImages'].moveTargetData.moving && modules['showImages'].moveTargetData.hasMoved) {
+					modules['showImages'].moveTargetData.moving = false;
+					e.preventDefault();
+				}
+			}, false);
+			imageTag.addEventListener('mousemove', modules['showImages'].checkMoveImage, false);
+			imageTag.addEventListener('mouseout', function(e) {
+				modules['showImages'].moveTargetData.moving = false;
+			}, false);
+			// Set this so the image is displayed above the "Set tag" buttons
+			imageTag.style.zIndex = 1;
+		}
+	},
 	mousedownImage: function(e) {
 		if (e.button === 0) {
-			if (e.target.tagName === 'VIDEO' && e.target.hasAttribute("controls")) {
-				var rc = e.target.getBoundingClientRect();
-				// ignore drag if click is in control area (40 px from bottom of video)
-				if ((rc.height - 40) < (e.clientY - rc.top)) {
-					return true;
-				} 
+			if(!e.shiftKey) {
+                if (e.target.tagName === 'VIDEO' && e.target.hasAttribute("controls")) {
+                    var rc = e.target.getBoundingClientRect();
+                    // ignore drag if click is in control area (40 px from bottom of video)
+                    if ((rc.height - 40) < (e.clientY - rc.top)) {
+                        return true;
+                    }
+                }
+				if (!e.target.minWidth) e.target.minWidth = Math.max(1, Math.min($(e.target).width(), 100));
+				modules['showImages'].dragTargetData.imageWidth = $(e.target).width();
+				modules['showImages'].dragTargetData.diagonal = modules['showImages'].getDragSize(e);
+				modules['showImages'].dragTargetData.dragging = false;
+				modules['showImages'].dragTargetData.hasChangedWidth = false;
+			} else {
+				// Record where the move began, both for the cursor and the image
+				modules['showImages'].moveTargetData.moving = true;
+				modules['showImages'].moveTargetData.hasMoved = false;
+				modules['showImages'].moveTargetData.mouseLastPos = [e.clientX, e.clientY];
 			}
-			if (!e.target.minWidth) e.target.minWidth = Math.max(1, Math.min($(e.target).width(), 100));
-			modules['showImages'].dragTargetData.imageWidth = $(e.target).width();
-			modules['showImages'].dragTargetData.diagonal = modules['showImages'].getDragSize(e);
-			modules['showImages'].dragTargetData.dragging = false;
-			modules['showImages'].dragTargetData.hasChangedWidth = false;
 			e.preventDefault();
 		}
 	},
@@ -1372,6 +1413,21 @@ modules['showImages'] = {
 		if (e.type === 'mouseup') {
 			modules['showImages'].dragTargetData.diagonal = 0;
 		}
+	},
+	checkMoveImage: function(e) {
+		if(modules['showImages'].moveTargetData.moving) {
+			var deltaX = e.clientX - modules['showImages'].moveTargetData.mouseLastPos[0],
+				deltaY = e.clientY - modules['showImages'].moveTargetData.mouseLastPos[1];
+			modules['showImages'].moveImage(e.target, deltaX, deltaY);
+
+			modules['showImages'].moveTargetData.mouseLastPos[0] = e.clientX;
+			modules['showImages'].moveTargetData.mouseLastPos[1] = e.clientY;
+			modules['showImages'].moveTargetData.hasMoved = true;
+		}
+	},
+	moveImage: function(image, deltaX, deltaY) {
+		$(image).css('margin-left', parseInt($(image).css('margin-left')) + deltaX);
+		$(image).css('margin-top', parseInt($(image).css('margin-top')) + deltaY);
 	},
 	clickImage: function(e) {
 		modules['showImages'].dragTargetData.diagonal = 0;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -389,6 +389,34 @@ RESUtils.elementInViewport = function(obj) {
 		(left + width) <= (window.pageXOffset + window.innerWidth)
 	);
 };
+// Returns percentage of the element that is within the viewport along the y-axis
+// Note that it doesn't matter where the element is on the x-axis, it can be totally invisible to the user
+// and this function might still return 1!
+RESUtils.getPercentageVisibleYAxis = function(obj) {
+	var rect = obj.getBoundingClientRect();
+	var top = Math.max(0, rect["bottom"] - rect["height"]);
+	var bottom = Math.min(document.documentElement.clientHeight, rect["bottom"]);
+    if(rect["height"] == 0) {
+        return 0;
+    }
+	return Math.max(0, (bottom - top) / rect["height"]);
+};
+// Returns percentage of the element that is within the viewport along the x-axis
+// Note that it doesn't matter where the element is on the y-axis, it can be totally invisible to the user
+// and this function might still return 1!
+RESUtils.getPercentageVisibleXAxis = function(obj) {
+	var rect = obj.getBoundingClientRect();
+	var left = Math.max(0, rect["left"]);
+	var right = Math.min(document.documentElement.clientWidth, rect["right"]);
+    if(rect["width"] == 0) {
+        return 0;
+    }
+	return Math.max(0, (right - left) / rect["width"]);
+};
+// Returns percentage of the element that is within the viewport
+RESUtils.getPercentageVisible = function(obj) {
+	return RESUtils.getPercentageVisibleXAxis(obj) * RESUtils.getPercentageVisibleYAxis(obj);
+};
 RESUtils.setMouseXY = function(e) {
 	e = e || window.event;
 	var cursor = {


### PR DESCRIPTION
Hi!

I was viewing [this](http://www.reddit.com/r/programming/comments/1zsnde/thinking_about_quickly_writing_an_http_server/) earlier today when I noticed how bad RES is at displaying pictures when you make the image larger than your screen. In the particular picture I linked you will probably only be able to read the top left part of the picture, because the rest of it disappears in the void that is the outside of your screen.

I added the ability to move images by dragging (as you do when resizing) and holding down shift (actually only holding shift at the start of the drag is enough).

Please be ge[m]tle, first pull request.

Tested on Chrome Version 33.0.1750.146 on Ubuntu 13.10 64 bit.
