### PR TITLE
Better autoExpandSelfText description

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -78,7 +78,7 @@ modules['showImages'] = {
 		autoExpandSelfText: {
 			type: 'boolean',
 			value: true,
-			description: 'When loading selftext from an Aa+ expando, auto reveal images.'
+			description: 'When loading selftext from an Aa+ expando, auto expand images, videos, and embeds.'
 		},
 		imageZoom: {
 			type: 'boolean',
@@ -1811,11 +1811,11 @@ modules['showImages'] = {
 				return href.indexOf('fitbamob.com') !== -1 || href.indexOf('offsided.com') !== -1 ;
 			},
 			handleLink: function(elem) {
-				
+
 				var hashRe = /r\/[a-zA-Z0-9]+\/([a-zA-Z0-9]+[\/]*$)|b\/([a-zA-Z0-9]+[\/]*$)|v\/([a-zA-Z0-9]+[\/]*$)/i;
 				var def = $.Deferred();
 				var groups = hashRe.exec(elem.href);
-				
+
 				if (!groups) return def.reject();
 				var href = elem.href.toLowerCase();
 
@@ -1825,7 +1825,7 @@ modules['showImages'] = {
 					link_id = encodeURIComponent(groups[1]);
 				}else if(typeof groups[2] !== 'undefined'){
 					link_id = encodeURIComponent(groups[2]);
-				}else{	
+				}else{
 					link_id = encodeURIComponent(groups[3]);
 				}
 				var apiURL = 'http://fitbamob.com/link/' + link_id + '/?format=json';


### PR DESCRIPTION
Refer to media content instead of images for description of the setting `autoExpandSelfText`.

---

Wouldn't it be better to change all instances of 'images' to 'media' in any and all appropriate contexts?

Example: Rename `showImages.js` to `showMedia.js`.
