### PR TITLE
Trying to correct the glyphs in subreddit manager

### DIFF
--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -109,7 +109,7 @@ modules['subredditManager'] = {
 			RESUtils.addCSS('#editShortcutDialog .row { float: left; position: relative; }');
 			RESUtils.addCSS('#editShortcutDialog label { clear: both; float: left; width: 100px; margin-top: 12px; }');
 			RESUtils.addCSS('#editShortcutDialog input { float: left; width: 126px; margin-top: 10px; }');
-			RESUtils.addCSS('#editShortcutDialog #sortButton { padding: 0 0 4px 0; margin: 0; font-size: 10px; position: absolute; top: 10px; left: 80px; background-color: #fff; border: 1px solid #bbb; color: #bbb; line-height: 10px; }');
+			RESUtils.addCSS('#editShortcutDialog #sortButton { padding: 0 0 4px 0; margin: 0; position: absolute; top: 10px; left: 80px; background-color: #fff; border: 1px solid #bbb; color: #bbb; line-height: 1; }');
 			RESUtils.addCSS('#editShortcutDialog input[type=button] { float: right; width: 45px; margin-left: 10px; cursor: default; padding: 3px 5px; font-size: 12px; color: #fff; border: 1px solid #636363; border-radius: 3px; background-color: #5cc410; }');
 			RESUtils.addCSS('#srLeftContainer { z-index: 4; padding-left: 4px; }');
 			RESUtils.addCSS('#RESShortcutsViewport { width: auto; overflow: hidden; position: relative; padding-left: 6px; } ');
@@ -118,10 +118,11 @@ modules['subredditManager'] = {
 			RESUtils.addCSS('#RESSubredditGroupDropdown { display: none; position: absolute; z-index: 99999; padding: 3px; background-color: #F0F0F0; border-left: 1px solid black; border-right: 1px solid black; border-bottom: 1px solid black; }');
 			RESUtils.addCSS('#RESSubredditGroupDropdown li { padding-left: 3px; padding-right: 3px; margin-bottom: 2px; }');
 			RESUtils.addCSS('#RESSubredditGroupDropdown li:hover { background-color: #F0F0FC; }');
-			RESUtils.addCSS('#RESShortcutsEditContainer { width: auto; position: absolute; right: 0; top: 0 !important; z-index: 7; height: 100%; user-select: none; -webkit-user-select: none; -moz-user-select: none; line-height: 1; color: #369; }');
-			RESUtils.addCSS('#RESShortcutsEditContainer div { float: left; cursor: pointer; font-size: 15px !important; height: 100%; line-height: 18px; color: #369; background-color: #f0f0f0; }');
-			RESUtils.addCSS('#RESShortcutsEditContainer div:hover { color: orangered !important; }');
+			RESUtils.addCSS('#RESShortcutsEditContainer { width: auto; position: absolute; right: 0; top: 0 !important; z-index: 7; height: 100%; user-select: none; -webkit-user-select: none; -moz-user-select: none; line-height: 1; color: #369; font-family: monospace; }');
+			RESUtils.addCSS('#RESShortcutsEditContainer div { float: left; cursor: pointer; font-size: 18px !important; height: 100%; line-height: 1; color: #369; background-color: #f0f0f0; width: auto !important; }');
+			RESUtils.addCSS('#RESShortcutsSort { font-family: verdana; }');
 			RESUtils.addCSS('#RESShortcutsTrash { display: none; user-select: none; -webkit-user-select: none; -moz-user-select: none; }');
+			RESUtils.addCSS('#RESShortcutsEditContainer div:hover { color: orangered !important; }');
 			RESUtils.addCSS('.srSep { margin-left: 6px; }');
 			RESUtils.addCSS('.RESshortcutside { margin-right: 5px; margin-top: 2px; color: white; background-image: url(https://redditstatic.s3.amazonaws.com/bg-button-add.png); cursor: pointer; text-align: center; width: 68px; font-weight: bold; font-size: 10px; border: 1px solid #444; padding: 1px 6px; border-radius: 3px 3px 3px 3px; }');
 			RESUtils.addCSS('.RESshortcutside.remove { background-image: url(https://redditstatic.s3.amazonaws.com/bg-button-remove.png) }');
@@ -778,13 +779,13 @@ modules['subredditManager'] = {
 			this.sortShortcutsButton = document.createElement('div');
 			this.sortShortcutsButton.setAttribute('id', 'RESShortcutsSort');
 			this.sortShortcutsButton.setAttribute('title', 'sort subreddit shortcuts');
-			this.sortShortcutsButton.innerHTML = '&udarr;';
+			this.sortShortcutsButton.innerHTML = '&uarr;&darr;';
 			this.sortShortcutsButton.addEventListener('click', modules['subredditManager'].showSortMenu, false);
 
 			// add right scroll arrow...
 			this.shortCutsRight = document.createElement('div');
 			this.shortCutsRight.setAttribute('id', 'RESShortcutsRight');
-			this.shortCutsRight.innerHTML = '&#10095;';
+			this.shortCutsRight.innerHTML = '&gt;';
 			this.shortCutsRight.addEventListener('click', function(e) {
 				modules['subredditManager'].containerWidth = modules['subredditManager'].shortCutsContainer.offsetWidth;
 				var marginLeft = modules['subredditManager'].shortCutsContainer.firstChild.style.marginLeft;
@@ -878,7 +879,7 @@ modules['subredditManager'] = {
 			// add left scroll arrow...
 			this.shortCutsLeft = document.createElement('div');
 			this.shortCutsLeft.setAttribute('id', 'RESShortcutsLeft');
-			this.shortCutsLeft.innerHTML = '&#10094;';
+			this.shortCutsLeft.innerHTML = '&lt;';
 			this.shortCutsLeft.addEventListener('click', function(e) {
 				var marginLeft = modules['subredditManager'].shortCutsContainer.firstChild.style.marginLeft;
 				marginLeft = parseInt(marginLeft.replace('px', ''), 10);
@@ -898,7 +899,6 @@ modules['subredditManager'] = {
 			this.shortCutsEditContainer.appendChild(this.shortCutsAdd);
 			this.shortCutsEditContainer.appendChild(this.shortCutsTrash);
 			this.shortCutsEditContainer.appendChild(this.shortCutsRight);
-
 			this.redrawShortcuts();
 		}
 	},


### PR DESCRIPTION
![sr-header-area-fixes-02](https://cloud.githubusercontent.com/assets/7245595/3425664/15554136-000b-11e4-9d92-f3e23d841517.png)

It _should_ look like that ^, but the glyphs can change significantly depending on your installed fonts. I had to use monospace to remove the [jaggies](https://cloud.githubusercontent.com/assets/7245595/3425711/fdc67b1a-000b-11e4-8d1d-01622967ba5a.png) from the gt/lt signs, but that made the up/down arrows too small and unaligned, so I set only them to verdana (any other font and the alignment goes off).

Below shows the difference the font-family can make, the first one is monospace and the second is using sans-serif. On my system the monospace is smooth, while the sans-serif is pixelated/jagged. In Verdana (reddit default) it looks so much worse.
#### `↑↓<+>` ↑↓<+>

I'm not sure how they compare on OSX and Linux.

This is how it would look in monospace with the left/right sorting arrows:
#### `⇆<+>`

![sr-header-area-fixes-03](https://cloud.githubusercontent.com/assets/7245595/3425810/519d099a-000f-11e4-9329-1725648654db.png)

It aligns much better than the up/down arrows.

Thoughts?
