### PR TITLE
Keyboard shortcut for submitting comments

### DIFF
--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -1825,3 +1825,7 @@ RESUtils.cssPrefix = function(css) {
 		'-ms-' + css + ';' + css + ';';
 };
 RESUtils.baseStyleProtection = 'margin: 0 !important; background-color: inherit !important; color: inherit !important; position: relative !important; left: 0 !important; top: 0 !important; max-height: none!important; max-width: none!important; height: auto !important; width: auto !important; visibility: visible !important; overflow: auto !important; text-indent: 0 !important; font-size: 12px !important; float: none !important; opacity: 1 !important;' + RESUtils.cssPrefix('transform: none !important;') + RESUtils.cssPrefix('filter: none !important;');
+RESUtils.isCommandKey = function(keyEvent) {
+	return ((keyEvent.keyCode == 91 || keyEvent.keyCode == 93) && (BrowserDetect.isChrome() || BrowserDetect.isSafari() || BrowserDetect.isOperaBlink() || BrowserDetect.isOpera()))
+		|| (keyEvent.keyCode == 224 && BrowserDetect.isFirefox());
+};

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -26,6 +26,16 @@ modules['commentTools'] = {
 			value: true,
 			description: 'Use keyboard shortcuts to apply styles to selected text'
 		},
+		ctrlEnterSubmitsComments: {
+			type: 'boolean',
+			value: true,
+			description: 'Pressing Ctrl+Enter or Cmd+Enter will submit your comment/wiki edit.'
+		},
+		ctrlEnterSubmitsPosts: {
+			type: 'boolean',
+			value: true,
+			description: 'Pressing Ctrl+Enter or Cmd+Enter will submit your post.'
+		},
 		commentingAs: {
 			type: 'boolean',
 			value: true,
@@ -307,6 +317,30 @@ modules['commentTools'] = {
 					}
 				});
 			}
+			if (this.options.ctrlEnterSubmitsComments.value) {
+				this.bindCtrlEnterAction({
+					captureSelectors: '.usertext-edit textarea, #BigEditor textarea, #wiki_page_content',
+					performAction: function(e) {
+						var currentForm = $(e.target).closest('form');
+						var saveButton = currentForm.find('.save')[0] || currentForm.find('#wiki_save_button')[0] || $('.BEFoot button')[0];
+						RESUtils.click(saveButton);
+					}
+				});
+			}
+			if (this.options.ctrlEnterSubmitsPosts.value) {
+				this.bindCtrlEnterAction({
+					captureSelectors: '#title-field textarea, #text-field textarea, #url, #sr-autocomplete, input.captcha',
+					performAction: function() {
+						var captcha = $('input.captcha:not(.cap-text)');
+						if (captcha.length && captcha.val() === '') {
+							captcha.focus();
+						} else {
+							RESUtils.click($('.spacer .btn')[0]);
+						}
+					}
+				});
+			}
+
 			if (this.options.subredditAutocomplete.value || this.options.userAutocomplete.value) {
 				this.addAutoCompletePop();
 			}
@@ -1302,5 +1336,23 @@ modules['commentTools'] = {
 			.find("textarea")
 			.filter("#BigText, [name=text], [name=description], [name=public_description], #wiki_page_content")
 			.first();
+	},
+	bindCtrlEnterAction: function(options) {
+		var $body = $('body');
+		var commandDown = false;
+		$body.on('keydown', options.captureSelectors, function(e) {
+			if (RESUtils.isCommandKey(e)) {
+				commandDown = true;
+			}
+			if (e.keyCode === modules['commentTools'].KEYS.ENTER && (e.ctrlKey || commandDown)) {
+				e.preventDefault();
+				options.performAction(e);
+			}
+		});
+		$body.on('keyup', options.captureSelectors, function(e) {
+			if (RESUtils.isCommandKey(e)) {
+				commandDown = false;
+			}
+		});
 	}
 };


### PR DESCRIPTION
Fixes #1546 
- Use ctrl+enter or cmd+enter to submit comments
- Added `isCommandKey(keyEvent)` method to RESUtils for developing other command key shortcuts

`commandDown` flag is used because otherwise we would need to rely on `e.metaKey`, which may or may not be the command key in all cases. 

Works in comments and the Wiki editor. Could probably be extended to posts if that is desired. 
