### PR TITLE
Added functionality for Photobucket images.

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -2982,13 +2982,6 @@ modules['showImages'] = {
 		},
         photobucket: {
             domains: ['photobucket.com'],
-            options: {
-                'display photobucket': {
-                    description: 'Display expander for photobucket',
-                    value: true,
-                    type: 'boolean'
-                }
-            },
             go: function() {},
             detect: function(href, elem) {
                 return href.indexOf('photobucket.com') !== -1;


### PR DESCRIPTION
This pull request adds functionality to RES to display images that come from s###, i###, and media subdomains on photobucket.com.
