### PR TITLE
Fix image resize and move while the image is loading

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1470,7 +1470,7 @@ modules['keyboardNav'] = {
 		}
 	},
 	imageResize: function(factor) {
-		var images = $(this.activeElement).find('.RESImage.loaded, .madeVisible video'),
+		var images = $(this.activeElement).find('.RESImage, .madeVisible video'),
 			thisWidth;
 
 		for (var i = 0, len = images.length; i < len; i++) {
@@ -1499,7 +1499,7 @@ modules['keyboardNav'] = {
 		this.imageMove(50, 0);
 	},
 	imageMove: function(deltaX, deltaY) {
-		var images = $(document).find('.RESImage.loaded');
+		var images = $(document).find('.RESImage');
 		if(images.length == 0) {
 			return;
 		}

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1323,14 +1323,17 @@ modules['showImages'] = {
 			// Add listeners for drag to resize functionality...
 			$(imageTag).parent().append($(imageTag).data('imagePlaceholder'));
 		}
-		$(imageTag).load(modules['showImages'].syncPlaceholder);
+		$(imageTag).load(function () {
+			modules['showImages'].syncPlaceholder(imageTag);
+			$(imageTag).addClass('loaded');
+		});
 	},
 	syncPlaceholder: function(e) {
 		var ele = e.target || e;
 		var thisPH = $(ele).data('imagePlaceholder');
 		$(thisPH).width($(ele).width() + 'px');
 		$(thisPH).height($(ele).height() + 'px');
-		$(ele).addClass('loaded');
+		ele.style.position = 'absolute';
 	},
 	makeImageZoomable: function(imageTag) {
 		if (this.options.imageZoom.value) {
@@ -1428,6 +1431,8 @@ modules['showImages'] = {
 	moveImage: function(image, deltaX, deltaY) {
 		$(image).css('margin-left', parseInt($(image).css('margin-left')) + deltaX);
 		$(image).css('margin-top', parseInt($(image).css('margin-top')) + deltaY);
+
+		modules['showImages'].syncPlaceholder(image);
 	},
 	clickImage: function(e) {
 		modules['showImages'].dragTargetData.diagonal = 0;
@@ -1456,9 +1461,7 @@ modules['showImages'] = {
 			image.style.maxHeight = '';
 			image.style.height = 'auto';
 
-			var thisPH = $(image).data('imagePlaceholder');
-			$(thisPH).width($(image).width() + 'px');
-			$(thisPH).height($(image).height() + 'px');
+			modules['showImages'].syncPlaceholder(image);
 		}
 	},
 	siteModules: {


### PR DESCRIPTION
This fixes a couple issues with resizing or moving an image that is still loading (notably gifs):
- Resizing now doesn't create an empty space under the image.
- Moving is no longer bounded by the container.
- Keyboard shortcuts now works.
