### PR TITLE
Self-text expando and comment max height

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -91,13 +91,13 @@ modules['showImages'] = {
 		},
 		selfTextMaxHeight: {
 			type: 'text',
-			value: '0',
+			value: 0,
 			description: 'Add a scroll bar to text expandos taller than [x] pixels (enter zero for unlimited).',
 			advanced: true
 		},
 		commentMaxHeight: {
 			type: 'text',
-			value: '0',
+			value: 0,
 			description: 'Add a scroll bar to comments taller than [x] pixels (enter zero for unlimited).',
 			advanced: true
 		},
@@ -1922,17 +1922,20 @@ modules['showImages'] = {
 	},
 	updateParentHeight: function(ele) {
 		if (this.options.autoMaxHeight.value && ele) {
-			var parent = $(ele).closest('.md')[0];
-			var type = $(parent).closest('body:not(.comments-page) .expando')[0] || $(parent).closest('.thing')[0];
+			var parent = $(ele).closest('.md')[0],
+				type = $(parent).closest('body:not(.comments-page) .expando')[0] || $(parent).closest('.thing')[0];
 			if (parent && (type.classList.contains('expando') || type.classList.contains('comment'))) {
-				var placeholders = $(parent).find('.expando-button.expanded + * .RESImagePlaceholder, .expando-button.expanded + * > *:not(p)');
-				var height = 0, tempHeight;
-				var selfMax = parseInt(this.options.selfTextMaxHeight.value, 10);
-				var commentMax = parseInt(this.options.commentMaxHeight.value, 10);
+				var placeholders = $(parent).find('.expando-button.expanded + * .RESImagePlaceholder, .expando-button.expanded + * > *:not(p)'),
+					height = 0,
+					tempHeight,
+					selfMax = parseInt(this.options.selfTextMaxHeight.value, 10),
+					commentMax = parseInt(this.options.commentMaxHeight.value, 10);
 
 				for (var i = 0; i < placeholders.length; i++) {
 					tempHeight = $(placeholders[i]).height();
-					if ((tempHeight || 0) > height) height = tempHeight;
+					if ((tempHeight || 0) > height) {
+						height = tempHeight;
+					}
 				}
 
 				if (selfMax && type.classList.contains('expando')) {


### PR DESCRIPTION
Relates to #1497.

~~I'm not sure how feasible it is to add the same kind of option for comment max height (as requested), since we'll have to deal with inline expandos (i.e. when an expando is opened, override the max-height style in the current .usertext-body element, and when an expando is closed check if it is the last one in this comment to be closed [preferably: check if closing it will reduce the comment's height to within the specified max height] and remove the override).
I don't know if that much work would be worth it.~~

**Edit:** This now applies a max-height to both text expandos and comments, and adjusts their height to the largest expando within them (and at least the specified height).

Tested with all expando types (AFAIK).
