### PR TITLE
Add expando for Clyp audio uploads (http://clyp.it)

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -3019,7 +3019,10 @@ modules['showImages'] = {
 			},
 			go: function() {},
 			detect: function(href, elem) {
-				return href.indexOf('clyp.it') !== -1;
+				if (href.indexOf('clyp.it') !== -1) {
+					if (elem.className.indexOf("title") === -1) return true;
+				}
+				return false;
 			},
 			handleLink: function(elem) {
 				var def = $.Deferred();


### PR DESCRIPTION
Clyp is a free service that allows you to anonymously upload and share audio files. It's been around Reddit for a whlie and was originally known as Audiour, or the "Imgur of Audio." 

This add an expando for loading Clyp's embeddable widget for any shared audio files.

Here's an example of some of the files shared via Clyp:
http://www.reddit.com/domain/clyp.it/top
http://www.reddit.com/domain/audiour.com/top
