### PR TITLE
Consistently prevent default action of all handled hotkeys

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -521,7 +521,9 @@ modules['keyboardNav'] = {
 			}
 			this.drawHelp();
 			window.addEventListener('keydown', function(e) {
-				modules['keyboardNav'].handleKeyPress(e);
+				if (modules['keyboardNav'].handleKeyPress(e)) {
+					e.preventDefault();
+				}
 			}, true);
 			this.scanPageForKeyboardLinks();
 			// listen for new DOM nodes so that modules like autopager, never ending reddit, "load more comments" etc still get keyboard nav.
@@ -805,373 +807,332 @@ modules['keyboardNav'] = {
 					switch (true) {
 						case RESUtils.checkKeysForEvent(e, this.options.moveUp.value):
 							this.moveUp();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.moveDown.value):
 							this.moveDown();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.moveTop.value):
 							this.moveTop();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.moveBottom.value):
 							this.moveBottom();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.followLink.value):
 							this.followLink();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.followLinkNewTab.value):
-							e.preventDefault();
 							this.followLink(true);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.followComments.value):
 							this.followComments();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.followCommentsNewTab.value):
 							e.preventDefault();
 							this.followComments(true);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.toggleExpando.value):
 							this.toggleExpando();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.imageSizeUp.value):
 							this.imageSizeUp();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.imageSizeDown.value):
 							this.imageSizeDown();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.imageSizeUpFine.value):
 							this.imageSizeUp(true);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.imageSizeDownFine.value):
 							this.imageSizeDown(true);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.previousGalleryImage.value):
 							this.previousGalleryImage();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.nextGalleryImage.value):
 							this.nextGalleryImage();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.toggleViewImages.value):
 							this.toggleViewImages();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.followLinkAndCommentsNewTab.value):
-							e.preventDefault();
 							this.followLinkAndComments();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.followLinkAndCommentsNewTabBG.value):
-							e.preventDefault();
 							this.followLinkAndComments(true);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.upVote.value):
 							this.upVote(true);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.downVote.value):
 							this.downVote(true);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.save.value):
 							this.saveLink();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.goMode.value):
-							e.preventDefault();
 							this.goMode();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.inbox.value):
-							e.preventDefault();
 							this.inbox();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.inboxNewTab.value):
-							e.preventDefault();
 							this.inbox(true);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.profile.value):
-							e.preventDefault();
 							this.profile();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.profileNewTab.value):
-							e.preventDefault();
 							this.profile(true);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.frontPage.value):
-							e.preventDefault();
 							this.frontPage();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.subredditFrontPage.value):
-							e.preventDefault();
 							this.frontPage(true);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.nextPage.value):
-							e.preventDefault();
 							this.nextPage();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.prevPage.value):
-							e.preventDefault();
 							this.prevPage();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.toggleHelp.value):
 							this.toggleHelp();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.toggleCmdLine.value):
 							modules['commandLine'].toggleCmdLine();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.hide.value):
 							this.hide();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.followSubreddit.value):
 							this.followSubreddit();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.followSubredditNewTab.value):
 							this.followSubreddit(true);
-							break;
+							return true;
 						default:
 							// do nothing. unrecognized key.
-							break;
+							return false;
 					}
-					break;
+					return false;
 				case 'comments':
 					switch (true) {
 						case RESUtils.checkKeysForEvent(e, this.options.toggleHelp.value):
 							this.toggleHelp();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.toggleCmdLine.value):
 							modules['commandLine'].toggleCmdLine();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.moveUp.value):
 							this.moveUp();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.moveDown.value):
 							this.moveDown();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.moveUpSibling.value):
 							this.moveUpSibling();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.moveDownSibling.value):
 							this.moveDownSibling();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.moveUpThread.value):
 							this.moveUpThread();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.moveDownThread.value):
 							this.moveDownThread();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.moveToTopComment.value):
 							this.moveToTopComment();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.moveToParent.value):
 							this.moveToParent();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.showParents.value):
 							this.showParents();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.toggleChildren.value):
 							this.toggleChildren();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.followLinkNewTab.value):
 							// only execute if the link is selected on a comments page...
 							if (this.activeIndex === 0) {
-								e.preventDefault();
 								this.followLink(true);
+								return true;
 							}
