### PR TITLE
Fix issues related to multireddits misbehaving

### DIFF
--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -378,6 +378,16 @@ RESUtils.currentDomain = function(check) {
 	}
 };
 RESUtils.currentUserProfile = function() {
+	// Multireddits owned by users other than the logged-in user present similarly
+	// to user profiles. For example, a multireddit may look like:
+	//   <http://www.reddit.com/user/uzunyusuf/m/ai>
+	// Whereas, 
+	//   <http://www.reddit.com/user/uzunyusuf/>
+	// is a user profile. To ensure that we don't misreport user profiles as
+	// multireddits, we die early if the current page is a multireddit.
+	if ((typeof this.curMulti !== 'undefined' && this.curMulti !== null) || RESUtils.currentMultireddit()) {
+		return null;
+	}
 	if (typeof this.curUserProfile === 'undefined') {
 		var match = location.href.match(/^https?:\/\/(?:[-\w\.]+\.)?reddit\.com\/user\/([\w\.]+)/i);
 		if (match !== null) {

--- a/lib/modules/commandLine.js
+++ b/lib/modules/commandLine.js
@@ -531,6 +531,8 @@ addModule('commandLine', function(module, moduleID) {
 					modules['commandLine'].navigateTo('/user/' + RESUtils.currentUserProfile() + '?sort=' + theInput, e);
 				} else if (RESUtils.currentSubreddit()) {
 					modules['commandLine'].navigateTo('/r/' + RESUtils.currentSubreddit() + '/' + theInput, e);
+				} else if (RESUtils.currentMultireddit()) {
+					modules['commandLine'].navigateTo('/' + RESUtils.currentMultireddit() + '/' + theInput, e);
 				} else {
 					modules['commandLine'].navigateTo('/' + theInput, e);
 				}


### PR DESCRIPTION
RES fails to handle multireddits correctly in at least two ways:
1. The hot/new/rising/etc tabs on a multireddit link to an incorrect
   location if the multireddit is owned by a user other than the logged-in
   user.
2. The commandline commands for switching to a different tab (`/t`,
   `/c`, etc.) take you to an incorrect location if used on a multireddit
   (owned by any user).

This commit addresses both those issues. The fix in utils.js is kind of
a kludge, but I don't want to risk breaking the `match` regex in
`RESUtils.currentUserProfile()`.

Addresses issue #1720.
