### PR TITLE
Fix Macro Menu

### DIFF
--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -228,8 +228,9 @@ modules['commentTools'] = {
 				box.dispatchEvent(inputEvent);
 			}).on("click", ".RESMacroDropdownTitle", function(e) {
 				var pos = $(this).position();
+				var titleHeight = $(this).height();
 				$(this).next().css({
-					top: (pos).top + "px",
+					top: (pos.top + titleHeight + 2) + "px",
 					left: (pos).left + "px"
 				}).show();
 			}).on("mouseleave", ".RESMacroDropdown", function(e) {
@@ -734,7 +735,7 @@ modules['commentTools'] = {
 		} else {
 			macroGroup = this.macroDropDownTable[groupName] = {};
 			macroGroup.titleButton = $('<span class="RESMacroDropdownTitle">' + groupName + '</span>');
-			macroGroup.container = $('<span class="RESMacroDropdown"><span class="RESMacroDropdownTitleOverlay">' + groupName + '</span></span>').hide();
+			macroGroup.container = $('<span class="RESMacroDropdown"></span>').hide();
 			macroGroup.dropdown = $('<ul class="RESMacroDropdownList RESDropdownList"></ul>');
 			macroGroup.container.append(macroGroup.dropdown);
 		}


### PR DESCRIPTION
Else on clicking on category name this will double it but with an offset
so we are seeing two time the same name overlapping do to the offset.
Moreover, it's prevent user clicking on the next macro category when the
previous macro category is open.

@andytuba I removed your RESMacroDropdownTitleOverlay, it seem he is not usefull (exept for good positioning) but maybe I'm wrong.
