### PR TITLE
Precise it's on the user tags tab for tagsPerPage

### DIFF
--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -35,7 +35,7 @@ modules['dashboard'] = {
 		tagsPerPage: {
 			type: 'text',
 			value: 25,
-			description: 'How many user tags to show per page. (enter zero to show all on one page)'
+			description: 'How many user tags to show per page on the <a href="/r/Dashboard/#userTaggerContents">my users tags</a> tab. (enter zero to show all on one page)'
 		}
 	},
 	description: 'The RES Dashboard is home to a number of features including widgets and other useful tools',


### PR DESCRIPTION
Fix #1152

Because else, you think about the main dashboard tab, and try to understand why it would limit the user tags on link list.
