### PR TITLE
Better formatting from search share button

### DIFF
--- a/lib/modules/settingsNavigation.js
+++ b/lib/modules/settingsNavigation.js
@@ -342,6 +342,8 @@ addModule('search', function(module, moduleID) {
 			result.title = optionKey;
 			result.description = option.description;
 			result.advanced = option.advanced;
+			result.category = module.category;
+			result.moduleName = module.moduleName;
 			result.moduleID = moduleKey;
 			result.optionKey = optionKey;
 
@@ -358,6 +360,7 @@ addModule('search', function(module, moduleID) {
 			].join(' > ');
 			result.title = module.moduleName;
 			result.description = module.description;
+			result.category = module.category;
 			result.moduleID = moduleKey;
 
 			return result;
@@ -515,17 +518,23 @@ addModule('search', function(module, moduleID) {
 			alert('<textarea rows="5" cols="50">' + markdown + '</textarea>');
 		},
 		makeOptionSearchResultLink: function(result) {
-			var url = document.location.protocol + '//' + document.location.host + document.location.pathname +
-				modules['settingsNavigation'].makeUrlHash(result.moduleID, result.optionKey);
-
-			var text = [
-				result.breadcrumb,
-				'[' + result.title + '](' + url + ')',
-				'  \n',
-				result.description,
-				'  \n',
-				'  \n'
-			].join(' ');
+			var baseUrl = document.location.protocol + '//' + document.location.host + document.location.pathname,
+				url =  baseUrl + modules['settingsNavigation'].makeUrlHash(result.moduleID, result.optionKey),
+				moduleUrl = baseUrl + modules['settingsNavigation'].makeUrlHash(result.moduleID, null),
+				settingsUrl = baseUrl + '#!settings',
+				text = [
+					'[' + result.title + '](' + url + ((result.optionKey) ? ')' : ' \"' + result.moduleID + '\")'),
+					'([](#gear)[RES settings console](' + settingsUrl + ')',
+					'>',
+					result.category,
+					'>',
+					'[' + (result.moduleName || result.title) + '](' + moduleUrl + ' \"' + result.moduleID + '\")' +
+						((result.optionKey) ? ' > [' + result.title + '](' + url + '))' : ')'),
+					' \n',
+					result.description,
+					'\n',
+					'\n'
+				].join(' ');
 			return text;
 		}
 	});


### PR DESCRIPTION
As suggested in #1646.

Produces [+ two ending line breaks]:

---

[display gifyoutube](https://www.reddit.com/#!settings/showImages/display gifyoutube) (`[](#gear)`[RES settings console](https://www.reddit.com/#!settings) > UI > [Inline Image Viewer](https://www.reddit.com/#!settings/showImages) > [display gifyoutube](https://www.reddit.com/#!settings/showImages/display gifyoutube))  
 Display expander for gifyoutube 

---

[Inline Image Viewer](https://www.reddit.com/#!settings/showImages) (`[](#gear)`[RES settings console](https://www.reddit.com/#!settings) > UI > [Inline Image Viewer](https://www.reddit.com/#!settings/showImages))  
 Opens images inline in your browser with the click of a button. Also has configuration options, check it out! 

---

I used `[](#gear)` instead of `[RES gear](#gear)` because the words make it look kinda weird on /r/enhancement, but I can put it back in if you want.

I didn't use (or modify) `result.breadcrumb` as I needed to add Markdown links within it, and `result.breadcrumb` is also used on the settings page which isn't parsed with Markdown (as far as I could tell).

I also just realized that Markdown breaks links to options with spaces in their names (like "display gifyoutube") because it replaces space with %20 (like a normal URL).
