### PR TITLE
userTagger: Rework calls to updateOpenLink to work the same way

### DIFF
--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -281,7 +281,9 @@ modules['userTagger'] = {
 			this.userTaggerColor.addEventListener('change', modules['userTagger'].updateTagPreview, false);
 			this.userTaggerPreview = this.userTaggerToolTip.querySelector('#userTaggerPreview');
 			var userTaggerLink = this.userTaggerToolTip.querySelector('#userTaggerLink');
-			userTaggerLink.addEventListener('keyup', modules['userTagger'].updateOpenLink, false);
+			userTaggerLink.addEventListener('keyup', function(e) {
+				modules['userTagger'].updateOpenLink(userTaggerLink);
+			}, false);
 			var userTaggerSave = this.userTaggerToolTip.querySelector('#userTaggerSave');
 			userTaggerSave.setAttribute('type', 'submit');
 			userTaggerSave.setAttribute('value', '✓ save tag');
@@ -698,7 +700,7 @@ modules['userTagger'] = {
 		}
 		this.userTaggerToolTip.setAttribute('style', 'display: block; top: ' + thisXY.y + 'px; left: ' + thisXY.x + 'px;');
 		document.getElementById('userTaggerTag').focus();
-		modules['userTagger'].updateOpenLink.call(userTaggerLink);
+		modules['userTagger'].updateOpenLink(document.getElementById('userTaggerLink'));
 		modules['userTagger'].updateTagPreview();
 		return false;
 	},
@@ -724,11 +726,11 @@ modules['userTagger'] = {
 		modules['userTagger'].userTaggerPreview.style.backgroundColor = (bgcolor === "none") ? "transparent" : bgcolor;
 		modules['userTagger'].userTaggerPreview.style.color = modules['userTagger'].bgToTextColorMap[bgcolor];
 	},
-	updateOpenLink: function(){
-		if(this.value !== "") {
+	updateOpenLink: function(userTaggerLink) {
+		if (userTaggerLink.value) {
 			var openLinkSpan = modules['userTagger'].userTaggerToolTip.querySelector('.userTaggerOpenLink');
 			openLinkSpan.style.display = 'inline';
-			openLinkSpan.getElementsByTagName('a')[0].href = this.value;
+			openLinkSpan.getElementsByTagName('a')[0].href = userTaggerLink.value;
 		} else {
 			modules['userTagger'].userTaggerToolTip.querySelector('.userTaggerOpenLink').style.display = 'none';
 		}


### PR DESCRIPTION
Before, one call was as an event handler, while the other was just a normal call to the method. This change makes `updateOpenLink` work more consistently. Fixes #1482.
