### PR TITLE
Throw if a.protocol unsupported, fix comment

### DIFF
--- a/lib/HTMLPasteurizer.js
+++ b/lib/HTMLPasteurizer.js
@@ -75,7 +75,7 @@
                 if(node.protocol !== undefined) {
                     var scrubbedProto = node.protocol.replace(SCHEME_FILTER, "");
 
-                    // Only allow non-whitelisted schemes unless the document was served via
+                    // Only allow whitelisted schemes unless the document was served via
                     // the same scheme.
                     if(config.schemeWhitelist.indexOf(scrubbedProto) === -1 &&
                        scrubbedProto !== document.location.protocol) {
@@ -84,6 +84,7 @@
                 } else {
                     // TODO: Handle UAs that don't support a.protocol?
                     // we may need to bundle URL.js.
+                    throw "Pasteurizer: a.protocol unsupported.";
                 }
             }
         }


### PR DESCRIPTION
This fixes some minor issues with HTMLPasteurizer
