### PR TITLE
Use direct lookup in showImages (rather than looping through)

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -159,12 +159,7 @@ modules['showImages'] = {
 			if(site === 'default' || typeof this.siteModules[site].alias !== 'undefined') continue;
 
 			// Auto add on / off options
-			var name = (typeof this.siteModules[site].name === 'undefined') ? site : this.siteModules[site].name;
-			this.options['display ' + name] = {
-				description: 'Display expander for ' + name,
-				value: true,
-				type: 'boolean'
-			}
+			this.createSiteModuleEnabledOption(site);
 
 			// Find out if module has any additional options - if it does add them
 			if(this.siteModules[site].options !== 'undefined'){
@@ -173,6 +168,23 @@ modules['showImages'] = {
 				}
 			}
 		}
+	},
+	getSiteModuleName: function(site){
+		// Get site module name (if provided) - else use module id
+		return (typeof this.siteModules[site].name === 'undefined') ? site : this.siteModules[site].name;
+	},
+	createSiteModuleEnabledOption: function(site){
+		// Create on/off option for given module
+		var name = this.getSiteModuleName(site);
+		this.options['display ' + name] = {
+			description: 'Display expander for ' + name,
+			value: true,
+			type: 'boolean'
+		}
+	},
+	siteModuleEnabled: function(site) {
+		var key = 'display ' + this.getSiteModuleName(site);
+		return (typeof this.options[key] === 'undefined') ? true : this.options[key].value;
 	},
 	beforeLoad: function() {
 		if ((this.isEnabled()) && (this.isMatchURL())) {
@@ -518,12 +530,6 @@ modules['showImages'] = {
 			RESUtils.insertAfter(elem, textFrag);
 		}
 	},
-
-	siteModuleEnabled: function(site) {
-		var key = 'display ' + ( (typeof this.siteModules[site].name !== 'undefined') ? this.siteModules[site].name : site );
-		return (typeof this.options[key] === 'undefined') ? true : this.options[key].value;
-	},
-
 	createImageExpando: function(elem) {
 		var mod = modules['showImages'];
 		if (!elem) return false;
@@ -2751,7 +2757,7 @@ modules['showImages'] = {
 				return $.Deferred().resolve(elem).promise();
 			}
 		},
-		youtu: { alias: "youtube" },
+		youtu: { alias: "youtube", name: "youtube" },
 		vimeo: {		
 			detect: function(href, elem) {
 				// Only find comments, not the titles.


### PR DESCRIPTION
First attempt at a hash based solution for loading site modules. Rather than looping through all available modules until a detect matches, this version should now use the `domainToModuleName` method to programmatically figure out the modules name. (Similar to the HB's betterzoom)

In order to get this working I've had to make a few minor tweaks.
- `go()` has been removed (mostly as nothing appeared to using this)
- A few modules have changed names in order to match their hash lookups ("bac.on" with this approach would need the name "bac")
- Add support for alias's for sites that utilize multiple domains (so far this just youtube)
- support for 2 part tld's exists, but I've commented it out for now as its not currently needed.
- potentially some siteModules could just return true with this apprach, rather than actually bothering to check the domain.

Whats everyone's thoughts?
