### PR TITLE
Keyboard shortcuts for adding links, superscript and quotes

### DIFF
--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -509,13 +509,13 @@ modules['commentTools'] = {
 			editBar.append(this.makeEditButton("<del>strike</del>", "strike (ctrl-s)", [83, false, true, false, false], 'btn-strike', function(button, box) {
 				this.wrapSelection(box, "~~", "~~");
 			}));
-			editBar.append(this.makeEditButton("<sup>sup</sup>", "super", null, 'btn-superscript', function(button, box) {
+			editBar.append(this.makeEditButton("<sup>sup</sup>", "super (ctrl-+)", [187, false, true, true, false], 'btn-superscript', function(button, box) {
 				this.wrapSelectedWords(box, "^");
 			}));
 			editBar.append(this.makeEditButton("Link", "link (ctrl-k)", [75, false, true, false, false], 'btn-link', function(button, box) {
 				this.linkSelection(box);
 			}));
-			editBar.append(this.makeEditButton(">Quote", "quote", null, 'btn-quote', function(button, box) {
+			editBar.append(this.makeEditButton(">Quote", "quote (ctrl->)", [190, false, true, true, false], 'btn-quote', function(button, box) {
 				this.wrapSelectedLines(box, "> ", "");
 			}));
 			editBar.append(this.makeEditButton("<span style=\"font-family: monospace\">Code</span>", "code", null, 'btn-code', function(button, box) {


### PR DESCRIPTION
Resolves the last remaining part of #531.

ctrl-+ (ctrl-shift-=) for superscript
ctrl-k for links
ctrl-> (ctrl-shift-.) for quotes (there didn't seem to be a standard so I chose this on a whim, I'm open to suggestions)
