### PR TITLE
showImages.options.clippy: show 'drag to resize' ...

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -114,6 +114,11 @@ modules['showImages'] = {
 			value: true,
 			description: 'Allow dragging while holding shift to move images.'
 		},
+		clippy: {
+			type: 'boolean',
+			value: true,
+			description: 'Show educational tooltips, such as showing "drag to resize" when your mouse hovers over an image.'
+		},
 		markVisited: {
 			type: 'boolean',
 			value: true,
@@ -987,7 +992,9 @@ modules['showImages'] = {
 			image.classList.add('RESImage');
 			image.id = 'RESImage-' + RESUtils.randomHash();
 			image.src = sourceImage.src;
-			image.title = 'drag to resize or shift+drag to move';
+			if (modules['showImages'].options.clippy.value) {
+				image.title = 'drag to resize or shift+drag to move';
+			}
 			image.style.maxWidth = thisHandle.options.maxWidth.value + 'px';
 			image.style.maxHeight = thisHandle.options.maxHeight.value + 'px';
 			imageLink.image = image;


### PR DESCRIPTION
... and other helpful tips, in whatever form factor.
