### PR TITLE
Fixed hiding of images if off screen

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -308,8 +308,8 @@ modules['showImages'] = {
 			height = $img.height();
 			// only hide the image if it has a width and height (it may not be loaded yet)
 			if (width && height && $img.data('loaded')) {
-				// preserve src and dimensions
-				$img.data('src',src).attr('width',width).attr('height',height);
+				// preserve src and dimensions, set width to height so the image scales right
+				$img.data('src',src).attr('width',height).attr('height',height);
 				// swap img with transparent gif to save memory
 				$img.attr('src',this.transparentGif);
 			}


### PR DESCRIPTION
Fixed it by using the boundingbox of the image instead of the position of the toggle element.
