### PR TITLE
Macro placeholders for OP, reply_to, me

### DIFF
--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -85,7 +85,7 @@ modules['commentTools'] = {
 	},
 	loadDynamicOptions: function() {
 		if (modules['commentTools'].magicPlaceholders.length) {
-			var macroPlaceholdersDescription = '<br><br>Some placeholders are automatically filled in when you use the macro.\<dl>';
+			var macroPlaceholdersDescription = '<br><br>Some placeholders are automatically filled in when you use the macro:\<dl>';
 			macroPlaceholdersDescription += modules['commentTools'].magicPlaceholders.map(function(placeholder) {
 				var description = "<dt>" + placeholder.matches.map(function(placeholder) { return "{{" + placeholder + "}}" }).join("<br>") + "</dt>";
 				if (placeholder.description) {


### PR DESCRIPTION
Filled in {{op}}, {{op_username}}, {{reply_to}}, {{reply_to_username}}, added {{me}}

Magic placeholders own their description; macroPlaceholder option descriptions dynamically includes magic placeholders' keys and descriptions
