### PR TITLE
elementInViewport(): return false if element is falsey

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -371,6 +371,9 @@ RESUtils.getXYpos = function(obj) {
 	};
 };
 RESUtils.elementInViewport = function(obj) {
+	if (!obj) {
+		return false;
+	}
 	// check the headerOffset - if we've pinned the subreddit bar, we need to add some pixels so the "visible" stuff is lower down the page.
 	var headerOffset = this.getHeaderOffset();
 	var top = obj.offsetTop - headerOffset;


### PR DESCRIPTION
This is somewhat related to PR #1048 -- you can dismiss this if you'd like as my other fix for the scrolling sidebar won't run into this issue any more.

None the less, I figured it wouldn't hurt to short circuit the RESUtils.elementInViewport function to return false if obj is falsey (e.g. doesn't exist)
