### PR TITLE
Add score coloration for link and comments (disabled by default)

### DIFF
--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -260,6 +260,7 @@ modules['styleTweaks'] = {
 				this.floatSideBar();
 			}
 			if (this.options.colorLinkScore.value) {
+				RESUtils.addCSS('.link .rank { color: #fff; text-align: center; border-radius: 1em; font-size: 12px; padding: 4px; line-height: 1; height: 1em; min-width: 1em; }');
 				this.applyLinkScoreColor();
 				RESUtils.watchForElement('siteTable', modules['styleTweaks'].applyLinkScoreColor);
 			}
@@ -673,7 +674,9 @@ modules['styleTweaks'] = {
 		for (var i = 0, len = scoreNode.length; i < len; i++) {
 			var node = scoreNode[i];
 			if (!isNaN(parseInt(node.innerText), 10)) {
-				node.style.color = 'hsl(' + 180+360*(1-100/(150+parseInt(node.innerText, 10))) + ', 100%,50%)';
+				$(node).closest('.thing').find('.rank')[0].style.background = 'hsl(' + 180+360*(1-100/(150+parseInt(node.innerText, 10))) + ', 75%,50%)';
+			} else {
+				$(node).closest('.thing').find('.rank')[0].style.background = '#c6c6c6';
 			}
 		};
 	},


### PR DESCRIPTION
So, here are two option I just write. There are disabled by default (which is logicial), but I think some people could be interessed. But this may be something you don't want to add to RES.

Theses options add color to links and comments score, allowing to quickly see if they are popular or not.

![image](https://cloud.githubusercontent.com/assets/339611/3211456/d305766e-ef18-11e3-961a-1d4be96e1322.png)
![image](https://cloud.githubusercontent.com/assets/339611/3211458/dba16af8-ef18-11e3-86dd-06a4a1082524.png)

As you can see, it handle very popular post/comments and also very few popular. The color change quickly for lower number, and slowly for bigger number.

Edit : [Link Color Legend](http://jsbin.com/sehexi/1) [Comment Color Legend](http://jsbin.com/sehexi/2)
