### PR TITLE
Gfycat album support through Gfygur

### DIFF
--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -37,6 +37,7 @@
 				"hogan-2.0.0.js",
 				"mediacrush.js",
 				"gfycat.js",
+				"gfygur.js",
 				"reddit_enhancement_suite.user.js",
 				"modules/betteReddit.js",
 				"modules/userTagger.js",
@@ -114,6 +115,7 @@
 		"http://backend.deviantart.com/oembed?url=*",
 		"http://api.tumblr.com/v2/blog/*/posts?api_key=*&id=*",
 		"https://mediacru.sh/*",
+		"http://gfycat.com/cajax/get/*",
 		"http://noembed.com/embed?url=*"
 	],
 	"optional_permissions": [

--- a/lib/gfygur.js
+++ b/lib/gfygur.js
@@ -1,0 +1,192 @@
+//Mostly a copy of gfycat.js but adds in album features
+(function () {
+    var gfygurObject;
+
+    gfygurObject = function (element, url, gfyFrameRate) {
+        var ctrlPausePlay;
+        var ctrlSlower;
+        var ctrlFaster;
+        var ctrlReverse;
+        var vid;
+        var mp4src;
+        var webmsrc;
+        var isReverse = false;
+        var ctrlBox;
+        var isOverVid = false;
+        var isOverCtrl = false;
+        var albumPos;
+        var albumNext;
+        var albumPrev;
+        var album;
+        var albumGfy;
+
+        ctrlBox = element.querySelector('.gfygur .ctrlBox');
+        vid = element.querySelector('.gfygur .gfyRVid');
+        ctrlReverse = element.querySelector('.gfygur .gfyRCtrlReverse');
+        ctrlPausePlay = element.querySelector('.gfygur .gfyRCtrlPause');
+        ctrlSlower = element.querySelector('.gfygur .gfyRCtrlSlower');
+        ctrlFaster = element.querySelector('.gfygur .gfyRCtrlFaster');
+        mp4src = element.querySelector('.gfygur .gfyRmp4src');
+        webmsrc = element.querySelector('.gfygur .gfyRwebmsrc');
+        ctrlSlower.onclick = slower;
+        ctrlFaster.onclick = faster;
+        ctrlPausePlay.onclick = pauseClick;
+	   vid.onpause = vid.onplay = pauseEvent;
+        ctrlReverse.onclick = reverse;
+        element.onmouseover = ctrlOnMouseOver;
+        element.onmouseout = ctrlOnMouseOut;
+        var speed = getURLParameters('speed', url);
+        var direction = getURLParameters('direction', url);
+        var frameNum = getURLParameters('frameNum', url);
+        /*Gfygur custom album code*/
+            albumPos = element.querySelector('.gfygur .RESGalleryLabel');
+            albumNext = element.querySelector('.gfygur .next');
+            albumPrev = element.querySelector('.gfygur .previous');
+            album = element.querySelectorAll('.gfygur .gfy-data');
+            albumGfy = element;
+
+            albumPos.currentPos = 1;
+            albumPos.innerHTML = '1 of ' + album.length;
+
+            albumPrev.onclick = prevAlbum;
+            albumNext.onclick = nextAlbum;
+
+
+
+            function nextAlbum(){
+                albumPos.currentPos++;
+                if (albumPos.currentPos > album.length) {albumPos.currentPos = 1;}
+                albumPos.innerHTML =  albumPos.currentPos + ' of ' + album.length;
+                albumVid = albumGfy.querySelector('video source, this');
+                albumVid.setAttribute('src', album[albumPos.currentPos - 1].getAttribute('data-url'));
+                albumVid.parentElement.load()
+            }
+            function prevAlbum(){
+                albumPos.currentPos--;
+                if (albumPos.currentPos == 0) {albumPos.currentPos = album.length;}
+                albumPos.innerHTML =  albumPos.currentPos + ' of ' + album.length;
+                albumVid = albumGfy.querySelector('video source, this');
+                albumVid.setAttribute('src', album[albumPos.currentPos -1 ].getAttribute('data-url'));
+                albumVid.parentElement.load()
+            }
+        /*End - Gfygur custom album code*/    
+
+        if (speed) {
+            vid.playbackRate = speed;
+        }
+
+        if (direction && direction == 'reverse') {
+            if (!isReverse) {
+                reverse();
+            }
+        }
+
+        if (frameNum) {
+	    vid.addEventListener('loadeddata', function() {
+	        vid.pause();	
+		vid.currentTime = (frameNum / gfyFrameRate);
+	    }, false);
+        }
+
+
+
+        function stepForward() {
+            vid.currentTime += (1 / gfyFrameRate);
+        }
+
+        function ctrlOnMouseOver() {
+            ctrlBox.style.display = "block";
+        }
+
+        function ctrlOnMouseOut() {
+            ctrlBox.style.display = "none";
+        }
+
+        function stepBackward() {
+            vid.currentTime -= (1 / gfyFrameRate);
+        }
+
+        function getURLParameters(paramName, s_url) {
+            if (s_url.indexOf("?") > 0) {
+                var s_query = s_url.split("?");
+                var params = s_query[1].split("&");
+                var paramNames = new Array(params.length);
+                var paramValues = new Array(params.length);
+                var i = 0;
+                for (i = 0; i < params.length; i++) {
+                    var thisParam = params[i].split("=");
+                    paramNames[i] = thisParam[0];
+                    if (thisParam[1] != "")
+                        paramValues[i] = unescape(thisParam[1]);
+                    else
+                        paramValues[i] = "No Value";
+                }
+
+                for (i = 0; i < params.length; i++) {
+                    if (paramNames[i] == paramName) {
+                        return paramValues[i];
+                    }
+                }
+                return 0;
+            }
+        }
+
+    	function pauseEvent() {
+            if (vid.paused) {
+		ctrlPausePlay.innerHTML="&#xf16b;";
+                ctrlSlower.innerHTML="&#xf168;";
+                ctrlFaster.innerHTML="&#xf16e;"
+                ctrlSlower.onclick = stepBackward;
+                ctrlFaster.onclick = stepForward;
+            } else {
+		ctrlPausePlay.innerHTML="&#xf16c;";
+                ctrlSlower.innerHTML="&#xf14d;";
+                ctrlFaster.innerHTML="&#xf14c;"
+                ctrlSlower.onclick = slower;
+                ctrlFaster.onclick = faster;
+            }
+	   }
+
+        function pauseClick() {
+            if (vid.paused) {
+                vid.play();
+            } else {
+                vid.pause();
+            }
+	    pauseEvent();
+        }
+
+        function faster() {
+            if (vid.playbackRate <= 1) {
+                vid.playbackRate = vid.playbackRate * 2;
+            } else {
+                vid.playbackRate = parseFloat(vid.playbackRate) + 1;
+            }
+        }
+
+        function slower() {
+            if (vid.playbackRate <= 1)
+                vid.playbackRate = vid.playbackRate / 2;
+            else
+                vid.playbackRate--;
+        }
+
+        function reverse() {
+            if (isReverse) {
+                mp4src.src = mp4src.src.replace(/-reverse\.mp4/g, ".mp4");
+                webmsrc.src = webmsrc.src.replace(/-reverse\.webm/g, ".webm");
+		ctrlReverse.innerHTML="&#xf169;";
+                isReverse = false;
+            } else {
+                mp4src.src = mp4src.src.replace(/\.mp4/g, "-reverse.mp4");
+                webmsrc.src = webmsrc.src.replace(/\.webm/g, "-reverse.webm");
+		ctrlReverse.innerHTML="&#xf16d;";
+                isReverse = true;
+            }
+            vid.load();
+            vid.pause();
+            pauseClick();
+        }
+    }
+    window.gfygurObject = gfygurObject;
+}).call(this);

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1793,6 +1793,158 @@ modules['showImages'] = {
 
 				return $.Deferred().resolve(elem).promise();
 			}
+		},		
+		gfygur: {
+			options: {
+				'display gfycat': {
+					description: ' Dispaly albums of gfycat from gfygur links',
+					value: true,
+					type: 'boolean'
+				}
+			},
+			calls: {},
+			go: function() {},
+			detect: function(elem) {
+				var href = elem.href.toLowerCase();
+				return href.indexOf('gfygur.com/album/') !== -1 && href.substring(-1) !== '+';
+			},
+			handleLink: function(elem) {
+				var hashRe = /^http:\/\/[a-zA-Z0-9\-\.]*gfycat\.com\/(\w+)\.?/i;
+				var def = $.Deferred();
+				var groups = (elem.href).split('gfygur.com/album/')[1];
+				var groups = groups.split('/');
+				//var gfyAlbum = new Array;
+				var video = {};
+				
+				if (!groups) return def.reject();
+				
+				
+				var href = elem.href.toLowerCase();
+				var hotLink = false;
+				if(href.match(/(giant|fat|zippy)*.gif/g))
+				        hotLink = true;
+				var siteMod = modules['showImages'].siteModules['gfycat'];
+				var apiURL = 'http://gfycat.com/cajax/get/' + groups[0];
+
+				if (apiURL in siteMod.calls) {
+					if (siteMod.calls[apiURL] != null) {
+						def.resolve(elem, siteMod.calls[apiURL]);
+					} else {
+						siteMod.calls[apiURL] = null;
+						def.reject();
+					}
+				} else {
+		            /*
+		             * Retrieves information for the specified url segments.
+		             */
+		             var album = new Array;
+
+	             	if (groups[groups.length-1] == "") {groups.pop();};
+		            for (var i = 0; i < groups.length; i++) {
+		               getXHR(groups[i]); 
+		            };
+
+
+		            function gfyRequests(method, url) {
+		                    var xhr = new XMLHttpRequest();
+		                    xhr.open(method, 'http://gfycat.com/cajax/get/' + url, true);
+		                    xhr.setRequestHeader('X-CORS-Status', 'true');
+		                    return xhr;
+		            };
+
+		            function getXHR(url){
+		                var xhr;
+		                xhr = gfyRequests('GET', url);
+		                
+		                xhr.onload = function() {
+		                    
+		                    var json = JSON.parse(this.responseText);
+		                    var gfyItem = json.gfyItem;
+		                    album.push(
+		                        {
+		                            'source': gfyItem.webmUrl,
+		                            'type': 'video/webm',
+		                            'class': 'gfyRwebmsrc'
+		                        }
+		                    );
+		                    def.resolve(elem, json.gfyItem, album, groups).promise();
+		                };
+		                xhr.send();
+		            }
+				
+				}
+				return def.promise();
+			},
+			handleInfo: function(elem, info, album, urls) {
+				function humanSize(bytes) {
+					var byteUnits = [' kB', ' MB'];
+					for (var i = -1; bytes > 1024; i++) {
+						bytes = bytes / 1024;
+					}
+					return Math.max(bytes, 0.1).toFixed(1) + byteUnits[i];
+				}
+				if (info.hotLink) {
+					elem.type = "IMAGE";
+					elem.src = info.src;
+					elem.imageTitle = humanSize(info.gifSize);
+					if (((info.gifSize > 524288 && (info.gifSize / info.mp4Size) > 5) ||
+							(info.gifSize > 1048576 && (info.gifSize / info.mp4Size) > 2)) &&
+							document.createElement('video').canPlayType)
+						elem.imageTitle += ' (' + humanSize(info.mp4Size) + " for <a href='http://gfycat.com/" + info.gfyName + "'>HTML5 version.</a>)";
+
+					if (RESUtils.pageType() === 'linklist') {
+						$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
+					}
+					return $.Deferred().resolve(elem).promise();
+				}
+				RESTemplates.load('GfycatUI');
+
+				var generate = function(options) {
+					var template = RESTemplates.getSync('GfycatUI');
+					var video = {
+						loop: true,
+						autoplay: true,
+						muted: true,
+						directurl: elem.href,
+
+					};
+					video.poster = 'http://thumbs.gfycat.com/'+info.gfyName+'-poster.jpg';
+
+					video.sources = (
+						{
+							'source': info.webmUrl,
+							'type': 'video/webm',
+							'class': 'gfyRwebmsrc'
+						},
+						{
+							'source': info.mp4Url,
+							'type': 'video/mp4',
+							'class': 'gfyRmp4src'
+						}
+					);
+
+					video.album = album;
+					video.control = ({});
+					video.gfygur = ({});
+
+					var element = template.html(video)[0];
+					new window.gfygurObject(element,elem.href,info.frameRate);
+					modules['showImages'].makeImageZoomable(element.querySelector('video'));
+					return element;
+				};
+				elem.type = 'GENERIC_EXPANDO';
+				elem.expandoClass = ' image gallery collapsed';
+				elem.expandoOptions = {
+					generate: generate,
+					media: info
+				};
+
+				if (RESUtils.pageType() === 'linklist') {
+					$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
+				}
+
+				return $.Deferred().resolve(elem).promise();
+			}
 		},
 		fitbamob: {
 			options: {
@@ -3054,4 +3206,3 @@ modules['showImages'] = {
 		},
 	}
 };
