### PR TITLE
Load new tabs in foreground if browser.tabs.loadInBackground == false

### DIFF
--- a/XPI/lib/main.js
+++ b/XPI/lib/main.js
@@ -233,7 +233,7 @@ pageMod.PageMod({
 		});
 		worker.on('message', function(data) {
 			let request = data,
-				inBackground = prefs.getBoolPref('browser.tabs.loadInBackground') || true,
+				inBackground = prefs.getBoolPref('browser.tabs.loadInBackground'),
 				isPrivate, thisLinkURL;
 
 			switch (request.requestType) {
@@ -314,7 +314,6 @@ pageMod.PageMod({
 					worker.postMessage({status: 'success'});
 					break;
 				case 'keyboardNav':
-					inBackground = (request.button === 1);
 					isPrivate = priv.isPrivate(windows.activeWindow);
 
 					// handle requests from keyboardNav module


### PR DESCRIPTION
This has been broken for a while, and I finally figured out why: inBackground always gets set to true due to "|| true", and it also gets set in the 'keyboardNav' case.