### PR TITLE
Change how autoplay is used on MediaCrush videos

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -2962,8 +2962,9 @@ modules['showImages'] = {
 						autoplay = false;
 					}
 				}
-				if (typeof info.flags !== 'undefined') {
-					info.flags.autoplay = autoplay;
+				if (typeof info.metadata.has_audio !== "undefined" && info.metadata.has_audio 
+						&& typeof info.flags !== 'undefined' && autoplay === false) {
+					info.flags.autoplay = false;
 				}
 
 				var generate = function(options) {

--- a/lib/vendor/mediacrush.js
+++ b/lib/vendor/mediacrush.js
@@ -99,7 +99,7 @@ window.MediaCrush = (function() {
 			RESTemplates.load('VideoUI', function(template) {
 				var video = {
 					loop: media.type === 'image/gif',
-					autoplay: media.flags.autoplay, // media.type === 'image/gif',
+					autoplay: media.type === 'image/gif',
 					muted: media.type === 'image/gif',
 					download: 'https://mediacru.sh/download/' + media.original,
 					poster: 'https://cdn.mediacru.sh/' + media.hash + '.jpg',


### PR DESCRIPTION
Basically, this stops the autoplay RES setting from being meaningful if the video has audio. It's on by default and we keep getting complaints about autoplaying video, it's quite frustrating.
