### PR TITLE
migrate: Bugfix arguments.join()

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -35,14 +35,14 @@ var RESOptionsMigrate = {
 				try {
 					RESUtils.setOption(newModuleID, newOptionName, RESOptionsMigrate.f.utils.getRawOptions(oldModuleID)[oldOptionName].value);
 				} catch (e) {
-					console.error('Couldn\'t migrate (' + e + ' ; ' + arguments.join() + ')');
+					console.error('Couldn\'t migrate (' + e + ' ; ' + Array.prototype.join.call(arguments, ',') + ')');
 				}
 			},
 			moveWithFunction: function(oldModuleID, oldOptionName, newModuleID, newOptionName, f) {
 				try {
 					RESUtils.setOption(newModuleID, newOptionName, f(RESOptionsMigrate.f.utils.getRawOptions(oldModuleID)[oldOptionName].value));
 				} catch (e) {
-					console.error('Couldn\'t migrate (' + e + ' ; ' + arguments.join() + ')');
+					console.error('Couldn\'t migrate (' + e + ' ; ' + Array.prototype.join.call(arguments, ',') + ')');
 				}
 			}
 		},


### PR DESCRIPTION
`arguments` is not an array, so it does not have a `join()` method.
