### PR TITLE
Gruntfile: Copy browsersupport-chrome.js for OperaBlink

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,7 +16,10 @@ module.exports = function(grunt) {
 				files: [{ expand: true, cwd: 'lib/', src: ['**'], dest: 'Opera/'}]
 			},
 			operablink: {
-				files: [{ expand: true, cwd: 'lib/', src: ['**'], dest: 'OperaBlink/'}]
+				files: [
+					{ expand: true, cwd: 'lib/', src: ['**'], dest: 'OperaBlink/'},
+					{ expand: true, cwd: 'Chrome/', src: ['browsersupport-chrome.js'], dest: 'OperaBlink/'}
+				]
 			},
 			safari: {
 				files: [{ expand: true, cwd: 'lib/', src: ['**'], dest: 'RES.safariextension/'}]
@@ -29,19 +32,24 @@ module.exports = function(grunt) {
 		// Watch for changes
 		watch: {
 			chrome: {
-				files: ['lib/*', 'lib/*/*'], tasks: ['copy:chrome']
+				files: ['lib/*', 'lib/*/*'],
+				tasks: ['copy:chrome']
 			},
 			opera: {
-				files: ['lib/*', 'lib/*/*'], tasks: ['copy:opera']
+				files: ['lib/*', 'lib/*/*'],
+				tasks: ['copy:opera']
 			},
 			operablink: {
-				files: ['lib/*', 'lib/*/*'], tasks: ['copy:operablink']
+				files: ['lib/*', 'lib/*/*', 'Chrome/browsersupport-chrome.js'],
+				tasks: ['copy:operablink']
 			},
 			safari: {
-				files: ['lib/*', 'lib/*/*'], tasks: ['copy:safari']
+				files: ['lib/*', 'lib/*/*'],
+				tasks: ['copy:safari']
 			},
 			firefox: {
-				files: ['lib/*', 'lib/*/*'], tasks: ['copy:firefox']
+				files: ['lib/*', 'lib/*/*'],
+				tasks: ['copy:firefox']
 			}
 		},
 


### PR DESCRIPTION
Just a bit more convenient for OperaBlink developers.
