### PR TITLE
Add a sort button for subreddits in shortcut menus

### DIFF
--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -100,8 +100,10 @@ modules['subredditManager'] = {
 			RESUtils.addCSS('#editShortcutDialog { display: none; z-index: 999; position: absolute; top: 25px; left: 5px; width: 230px; padding: 10px; background-color: #f0f3fc; border: 1px solid #c7c7c7; border-radius: 3px; font-size: 12px; color: #000; }');
 			RESUtils.addCSS('#editShortcutDialog h3 { display: inline-block; float: left; font-size: 13px; margin-top: 6px; }');
 			RESUtils.addCSS('#editShortcutClose { float: right; margin-top: 2px; margin-right: 0; }');
+			RESUtils.addCSS('#editShortcutDialog .row { float: left; position: relative; }');
 			RESUtils.addCSS('#editShortcutDialog label { clear: both; float: left; width: 100px; margin-top: 12px; }');
 			RESUtils.addCSS('#editShortcutDialog input { float: left; width: 126px; margin-top: 10px; }');
+			RESUtils.addCSS('#editShortcutDialog #sortButton { padding: 0 0 4px 0; margin: 0; font-size: 10px; position: absolute; top: 10px; left: 80px; background-color: #fff; border: 1px solid #bbb; color: #bbb; line-height: 10px; }');
 			RESUtils.addCSS('#editShortcutDialog input[type=button] { float: right; width: 45px; margin-left: 10px; cursor: pointer; padding: 3px 5px; font-size: 12px; color: #fff; border: 1px solid #636363; border-radius: 3px; background-color: #5cc410; }');
 			RESUtils.addCSS('#srLeftContainer { z-index: 4; padding-left: 4px; margin-right: 6px; }'); // RESUtils.addCSS('#RESShortcuts { position: absolute; left: '+ this.srLeftContainerWidth+'px;  z-index: 6; white-space: nowrap; overflow-x: hidden; padding-left: 2px; margin-top: -2px; padding-top: 2px; }');
 			RESUtils.addCSS('#srLeftContainer { z-index: 4; padding-left: 4px; margin-right: 6px; }');
@@ -435,11 +437,15 @@ modules['subredditManager'] = {
 		var thisForm = '<form name="editSubredditShortcut"> \
 		                    <h3>Edit Shortcut</h3> \
 		                    <div id="editShortcutClose" class="RESCloseButton">&times;</div> \
-		                    <label for="subreddit">Subreddit:</label> \
-		                    <input type="text" name="subreddit" value="' + subreddit + '" id="shortcut-subreddit"> \
-		                    <br> \
-		                    <label for="displayName">Display Name:</label> \
-		                    <input type="text" name="displayName" value="' + ele.textContent + '" id="shortcut-displayname"> \
+		                    <div class="row"> \
+			                <button id="sortButton" title="Sort subreddits alphabetically">&#8593;&#8595;</button> \
+			                <label for="subreddit">Subreddit:</label> \
+			                <input type="text" name="subreddit" value="' + subreddit + '" id="shortcut-subreddit"> \
+		                    </div> \
+			                <div class="row"> \
+			                <label for="displayName">Display Name:</label> \
+			                <input type="text" name="displayName" value="' + ele.textContent + '" id="shortcut-displayname"> \
+		                    </div> \
 		                    <input type="hidden" name="idx" value="' + idx + '"> \
 		                    <input type="button" name="shortcut-save" value="save" id="shortcut-save"> \
 						</form>';
@@ -510,6 +516,24 @@ modules['subredditManager'] = {
 			modules['subredditManager'].editShortcutDialog.style.display = 'none';
 			modules['subredditManager'].redrawShortcuts();
 			modules['subredditManager'].populateSubredditDropdown();
+		}, false);
+
+		// handle the sort button
+		var sortButton = this.editShortcutDialog.querySelector('#sortButton');
+		sortButton.addEventListener('click', function(e) {
+			var inputEl = modules['subredditManager'].editShortcutDialog.querySelector('input[name=subreddit]');
+			var currStr = inputEl.value;
+			var ascStr, descStr, ascArr, descArr;
+			// sort ASC
+			ascArr = currStr.split('+');
+			ascArr.sort();
+			ascStr = ascArr.join('+');
+			// sort DESC
+			descArr = ascArr;
+			descArr.reverse();
+			descStr = descArr.join('+');
+			// if sorted ASC, sort DESC. If unsorted or sorted DESC, sort ASC
+			inputEl.value = (currStr == ascStr ? descStr : ascStr);
 		}, false);
 
 		// handle enter and escape keys in the dialog box...


### PR DESCRIPTION
When editing a subreddit shortcut, you can add multiple subreddits to create a dropdown menu. Currently, if you want the subreddits in the dropdown menu to be sorted, you have to do so manually. This pull request adds a button to sort the subreddits alphabetically if desired. It toggles between ascending and descending order if clicked repeatedly. You can see a screenshot of what it looks like here: http://imgur.com/8FFAOPC Constructive criticism or requests for changes are welcome!
