### PR TITLE
Option to display an image's resolution in its tooltip

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -84,6 +84,11 @@ modules['showImages'] = {
 			description: 'Max height of image displayed onscreen',
 			advanced: true
 		},
+		displayOriginalResolution: {
+			type: 'boolean',
+			value: false,
+			description: 'Display each image\'s original (unresized) resolution in a tooltip.'
+		},
 		openInNewWindow: {
 			type: 'boolean',
 			value: true,
@@ -975,6 +980,9 @@ modules['showImages'] = {
 			};
 			image.onload = function() {
 				image.classList.remove('RESImageError');
+				if (modules['showImages'].options.displayOriginalResolution.value && this.naturalWidth && this.naturalHeight) {
+					this.title = this.naturalWidth + " x " + this.naturalHeight + " px";
+				}
 			};
 			image.classList.add('RESImage');
 			image.id = 'RESImage-' + RESUtils.randomHash();


### PR DESCRIPTION
Suggested by [this reddit post.](https://www.reddit.com/r/Enhancement/comments/2jqkh9/is_there_a_way_to_see_the_image_resolution_when/)

I've tested it with pretty much every image expando possible and image albums (in Chrome).

Although a lot of people probably won't use this, it is a pretty lightweight change so I think it would still be worthwhile.
