### PR TITLE
Handle undefined subredditStylesWhitelist

### DIFF
--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -182,7 +182,7 @@ addModule('nightMode', function(module, moduleID) {
 	},
 	handleNightModeAtStart: function() {
 		var curSubreddit = RESUtils.currentSubreddit() || '',
-			index = module.options.subredditStylesWhitelist.value.split(',').indexOf(curSubreddit.toLowerCase());
+			index = (module.options.subredditStylesWhitelist.value || '').split(',').indexOf(curSubreddit.toLowerCase());
 
 		if (index !== -1) {
 			// go no further. this subreddit is whitelisted.


### PR DESCRIPTION
I'm not sure if this is just a problem with loading dev versions or something we've changed since the last release (because I've never seen it reported), but a fresh install of RES (either loaded unpacked in Chrome, or in Firefox using `cfx run`) will crash until subredditStylesWhitelist has a value.

**Edit:** Nevermind, I'm an idiot, we're just missing the default value.
