### PR TITLE
userHighlight.options.dontHighlightFirstComment

### DIFF
--- a/lib/modules/userHighlight.js
+++ b/lib/modules/userHighlight.js
@@ -69,6 +69,11 @@ modules['userHighlight'] = {
 			value: false,
 			description: 'Highlight the person who has the first comment in a tree, within that tree'
 		},
+		dontHighlightFirstComment: {
+			type: 'boolean',
+			value: true,
+			description: 'Don\'t highlight the "first commenter" on the first comment in a tree'
+		},
 		firstCommentColor: {
 			type: 'text',
 			value: '#46B6CC',
@@ -211,7 +216,11 @@ modules['userHighlight'] = {
 			var authorDidReply = element.querySelector('.child .' + authorClass);
 			if (!authorDidReply) return;
 
-			modules['userHighlight'].doHighlight('firstComment', authorClass, '.' + idClass);
+			var container = '.' + idClass;
+			if (modules['userHighlight'].options.dontHighlightFirstComment.value) {
+				container += ' .child';
+			}
+			modules['userHighlight'].doHighlight('firstComment', authorClass, container);
 		});
 	},
 	firstComments: {},


### PR DESCRIPTION
type=boolean  
default=false

Paired with userHighlight.options.highlightFirstCommenter -- don't highlight the username on that top comment, only on that user's replies within the tree
