### PR TITLE
Split the save keyboard shortcut into save and saveRES

### DIFF
--- a/lib/core/migrate.js
+++ b/lib/core/migrate.js
@@ -82,6 +82,8 @@ var RESOptionsMigrate = {
 			versionNumber: '4.5.3',
 			go: function() {
 				RESOptionsMigrate.migrators.generic.updateOption('searchHelper', 'addSubmitButton', true, false);
+				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'save', 'keyboardNav', 'savePost');
+				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'save', 'keyboardNav', 'saveRES');
 			}
 		}
 	],

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -327,14 +327,19 @@ modules['keyboardNav'] = {
 			value: [90, false, false, true], // z
 			description: 'Downvote selected link or comment (but don\'t remove the downvote)'
 		},
-		save: {
+		savePost: {
 			type: 'keycode',
 			value: [83, false, false, false], // s
-			description: 'Save the current link or comment to your reddit account. This is accessible from anywhere that you\'re logged in, but does not preserve the original text if it\'s edited or deleted.'
+			description: 'Save the current post to your reddit account. This is accessible from anywhere that you\'re logged in, but does not preserve the original text if it\'s edited or deleted.'
+		},
+		saveComment: {
+			type: 'keycode',
+			value: [83, false, false, true], // shift-s
+			description: 'Save the current comment to your reddit account. This is accessible from anywhere that you\'re logged in, but does not preserve the original text if it\'s edited or deleted.'
 		},
 		saveRES: {
 			type: 'keycode',
-			value: [83, false, false, true], // shift-s
+			value: [83, false, false, false], // s
 			description: 'Save the current comment with RES. This does preserve the original text of the comment, but is only saved locally.'
 		},
 		reply: {
@@ -1089,7 +1094,7 @@ modules['keyboardNav'] = {
 						case RESUtils.checkKeysForEvent(e, this.options.downVote.value):
 							this.downVote(true);
 							return true;
-						case RESUtils.checkKeysForEvent(e, this.options.save.value):
+						case RESUtils.checkKeysForEvent(e, this.options.savePost.value):
 							this.saveLink();
 							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.goMode.value):
@@ -1193,19 +1198,14 @@ modules['keyboardNav'] = {
 								return true;
 							}
 							return false;
-						case RESUtils.checkKeysForEvent(e, this.options.save.value):
-							if (this.activeIndex === 0) {
-								this.saveLink();
-							} else {
-								this.saveComment();
-								modules['saveComments'].showEducationalNotification();
-							}
+						case RESUtils.checkKeysForEvent(e, this.options.savePost.value) && this.activeIndex === 0:
+							this.saveLink();
 							return true;
-						case RESUtils.checkKeysForEvent(e, this.options.saveRES.value):
-							if (this.activeIndex !== 0) {
-								this.saveCommentRES();
-								modules['saveComments'].showEducationalNotification();
-							}
+						case RESUtils.checkKeysForEvent(e, this.options.saveComment.value) && this.activeIndex !== 0:
+							this.saveComment();
+							return true;
+						case RESUtils.checkKeysForEvent(e, this.options.saveRES.value) && this.activeIndex !== 0:
+							this.saveCommentRES();
 							return true;
 						case RESUtils.checkKeysForEvent(e, this.options.toggleExpando.value):
 							this.toggleAllExpandos();
@@ -1942,6 +1942,7 @@ modules['keyboardNav'] = {
 		var saveComment = this.keyboardLinks[this.activeIndex].querySelector('.saveComments, .unsaveComments');
 		if (saveComment) {
 			RESUtils.click(saveComment);
+			modules['saveComments'].showEducationalNotification();
 		}
 	},
 	reply: function() {

--- a/lib/modules/saveComments.js
+++ b/lib/modules/saveComments.js
@@ -280,7 +280,7 @@ modules['saveComments'] = {
 
 		var saveRESTips = document.createElement('div');
 		saveRESTips.classList.add('savedComment', 'entry');
-		$(saveRESTips).safeHtml('<p><b>Tip:</b> Don\'t see a comment here? Check the "saved - reddit" tab above.</p><p>Currently, the keyboard shortcut "' + modules['keyboardNav'].getNiceKeyCode('save') + '" saves a post or comment to your reddit account, and "' + modules['keyboardNav'].getNiceKeyCode('saveRES') + '" saves a comment locally with RES. This can be changed in the <a href="#!settings/keyboardNav/save">settings console</a>.</p>');
+		$(saveRESTips).safeHtml('<p><b>Tip:</b> Don\'t see a comment here? Check the "saved - reddit" tab above.</p><p>Currently, the keyboard shortcut "' + modules['keyboardNav'].getNiceKeyCode('savePost') + '" saves a post to your reddit account, "' + modules['keyboardNav'].getNiceKeyCode('saveComment') + '" saves a comment to your reddit account, and "' + modules['keyboardNav'].getNiceKeyCode('saveRES') + '" saves a comment locally with RES. These can be changed in the ' + modules['settingsNavigation'].makeUrlHashLink('keyboardNav', 'savePost', 'settings console') + '.</p>');
 		this.savedCommentsContent.appendChild(saveRESTips);
 
 		for (var i in this.storedComments) {
@@ -368,13 +368,14 @@ modules['saveComments'] = {
 	showEducationalNotification: function() {
 		modules['notifications'].showNotification({
 			moduleID: this.moduleID,
+			optionKey: 'savePost',
 			notificationID: 'saveRES-educational',
 			closeDelay: 10000,
 			cooldown: 3 * 7 * 24 * 60 * 60 * 1000,
 			header: 'Saving Posts and Comments',
-			message: '<p>The keyboard shortcut <b>"' + modules['keyboardNav'].getNiceKeyCode('save') + '"</b>, will save a post or comment to your reddit account (same as the "save" button). It will be accessible from anywhere that you\'re logged in, but the original text will not preserved if it is edited or deleted.</p>' +
+			message: '<p>The keyboard shortcuts <b>"' + modules['keyboardNav'].getNiceKeyCode('savePost') + '"</b> (posts) and <b>"' + modules['keyboardNav'].getNiceKeyCode('saveComment') + '"</b> (comments) will save a post/comment to your reddit account (same as the "save" button). It will be accessible from anywhere that you\'re logged in, but the original text will not be preserved if it is edited or deleted.</p>' +
 				'<p>The keyboard shortcut <b>"' + modules['keyboardNav'].getNiceKeyCode('saveRES') + '"</b> will save a comment to RES (same as the "save-RES" button). It will only be available locally, but the original text will be preserved if the comment is edited or deleted.</p>' +
-				'<p>These shortcuts can be changed in the <a href="#!settings/keyboardNav/save">settings console</a>.<p>'
+				'<p>These shortcuts can be changed in the ' + modules['settingsNavigation'].makeUrlHashLink('keyboardNav', 'savePost', 'settings console') + '.<p>'
 		});
 	}
 };


### PR DESCRIPTION
Suggested in #417.

This does change existing behavior (the save key now saves comments to reddit instead of saving them to RES, which now has its own key), but I think most users who are smart enough to save posts to RES should be able to figure out the new shortcut.

This also allows the save-RES status to be toggled before a refresh (i.e. you click `save-RES` and it becomes `unsave-RES` and can be toggled, but after a refresh it becomes `saved-RES` and you must go to the saved page to delete it), which I think is a fair balance: users can easily unsave something if it was an accident, but can't accidentally unsave something that they are revisiting.
