### PR TITLE
Fix video pausing from parent comments

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -881,7 +881,7 @@ modules['showImages'] = {
 
 		// Pause if comment (or any parent of comment) is collapsed
 		if (RESUtils.pageType() == 'comments') {
-			$(expandoButton).parents(".comment").find(".tagline > .expand").click(function(){
+			$(expandoButton).parents(".comment").find("> .entry .tagline > .expand").click(function(){
 				$(wrapperDiv).children("iframe")[0].contentWindow.postMessage(imageLink.getAttribute("data-pause"), '*');
 			});
 		}


### PR DESCRIPTION
This fixes an issue where collapsing a parent comment's children would also pause the video.
Now as intended, collapsing only the comment or parent comments will pause the video.
