### PR TITLE
Add basic renderer for 500px images.

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1807,7 +1807,7 @@ modules['showImages'] = {
 		'default': {
 			domains: [],
 			acceptRegex: /^[^#]+?\.(gif|jpe?g|png)(?:[?&#_].*|$)/i,
-			rejectRegex: /(?:wikipedia\.org\/wiki|photobucket\.com|gifsound\.com|mediacru\.sh|\/wiki\/File:.*|reddit\.com|onedrive\.live\.com)/i,
+			rejectRegex: /(?:wikipedia\.org\/wiki|photobucket\.com|gifsound\.com|mediacru\.sh|\/wiki\/File:.*|reddit\.com|onedrive\.live\.com|500px\.(?:com|net|org))/i,
 			detect: function(href, elem) {
 				var siteMod = modules['showImages'].siteModules['default'];
 				return (siteMod.acceptRegex.test(href) && !siteMod.rejectRegex.test(href));
@@ -2599,6 +2599,28 @@ modules['showImages'] = {
 					def.reject();
 				}
 				return def.promise();
+			}
+		},
+		fiveHundredPx: {
+			domains: ['ppcdn.500px.org', 'pcdn.500px.net'],
+			detect: function(href, elem) {
+				return /pcdn\.500px\.(?:org|net)/.test(elem.href)
+			},
+			handleLink: function(elem) {
+				var def = $.Deferred();
+				var photoId = elem.href.match(/pcdn\.500px\.(?:net|com|org)\/([0-9]+)\//);
+				if (photoId == null) {
+						def.reject();
+				} else {
+						def.resolve(elem, photoId[1]);
+				}
+				return def.promise();
+			},
+			handleInfo: function(elem, photoId) {
+				elem.type = 'IMAGE';
+				elem.src = elem.href.replace(/\/[0-9]+\.jpg$/, "/5.jpg")
+				elem.credits = 'View original and details at: <a href="http://500px.com/photo/' + RESUtils.sanitizeHTML(photoId) + '">500px.com</a>';
+				return $.Deferred().resolve(elem).promise();
 			}
 		},
 		flickr: {
@@ -3464,4 +3486,3 @@ modules['showImages'] = {
 		}
 	}
 };
-


### PR DESCRIPTION
This adds a link in the image credits back to the original photo on 500px when unattributed images are linked.
