### PR TITLE
Hide only play/pause controls on fallback

### DIFF
--- a/lib/vendor/gifyoutube.js
+++ b/lib/vendor/gifyoutube.js
@@ -14,7 +14,7 @@
 		var frameRate = 30;
 
 		vid = element.querySelector('.gifyoutubeVid');
-		ctrlContainer = element.querySelector('.ctrlContainer');
+		ctrlContainer = element.querySelector('.gifyoutube-controls');
 		ctrlPausePlay = element.querySelector('.gifyoutubeCtrlPause');
 		ctrlSlower = element.querySelector('.gifyoutubeCtrlSlower');
 		ctrlFaster = element.querySelector('.gifyoutubeCtrlFaster');


### PR DESCRIPTION
Hiding just the gifyoutube-controls container and not the whole ctrlContainer allows the "Watch Whole Video" button to remain visible when it is forced to fall back to a standard gif.

reported by /u/YOYOYOYO1239 (one of gifyoutube founders) in PM. 
