### PR TITLE
Use ctrl instead of shift for imageMove

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -234,22 +234,22 @@ modules['keyboardNav'] = {
 		},
 		imageMoveUp: {
 			type: 'keycode',
-			value: [38, false, false, true], // shift-up
+			value: [38, false, true, false], // ctrl-up
 			description: 'Move the image(s) in the highlighted post area up'
 		},
 		imageMoveDown: {
 			type: 'keycode',
-			value: [40, false, false, true], // shift-down
+			value: [40, false, true, false], // ctrl-down
 			description: 'Move the image(s) in the highlighted post area down'
 		},
 		imageMoveLeft: {
 			type: 'keycode',
-			value: [37, false, false, true], // shift-left
+			value: [37, false, true, false], // ctrl-left
 			description: 'Move the image(s) in the highlighted post area left'
 		},
 		imageMoveRight: {
 			type: 'keycode',
-			value: [39, false, false, true], // shift-right
+			value: [39, false, true, false], // ctrl-right
 			description: 'Move the image(s) in the highlighted post area right'
 		},
 		previousGalleryImage: {


### PR DESCRIPTION
This way it doesn't interfere with the default highlighting behavior of browsers.
