### PR TITLE
fix launching user tagger from command line

### DIFF
--- a/lib/modules/commandLine.js
+++ b/lib/modules/commandLine.js
@@ -350,8 +350,11 @@ addModule('commandLine', function(module, moduleID) {
 			var val = splitWords.join(' ');
 			switch (command) {
 				case 'tag':
-					var tagLink = searchArea.querySelector('a.userTagLink');
 					var searchArea = modules['keyboardNav'].keyboardLinks[modules['keyboardNav'].activeIndex];
+					if (!searchArea) {
+						searchArea = document.body;
+					}
+					var tagLink = searchArea.querySelector('a.userTagLink');
 					if (tagLink) {
 						RESUtils.click(tagLink);
 						setTimeout(function() {


### PR DESCRIPTION
gotta have a searchArea before you can search it (maybe bad merge?)
also fallback to document.body if no currently selected keyboard area (e.g. if keyboardNav is disabled)
