### PR TITLE
Quick Fix: gear icon should lose hover state

### DIFF
--- a/lib/res.css
+++ b/lib/res.css
@@ -63,12 +63,12 @@
 	height: auto;
 }
 #RESPrefsDropdown {
-	display: none;
+	visibility: hidden;
 	position: absolute;
 	z-index: 1000006;
 }
 #RESPrefsDropdown.hover {
-	display: block;
+	visibility: visible; /* don't use display: for this */
 }
 #RESPrefsDropdown > ul {
 	list-style: none;


### PR DESCRIPTION
The gear icon was keeping its 'hover' state if you moved over it too quickly. Replacing 'display:' with 'visibility:' fixes it.
