### PR TITLE
Option to search when clicking on flair

### DIFF
--- a/lib/modules/searchHelper.js
+++ b/lib/modules/searchHelper.js
@@ -39,7 +39,7 @@ modules['searchHelper'] = {
 		searchByFlair: {
 			type: 'boolean',
 			value: true,
-			description: 'When clicking on a flair, searches that subreddit for other posts with said flair. May not work in some subreddits that hide the actual flair and add pseudo-flair with CSS (only workaround is to disable subreddit style).'
+			description: 'When clicking on a post\'s flair, search its subreddit for that flair. <p>May not work in some subreddits that hide the actual flair and add pseudo-flair with CSS (only workaround is to disable subreddit style).</p>'
 		}
 	},
 	description: 'Provide help with the use of search.',
@@ -106,19 +106,17 @@ modules['searchHelper'] = {
 				});
 			}
 			if (this.options.searchByFlair) {
-				$(document).on('mouseenter', 'span.linkflairlabel', function(e) {
+				RESUtils.addCSS('.res-flairSearch { cursor: pointer; position: relative; } .linkflairlabel.res-flairSearch a { position: absolute; top: 0; left: 0; right: 0; bottom: 0; }');
+				$('#siteTable').on('mouseenter', '.title > .linkflairlabel:not(.res-flairSearch)', function(e) {
 					var parent = $(e.target).closest('.thing')[0],
-						flair = parent.className.match(/linkflair-([a-z0-9-]+)\s/i)[1],
-						srMatch = RESUtils.subredditRegex.exec(parent.querySelector('.entry a.subreddit'))
-						subreddit = (srMatch) ? srMatch[1] : RESUtils.currentSubreddit();
+						srMatch = RESUtils.subredditRegex.exec(parent.querySelector('.entry a.subreddit')),
+						subreddit = (srMatch) ? srMatch[1] : RESUtils.currentSubreddit(),
+						flair = e.target.title.replace(/\s/g, '+');
 					if (flair && subreddit) {
-						var newElem = document.createElement('a');
-						for (var i = 0, len = e.target.attributes.length; i < len; i++) {
-							newElem.setAttribute(e.target.attributes[i].name, e.target.attributes[i].value);
-						}
-						newElem.appendChild(e.target.firstChild);
-						newElem.href = '/r/' + encodeURIComponent(subreddit) + '/search?sort=new&restrict_sr=on&q=flair%3A' + encodeURIComponent(flair);
-						e.target.parentNode.replaceChild(newElem, e.target);
+						var link = document.createElement('a');
+						link.href = '/r/' + encodeURIComponent(subreddit) + '/search?sort=new&restrict_sr=on&q=flair%3A' + encodeURIComponent(flair);
+						e.target.classList.add('res-flairSearch');
+						e.target.appendChild(link);
 					}
 				});
 			}


### PR DESCRIPTION
fixes #1786.
Not sure if this is the best way to do it (do we want to be changing an element's type/tag?); I can change it to just `location.href = ...` if you prefer.
Results sorted by new because hot sorting on searches doesn't seem to be the same as hot on the frontpage (i.e. search for the flair of the top post in a subreddit, and it isn't even on the first page of search results when sorted by hot).
