### PR TITLE
Fix broken Giflike implementation.

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -2292,74 +2292,46 @@ modules['showImages'] = {
 				return $.Deferred().resolve(elem).promise();
 			}
 		},
-		giflike: {
+        giflike: {
 			domains: ['giflike.com'],
-			calls: {},
-			detect: function(href, elem) {
-				return href.indexOf('giflike.com') !== -1 && href.substring(-1) !== '+';
-			},
-			handleLink: function(elem) {
-				var hashRe = /^http:\/\/www\.giflike\.com\/a\/(\w+)/i;
-				var def = $.Deferred();
-				var groups = hashRe.exec(elem.href);
-
-				if (!groups) return def.reject();
-				var href = elem.href.toLowerCase();
-
+			acceptRegex: /^https?:\/\/(?:\w+\.)?giflike\.com\/(?:a\/)?(\w{7})(?:\/.*)?/i,
+			detect: function (href, elem) {
 				var siteMod = modules['showImages'].siteModules['giflike'];
-				var apiURL = 'http://www.giflike.com/a/' + encodeURIComponent(groups[1]) + '.json';
-
-				if (apiURL in siteMod.calls) {
-					if (siteMod.calls[apiURL] != null) {
-						def.resolve(elem, siteMod.calls[apiURL]);
-					} else {
-						siteMod.calls[apiURL] = null;
-						def.reject();
-					}
+				return siteMod.acceptRegex.test(href);
+			},
+			handleLink: function (elem) {
+				var def = $.Deferred();
+				var siteMod = modules['showImages'].siteModules['giflike'];
+				var groups = siteMod.acceptRegex.exec(elem.href);
+				if (groups) {
+                    def.resolve(elem, {
+                        videoId: groups[1]
+                    });
 				} else {
-					GM_xmlhttpRequest({
-						method: 'GET',
-						url: apiURL,
-						aggressiveCache: true,
-						onload: function(response) {
-							try {
-								var json = JSON.parse(response.responseText);
-								siteMod.calls[apiURL] = json;
-								var mp4Sizes = json['sizes'] ? json['sizes']['mp4'] : {};
-								var size = mp4Sizes['d'] || mp4Sizes['p'] || mp4Sizes['o'];
-								if (!size) {
-									def.reject();
-								} else {
-									json['token'] = size.name;
-									def.resolve(elem, json);
-								}
-							} catch (error) {
-								siteMod.calls[apiURL] = null;
-								def.reject();
-							}
-						},
-						onerror: function(response) {
-							def.reject();
-						}
-					});
+					def.reject();
 				}
 				return def.promise();
 			},
-			handleInfo: function(elem, info) {
+			handleInfo: function (elem, info) {
 				elem.expandoOptions = {
-					autoplay: true, // giflike is another host with muted / no audio so autoplay is OK
-					loop: true
+					autoplay: true, // Giflike only supports muted videos.
+					loop: true // Loops since it's gif-like, short form.
 				};
+
 				sources = [];
-				var token = info['token'];
-				sources[0] = {
-					'file': 'http://i.giflike.com/' + info['animation_id'] + '_' + token + '.mp4',
-					'type': 'video/mp4'
-				};
-				sources[1] = {
-					'file': 'http://i.giflike.com/' + info['animation_id'] + '_' + token + '.webm',
-					'type': 'video/webm'
-				};
+                sources[0] = {
+                    'file': 'http://i.giflike.com/' + info.videoId + '.webm',
+                    'type': 'video/webm'
+                };
+                sources[1] = {
+                    'file': 'http://i.giflike.com/' + info.videoId + '.mp4',
+                    'type': 'video/mp4'
+                };
+                sources[2] = {
+                    'file': 'http://i.giflike.com/' + info.videoId + '.gif',
+                    'type': 'image/gif'
+                };
+
 				elem.type = 'VIDEO';
 				$(elem).data('sources', sources);
 				if (RESUtils.pageType() === 'linklist') {
@@ -2367,7 +2339,7 @@ modules['showImages'] = {
 				}
 				return $.Deferred().resolve(elem).promise();
 			}
-		},
+        },
 		ctrlv: {
 			name: 'CtrlV.in',
 			domains: ['ctrlv.in'],


### PR DESCRIPTION
Since moving to SSL only the previous Giflike code broke (because I stupidly hard coded "http" into a regex). This new implementation is based on defaultVideo.
