### PR TITLE
Removing redundant code in memoryConserve methods

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -310,8 +310,6 @@ modules['showImages'] = {
 			if (width && height && $img.data('loaded')) {
 				// preserve src and set the width to height to make the page not jump
 				$img.data('src',src).attr('width',width).attr('height',height);
-				// Save the original width
-				$img.data('originalWidth', width);
 				// swap img with transparent gif to save memory
 				$img.attr('src',this.transparentGif);
 			}
@@ -325,13 +323,6 @@ modules['showImages'] = {
 			src = $img.data('src');
 			if (src) {
 				$img.attr('src',src);
-			}
-
-			// Restore the original width
-			originalWidth = $img.data('originalWidth');
-			if (originalWidth) {
-				this.resizeMedia(ele.imageLink.image, originalWidth);
-				$img.data("originalWidth", false);
 			}
 		}
 	},


### PR DESCRIPTION
Since the width no longer gets changed we don't have to restore to the original width
