### PR TITLE
Implement automatic night mode

### DIFF
--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -79,8 +79,8 @@ modules['styleTweaks'] = {
 		},
 		nightModeOverrideHours: {
 			type: 'text',
-			value: 24,
-			description: 'Number of hours that the automatic night mode override lasts. Default is 24 (hours).\
+			value: 8,
+			description: 'Number of hours that the automatic night mode override lasts. Default is 8 (hours).\
 				<br>You can use a decimal number of hours here as well; e.g. 0.1 hours (which is 6 min).'
 		},
 		useSubredditStyleInDarkMode: {


### PR DESCRIPTION
This implements the frequently-requested "automatic night mode", where night mode is automatically enabled after a certain time and disabled after another. Fixes #384.

Here is a screenshot of the settings added to styleTweaks:
![Screenshot of automatic night mode settings](http://i.imgur.com/76kuctL.png)

As noted in the description for the setting, automatic night mode begins at `nightModeStart` and ends at `nightModeEnd`. Automatic night mode can be temporarily disabled (for `nightModeOverrideHours` hours) by clicking on the night mode toggle located in the Gears dropdown menu.

This setting is currently defaulted to "off".
