### PR TITLE
Show real username on mouseover with usernameHider enabled

### DIFF
--- a/lib/modules/usernameHider.js
+++ b/lib/modules/usernameHider.js
@@ -71,17 +71,17 @@ modules['usernameHider'] = {
 			RESUtils.addCSS('p.tagline > .moderator[href*=\'/' + user + '\']:hover:after{ background-color:' + modules['userHighlight'].options.modColorHover.value + ';}');
 		}
 		if (curatedBy && curatedBy.href.slice(-(user.length + 1)) === '/' + user) {
-			curatedBy.textContent = 'curated by /u/' + this.options.displayText.value;
+			curatedBy.textContent = curatedBy.textContent.replace(user, this.options.displayText.value);
 
 			// Show username on hover
 			if (this.options.showUsernameOnHover.value) {
 				(function(user, displayText) {
 					$(curatedBy)
 						.on('mouseenter', function() {
-							$(this).text('curated by /u/' + user);
+							this.textContent = this.textContent.replace(displayText, user);
 						})
 						.on('mouseleave', function() {
-							$(this).text('curated by /u/' + displayText);
+							this.textContent = this.textContent.replace(user, displayText);
 						});
 				}(user, this.options.displayText.value));
 			}


### PR DESCRIPTION
It'd probably be better to do this with JavaScript instead of ugly CSS hacks, but this will do for now. Fixes #1139.
