### PR TITLE
only add scroll event if the sidebar exists

### DIFF
--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -236,7 +236,9 @@ modules['styleTweaks'] = {
 
 	floatSideBar: function() {
 		this.sideBarElement = document.querySelector('.listing-chooser');
-		window.addEventListener('scroll', modules['styleTweaks'].handleScroll, false);
+		if (this.sideBarElement) {
+			window.addEventListener('scroll', modules['styleTweaks'].handleScroll, false);
+		}
 	},
 	handleScroll: function(e) {
 		if (modules['styleTweaks'].scrollTimer) {


### PR DESCRIPTION
I originally added this functionality, but only just now noticed that it gives errors on comment pages where the sidebar doesn't exist. This is mostly only an issue with developers who have pausing on exceptions enabled, but figured it was worth the fix anyways.
