### PR TITLE
Allow sidebar md changes to be previewed directly

### DIFF
--- a/lib/modules/commentPreview.js
+++ b/lib/modules/commentPreview.js
@@ -43,6 +43,12 @@ modules['commentPreview'] = {
 			value: true,
 			description: 'Show preview for ban notes',
 			advanced: true
+		},
+		sidebarPreview: {
+			type: 'boolean',
+			value: true,
+			description: 'Show the markdown live preview directly in the sidebar when editing',
+			advanced: true
 		}
 	},
 	description: 'Provides a live preview of comments, as well as a two column editor for writing walls of text.',
@@ -246,24 +252,37 @@ modules['commentPreview'] = {
 			}
 		}
 		$(usertext).find('.usertext-edit, .ban-details:has(#ban_message)').each(function() {
-			if ($(this).closest('.commentarea, .message').length && !modules['commentPreview'].options.enableForComments.value) return;
+			var $this = $(this);
+
+			if ($this.closest('.commentarea, .message').length && !modules['commentPreview'].options.enableForComments.value) return;
 			if ((RESUtils.pageType() === 'submit' || $(this).closest('.link').length) && !modules['commentPreview'].options.enableForPosts.value) return;
 			if (/^https?:\/\/(?:[-\w\.]+\.)?reddit\.com\/r\/[\-\w\.]+\/about\/edit/i.test(document.location.href)
 					&& !modules['commentPreview'].options.enableForSubredditConfig.value) return;
 			if (/^https?:\/\/(?:[-\w\.]+\.)?reddit\.com\/r\/[\-\w\.]+\/about\/banned/i.test(document.location.href)
 					&& !modules['commentPreview'].options.enableForBanMessages.value) return;
 
-			var preview = $(this).find('.livePreview');
+			var preview = $this.find('.livePreview');
+
 			if (preview.length === 0) {
 				preview = modules['commentPreview'].makePreviewBox();
-				$(this).append(preview);
+				$this.append(preview);
 			}
+
 			var contents = preview.find('.RESDialogContents');
-			var textareas = $(this).find('textarea[name=text], textarea[name=description], textarea[name=public_description], textarea[name=ban_message]');
+			var textareas = $this.find('textarea[name=text], textarea[name=description], textarea[name=public_description], textarea[name=ban_message]');
+
+			if (textareas.attr('name') === 'description' && modules['commentPreview'].options.sidebarPreview.value) {
+				var sideMd = $('.side .usertext-body .md:first');
+
+				if (sideMd.length) {
+					contents.push(sideMd[0]);
+				}
+			}
+
 			textareas.on('input', modules['commentPreview'].onTextareaInput.bind(this, preview, contents));
 
 			// check for reply --> quoted text
-			$(this).closest('.thing').find('.buttons a[onclick*="reply"]') /* terrible selector */
+			$this.closest('.thing').find('.buttons a[onclick*="reply"]') /* terrible selector */
 				.on('click', textareas.trigger.bind(textareas, 'input'));
 			setTimeout(textareas.trigger.bind(textareas, 'input'), 1);
 		});


### PR DESCRIPTION
This PR tweaks commentPreview.js to apply the rendered preview html from the sidebar markdown editor directly to the sidebar, which is really handy for previewing in a subreddit that uses a ton of CSS hacks
