### PR TITLE
Add followPermalink shortcut

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -279,6 +279,16 @@ modules['keyboardNav'] = {
 			value: [82, false, false, false], // r
 			description: 'Reply to current comment (comment pages only)'
 		},
+		followPermalink: {
+			type: 'keycode',
+			value: [89, false, false, false], // y
+			description: 'Open the current comment\'s permalink (comment pages only)'
+		},
+		followPermalinkNewTab: {
+			type: 'keycode',
+			value: [89, false, false, true], // shift-y
+			description: 'Open the current comment\'s permalink in a new tab (comment pages only)'
+		},
 		openBigEditor: {
 			type: 'keycode',
 			value: [69, false, true, false], // control-e
@@ -1002,6 +1012,12 @@ modules['keyboardNav'] = {
 							e.preventDefault();
 							this.reply();
 							break;
+						case RESUtils.checkKeysForEvent(e, this.options.followPermalink.value):
+							this.followPermalink();
+							break;
+						case RESUtils.checkKeysForEvent(e, this.options.followPermalinkNewTab.value):
+							this.followPermalink(true);
+							break;
 						case RESUtils.checkKeysForEvent(e, this.options.goMode.value):
 							e.preventDefault();
 							this.goMode();
@@ -1463,6 +1479,22 @@ modules['keyboardNav'] = {
 	},
 	followLink: function(newWindow) {
 		var thisA = this.keyboardLinks[this.activeIndex].querySelector('a.title');
+		var thisHREF = thisA.getAttribute('href');
+		if (newWindow) {
+			var button = (this.options.followLinkNewTabFocus.value) ? 0 : 1,
+				thisJSON = {
+					requestType: 'keyboardNav',
+					linkURL: thisHREF,
+					button: button
+				};
+
+			RESUtils.sendMessage(thisJSON);
+		} else {
+			location.href = thisHREF;
+		}
+	},
+	followPermalink: function(newWindow) {
+		var thisA = this.keyboardLinks[this.activeIndex].querySelector('a.bylink');
 		var thisHREF = thisA.getAttribute('href');
 		if (newWindow) {
 			var button = (this.options.followLinkNewTabFocus.value) ? 0 : 1,


### PR DESCRIPTION
I implemented a new keyboard shortcut to open the current comment's permalink. Default key is currently 'Y' for opening in current tab, 'shift-Y' for opening in new tab. I chose that because it isn't currently assigned to anything else, so feel free to change it.

http://www.reddit.com/r/Enhancement/comments/20qlmj/feature_request_keyboard_shortcut_to_open/
