### PR TITLE
don't escapeNP on links inside markdown

### DIFF
--- a/lib/modules/noParticipation.js
+++ b/lib/modules/noParticipation.js
@@ -78,6 +78,7 @@ addModule('noParticipation', function(module, moduleID) {
 	function removeNpFromLink(event) {
 		var elem = event.target;
 		if (elem.tagName !== 'A') return;
+		if (elem.matches('.md a')) return;
 		var href = elem.getAttribute('href');
 		if (href[0] === '/' || npHrefRegex.test(href)) {
 			var hrefSansNp = replaceNpWith + href.match(removeNpRegexp)[1];


### PR DESCRIPTION
those are intentionally NP and should stay that way
