### PR TITLE
migrate: Clarify code and fix logic

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -11,15 +11,7 @@ var RESOptionsMigrate = {
 		Use RESOptionsMigrate to migrate data if you just want to move an option.
 	*/
 	migrate: function() {
-		var RESOptionsVersion = RESStorage.getItem('RESOptionsVersion'),
-			hasMigrateRun = (RESOptionsVersion !== null);
-
-		if (!hasMigrateRun) {
-			// Assume that users have v4.3.2.1 before upgrading to a later version
-			var newInstall = !RESStorage.getItem('RES.firstRun.4.3.2.1');
-
-			RESOptionsVersion = newInstall ? -1 : 0;
-		}
+		var RESOptionsVersion = RESOptionsMigrate.getOptionsVersion();
 
 		switch (RESOptionsVersion) {
 			case -1: // It's the first time we install RES, there is nothing to migrate
@@ -49,6 +41,19 @@ var RESOptionsMigrate = {
 				RESStorage.setItem('RESOptionsVersion', this.lastVersion);
 			break;
 		}
+	},
+	getOptionsVersion: function() {
+		var RESOptionsVersion = RESStorage.getItem('RESOptionsVersion'),
+			hasMigrateRun = (RESOptionsVersion !== null);
+
+		if (!hasMigrateRun) {
+			// Assume that users have v4.3.2.1 before upgrading to a later version
+			var newInstall = !RESStorage.getItem('RES.firstRun.4.3.2.1');
+
+			RESOptionsVersion = newInstall ? -1 : 0;
+		}
+
+		return RESOptionsVersion;
 	},
 	f: { // Migration functions
 		generic: { // Generic migration function


### PR DESCRIPTION
`!RESStorage.getItem('RES.firstRun.4.3.2.1') && -1` will either return false or -1, never null, so the null case would never be run. Switching to the use of 0 for the case allows us to consistently use integers.
