### PR TITLE
Make more elements not show up in searches (noCtrlF)

### DIFF
--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -195,10 +195,10 @@ modules['betteReddit'] = {
 
 			if (this.options.doNoCtrlF.value) {
 				if ((RESUtils.pageType() === 'inbox') || (RESUtils.pageType() === 'profile') || (RESUtils.pageType() === 'linklist')) {
-					this.applyNoCtrlF();
+					this.applyNoCtrlF(document);
 					RESUtils.watchForElement('siteTable', this.applyNoCtrlF);
 				} else if (RESUtils.pageType() === 'comments') {
-					this.applyNoCtrlF();
+					this.applyNoCtrlF(document);
 					RESUtils.watchForElement('newComments', this.applyNoCtrlF);
 				}
 			}
@@ -1020,8 +1020,8 @@ modules['betteReddit'] = {
 		li.appendChild(a);
 		tabmenu.appendChild(li);
 	},
-	applyNoCtrlF: function() {
-		var elems = document.querySelectorAll('ul.flat-list.buttons li a:not(.noCtrlF)');
+	applyNoCtrlF: function(searchIn) {
+		var elems = searchIn.querySelectorAll('ul.flat-list.buttons li a:not(.noCtrlF)');
 		RESUtils.forEachChunked(elems, 25, 100, function(e) {
 			e.classList.add('noCtrlF');
 			e.setAttribute('data-text', e.textContent);

--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -127,6 +127,11 @@ modules['betteReddit'] = {
 			type: 'boolean',
 			value: false,
 			description: 'The saved tab on pages with the multireddit side bar is now located in that collapsible bar. This will restore it to the header. If you have the \'Save Comments\' module enabled then you\'ll see both the links <em>and</em> comments tabs.'
+		},
+		doNoCtrlF: {
+			type: 'boolean',
+			value: false,
+			description: 'Modify reddit\'s comment/link buttons ("perma-link source save...") such that they don\'t show up in searches. Disabled by default due to a slight performance impact.'
 		}
 	},
 	description: 'Adds a number of interface enhancements to Reddit, such as "full comments" links, the ability to unhide accidentally hidden posts, and more',
@@ -187,6 +192,17 @@ modules['betteReddit'] = {
 			// if ((this.options.turboSelfText.value) && (RESUtils.pageType() === 'linklist')) {
 			// 	this.setUpTurboSelfText();
 			// }
+
+			if (this.options.doNoCtrlF.value) {
+				if ((RESUtils.pageType() === 'inbox') || (RESUtils.pageType() === 'profile') || (RESUtils.pageType() === 'linklist')) {
+					this.applyNoCtrlF();
+					RESUtils.watchForElement('siteTable', this.applyNoCtrlF);
+				} else if (RESUtils.pageType() === 'comments') {
+					this.applyNoCtrlF();
+					RESUtils.watchForElement('newComments', this.applyNoCtrlF);
+				}
+			}
+
 			this.setupFaviconBadge();
 
 			if ((modules['betteReddit'].options.showLastEditedTimestamp.value) && ((RESUtils.pageType() === 'linklist') || (RESUtils.pageType() === 'comments'))) {
@@ -1001,5 +1017,13 @@ modules['betteReddit'] = {
 		a.href = '/user/' + user + '/saved/';
 		li.appendChild(a);
 		tabmenu.appendChild(li);
+	},
+	applyNoCtrlF: function() {
+		var elems = document.querySelectorAll('ul.flat-list.buttons li a:not(.noCtrlF)');
+		RESUtils.forEachChunked(elems, 25, 100, function(e) {
+			e.classList.add('noCtrlF');
+			e.setAttribute('data-text', e.textContent);
+			e.textContent = '';
+		})
 	}
 };

--- a/lib/modules/commentNavigator.js
+++ b/lib/modules/commentNavigator.js
@@ -102,8 +102,8 @@ modules['commentNavigator'] = {
 							break;
 					}
 					thisEle.setAttribute('index', i + 1);
-					thisEle.classList.add('commentNavSortType');
-					thisEle.textContent = thisCategory;
+					thisEle.setAttribute('data-text', thisCategory);
+					thisEle.classList.add('commentNavSortType', 'noCtrlF');
 					if (thisCategory === 'new') {
 						var isGold = document.body.querySelector('.gold-accent.comment-visits-box');
 						if (isGold) {


### PR DESCRIPTION
As suggested in #1562, this handles comment navigator buttons (no performance impact) and reddit's comment/link buttons (slight performance impact, so disabled by default).

It's not very feasible to apply this to submission times (as was suggested), since they are dynamically updated.