### PR TITLE
Fix gifv expandos overlapping content and double-size image expandos

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1522,6 +1522,7 @@ modules['showImages'] = {
 		expandoButton.classList.remove('collapsedExpando');
 		expandoButton.classList.remove('collapsed');
 		expandoButton.classList.add('expanded');
+		$(expandoButton).data('associatedImage', element);
 
 		if (video) {
 			modules['showImages'].makeMediaZoomable(video);
@@ -1749,24 +1750,22 @@ modules['showImages'] = {
 		}
 	},
 	handleMediaLoad: function() {
-		RESUtils.debounce('handleMediaLoad', 50, function() { //debounce to fix issue #1672
-			// don't do this twice (e.g. on image reload from cache), as we get bad height/width data.
-			if ($(this).data('loaded')) {
-				return;
-			}
-			modules['showImages'].syncPlaceholder(this);
-			
-			if(! this.tagName) { //validation to fix issue #1672
-				return;
-			}
-			$(this).data('loaded', true);
-			if (this.tagName !== 'VIDEO') {
-				this.style.position = 'absolute';
-			} else {
-				var $resPlayer = $(this.parentNode).closest('.res-player');
-				$resPlayer[0].style.position = 'absolute';
-			}
-		});
+		// don't do this twice (e.g. on image reload from cache), as we get bad height/width data.
+		if ($(this).data('loaded')) {
+			return;
+		}
+		modules['showImages'].syncPlaceholder(this);
+
+		if(! this.tagName) { //validation to fix issue #1672
+			return;
+		}
+		$(this).data('loaded', true);
+		if (this.tagName !== 'VIDEO') {
+			this.style.position = 'absolute';
+		} else {
+			var $resPlayer = $(this.parentNode).closest('.res-player');
+			$resPlayer[0].style.position = 'absolute';
+		}
 	},
 	syncPlaceholder: function(e) {
 		var ele = e.target || e;


### PR DESCRIPTION
Related to #1672.

The existing debounce did nothing, it just set the placeholder a bit later: to the height of the closed expando (0 height) instead of the opened, unloaded expando (~0 height).

This works because we already have code to update the placeholder size when revealing expandos (in `revealImage()`), but only when the expando button stores the `associatedImage` in jquery data. Previously, this was only done for image expandos.
