### PR TITLE
escapeNP option for noParticipation

### DIFF
--- a/lib/modules/noParticipation.js
+++ b/lib/modules/noParticipation.js
@@ -32,7 +32,7 @@ addModule('noParticipation', function(module, moduleID) {
 		},
 		escapeNP: {
 			type: 'boolean',
-			value: true
+			value: true,
 			description: "Remove np mode when leaving a No-Participation page"
 		}
 	};


### PR DESCRIPTION
reset base url to http[s]://reddit.com/foo/bar/baz/ on np.reddit.com pages

only tested proof of concept locally, not against reddit/RES properly.  
edit: tested a little.  <base href="a different subdomain"> breaks opening the settings console (specifically the "adding to history" call)
