### PR TITLE
Restore to original width only once per hide

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -330,7 +330,11 @@ modules['showImages'] = {
 			}
 			
 			// Restore the original width
-			this.resizeMedia(ele.imageLink.image, $img.data('originalWidth'));
+			originalWidth = $img.data('originalWidth');
+			if (originalWidth) {
+				this.resizeMedia(ele.imageLink.image, originalWidth);
+				$img.data("originalWidth", false);
+			}
 		}
 	},
 	findAllImagesInSelfText: function(ele) {


### PR DESCRIPTION
Fixes being able to resize the image and then scroll without it restoring back after the image has been hidden
