### PR TITLE
nightmode: Add styling for p tags in Markdown, simplify style rules

### DIFF
--- a/lib/modules/nightmode.css
+++ b/lib/modules/nightmode.css
@@ -271,12 +271,13 @@
 	background: #666;
 }
 
-.res-nightmode.wiki-page .wiki-page-content .md.wiki h1,
-.res-nightmode.wiki-page .wiki-page-content .md.wiki h2,
-.res-nightmode.wiki-page .wiki-page-content .md.wiki h3,
-.res-nightmode.wiki-page .wiki-page-content .md.wiki h4,
-.res-nightmode.wiki-page .wiki-page-content .md.wiki h5,
-.res-nightmode.wiki-page .wiki-page-content .md.wiki h6 {
+.res-nightmode .wiki-page-content .md.wiki h1,
+.res-nightmode .wiki-page-content .md.wiki h2,
+.res-nightmode .wiki-page-content .md.wiki h3,
+.res-nightmode .wiki-page-content .md.wiki h4,
+.res-nightmode .wiki-page-content .md.wiki h5,
+.res-nightmode .wiki-page-content .md.wiki h6,
+.res-nightmode .wiki-page-content .md.wiki p {
 	color: #ddd;
 }
 


### PR DESCRIPTION
Fixes #1825. If the text would be better as another color, I'm happy to change that.
