### PR TITLE
Don't show Full context link if it's a top comment (#1052)

### DIFF
--- a/lib/modules/context.js
+++ b/lib/modules/context.js
@@ -41,7 +41,10 @@ modules['context'] = {
 		if(location.search !== "?context=10000") {
 			var pInfobar = document.querySelector(".infobar:not(#searchexpando) p");
 			if(pInfobar) {
-				pInfobar.innerHTML += '&nbsp;<a href="?context=10000">view the full context</a>&nbsp;→';
+				// check if there is a Parent button, if not it's a top comment so don't show full context link
+				if($('.sitetable:eq(1) .buttons:first .bylink').length > 1) { // Permalink and Parent have bylink class
+					pInfobar.innerHTML += '&nbsp;<a href="?context=10000">view the full context</a>&nbsp;→';
+				}
 			}
 		}
 	},


### PR DESCRIPTION
Fix #1066
