### PR TITLE
Make Dashboard tabs look same as other subs

### DIFF
--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -62,8 +62,8 @@ modules['dashboard'] = {
 						this.widgets = [];
 					}
 					if (RESUtils.currentSubreddit('dashboard')) {
-						$('#noresults, #header-bottom-left .tabmenu:not(".viewimages")').hide();
-						$('#header-bottom-left .redditname a:first').text('My Dashboard');
+						$('#header-bottom-left .redditname a').prepend('My ');
+						$('ul.tabmenu').prepend('<li class="dashboardTab"><a href="/r/Dashboard">main</a></li>');
 						this.drawDashboard();
 					}
 					if (this.options.dashboardShortcut.value == true) this.addDashboardShortcuts();
@@ -128,11 +128,6 @@ modules['dashboard'] = {
 		RESUtils.addCSS('#userTaggerContents .show { display: inline-block; }');
 		RESUtils.addCSS('#tagPageControls { display: inline-block; position: relative; top: 9px;}');
 
-		var dbLinks = $('span.redditname a');
-		if ($(dbLinks).length > 1) {
-			$(dbLinks[0]).addClass('active');
-		}
-
 		// add each subreddit widget...
 		// add the "add widget" form...
 		this.attachContainer();
@@ -188,19 +183,20 @@ modules['dashboard'] = {
 		this.siteTable = $('#siteTable.linklisting');
 		$(this.siteTable).append('<div id="dashboardContents" class="dashboardPane" />');
 		if ((location.hash !== '') && (location.hash !== '#dashboardContents')) {
-			$('span.redditname a').removeClass('active');
 			var activeTabID = location.hash.replace('#', '#tab-');
-			$(activeTabID).addClass('active');
+			$(activeTabID).parent().addClass('selected');
 			$('.dashboardPane').hide();
 			$(location.hash).show();
 		} else {
+			$('ul.tabmenu li:first').addClass('selected');
+			$('#newCommentsContents').hide();
 			$('#userTaggerContents').hide();
 		}
-		$('span.redditname a:first').click(function(e) {
+		$('li.dashboardTab').click(function(e) {
 			e.preventDefault();
 			location.hash = 'dashboardContents';
-			$('span.redditname a').removeClass('active');
-			$(this).addClass('active');
+			$('ul.tabmenu li').removeClass('selected');
+			$(this).addClass('selected');
 			$('.dashboardPane').hide();
 			$('#dashboardContents').show();
 		});
@@ -817,13 +813,19 @@ modules['dashboard'] = {
 	},
 	addTab: function(tabID, tabName) {
 		$('#siteTable.linklisting').append('<div id="' + tabID + '" class="dashboardPane" />');
-		$('span.redditname').append('<a id="tab-' + tabID + '" class="dashboardTab" title="' + tabName + '">' + tabName + '</a>');
+		// Add dashboard tabs to existing tabmenu as list items.
+		$('ul.tabmenu').prepend('<li class="dashboardTab"><a href="#' + tabID + '" id="tab-' + tabID + '">' + tabName + '</a></li>');
 		$('#tab-' + tabID).click(function(e) {
 			location.hash = tabID;
-			$('span.redditname a').removeClass('active');
-			$(this).addClass('active');
+			$('ul.tabmenu li').removeClass('selected');
+			$(this).parent().addClass('selected');
 			$('.dashboardPane').hide();
 			$('#' + tabID).show();
+			return false;
 		});
+		// Hide any tabs that don't apply to /r/dashboard.
+		$('ul.tabmenu li').not('.dashboardTab').hide();
+		// show 'view images' tab individually because it has unique ID.
+		$('ul.tabmenu li a#viewImagesButton').parent().show();
 	}
 };

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -53,7 +53,7 @@ modules['newCommentCount'] = {
 			} else if (RESUtils.currentSubreddit('dashboard')) {
 				// If we're on the dashboard, add a tab to it...
 				// add tab to dashboard
-				modules['dashboard'].addTab('newCommentsContents', 'My Subscriptions');
+				modules['dashboard'].addTab('newCommentsContents', 'my subscriptions');
 				// populate the contents of the tab
 				var showDiv = $('<div class="show">Show:</div>')
 				var subscriptionFilter = $('<select id="subscriptionFilter"><option>subscribed threads</option><option>all threads</option></select>')

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -216,8 +216,7 @@ modules['showImages'] = {
 
 		if ((/search\?\/?q\=/.test(location.href)) ||
 				(/\/about\/(?:reports|spam|unmoderated)/.test(location.href)) ||
-				(location.href.indexOf('/modqueue') !== -1) ||
-				(location.href.toLowerCase().indexOf('/dashboard') !== -1)) {
+				(location.href.indexOf('/modqueue') !== -1)) {
 			var hbl = document.getElementById('header-bottom-left');
 			if (hbl) {
 				mainMenuUL = document.createElement('ul');

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -151,7 +151,7 @@ modules['userTagger'] = {
 			// If we're on the dashboard, add a tab to it...
 			if (RESUtils.currentSubreddit('dashboard')) {
 				// add tab to dashboard
-				modules['dashboard'].addTab('userTaggerContents', 'My User Tags');
+				modules['dashboard'].addTab('userTaggerContents', 'my user tags');
 				// populate the contents of the tab
 				var showDiv = $('<div class="show">Show:</div>');
 				var tagFilter = $('<select id="tagFilter"><option>tagged users</option><option>all users</option></select>');


### PR DESCRIPTION
HTML cleanup for the tabs on /r/dashboard which makes them look
consistent with Reddit's default tabs. No change to functionality but
simplifies the code, while reducing amount of CSS. IMPORTANT: requires
changes to custom stylesheet of /r/dashboard subreddit. See new CSS in
pull request description.

New CSS for /r/dashboard subreddit custom stylesheet for @honestbleeps:

    .side span.rank,.side div.midcol,.side div.entry div.expando-button,.side p.tagline,.side ul,.side div.expando{display:none}.side a.title{display:block;position:absolute;top:-50px;left:2130px;width:600px;font-size:11px;z-index:500}#noresults,div.titlebox,div.sidebox,div.sidecontentbox{display:none}#userTaggerTable .deleteButton{cursor:pointer;color:orangered;text-decoration:underline;float:right}#userTaggerTable,#newCommentsTable{border:1px solid #cccccc}#userTaggerTable thead,#newCommentsTable thead{background-color:#f0f3f7}#userTaggerTable td,#newCommentsTable td{border:1px solid #cccccc;padding:14px 18px;min-width:140px}#userTaggerTable td{white-space:nowrap}#userTaggerTable td:first-child{width:170px}#userTaggerTable th.delete,#userTaggerTable td.delete{max-width:40px;text-align:center}#userTaggerTable th,#newCommentsTable th{cursor:pointer;border:1px solid #cccccc;padding:14px 18px;min-width:100px}#userTaggerTable thead td,#newCommentsTable thead td{cursor:pointer}div.show{margin-bottom:12px}#newCommentsTable th:first-child,#newCommentsTable td:first-child{width:400px}#userTaggerTable td:nth-child(2){white-space:normal}

The above CSS removes 'display: none' from #newCommentsContents and also removes all styling affecting .redditname and .tabmenu. It's been compressed because I can't access the original stylesheet.