### PR TITLE
add escape character to look of dissaproval macro

### DIFF
--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -458,7 +458,7 @@ modules['commentTools'] = {
 		}));
 
 		this.addButtonToMacroGroup("", this.makeEditButton("&#3232;\_&#3232;", "Look of disaproval", null, function(button, box) {
-			this.macroSelection(box, "&#3232;\_&#3232;");
+			this.macroSelection(box, "&#3232;\\_&#3232;");
 		}));
 
 		this.addButtonToMacroGroup("", this.makeEditButton("Current timestamp", "", null, function(button, box) {


### PR DESCRIPTION
In regard to this bug report: http://www.reddit.com/r/RESissues/comments/1zy907/bug_defaults_in_the_comment_macro_need_slight/.

An escape character is needed, or adding an "_" after the macro italicizes text.
