### PR TITLE
Add the user tag next to commentingAs nickname.

### DIFF
--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -212,7 +212,7 @@ modules['commentTools'] = {
 				modules["commentTools"].viewSource(this);
 			}).on("click", ".usertext-edit.viewSource .cancel", function() {
 				$(this).parents(".usertext-edit.viewSource").hide();
-			}).on("click", "div.markdownEditor-wrapper a", function(e) {
+			}).on("click", "div.markdownEditor-wrapper a:not(.userTagLink)", function(e) {
 				e.preventDefault();
 
 				var index = $(this).data("macro-index");
@@ -541,7 +541,8 @@ modules['commentTools'] = {
 
 		if (this.options.commentingAs.value && (!modules['usernameHider'].isEnabled())) {
 			// show who we're commenting as...
-			var commentingAs = $('<div class="commentingAs">').text('Commenting as: ' + RESUtils.loggedInUser());
+			var commentingAs = $('<div class="commentingAs">').html('Commenting as: <span class="commentingAsUser" data-user="'+ RESUtils.loggedInUser() +'">' + RESUtils.loggedInUser() + '</span>');
+			modules['userTagger'].applyTagToAuthor(commentingAs.find('.commentingAsUser')[0]);
 			if(this.options.highlightIfAltAccount.value && modules['accountSwitcher'].options.accounts.value.length && RESUtils.loggedInUser().toLowerCase() !== modules['accountSwitcher'].options.accounts.value[0][0].toLowerCase()) {
 				commentingAs.addClass('highlightedAltAccount');
 			}

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -789,7 +789,7 @@ modules['userTagger'] = {
 		if (ele == null) {
 			ele = document;
 		}
-		var authors = ele.querySelectorAll('.noncollapsed a.author, p.tagline a.author, #friend-table span.user a, .sidecontentbox .author, div.md a[href^="/u/"]:not([href*="/m/"]), div.md a[href*="reddit.com/u/"]:not([href*="/m/"]), .usertable a.author, .usertable span.user a, div.wiki-page-content .author');
+		var authors = ele.querySelectorAll('.noncollapsed a.author, p.tagline a.author, #friend-table span.user a, .sidecontentbox .author, div.md a[href^="/u/"]:not([href*="/m/"]), div.md a[href*="reddit.com/u/"]:not([href*="/m/"]), .usertable a.author, .usertable span.user a, div.wiki-page-content .author, .commentingAsUser');
 		RESUtils.forEachChunked(authors, 15, 1000, function(arrayElement, index, array) {
 			modules['userTagger'].applyTagToAuthor(arrayElement);
 		});
@@ -818,9 +818,13 @@ modules['userTagger'] = {
 					clearTimeout(modules['userTagger'].showTimer);
 				}, false);
 			}
-			test = thisAuthorObj.href.match(this.usernameRE);
-			if (test) {
-				thisAuthor = test[1];
+			if (thisAuthorObj.href) {
+				test = thisAuthorObj.href.match(this.usernameRE);
+				if (test) {
+					thisAuthor = test[1];
+				}
+			} else if (thisAuthorObj.getAttribute('data-user')) {
+				thisAuthor = thisAuthorObj.getAttribute('data-user');
 			}
 			// var thisAuthor = thisAuthorObj.text;
 			noTag = false;


### PR DESCRIPTION
Fix #1100

Note : We can't edit the tag, first this was because an unknow bug making the click event doesn't work, but in fact, it's better without (because if we don't have a tag, it's ugly and useless to add the icon tag).

edit : see #1183
