### PR TITLE
Fix neverEndingReddit.js rank-width-updating

### DIFF
--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -482,7 +482,7 @@ modules['neverEndingReddit'] = {
 							newHTML = stMultiCheck[1];
 						}
 						newHTML.setAttribute('ID', 'siteTable-' + modules['neverEndingReddit'].currPage + 1);
-						firstLen = $(newHTML).find('.link:first .rank').text().length;
+						firstLen = $("body").find('.link:last .rank').text().length;
 						lastLen = $(newHTML).find('.link:last .rank').text().length;
 						if (lastLen > firstLen) {
 							lastLen = (lastLen * 1.1).toFixed(1);


### PR DESCRIPTION
It used to compare the first and last ranks
in the new page; this doesn't work for when
you skip pages, i.e. with the "return to
previous page" feature.

(Try https://www.reddit.com/#page=5)

Now it compares the last rank in the new page
with the last rank on the existing page.

IMO there's actually no good reason
to check against firstLen at all, except
you'd build up some extraneous CSS.
