### PR TITLE
styleTweaks: Fix missing this.head issue

### DIFF
--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -164,7 +164,7 @@ modules['styleTweaks'] = {
 	go: function() {
 		if ((this.isEnabled()) && (this.isMatchURL())) {
 			// get the head ASAP!
-			this.head = document.getElementsByTagName("head")[0];
+			this.head = this.head || document.getElementsByTagName("head")[0];
 
 			// get rid of antequated option we've removed (err, renamed) due to performance issues.
 			if (typeof this.options.commentBoxHover !== 'undefined') {
@@ -518,6 +518,7 @@ modules['styleTweaks'] = {
 	},
 	enableSubredditStyle: function(subreddit) {
 		var togglesr = subreddit ? subreddit.toLowerCase() : this.curSubReddit;
+		this.head = this.head || document.getElementsByTagName("head")[0];
 
 		if (modules['nightMode'].isNightModeOn() &&
 				!modules['nightMode'].isNightmodeCompatible) {
@@ -541,6 +542,7 @@ modules['styleTweaks'] = {
 	},
 	disableSubredditStyle: function(subreddit) {
 		var togglesr = subreddit ? subreddit.toLowerCase() : this.curSubReddit;
+		this.head = this.head || document.getElementsByTagName("head")[0];
 
 		if (modules['nightMode'].isNightModeOn() &&
 				!modules['nightMode'].isNightmodeCompatible) {


### PR DESCRIPTION
When `nightMode` (or another module) that loads before `styleTweaks` calls
`enableSubredditStyle` or `disableSubredditStyle`, `this.head` is undefined. This is kind of an ugly hack but it's mainly due to how styleTweaks and nightMode are somewhat coupled right now.