-

--- a/lib/templates.html
+++ b/lib/templates.html
@@ -166,14 +166,17 @@
 		<!--/VideoUI-->
 		<!--GfycatUI-->
 		<script id="GfycatUI" type="application/x-template">
-			<div class="res-player video gfycatR">
+			<div class="res-player video gfycatR {{#gfygur}}gfygur{{/gfygur}}">
+{{#control}}<div class='gfyCtrl'><span class="RESGalleryControls"><a class="previous noKeyNav"></a><span class="RESGalleryLabel">1 of 1</span><a class="next noKeyNav"></a></span></div>{{/control}}			
 				<a class="madeVisible" href="{{ directurl }}" target="_blank">
 				<video autoplay loop muted preload title="Drag to Resize" class="gfyRVid" poster="{{ poster }}"">
 					{{#sources}}
 					<source src="{{ source }}" {{#type}}type="{{ type }}"{{/type}} class="{{ class }}">
 					{{/sources}}
 				</video>
+
 				</a>
+				{{#album}}<div class='gfy-data' data-url="{{source}}""></div>{{/album}}
 				<div style="height: 35px;" class="ctrlContainer">
 					<div style="width: 90px; height: 25px; float: right; padding: 5px; display: none;" class="ctrlBox">
 						<div  class="res-icon res-lightweight-player-controls gfyRCtrlFaster" >&#xf14c;</div>


### PR DESCRIPTION
Added support to show gfycat albums shown on gfygur.com 
Parses urls from gfygur.com/album/gfyname1/gfynam2/....
Files modified: showimages.js, templates.html, manifest.json
Added. gfygur.js