### PR TITLE
Added X1-Online.com website to expando list.

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1114,6 +1114,15 @@ modules['showImages'] = {
 			if (options.loop) {
 				video.setAttribute('loop', '');
 			}
+			if (options.poster) {
+				video.setAttribute('poster', options.poster);
+			}
+			if (options.width) {
+				video.setAttribute('width', options.width);
+			}
+			if (options.height) {
+				video.setAttribute('height', options.height);
+			}
 		}
 		var sourcesHTML = "",
 			sources = $(imageLink).data('sources'),
@@ -3299,6 +3308,43 @@ modules['showImages'] = {
 					$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
 				}
 
+				return $.Deferred().resolve(elem).promise();
+			}
+		},
+		x1online: {
+			domains: ['x1-online.com'],
+			go: function () { },
+			detect: function (href, elem) {
+				return href.indexOf('x1-online.com') !== -1;
+			},
+			handleLink: function (elem) {
+				var def = $.Deferred();
+				var hashRe = /^https?:\/\/(?:www\.)?x1-online\.com\/profile\/(.{1,15})\/clip\/(.{36,})/;
+				var groups = hashRe.exec(elem.href);
+				if (groups) {
+					def.resolve(elem, { gamertag: groups[1], clip_id: groups[2] });
+				} else {
+					def.reject();
+				}
+				return def.promise();
+			},
+			handleInfo: function (elem, info) {
+				elem.expandoOptions = {
+					autoplay: false,
+					loop: false,
+					width: '600px',
+					poster: 'http://x1-online.com/profile/' + info['gamertag'] + '/clip/' + info['clip_id'] + '/thumb-large.png'
+				};
+				sources = [];
+				sources[0] = {
+					'file': 'http://x1-online.com/profile/' + info['gamertag'] + '/clip/' + info['clip_id'] + '/direct.mp4',
+					'type': 'video/mp4'
+				};
+				elem.type = 'VIDEO';
+				$(elem).data('sources', sources);
+				if (RESUtils.pageType() === 'linklist') {
+					$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
+				}
 				return $.Deferred().resolve(elem).promise();
 			}
 		}


### PR DESCRIPTION
Added my website to the list of websites that will allow expandos.

The website will allow you to directly link to Xbox One gameclips without having to reupload it one of the other services (OneDrive, YouTube).

Microsoft only supports MP4 files for the videos so I'm unable to add support for WEBM.

Also added a few options to the `generateVideoExpando` function to allow for a `poster` and setting the `width`/`height`.
