### PR TITLE
Dashboard tables are difficult to read with subreddit style disabled

### DIFF
--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -127,6 +127,9 @@ modules['dashboard'] = {
 		RESUtils.addCSS('ul.widgetStateButtons li.refresh div { height: 16px; width: 16px; position: absolute; left: 4px; top: 4px; background-image: url("https://s3.amazonaws.com/e.thumbs.redditmedia.com/r22WT2K4sio9Bvev.png"); background-repeat: no-repeat; background-position: -16px -209px; }');
 		RESUtils.addCSS('#userTaggerContents .show { display: inline-block; }');
 		RESUtils.addCSS('#tagPageControls { display: inline-block; position: relative; top: 9px;}');
+		RESUtils.addCSS('.dashboardPane.md { max-width: none; font-size: x-small; }');
+		RESUtils.addCSS('.dashboardPane.md table { margin: 0; width: 100%; }');
+		RESUtils.addCSS('.dashboardPane.md th { font-weight: normal; }');
 
 		var dbLinks = $('span.redditname a');
 		if ($(dbLinks).length > 1) {
@@ -885,7 +888,7 @@ modules['dashboard'] = {
 		}
 	},
 	addTab: function(tabID, tabName) {
-		$('#siteTable.linklisting').append('<div id="' + tabID + '" class="dashboardPane" />');
+		$('#siteTable.linklisting').append('<div id="' + tabID + '" class="dashboardPane md" />');
 		$('span.redditname').append('<a id="tab-' + tabID + '" class="dashboardTab" title="' + tabName + '">' + tabName + '</a>');
 		$('#tab-' + tabID).click(function(e) {
 			location.hash = tabID;


### PR DESCRIPTION
This adds the class 'md' to the second two dashboard panes, which causes
the 'user' and 'subscription' tables to be styled according to Reddit's
standards. It only applies if the user has turned off custom subreddit stylesheets.

Screenshots: My Users + My Subscriptions: [Before](http://i.imgur.com/EQkp532.png) / [After](http://i.imgur.com/xCFpSb8.png)

If this commit is added along with #926 then /r/Dashboard will be perfectly usable for all users whether or not they have custom subreddit styles enabled. Furthermore, the total amount of CSS will be reduced despite helping more users.

Tested in Chrome and Firefox on Windows.
