### PR TITLE
Fix stuck console on tall screens

### DIFF
--- a/lib/res.css
+++ b/lib/res.css
@@ -30,7 +30,7 @@
 }
 #RESConsole.slideOut {
 	visibility: visible;
-	top: -1500px;
+	top: -100%;
 }
 #modalOverlay {
 	display: none;


### PR DESCRIPTION
On tall screens (e.g. full-HD monitor in portrait mode, or 4K monitors) the console will not slide all the way up.
