### PR TITLE
Fix whitelisting subreddits from the NSFW filter

### DIFF
--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -402,7 +402,6 @@ modules['filteReddit'] = {
 		this.addedNSFWFilterStyle = true;
 
 		RESUtils.addCSS('body:not(.allowOver18) .thing.over18:not(.allowOver18) { display: none !important; }');
-		RESUtils.addCSS('.thing.over18.allowOver18 { display: block !important; }');
 	},
 	filterNSFW: function(filterOn) {
 		this.addNSFWFilterStyle();


### PR DESCRIPTION
Reported in [this reddit post.](https://www.reddit.com/r/Enhancement/comments/2jx861/is_it_possible_to_have_only_certain_subreddits/)

Previously `body:not(.allowOver18) .thing.over18 { display: none !important; }` would override `.thing.over18.allowOver18 { display: block !important; }`

I believe the second line `.thing.over18.allowOver18 { display: block !important; }` is now redundant (removing it didn't seem to make a difference in testing), but I'm not sure.
