### PR TITLE
#!settings/showImages/display%20gifyoutube doesn't work

### DIFF
--- a/lib/modules/settingsNavigation.js
+++ b/lib/modules/settingsNavigation.js
@@ -114,15 +114,15 @@ modules['settingsNavigation'] = {
 		window.history.pushState('', document.title, window.location.pathname + window.location.search);
 	},
 	onHashChange: function(event) {
-		var hash = window.location.hash;
+		var hash = window.location.hash, moduleID, optionKey;
 		if (hash.substring(0, 10) !== '#!settings') return;
 
-		var params = hash.match(/\/[\w\s]+/g);
+		var params = hash.match(/\/(?:\w|\s|%20)+/g);
 		if (params && params[0]) {
-			var moduleID = params[0].substring(1);
+			moduleID = params[0].substring(1).replace('%20', ' ');
 		}
 		if (params && params[1]) {
-			var optionKey = params[1].substring(1);
+			optionKey = params[1].substring(1).replace('%20', ' ');
 		}
 
 		modules['settingsNavigation'].loadSettingsPage(moduleID, optionKey);


### PR DESCRIPTION
spin-off from #1714 

@erikdesjardins:

> I also just realized that Markdown breaks links to options with spaces in their names (like "display gifyoutube") because it replaces space with %20 (like a normal URL).

---

same goes for search links
