### PR TITLE
Remove 'summarize your post' from autofilled title on RESissues/Enh posts

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1403,16 +1403,16 @@ RESUtils.checkIfSubmitting = function() {
 							txt += "- Browser Version: " + BrowserDetect.version + "\n";
 							txt += "- Cookies Enabled: " + navigator.cookieEnabled + "\n";
 							txt += "- Platform: " + BrowserDetect.OS + "\n";
-							txt += "- Did you search /r/RESIssues before submitting this: No. That, or I didn't notice this text here and edit it!\n\n";
+							txt += "\n- Did you search /r/RESIssues before submitting this: No. That, or I didn't notice this text here and edit it!\n\n";
 							$('.usertext-edit textarea').val(txt);
-							title.value = '[bug] Please describe your bug here. If you have screenshots, please link them in the selftext.';
+							title.value = '[bug] ';
 						}
 					);
 					$('#submittingFeature').click(
 						function() {
 							$('#sr-autocomplete').val('Enhancement');
 							$('#submittingToEnhancement').fadeOut();
-							title.value = '[feature request] Please summarize your feature request here, and elaborate in the selftext.';
+							title.value = '[feature request] ';
 						}
 					);
 					$('#RESSubmitOther').click(


### PR DESCRIPTION
This is to help address two problems:
1. people don't notice they should post a real title
2. people mistakenly comment on these posts about unrelated requests/bugs.
