### PR TITLE
Moved if statement execution code inside brackets

### DIFF
--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -21,7 +21,9 @@ function RESdoBeforeLoad() {
 		// console.log('get options end: ' + Date());
 		for (var thisModuleID in modules) {
 			if (typeof modules[thisModuleID] === 'object') {
-				if (typeof modules[thisModuleID].beforeLoad === 'function') modules[thisModuleID].beforeLoad();
+				if (typeof modules[thisModuleID].beforeLoad === 'function') {
+					modules[thisModuleID].beforeLoad();
+				}
 			}
 		}
 		// apply style...


### PR DESCRIPTION
Hi, I noticed the execution code for one if statement was not inside any brackets. I didn't see this mentioned in the style guide but thought it is cleaner and more readable this way.

Before: 
![unedited_code](https://cloud.githubusercontent.com/assets/8083944/4469941/e50e22e0-491b-11e4-98da-58786a68c8c1.jpg)

After:
![edited_code](https://cloud.githubusercontent.com/assets/8083944/4469945/f6843dde-491b-11e4-9824-c3cb377b00d0.jpg)
