### PR TITLE
Add "show anyway" option on ignored posts

### DIFF
--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -923,7 +923,6 @@ modules['userTagger'] = {
 									thisPost.innerHTML = thisAuthor + ' is an ignored user. <a href="#">show anyway?</a>';
 									// Show anyway action
 									$(thisPost).find("a").click(function(e){
-										console.log($(this).parent());
 										$(this).parent().html($(this).parent().attr("data-original")).removeClass("ignoredUserPost").addClass("md");
 										e.preventDefault();
 									});
@@ -937,7 +936,6 @@ modules['userTagger'] = {
 		}
 	},
 	ignoreComment: function(thisAuthorObj, thisAuthor){
-
 		thisComment = thisAuthorObj.parentNode.parentNode.querySelector('.usertext');
 		if (thisComment) {
 			// store original
@@ -950,7 +948,6 @@ modules['userTagger'] = {
 				$(this).parent().html($(this).parent().attr("data-original")).removeClass("ignoredUserComment");
 				e.preventDefault();
 			});
-
 			return thisComment;
 		}
 		return false;


### PR DESCRIPTION
- Adds "show anyway" option to ignored comments ( & posts if soft ignore)
- Fixes hard ignore failing to hide comments (it was previously only collapsing them)
- Re-factor ignore comment code, to share same method.

closes: https://github.com/honestbleeps/Reddit-Enhancement-Suite/issues/828
