### PR TITLE
Add comment tools to modqueue-like pages

### DIFF
--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -94,8 +94,8 @@ modules['commentTools'] = {
 		'inbox',
 		'submit',
 		'profile',
-		/^https?:\/\/(?:[-\w\.]+\.)?reddit\.com\/r\/[\-\w\.]+\/about\/(edit|modqueue|reports|spam)\/?/i,
-		/^https?:\/\/(?:[-\w\.]+\.)?reddit\.com\/r\/[\-\w\.]+\/wiki\/(create|edit)(\/\w+)?/i
+		/^https?:\/\/(?:[-\w\.]+\.)?reddit\.com\/r\/[\-\w\.]+\/about\/(?:edit|modqueue|reports|spam)\/?/i,
+		/^https?:\/\/(?:[-\w\.]+\.)?reddit\.com\/r\/[\-\w\.]+\/wiki\/(?:create|edit)(\/\w+)?/i
 	],
 	isMatchURL: function() {
 		return RESUtils.isMatchURL(this.moduleID);


### PR DESCRIPTION
Recently, a reply button was added to modqueue pages ([via](https://www.reddit.com/r/modnews/comments/2kppi1/moderators_you_can_now_reply_to_comments_directly/), github [changes](https://github.com/reddit/reddit/commit/85751e50899a6b7ec916d4045b254ca580caa665), /r/Enhancement [thread](https://www.reddit.com/r/Enhancement/comments/2l2apa/feature_request_adding_the_comment_macro_to/))
This change adds comment tools to these new reply boxes.