-							break;
+							return false;
 						case RESUtils.checkKeysForEvent(e, this.options.save.value):
 							if (this.activeIndex === 0) {
 								this.saveLink();
 							} else {
 								this.saveComment();
 							}
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.toggleExpando.value):
 							this.toggleAllExpandos();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.previousGalleryImage.value):
 							this.previousGalleryImage();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.imageSizeUp.value):
 							this.imageSizeUp();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.imageSizeDown.value):
 							this.imageSizeDown();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.imageSizeUpFine.value):
 							this.imageSizeUp(true);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.imageSizeDownFine.value):
 							this.imageSizeDown(true);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.nextGalleryImage.value):
 							this.nextGalleryImage();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.toggleViewImages.value):
 							this.toggleViewImages();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.upVote.value):
 							this.upVote();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.downVote.value):
 							this.downVote();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.reply.value):
-							e.preventDefault();
 							this.reply();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.followPermalink.value):
 							this.followPermalink();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.followPermalinkNewTab.value):
 							this.followPermalink(true);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.goMode.value):
-							e.preventDefault();
 							this.goMode();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.inbox.value):
-							e.preventDefault();
 							this.inbox();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.inboxNewTab.value):
-							e.preventDefault();
 							this.inbox(true);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.profile.value):
-							e.preventDefault();
 							this.profile();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.profileNewTab.value):
-							e.preventDefault();
 							this.profile(true);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.frontPage.value):
-							e.preventDefault();
 							this.frontPage();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.subredditFrontPage.value):
-							e.preventDefault();
 							this.frontPage(true);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.nextPage.value):
-							e.preventDefault();
 							this.nextPage();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.prevPage.value):
-							e.preventDefault();
 							this.prevPage();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.link1.value):
-							e.preventDefault();
 							this.commentLink(0);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.link2.value):
-							e.preventDefault();
 							this.commentLink(1);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.link3.value):
-							e.preventDefault();
 							this.commentLink(2);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.link4.value):
-							e.preventDefault();
 							this.commentLink(3);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.link5.value):
-							e.preventDefault();
 							this.commentLink(4);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.link6.value):
-							e.preventDefault();
 							this.commentLink(5);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.link7.value):
-							e.preventDefault();
 							this.commentLink(6);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.link8.value):
-							e.preventDefault();
 							this.commentLink(7);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.link9.value):
-							e.preventDefault();
 							this.commentLink(8);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.link10.value):
-							e.preventDefault();
 							this.commentLink(9);
-							break;
+							return true;
 						default:
 							// do nothing. unrecognized key.
-							break;
+							return false;
 					}
-					break;
+					return false;
 				case 'inbox':
 					switch (true) {
 						case RESUtils.checkKeysForEvent(e, this.options.toggleHelp.value):
 							this.toggleHelp();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.toggleCmdLine.value):
 							modules['commandLine'].toggleCmdLine();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.moveUp.value):
 							this.moveUp();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.moveDown.value):
 							this.moveDown();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.toggleExpando.value):
 							this.toggleExpando();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.toggleChildren.value):
 							this.toggleChildren();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.upVote.value):
 							this.upVote();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.downVote.value):
 							this.downVote();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.reply.value):
-							e.preventDefault();
 							this.reply();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.goMode.value):
-							e.preventDefault();
 							this.goMode();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.inbox.value):
-							e.preventDefault();
 							this.inbox();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.inboxNewTab.value):
-							e.preventDefault();
 							this.inbox(true);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.profile.value):
-							e.preventDefault();
 							this.profile();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.profileNewTab.value):
-							e.preventDefault();
 							this.profile(true);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.frontPage.value):
-							e.preventDefault();
 							this.frontPage();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.subredditFrontPage.value):
-							e.preventDefault();
 							this.frontPage(true);
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.nextPage.value):
-							e.preventDefault();
 							this.nextPage();
-							break;
+							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.prevPage.value):
-							e.preventDefault();
 							this.prevPage();
-							break;
+							return true;
 						default:
 							// do nothing. unrecognized key.
-							break;
+							return false;
 					}
-					break;
+					return false;
 			}
 		}
+		return false;
 	},
 	toggleHelp: function() {
 		if (document.getElementById('keyHelp').style.display === 'block') {


### PR DESCRIPTION
This avoids conflicts with possible browser bindings (e.g. if something is already bound to the J/K keys).

Split off from #884.
