### PR TITLE
Native Mp4, Webm, Ogv video support.

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1100,8 +1100,8 @@ modules['showImages'] = {
 		var wrapperDiv = document.createElement('div');
 		wrapperDiv.className = 'madeVisible';
 
-		var imgDiv = document.createElement('p');
-		imgDiv.className = '';
+		var imgDiv = document.createElement('div');
+		imgDiv.className = 'madeVisible';
 
 
 		var video = document.createElement('video');
@@ -1138,6 +1138,11 @@ modules['showImages'] = {
 
 		imgDiv.appendChild(video);
 
+		expandoButton.expandoBox = imgDiv;
+
+		expandoButton.classList.remove('collapsedExpando');
+		expandoButton.classList.remove('collapsed');
+		expandoButton.classList.add('expanded');
 
 		wrapperDiv.appendChild(imgDiv);
 		if (expandoButton.classList.contains('commentImg')) {
@@ -1145,12 +1150,6 @@ modules['showImages'] = {
 		} else {
 			expandoButton.parentNode.appendChild(wrapperDiv);
 		}
-		expandoButton.expandoBox = imgDiv;
-
-		expandoButton.classList.remove('collapsedExpando');
-		expandoButton.classList.remove('collapsed');
-		expandoButton.classList.add('expanded');
-
 
 		this.makeImageZoomable(video);
 		this.makeImageMovable(video);


### PR DESCRIPTION
Implemented native support for mp4, webm and ogv video files. 

Tries to detect if the browser supports the video format using `canPlayType` function. The function will return the strings `probably`, `maybe` or ` `. It will add the inline video player if the function returns`probably`or`maybe`. You can never be sure if the browser fully supports the video format until it plays. But this should cover 99%.

Browsers tested:
- Google Chrome 35.0.1916.153 m
- Opera 22.0.1471.70
- Firefox 30.0

Using Windows 8.1 64-bit
