### PR TITLE
Make restrict_sr checkbox not tick with multireddit's

### DIFF
--- a/lib/modules/searchHelper.js
+++ b/lib/modules/searchHelper.js
@@ -77,7 +77,7 @@ modules['searchHelper'] = {
 	searchSubredditByDefault: function() {
 		// Reddit now has this feature... but for some reason the box isn't checked by default, so we'll still do that...
 		var restrictSearch = document.body.querySelector('INPUT[name=restrict_sr]');
-		if (restrictSearch && !/^https?:\/\/www\.reddit\.com\/r\/[-\w\.]+\/search\?/i.test(location.href)) { // prevent autochecking after uncheck it
+		if (restrictSearch && !/^https?:\/\/www\.reddit\.com\/r\/[-\w\.+]+\/search\?/i.test(location.href)) { // prevent autochecking after uncheck it
 				restrictSearch.checked = true;
 		}
 	},


### PR DESCRIPTION
Changed line 80 and made + an accepted character in the regex. This means that the Restrict Subreddit checkbox will not be ticked when linking directly to a search using multireddit's.

EG: http://www.reddit.com/r/networking+sysadmin/search?q=UDP+joke
