### PR TITLE
Only show filteReddit's "posts filtered" notification if a minimum % of posts are hidden

### DIFF
--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -12,6 +12,12 @@ modules['filteReddit'] = {
 			value: false,
 			description: 'Filters all links labelled NSFW'
 		},
+		notificationThreshold: {
+			type: 'text',
+			value: '80',
+			description: 'If more than this percentage (0-100) of a page is filtered, show a notification',
+			advanced: true
+		},
 		NSFWQuickToggle: {
 			type: 'boolean',
 			value: true,
@@ -332,7 +338,9 @@ modules['filteReddit'] = {
 			}
 		}
 
-		if ((numFiltered || numNsfwHidden)) {
+		var notificationThreshold = parseInt(modules['filteReddit'].options.notificationThreshold.value, 10) / 100 || 1;
+		var percentageHidden = (numFiltered + numNsfwHidden) / entries.length;
+		if (percentageHidden && percentageHidden >= notificationThreshold) {
 			var notification = [];
 			if (numFiltered) notification.push(numFiltered + ' post(s) hidden by ' + modules['settingsNavigation'].makeUrlHashLink('filteReddit', 'keywords', 'custom filters') + '.');
 			if (numNsfwHidden) notification.push(numNsfwHidden + ' post(s) hidden by the ' + modules['settingsNavigation'].makeUrlHashLink('filteReddit', 'NSFWfilter', 'NSFW filter') + '.');
@@ -340,7 +348,7 @@ modules['filteReddit'] = {
 
 			var notification = notification.join('<br><br>');
 			modules['notifications'].showNotification({
-				header: modules['filteReddit'].postsFilteredNotificationHeader,
+				header: 'Posts Filtered',
 				moduleID: 'filteReddit',
 				message: notification
 			});


### PR DESCRIPTION
also scrap the old filteReddit.options.notification because notifications.options.notificationTypes deals with it.  people will survive turning it off again.
