### PR TITLE
Avoid a strange bug making the appendChild didn't work under strange con...

### DIFF
--- a/lib/alert.js
+++ b/lib/alert.js
@@ -49,7 +49,9 @@ var gdAlert = {
 		// create site overlay
 		if (gdAlert.overlay === false) {
 			gdAlert.overlay = RESUtils.createElementWithID("div", "alert_message_background");
-			document.body.appendChild(gdAlert.overlay);
+			setTimeout(function(overlay) {	// avoid a strange bug making the appendChild didn't work under strange conditions
+				document.body.appendChild(overlay);
+			}, 0, gdAlert.overlay);
 		}
 
 		gdAlert.container.style.top = Math.max(0, (($(window).height() - $(gdAlert.container).outerHeight()) / 2) ) + "px";


### PR DESCRIPTION
...ditions

It's ugly, but I think it's a king of bug from Google Chrome

Disable, then enable the extension, reload the page, open the alert => no overlay
A way to make it work is to open the console, reload the page then open the alert.
After that alert will always work (until disable/enable the extension).
