### PR TITLE
Limit commentsLinksNewTabs to comments

### DIFF
--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -250,7 +250,7 @@ modules['betteReddit'] = {
 	},
 	commentsLinksNewTabs: function(ele) {
 		ele = ele || document.body;
-		var links = ele.querySelectorAll('.comment div.md a');
+		var links = ele.querySelectorAll('.thing div.md a');
 		for (var i = 0, len = links.length; i < len; i++) {
 			links[i].target = '_blank';
 		}


### PR DESCRIPTION
Primarily to stop it touching sidebar links on comments pages. `thing`
might be more appropriate to retain behaviour that people have gotten
accustomed to.
