### PR TITLE
Fix keyboard navigation "Press a key" popup

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -247,7 +247,7 @@ var RESConsole = {
 				$(RESConsole.keyCodeModal).css({
 					display: "block",
 					top: RESUtils.mouseY + "px",
-					left: RESUtils.mouseX + "px;"
+					left: RESUtils.mouseX + "px"
 				});
 				// RESConsole.keyCodeModal.style.display = 'block';
 				RESConsole.captureKey = true;

--- a/lib/res.css
+++ b/lib/res.css
@@ -394,7 +394,7 @@
 	width: 200px;
 	height: 40px;
 	position: absolute;
-	z-index: 1000;
+	z-index: 200000000;
 	background-color: #FFF;
 	padding: 4px;
 	border: 2px solid #CCC;


### PR DESCRIPTION
The `z-index` was lower than the console's, and the trailing `;` was causing the x coordinate to be wrong (at least in Opera).
