### PR TITLE
Don't select images when expanding them

### DIFF
--- a/lib/res.css
+++ b/lib/res.css
@@ -500,7 +500,6 @@ p.moduleListing {
 	cursor: pointer;
 	-webkit-user-select: none;
 	-moz-user-select: none;
-	user-select: none;
 }
 .moduleHeader {
 	border: 1px solid #c7c7c7;
@@ -1134,6 +1133,8 @@ img {
 	margin-right: 6px;
 	cursor: pointer;
 	padding: 0;
+	-webkit-user-select: none;
+	-moz-user-select: none;
 }
 .expando-button.image.commentImg {
 	float: none;
@@ -1164,7 +1165,6 @@ img {
 .RESGalleryControls .previous { background-position: 0 -352px; }
 .RESGalleryControls .next { background-position: 16px -352px; }
 .RESGalleryControls .next,.RESGalleryControls .previous {
-	user-select: none;
 	-webkit-user-select: none;
 	-moz-user-select: none;
 }


### PR DESCRIPTION
This fixes one of my greatest annoyances with RES, it adds '-X-user-select: none' to expando image icons so you don't accidentally select the image below.

Also, 'user-select' isn't actually recognised in Firefox or Chrome [as explained here](https://developer.mozilla.org/en-US/docs/Web/CSS/user-select), so I removed both instances from res.css.
