### PR TITLE
use https for imgur links

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -2011,7 +2011,7 @@ modules['showImages'] = {
 											hash: hash
 										},
 										links: {
-											original: 'http://i.imgur.com/' + hash + '.jpg'
+											original: 'https://i.imgur.com/' + hash + '.jpg'
 										}
 									};
 								})
@@ -2024,7 +2024,7 @@ modules['showImages'] = {
 							image: {
 								links: {
 									//Imgur doesn't really care about the extension and the browsers don't seem to either.
-									original: 'http://i.imgur.com/' + groups[1] + '.jpg'
+									original: 'https://i.imgur.com/' + groups[1] + '.jpg'
 								},
 								image: {}
 							}
@@ -2088,7 +2088,7 @@ modules['showImages'] = {
 					info = {
 						image: {
 							links: {
-								original: 'http://i.imgur.com/' + elem.imgHash + '.jpg'
+								original: 'https://i.imgur.com/' + elem.imgHash + '.jpg'
 							},
 							image: {}
 						}


### PR DESCRIPTION
In light of reddit adding https ability, I noticed that all the imgur links are requested through http (even though imgur uses https itself; and sends a redirect). Since imgur is using https already, might as well avoid the redirect and keep the green "https" in the url
