### PR TITLE
utils: Check if nightMode module is enabled before styling

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,7 +10,7 @@ RESUtils.preInit = function() {
 RESUtils.getDocHTML = function() {
 	if (document && typeof modules !== 'undefined') {
 		document.html = document.documentElement;
-		if (localStorage.getItem('RES_nightMode')) {
+		if (localStorage.getItem('RES_nightMode') && modules['nightMode'].isEnabled()) {
 			// no need to check the background - we're in night mode for sure.
 			modules['nightMode'].enableNightMode();
 		}


### PR DESCRIPTION
Fixes #1433. Night mode should not be enabled if the module is disabled.
