### PR TITLE
Enable unsafe-content-script for Firefox

### DIFF
--- a/XPI/package.json
+++ b/XPI/package.json
@@ -7,6 +7,7 @@
 	"id": "jid1-xUfzOsOFlzSOXg",
 	"description": "A suite of tools to enhance Reddit",
 	"permissions": {
-		"private-browsing": true
+		"private-browsing": true,
+		"unsafe-content-script": true
 	}
 }


### PR DESCRIPTION
This makes RES work on Firefox 36 (nightly). This will likely break completely in the future, as Mozilla is making security-related [changes to UnsafeWindow](https://blog.mozilla.org/addons/2014/04/10/changes-to-unsafewindow-for-the-add-on-sdk/). For now, however, it makes RES work on the latest Firefox nightlies without issues.
