### PR TITLE
Fix so native controls on gfycat embeds are functional

### DIFF
--- a/lib/gfycat.js
+++ b/lib/gfycat.js
@@ -25,6 +25,7 @@
         ctrlSlower.onclick = slower;
         ctrlFaster.onclick = faster;
         ctrlPausePlay.onclick = pauseClick;
+	vid.onpause = vid.onplay = pauseEvent;
         ctrlReverse.onclick = reverse;
         element.onmouseover = ctrlOnMouseOver;
         element.onmouseout = ctrlOnMouseOut;
@@ -90,22 +91,29 @@
             }
         }
 
-        function pauseClick() {
+	function pauseEvent() {
             if (vid.paused) {
-                vid.play();
-		ctrlPausePlay.innerHTML="&#xf16c;";
-                ctrlSlower.innerHTML="&#xf14d;";
-                ctrlFaster.innerHTML="&#xf14c;"
-                ctrlSlower.onclick = slower;
-                ctrlFaster.onclick = faster;
-            } else {
-                vid.pause();
 		ctrlPausePlay.innerHTML="&#xf16b;";
                 ctrlSlower.innerHTML="&#xf168;";
                 ctrlFaster.innerHTML="&#xf16e;"
                 ctrlSlower.onclick = stepBackward;
                 ctrlFaster.onclick = stepForward;
+            } else {
+		ctrlPausePlay.innerHTML="&#xf16c;";
+                ctrlSlower.innerHTML="&#xf14d;";
+                ctrlFaster.innerHTML="&#xf14c;"
+                ctrlSlower.onclick = slower;
+                ctrlFaster.onclick = faster;
             }
+	}
+
+        function pauseClick() {
+            if (vid.paused) {
+                vid.play();
+            } else {
+                vid.pause();
+            }
+	    pauseEvent();
         }
 
         function faster() {

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1323,6 +1323,13 @@ modules['showImages'] = {
 	},
 	mousedownImage: function(e) {
 		if (e.button === 0) {
+			if (e.target.tagName === 'VIDEO' && e.target.hasAttribute("controls")) {
+				var rc = e.target.getBoundingClientRect();
+				// ignore drag if click is in control area (40 px from bottom of video)
+				if ((rc.height - 40) < (e.clientY - rc.top)) {
+					return true;
+				} 
+			}
 			if (!e.target.minWidth) e.target.minWidth = Math.max(1, Math.min($(e.target).width(), 100));
 			modules['showImages'].dragTargetData.imageWidth = $(e.target).width();
 			modules['showImages'].dragTargetData.diagonal = modules['showImages'].getDragSize(e);
@@ -1357,6 +1364,14 @@ modules['showImages'] = {
 		modules['showImages'].dragTargetData.diagonal = 0;
 		if (modules['showImages'].dragTargetData.hasChangedWidth) {
 			modules['showImages'].dragTargetData.dragging = false;
+			// if video let video controls function
+			if (e.target.tagName === 'VIDEO' && e.target.hasAttribute("controls")) {
+				var rc = e.target.getBoundingClientRect();
+				// ignore drag if click is in control area (40 px from bottom of video)
+				if ((rc.height - 40) < (e.clientY - rc.top)) {
+					return true;
+				} 
+			}
 			e.preventDefault();
 			return false;
 		}


### PR DESCRIPTION
The drag to zoom handlers override the native controls the user can pull up using "Right click -> Show Controls".  I hadn't noticed before.  

Re-added a small snippet to check if the controls are visible and prevent drag in the controls area.  
