### PR TITLE
Remove broken download control from imgurgifvUI

### DIFF
--- a/lib/core/templates.html
+++ b/lib/core/templates.html
@@ -301,10 +301,7 @@
 				<div style="height: 35px;" class="ctrlContainer">
 					<div class="imgurgifv-brand">
 						<img src="//i.imgur.com/favicon.ico">
-					</div>
-					<div class="imgurgifv-download">
-						<a href="{{ source }}">download</a>
-					</div>
+					</div>	
 				</div>
 			</div>
 		</script>


### PR DESCRIPTION
imgurgifvUI download control attempts to use "{{ source }}" outside of "{{#sources}}{{/sources}}" resulting in href="" for the download link.
