### PR TITLE
Allow the user to choose different usernameHider text for each account

### DIFF
--- a/lib/modules/usernameHider.js
+++ b/lib/modules/usernameHider.js
@@ -66,13 +66,13 @@ modules['usernameHider'] = {
 
 		if (loggedInUser && accounts) {
 			for (var i = 0, len = accounts.length; i < len; i++) {
-				if (accounts[i][0].toLowerCase() === loggedInUser) {
-					return accounts[i][1] || ' '; //non-breaking space, alt-0160
+				if (accounts[i][0].toLowerCase() === loggedInUser && accounts[i][1]) {
+					return accounts[i][1];
 				}
 			}
 		}
 
-		return this.options.displayText.value || ' ';
+		return this.options.displayText.value;
 	},
 	hideUsername: function() {
 		var user = RESUtils.loggedInUser(),


### PR DESCRIPTION
Issue #736.

I added a separate array of users to the usernameHider module instead of adding a new field to the existing array of users in accountSwitcher, primarily to make this option more obvious for the user (and obvious that you don't have to use accountSwitcher to use it).
