### PR TITLE
Fix to mark Gfycat'ed links as visited

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1328,6 +1328,7 @@ modules['showImages'] = {
 
 		modules['showImages'].makeMediaZoomable(video);
 		modules['showImages'].syncPlaceholder(video);
+		modules['showImages'].trackMediaLoad(imageLink, video)
 	},
 	handleGfycatSources: function (name, expandoButton, options) {
 		var xhr = new XMLHttpRequest();


### PR DESCRIPTION
This seems to fix gif links that are turned to gfycat videos not turning purple.

Notes:
- I only tested this on Chrome, sorry!
- Only researched the showImage.js file for a short time, so I don't know if this is the right way to do this.
  Should I use BrowserStrategy.addURLToHistory instead?
- I know technically we haven't visited the original gif, but I think it's expected to turn visited if we've enabled the option to use gfycat instead.
