### PR TITLE
Remove keyNav background-color from nightmode.css now that it is handled by keyboardNav.js

### DIFF
--- a/lib/modules/nightmode.css
+++ b/lib/modules/nightmode.css
@@ -727,13 +727,6 @@
 	font-size: 10px;
 }
 
-.res-nightmode .RES-keyNav-activeElement,
-.res-nightmode .RES-keyNav-activeElement .md,
-.res-nightmode .res-nightmode #REScommentNavBox,
-.res-nightmode .res-nightmode #commentNavCloseButton {
-	background-color: #666;
-}
-
 .res-nightmode .RES-keyNav-activeElement .title.loggedin:visited,
 .res-nightmode .RES-keyNav-activeElement .title:visited {
 	color: #dfdfdf;


### PR DESCRIPTION
This CSS rule causes background color to be applied in nightmode even when addFocusBGColor is disabled.
If enabled, this bug isn't noticable as addFocusBGColor() in keyboardNav.js is executed and adds CSS that overrides it.

I've tested this fix locally and it seems to work without causing any side effects.
