### PR TITLE
Use comments link as user tagger URL on link posts

### DIFF
--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -27,6 +27,12 @@ modules['userTagger'] = {
 			description: 'By default, store a link to the link/comment you tagged a user on',
 			advanced: true
 		},
+		useCommentsLinkAsSource: {
+			type: 'boolean',
+			value: true,
+			description: 'By default, store a link to the comments when tagging a user in a link post. Otherwise, the link (that the post refers to) will be used.',
+			advanced: true
+		},
 		hoverInfo: {
 			type: 'boolean',
 			value: true,
@@ -748,8 +754,12 @@ modules['userTagger'] = {
 		return false;
 	},
 	setLinkBasedOnTagLocation: function(obj) {
-		var closestEntry = $(obj).closest('.entry');
-		var linkTitle = $(closestEntry).find('a.title');
+		var closestEntry = $(obj).closest('.entry'),
+			linkTitle = '';
+
+		if (!modules['userTagger'].options.useCommentsLinkAsSource.value) {
+			linkTitle = $(closestEntry).find('a.title');
+		}
 		// if we didn't find anything, try a new search (works on inbox)
 		if (!linkTitle.length) {
 			linkTitle = $(closestEntry).find('a.bylink');


### PR DESCRIPTION
Issue #936.

Defaults to on (old behavior is off).
