### PR TITLE
fixes #1766 seems like youtube start time support already existed..

### DIFF
--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -774,7 +774,7 @@ modules['betteReddit'] = {
 			youtubeLinks = ytLinks;
 			var getYoutubeIDRegex = /\/?[\&|\?]?v\/?=?([\w\-]{11})&?/i;
 			var getShortenedYoutubeIDRegex = /([\w\-]{11})&?/i;
-			var getYoutubeStartTimeRegex = /\[[\d]+:[\d]+\]/i;
+			var getYoutubeStartTimeRegex = /#t=(\d+)/i;
 			var tempIDs = [];
 			modules['betteReddit'].youtubeLinkIDs = {};
 			modules['betteReddit'].youtubeLinkRefs = [];
@@ -798,7 +798,7 @@ modules['betteReddit'] = {
 				var timeMatch = getYoutubeStartTimeRegex.exec(youtubeLinks[i].getAttribute('href'));
 				var titleMatch = titleHasTimeRegex.test(youtubeLinks[i].textContent);
 				if (timeMatch && !titleMatch) {
-					youtubeLinks[i].textContent += ' (@' + timeMatch[1] + ')';
+					youtubeLinks[i].textContent += ' (@' + Math.floor(timeMatch[1] / 60) + ':' + timeMatch[1] % 60 + ')';
 				}
 			}
 			for (var id in modules['betteReddit'].youtubeLinkIDs) {


### PR DESCRIPTION
...but it had an improper regex or yt changed their start time format

Just hijacked the old code and fixed the regex, youtube uses #t=<seconds> for their start time in the url.

WIll display as (@startMinutes:startSeconds) - [lengthMinutes:lengthSeconds] e.g (@1:20) - [5:30]

fixes #1766