### PR TITLE
Clear floated contents of wiki md editor

### DIFF
--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -119,7 +119,7 @@ modules['commentTools'] = {
 		if ((this.isEnabled()) && (this.isMatchURL())) {
 			RESUtils.addCSS('.commentarea form.usertext { clear: left; }'); // just for naut, but nice to have.
 			RESUtils.addCSS('.markdownEditor-wrapper { width: 500px; }'); // same as textarea.
-			RESUtils.addCSS('.wiki-page-content .markdownEditor-wrapper { width: 100%; }'); // again, same as textarea.
+			RESUtils.addCSS('.wiki-page-content .markdownEditor-wrapper { width: 100%; overflow: hidden; }'); // again, same as textarea.
 
 			//  Formatting tools container
 			RESUtils.addCSS('.markdownEditor { white-space: nowrap; float: none; }');


### PR DESCRIPTION
Certain configs, like disabling macros, can expose some floated elements (commentingAs/RESCharCounter) and cause the textarea beneath to be pushed below the sidebar (wiki pages).
