### PR TITLE
migrate: this -> RESOptionsMigrate for safety

### DIFF
--- a/lib/core/migrate.js
+++ b/lib/core/migrate.js
@@ -234,7 +234,7 @@ var RESOptionsMigrate = {
 	},
 
 	getVersionNumbers: function() {
-		return this.migrations.map(function(migration) { return migration.versionNumber; });
+		return RESOptionsMigrate.migrations.map(function(migration) { return migration.versionNumber; });
 	},
 
 	// this function compares a given option value to its "former default" -- the default


### PR DESCRIPTION
In case getVersionNumbers is called in a place where `this` is redefined.
