### PR TITLE
The DIV .subButtons

### DIFF
--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -127,7 +127,6 @@ modules['dashboard'] = {
 		RESUtils.addCSS('ul.widgetStateButtons li.refresh div { height: 16px; width: 16px; position: absolute; left: 4px; top: 4px; background-image: url("https://s3.amazonaws.com/e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png"); background-repeat: no-repeat; background-position: -16px -209px; }');
 		RESUtils.addCSS('#userTaggerContents .show { display: inline-block; }');
 		RESUtils.addCSS('#tagPageControls { display: inline-block; position: relative; top: 9px;}');
-		RESUtils.addCSS('.subButtons { margin: 0; }');
 
 		var dbLinks = $('span.redditname a');
 		if ($(dbLinks).length > 1) {

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -144,6 +144,8 @@ modules['subredditManager'] = {
 			RESUtils.addCSS('#srLeftContainer, #RESShortcutsViewport, #RESShortcutsEditContainer{max-height:18px;}');
 			RESUtils.addCSS('#RESSubredditGroupDropdown .shortcutSuffix { opacity:0.4; }');
 			RESUtils.addCSS('#RESSubredditGroupDropdown a:hover .shortcutSuffix { opacity:0.6; }');
+			RESUtils.addCSS('.subButtons { margin: 0 !important; top: 0 !important; z-index: 1 !important; }');
+			RESUtils.addCSS('.RESshortcutside { display: inline-block !important; }');
 
 			// this shows the sr-header-area that we hid while rendering it (to curb opera's glitchy "jumping")...
 			if (BrowserDetect.isOpera()) {
@@ -191,7 +193,7 @@ modules['subredditManager'] = {
 					var thisSubredditFragment = $(subButton).next().text();
 				}
 				if ($('#subButtons-' + thisSubredditFragment).length === 0) {
-					var subButtonsWrapper = $('<div id="subButtons-' + thisSubredditFragment + '" class="subButtons" style="margin: 0 !important; top: 0 !important; z-index: 1 !important;"></div>');
+					var subButtonsWrapper = $('<div id="subButtons-' + thisSubredditFragment + '" class="subButtons"></div>');
 					$(subButton).wrap(subButtonsWrapper);
 					// move this wrapper to the end (after any icons that may exist...)
 					if (isMulti) {
@@ -204,7 +206,6 @@ modules['subredditManager'] = {
 					RESStorage.setItem('RESmodules.subredditManager.subreddits.lastCheck.' + RESUtils.loggedInUser(), 0);
 				}, false);
 				var theSC = document.createElement('span');
-				theSC.setAttribute('style', 'display: inline-block !important;');
 				theSC.setAttribute('class', 'RESshortcut RESshortcutside');
 				theSC.setAttribute('data-subreddit', thisSubredditFragment);
 				var idx = -1;


### PR DESCRIPTION
This began from frustrations while trying to theme a subreddit, it's a minor and simple change to make things easier for subreddit designers.

I wanted to adjust the spacing around the subscribe buttons but the inline CSS was making it difficult. The DIV .subButtons wraps around subreddits' subscribe button as well as the shortcut and dashboard buttons, it sits directly below the 'Use subreddit style' checkbox (which this commit doesn't touch). In the current developer build the DIV .subButtons has had RESUtils.baseStyleProtection slapped onto it, which is currently not doing anything useful because it doesn't actually protect the buttons inside the DIV.

My commit takes the inline CSS that has always been on .subButtons and moves it into a class declaration, so that it can be overridden with other CSS. Additionally I removed RESUtils.baseStyleProtection from the DIV .subButtons because it is ineffective and only gets in the way.
