### PR TITLE
migrate: Update "how-to" comment

### DIFF
--- a/lib/core/migrate.js
+++ b/lib/core/migrate.js
@@ -1,4 +1,14 @@
-// Add new migrations to the end of RESOptionsMigrate.migrations in the form  '#.#.#.#': function() { migration code }
+/*
+Add new migrations to the end of RESOptionsMigrate.migrations in the
+following form:
+
+{
+	versionNumber: '#.#.#.#',
+	go: function() {
+		// migration code
+	}
+}
+*/
 
 var RESOptionsMigrate = {
 	migrations: [


### PR DESCRIPTION
The original comment no longer provided the correct code.
