### PR TITLE
localDate: Use jQuery data instead of attributes

### DIFF
--- a/lib/modules/localDate.js
+++ b/lib/modules/localDate.js
@@ -17,13 +17,15 @@ modules['localDate'] = {
 		if ((this.isEnabled()) && (this.isMatchURL())) {
 			$('.sitetable')
 				.on('mouseenter', 'time', function() {
-					if (!this.getAttribute('data-original-title')) {
-						this.setAttribute('data-original-title', this.getAttribute('title'));
+					var $this = $(this);
+					if (!$this.data('originalTitle')) {
+						$this.data('originalTitle', $this.attr('title'));
 					}
-					this.setAttribute('title', new Date(this.getAttribute('datetime')));
+					$this.attr('title', new Date($this.attr('datetime')));
 				})
 				.on('mouseleave', 'time', function() {
-					this.setAttribute('title', this.getAttribute('data-original-title'));
+					var $this = $(this);
+					$this.attr('title', $this.data('originalTitle'));
 				});
 		}
 	}


### PR DESCRIPTION
If we're using jQuery, might as well stick with jQuery everywhere.
