### PR TITLE
fix for issue #1760 - hitting enter in captcha field on FF will bring up big editor

### DIFF
--- a/lib/modules/commentPreview.js
+++ b/lib/modules/commentPreview.js
@@ -215,7 +215,7 @@ modules['commentPreview'] = {
 		}
 	},
 	makeBigEditorButton: function() {
-		return $('<button class="RESBigEditorPop" tabIndex="3">big editor</button>');
+		return $('<button type="button" class="RESBigEditorPop" tabIndex="3">big editor</button>');
 	},
 	attachPreview: function(usertext) {
 		if (usertext == null) {


### PR DESCRIPTION
Firefox seems to think that a button on a form without a 'type' attribute defaults to type="submit" so it clicks the big editor button when you try to submit the form by hitting enter in the captcha field. Setting the 'type' attribute equal to "button" fixes this issue.
