### PR TITLE
Added Image Shrink module

### DIFF
--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -82,6 +82,7 @@
 				"modules/searchHelper.js",
 				"modules/logoLink.js",
 				"modules/voteEnhancements.js",
+				"modules/imageShrink.js",
 				"core/init.js"
 			],
 			"css": [

--- a/Opera/includes/loader.js
+++ b/Opera/includes/loader.js
@@ -88,6 +88,7 @@ window.addEventListener('DOMContentLoaded', function() {
 		'modules/userbarHider.js',
 		'modules/usernameHider.js',
 		'modules/voteEnhancements.js',
+		'modules/imageShrink.js',
 
 		'core/init.js',
 

--- a/OperaBlink/manifest.json
+++ b/OperaBlink/manifest.json
@@ -81,6 +81,7 @@
 				"modules/searchHelper.js",
 				"modules/logoLink.js",
 				"modules/voteEnhancements.js",
+				"modules/imageShrink.js",
 				"core/init.js"
 			],
 			"css": [

--- a/RES.safariextension/Info.plist
+++ b/RES.safariextension/Info.plist
@@ -92,6 +92,7 @@
 				<string>modules/searchHelper.js</string>
 				<string>modules/logoLink.js</string>
 				<string>modules/voteEnhancements.js</string>
+				<string>modules/imageShrink.js</string>
 				<string>core/init.js</string>
 			</array>
 		</dict>

--- a/XPI/lib/main.js
+++ b/XPI/lib/main.js
@@ -185,6 +185,7 @@ pageMod.PageMod({
 		self.data.url('modules/searchHelper.js'),
 		self.data.url('modules/logoLink.js'),
 		self.data.url('modules/voteEnhancements.js'),
+		self.data.url('modules/imageShrink.js'),
 		self.data.url('core/init.js')
 	],
 	contentStyleFile: [

--- a/lib/modules/imageShrink.js
+++ b/lib/modules/imageShrink.js
@@ -63,11 +63,11 @@ modules['imageShrink'] = {
                 isMain = true;
             }
 
-            if(!imgurCheck.test(aTag.href) || aTag.id == 'shrinkedUrl')//if not an imgur link, don't do anything special, or if it's already been edited
+            if (!imgurCheck.test(aTag.href) || aTag.id == 'shrinkedUrl') //if not an imgur link, don't do anything special, or if it's already been edited
                 continue;
 
-            if(isMain)//not part of the sidebar posts
-                post.getElementsByClassName('flat-list')[0].innerHTML+='<li><a href="' + aTag.href + '">original</a></li>';//adds a link to the original vid
+            if (isMain) //not part of the sidebar posts
+                post.getElementsByClassName('flat-list')[0].innerHTML += '<li><a href="' + aTag.href + '">original</a></li>'; //adds a link to the original vid
 
             aTag.id = 'shrinkedUrl';
             aTag.href = modules['imageShrink'].changeLink(aTag.href, modifier); //append the appropriate character to the end and updates tag

--- a/lib/modules/imageShrink.js
+++ b/lib/modules/imageShrink.js
@@ -1,0 +1,82 @@
+modules['imageShrink'] = {
+    moduleID: 'imageShrink',
+    moduleName: 'Image Shrink',
+    category: 'UI',
+    options: {
+        maxImageSize: {
+            type: 'enum',
+            values: [{
+                name: 'None (Full Size)',
+                value: ''
+            }, {
+                name: 'Small (160px)',
+                value: 't'
+            }, {
+                name: 'Medium (320px)',
+                value: 'm'
+            }, {
+                name: 'Large (640px)',
+                value: 'l'
+            }, {
+                name: 'Huge (1024px)',
+                value: 'h'
+            }],
+            value: '',
+            description: 'Choose the maximum size of imgur images to prevent excessive loading for excessively large images.'
+        }
+    },
+    description: 'Choose the maximum size of imgur images to prevent excessive loading for excessively large images.',
+    isEnabled: function() {
+        return RESConsole.getModulePrefs(this.moduleID);
+    },
+    isMatchURL: function() {
+        return RESUtils.isMatchURL(this.moduleID);
+    },
+    include: [
+        'all'
+    ],
+    go: function() {
+        if ((this.isEnabled()) && (this.isMatchURL())) {
+            modules['imageShrink'].updatePage();
+            RESUtils.watchForElement('siteTable', function(e) {
+                modules['imageShrink'].updatePage(e);
+                console.log(e);
+            });
+
+        }
+    },
+    updatePage: function(siteTable) {
+        siteTable = siteTable || document;
+
+        var modifier = this.options.maxImageSize.value;
+        if (modifier == '')
+            return;
+        var posts = siteTable.getElementsByClassName('thing');
+        for (var i = 0; i < posts.length; i++) {
+            var post = posts[i];
+            var aTag;
+            if (post.className.indexOf('half') > -1) { //sidebar differs from normal posts
+                aTag = post.getElementsByClassName('reddit-link-title')[0];
+            } else {
+                var title = post.getElementsByClassName('title')[0];
+                aTag = title.getElementsByTagName('a')[0];
+            }
+            if (aTag.id == 'shrinkedUrl') //already been edited
+                continue;
+            aTag.id = 'shrinkedUrl';
+            aTag.href = this.changeLink(aTag.href, modifier) || modules['imageShrink'].changeLink(aTag.href, modifier); //append the appropriate character to the end and updates tag
+        }
+    },
+    changeLink: function(link, suffix) {
+        var imgurCheck = new RegExp(/(https?\:)?\/\/(i\.)?imgur.com\/.*\.(jpg|png|gif|apng|jpeg)/i);
+
+        if (!imgurCheck.test(link))
+            return link;
+
+        var extension = new RegExp(/\.(jpg|png|gif|apng|jpeg)/i);
+        var index = link.search(extension);
+        link = link.substr(0, index) + suffix + link.substr(index);
+
+        return link;
+    }
+};

--- a/lib/modules/imageShrink.js
+++ b/lib/modules/imageShrink.js
@@ -66,8 +66,13 @@ modules['imageShrink'] = {
             if (!imgurCheck.test(aTag.href) || aTag.id == 'shrinkedUrl') //if not an imgur link, don't do anything special, or if it's already been edited
                 continue;
 
-            if (isMain) //not part of the sidebar posts
-                post.getElementsByClassName('flat-list')[0].innerHTML += '<li><a href="' + aTag.href + '">original</a></li>'; //adds a link to the original vid
+            if (isMain){ //not part of the sidebar posts
+                var li = post.getElementsByClassName('flat-list')[0].appendChild(document.createElement('li'));
+                var a = li.appendChild(document.createElement('a'));
+                a.href = aTag.href;
+                a.innerText = "original";
+                //post.getElementsByClassName('flat-list')[0].innerHTML += '<li><a href="' + aTag.href + '">original</a></li>'; //adds a link to the original vid
+            }
 
             aTag.id = 'shrinkedUrl';
             aTag.href = modules['imageShrink'].changeLink(aTag.href, modifier); //append the appropriate character to the end and updates tag

--- a/lib/modules/imageShrink.js
+++ b/lib/modules/imageShrink.js
@@ -40,31 +40,37 @@ modules['imageShrink'] = {
             modules['imageShrink'].updatePage();
             RESUtils.watchForElement('siteTable', function(e) {
                 modules['imageShrink'].updatePage(e);
-                console.log(e);
             });
 
         }
     },
     updatePage: function(siteTable) {
         siteTable = siteTable || document;
-
+        var imgurCheck = new RegExp(/(https?\:)?\/\/(i\.)?imgur.com\/.*\.(jpg|png|gif|apng|jpeg)/i);
         var modifier = this.options.maxImageSize.value;
         if (modifier == '')
             return;
         var posts = siteTable.getElementsByClassName('thing');
         for (var i = 0; i < posts.length; i++) {
             var post = posts[i];
-            var aTag;
+            var aTag, isMain;
             if (post.className.indexOf('half') > -1) { //sidebar differs from normal posts
                 aTag = post.getElementsByClassName('reddit-link-title')[0];
+                isMain = false;
             } else {
                 var title = post.getElementsByClassName('title')[0];
                 aTag = title.getElementsByTagName('a')[0];
+                isMain = true;
             }
-            if (aTag.id == 'shrinkedUrl') //already been edited
+
+            if(!imgurCheck.test(aTag.href) || aTag.id == 'shrinkedUrl')//if not an imgur link, don't do anything special, or if it's already been edited
                 continue;
+
+            if(isMain)//not part of the sidebar posts
+                post.getElementsByClassName('flat-list')[0].innerHTML+='<li><a href="' + aTag.href + '">original</a></li>';//adds a link to the original vid
+
             aTag.id = 'shrinkedUrl';
-            aTag.href = this.changeLink(aTag.href, modifier) || modules['imageShrink'].changeLink(aTag.href, modifier); //append the appropriate character to the end and updates tag
+            aTag.href = modules['imageShrink'].changeLink(aTag.href, modifier); //append the appropriate character to the end and updates tag
         }
     },
     changeLink: function(link, suffix) {


### PR DESCRIPTION
Basically, the image shrink module lets users choose a maximum image size for imgur images if they don't want to have to load extremely large images. For instance, a 5000px wide image of a few words doesn't need to be loaded when it can be seen perfectly fine at 1024px. It uses imgur's thumbnails, specified here: https://api.imgur.com/models/image#thumbs. Whenever an image is shrunken, a link to the original image is added to the post as well.