### PR TITLE
Shortcuts dropdown menu: breaks when you have a shortcut that contains a forward slash

### DIFF
--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -172,7 +172,7 @@ modules['subredditManager'] = {
 			if (this.options.lastUpdate.value && document.getElementsByClassName('listing-chooser').length) {
 				this.lastUpdate();
 			}
-			
+
 			this.manageSubreddits();
 			if (RESUtils.currentSubreddit() !== null) {
 				this.setLastViewtime();
@@ -353,7 +353,7 @@ modules['subredditManager'] = {
 							suffix = cleanSubreddits.substr(pos);
 							cleanSubreddits = cleanSubreddits.substr(0,pos);
 						}
-						if((pos = cleanSubreddits.lastIndexOf('/')) > cleanSubreddits.lastIndexOf('+')) // check both existance and correct form (i.e. not foo/new+bar)
+						if((pos = cleanSubreddits.indexOf('/')) > cleanSubreddits.lastIndexOf('+'))
 						{
 							suffix = cleanSubreddits.substr(pos) + suffix;
 							cleanSubreddits = cleanSubreddits.substr(0,pos);
@@ -1479,7 +1479,7 @@ modules['subredditManager'] = {
 		}
 		// we now remove inactive user
 		var inactiveThreshold = new Date().getTime() - 2592000000; // one month
-		for (var user in mySubredditListCachedObject) { 
+		for (var user in mySubredditListCachedObject) {
 			if (mySubredditListCachedObject[user].time < inactiveThreshold) {
 				delete mySubredditListCachedObject[user];
 			}


### PR DESCRIPTION
Screenshot (see modqueue repetition):

![dropdown-modqueue-broke](https://cloud.githubusercontent.com/assets/7245595/3465746/c746161c-026e-11e4-9abc-00f32d52d3d3.png)

This is the content of the above shortcut link: `all+TrueReddit+theoryofreddit+friends+spam+mod+mod/about/modqueue`

It doesn't matter what comes after the slash, for example `a/b` will apply `/b` to every other link in the menu.

I've been using this particular setup for a few months without an issue.
