### PR TITLE
setttings console shows "donate" module by default

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -1028,16 +1028,19 @@ var RESConsole = {
 		if (!this.RESConsoleContainer) {
 			RESConsole.create();
 		}
-		if (moduleIdOrCategory === 'search') {
-			moduleID = moduleIdOrCategory;
-			category = 'About RES';
-		} else {
+
+		if (modules[moduleIdOrCategory]) {
 			var module = modules[moduleIdOrCategory];
 			moduleID = module && module.moduleID;
 			category = module && module.category;
+		} else if (this.categories[moduleIdOrCategory]) {
+			category = moduleIdOrCategory;
+			moduleID = this.getModuleIDsByCategory(category)[0];
 		}
-		category = category || moduleIdOrCategory || this.categories[0];
-		moduleID = moduleID || this.getModuleIDsByCategory(category)[0];
+		if (!moduleID || !moduleID.length) {
+			moduleID = RESdefaultModuleID;
+			category = modules[moduleID].category;
+		}
 
 		// Draw the config panel
 		this.drawConfigPanel();

--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -1,4 +1,5 @@
 var RESVersion = "4.3.2.1";
+var RESdefaultModuleID = "contribute";  // Show this module by default when opening settings
 
 var jQuery, $, guiders, Tinycon, SnuOwnd;
 


### PR DESCRIPTION
if the user does not specifically select a module/category when opening the console, settings console will show the "donate" module.

pro: more donations, exposure to BabelExtish modules (notifications etc)

cons: people calling us out for begging (whatever, who cares); very slight hurdle to discovering RES modules
