### PR TITLE
filteReddit regex support, refactoring

### DIFF
--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -73,7 +73,8 @@ modules['filteReddit'] = {
 				/* { name: 'inclusions', type: 'list', source: location.protocol + '/api/search_reddit_names' } */
 			],
 			value: [],
-			description: 'Type in title keywords you want to ignore if they show up in a title'
+			description: 'Type in title keywords you want to ignore if they show up in a title.'
+				+ '\n\nRegExp like <code>/(this|that|theother)/i</code> is allowed for keyword (but not unlessKeyword).'
 		},
 		subreddits: {
 			type: 'table',
@@ -83,7 +84,8 @@ modules['filteReddit'] = {
 				type: 'text'
 			}],
 			value: [],
-			description: 'Type in a subreddit you want to ignore (only applies to /r/all or /domain/* urls)'
+			description: 'Type in a subreddit you want to ignore (only applies to /r/all or /domain/* urls).'
+			 	+ '\n\nRegExp like <code>/(this|that|theother)/i</code> is allowed for subreddit.'
 		},
 		domains: {
 			type: 'table',
@@ -116,6 +118,7 @@ modules['filteReddit'] = {
 			],
 			value: [],
 			description: 'Type in domain keywords you want to ignore. Note that "reddit" would ignore "reddit.com" and "fooredditbar.com"'
+				+ '\n\nRegExp like <code>/(this|that|theother)/i</code> is allowed for domain.'
 		},
 		flair: {
 			type: 'table',
@@ -148,6 +151,7 @@ modules['filteReddit'] = {
 			],
 			value: [],
 			description: 'Type in keywords you want to ignore if they are contained in link flair'
+				+ '\n\nRegExp like <code>/(this|that|theother)/i</code> is allowed for flair.'
 		},
 		allowNSFW: {
 			type: 'table',


### PR DESCRIPTION
- If filter's first item (keyword, subreddit, post domain, flair text, etc.) looks like a `/RegExp/gi`, then turn it into a regexp instead of using simple string matching
- Preprocess all the filters for efficiency on page >= 2
- Code readability cleanups

I haven't fully tested this yet, but I wanted to put it out there for critique (and maybe somebody else will do some testing too, hint hint).
