### PR TITLE
Add active class to subreddit shortcuts dropdown

### DIFF
--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -117,7 +117,7 @@ modules['subredditManager'] = {
 			RESUtils.addCSS('#RESShortcutsLeft { right: 31px; }');
 			RESUtils.addCSS('#RESShortcutsSort { right: 47px; }');
 
-			RESUtils.addCSS('#RESShortcutsSort, #RESShortcutsRight, #RESShortcutsLeft, #RESShortcutsAdd, #RESShortcutsTrash {  width: 16px; cursor: pointer; background: #F0F0F0; font-size: 20px; color: #369; height: 18px; line-height: 15px; position: absolute; top: 0; z-index: 999; background-color: #f0f0f0; user-select: none; -webkit-user-select: none; -moz-user-select: none;  } ');
+			RESUtils.addCSS('#RESShortcutsSort, #RESShortcutsRight, #RESShortcutsLeft, #RESShortcutsAdd, #RESShortcutsTrash { width: 16px; cursor: pointer; background: #F0F0F0; font-size: 20px; color: #369; height: 18px; line-height: 15px; position: absolute; top: 0; z-index: 999; background-color: #f0f0f0; user-select: none; -webkit-user-select: none; -moz-user-select: none; }');
 			RESUtils.addCSS('#RESShortcutsSort { font-size: 14px; }')
 			RESUtils.addCSS('#RESShortcutsTrash { display: none; font-size: 17px; width: 16px; cursor: pointer; right: 15px; height: 16px; position: absolute; top: 0; z-index: 1000; user-select: none; -webkit-user-select: none; -moz-user-select: none; }');
 			RESUtils.addCSS('.srSep { margin-left: 6px; }');
@@ -138,7 +138,7 @@ modules['subredditManager'] = {
 			RESUtils.addCSS('#shortCutsAddForm label { display: inline-block; width: 100px; }');
 			RESUtils.addCSS('#shortCutsAddForm input[type=text] { width: 170px; margin-bottom: 6px; }');
 			RESUtils.addCSS('#addSubreddit { float: right; cursor: pointer; padding: 3px 5px; font-size: 12px; color: #fff; border: 1px solid #636363; border-radius: 3px; background-color: #5cc410; }');
-			RESUtils.addCSS('.sr-bar a.RESShortcutsCurrentSub, li.RESShortcutsCurrentSub a { color: orangered; font-weight:bold; }');
+			RESUtils.addCSS('#sr-header-area a.RESShortcutsCurrentSub, #RESSubredditGroupDropdown .RESShortcutsCurrentSub a { color: orangered !important; font-weight: bold; }');
 			RESUtils.addCSS('#srLeftContainer, #RESShortcutsViewport, #RESShortcutsEditContainer{max-height:18px;}');
 
 			// this shows the sr-header-area that we hid while rendering it (to curb opera's glitchy "jumping")...
@@ -393,13 +393,11 @@ modules['subredditManager'] = {
 			$(this.subredditGroupDropdownUL).html('');
 
 			for (var i = 0, len = subreddits.length; i < len; i++) {
-				if (RESUtils.currentSubreddit() === subreddits[i]) {
-					var itemClass = ' class="RESShortcutsCurrentSub"';
-				} else {
-					var itemClass = '';
-				}
-				var thisLI = $('<li' + itemClass + '><a href="/r/' + subreddits[i] + '">' + subreddits[i] + '</a></li>');
+				var thisLI = $('<li><a href="/r/' + subreddits[i] + '">' + subreddits[i] + '</a></li>');
 				$(this.subredditGroupDropdownUL).append(thisLI);
+				if (RESUtils.currentSubreddit() === subreddits[i]) {
+					thisLI.addClass('RESShortcutsCurrentSub');
+				}
 			}
 
 			var thisXY = RESUtils.getXYpos(obj);


### PR DESCRIPTION
When you're viewing a sub from your shortcuts bar it highlights the link
orange-red and bold, this patch simply applies the same rule to links in
the dropdown menu. Also I cleaned up the CSS selectors and removed
unnecessary !important declarations.

Please review my if/else statement.
