### PR TITLE
Fix closing "Tips and Tricks" with the Escape key

### DIFF
--- a/lib/modules/RESTips.js
+++ b/lib/modules/RESTips.js
@@ -85,7 +85,7 @@ modules['RESTips'] = {
 	},
 	handleEscapeKey: function(event) {
 		if (event.which === 27) {
-			this.hideTip();
+			modules['RESTips'].hideTip();
 		}
 	},
 	dailyTip: function() {


### PR DESCRIPTION
`this` does not point to the current object when the function is called from an event handler.
