### PR TITLE
Fix for reply boxes getting pushed down

### DIFF
--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -212,7 +212,7 @@ modules['commentTools'] = {
 				margin-top: 10px; \
 				margin-bottom: 3px; \
 			}');
-			RESUtils.addCSS('.commentingAs a.userTagLink { cursor:default; }');
+			RESUtils.addCSS('.commentingAs a.userTagLink { cursor:default; display: inline; }');
 
 
 			// Table editor


### PR DESCRIPTION
Fixes #1807 
This bug occurs when commentBoxes is disabled and the logged in user is tagged.

This is one of a few ways to fix the issue (making the textarea `float: left`, reducing the height of the tag, etc.), so I'm not sure if this is the best way.
