### PR TITLE
Removed tests.js references in manifests for Chrome, Opera, and FF.

### DIFF
--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -72,7 +72,6 @@
 				"modules/commentHidePersistor.js",
 				"modules/bitcointip.js",
 				"modules/troubleshooter.js",
-				"modules/tests.js",
 				"init.js"
 			],
 			"css": [
@@ -93,7 +92,7 @@
 	],
 	"icons": {
 		"48": "icon48.png",
-		"128": "icon128.png" 
+		"128": "icon128.png"
 	},
 	"permissions": [
 		"cookies",

--- a/OperaBlink/manifest.json
+++ b/OperaBlink/manifest.json
@@ -72,7 +72,6 @@
 				"modules/commentHidePersistor.js",
 				"modules/bitcointip.js",
 				"modules/troubleshooter.js",
-				"modules/tests.js",
 				"init.js"
 			],
 			"css": [

--- a/XPI/lib/main.js
+++ b/XPI/lib/main.js
@@ -212,7 +212,6 @@ pageMod.PageMod({
 		self.data.url('modules/commentHidePersistor.js'),
 		self.data.url('modules/bitcointip.js'),
 		self.data.url('modules/troubleshooter.js'),
-		self.data.url('modules/tests.js'),
 		self.data.url('init.js')
 	],
 	contentStyleFile: [


### PR DESCRIPTION
Builds are currently broken because of stray references to the told tests.js file. This removes those references.
