### PR TITLE
Fix handling of last image in imgur 'hash list' albums

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -2120,7 +2120,8 @@ modules['showImages'] = {
 			// a redirect loop.  preserving the old one just in case.  however it also fixes detection of the extension (.jpg, for example) which
 			// was too greedy a search...
 			// the hashRe below was provided directly by MrGrim (well, everything after the domain was), using that now.
-			hashRe: /^https?:\/\/(?:i\.|m\.|edge\.|www\.)*imgur\.com\/(?!gallery)(?!removalrequest)(?!random)(?!memegen)([\w]{5,7}(?:[&,][\w]{5,7}(?:#\d+)?)*)[sbtmlh]?(\.(?:jpe?g|gif|png|gifv))?(\?.*)?$/i,
+			// in addition to the above, the album index was moved out of the first capture group.
+			hashRe: /^https?:\/\/(?:i\.|m\.|edge\.|www\.)*imgur\.com\/(?!gallery)(?!removalrequest)(?!random)(?!memegen)([\w]{5,7}(?:[&,][\w]{5,7})*)(?:#\d+)?[sbtmlh]?(\.(?:jpe?g|gif|png|gifv))?(\?.*)?$/i,
 			albumHashRe: /^https?:\/\/(?:i\.|m\.)?imgur\.com\/(?:a|gallery)\/([\w]+)(\..+)?(?:\/)?(?:#?\w*)?$/i,
 			apiPrefix: 'https://api.imgur.com/2/',
 			calls: {},
@@ -2142,8 +2143,7 @@ modules['showImages'] = {
 				if (groups && !albumGroups) {
 					// handling for separated list of IDs
 					if (groups[1].search(/[&,]/) > -1) {
-						var removeIndexRe = /([\w&,]*)#?/,
-							hashes = removeIndexRe.exec(groups[1])[1].split(/[&,]/);
+						var hashes = groups[1].split(/[&,]/);
 						def.resolve(elem, {
 							album: {
 								images: hashes.map(function(hash) {


### PR DESCRIPTION
I don't know if there's an issue filed for this (I couldn't find one), but I've experienced this a few times and this time I decided to fix it.

Basically, RES would encounter an album like this: `imgur.com/ACD9Lxc,8TSygIR#0` and would include the index of the current image (from when the link was copied) in the hash of the last image (i.e. `8TSygIR#0` instead of `8TSygIRm`), causing it to fail to load.

This change strips anything after `#`, if it's present.
