### PR TITLE
Contexts: allow certain functionality under certain conditions

### DIFF
--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -48,6 +48,7 @@
 				"modules/keyboardNav.js",
 				"modules/about.js",
 				"modules/commandLine.js",
+				"modules/contexts.js",
 				"modules/hover.js",
 				"modules/subredditTagger.js",
 				"modules/singleClick.js",

--- a/OperaBlink/manifest.json
+++ b/OperaBlink/manifest.json
@@ -47,6 +47,7 @@
 				"modules/keyboardNav.js",
 				"modules/about.js",
 				"modules/commandLine.js",
+				"modules/contexts.js",
 				"modules/hover.js",
 				"modules/subredditTagger.js",
 				"modules/singleClick.js",

--- a/RES.safariextension/Info.plist
+++ b/RES.safariextension/Info.plist
@@ -57,6 +57,7 @@
 				<string>modules/userTagger.js</string>
 				<string>modules/keyboardNav.js</string>
 				<string>modules/commandLine.js</string>
+				<string>modules/contexts.js</string>
 				<string>modules/about.js</string>
 				<string>modules/hover.js</string>
 				<string>modules/subredditTagger.js</string>

--- a/XPI/lib/main.js
+++ b/XPI/lib/main.js
@@ -174,6 +174,7 @@ pageMod.PageMod({
 		self.data.url('modules/userTagger.js'),
 		self.data.url('modules/keyboardNav.js'),
 		self.data.url('modules/commandLine.js'),
+		self.data.url('modules/contexts.js'),
 		self.data.url('modules/about.js'),
 		self.data.url('modules/hover.js'),
 		self.data.url('modules/subredditTagger.js'),

--- a/lib/core/templates.html
+++ b/lib/core/templates.html
@@ -390,6 +390,16 @@
 		</div>
 
 
+		<div id="contextToggleMenu" type="application/x-template">
+			<li title="{{ description }}">
+				{{ displayName }}
+				<div class="toggleButton {{#enabled}}enabled{{/enabled}}">
+					<span class="toggleOn">on</span>
+					<span class="toggleOff">off</span>
+				</div>
+			</li>
+		</div>
+
 		<pre id="optionLinkSnudown" type="application/x-template">
 **[{{title}}]({{url}})**
 -- [](#gear)

--- a/lib/core/templates.html
+++ b/lib/core/templates.html
@@ -406,6 +406,6 @@
 [RES settings console]({{settingsUrl}}) > {{category}} > [{{moduleName}}]({{moduleUrl}} "{{moduleID}}") {{#optionKey}} > [{{optionKey}}]({{optionUrl}}){{/optionKey}}
 
 {{description}}
-		</script>
+		</pre>
 	</body>
 </html>

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -740,39 +740,70 @@ RESUtils.indexOptionTable = function(moduleID, optionKey, keyFieldIndex) {
 	return RESUtils.indexArrayByProperty(source, keyFieldIndex, keyIsList);
 };
 RESUtils.indexArrayByProperty = function(source, keyIndex, keyValueSeparator) {
+	var index;
 	if (!source || !source.length) {
-		return function() {};
+		index = {
+			items: [],
+			keys: []
+		}
+	} else {
+		index = createIndex();
 	}
 
-	var index = createIndex();
+	Object.defineProperty(getItem, 'keys', {
+		value: index.keys,
+		writeable: false
+	});
+	Object.defineProperty(getItem, 'all', {
+		value: getAllItems,
+		writeable: false
+	});
 	return getItem;
 
 	function createIndex() {
-		var index = {};
+		var itemsByKey = {};
+		var allKeys = [];
 
 		for (var i = 0, length = source.length; i < length; i++) {
 			var item = source[i];
 			var key = item && item[keyIndex];
 			if (!key) continue;
 
+			var keys;
 			if (keyValueSeparator) {
-				var keys = key.toLowerCase().split(keyValueSeparator);
-				for (var ki = 0, klength = keys.length; ki < klength; ki++) {
-					key = keys[ki];
-					index[key] = item;
-				}
+				keys = key.split(keyValueSeparator);
 			} else {
-				index[key] = item;
+				keys = [ key && key ];
 			}
+			for (var ki = 0, klength = keys.length; ki < klength; ki++) {
+				key = keys[ki].toLowerCase();
+
+				itemsByKey[key] = itemsByKey[key] || [];
+				itemsByKey[key].push(item);
+			}
+
+			allKeys = allKeys.concat(keys);
 		}
 
-		return index;
+		allKeys = allKeys.filter(function(value, index, array) {
+			var unique = array.indexOf(value, index + 1) === -1;
+			return unique;
+		});
+
+		return {
+			items: itemsByKey,
+			keys: allKeys
+		};
 	}
 
 	function getItem(key) {
 		key = key && key.toLowerCase();
-		var item = index[key];
+		var item = index.items[key];
 		return item;
+	}
+
+	function getAllItems() {
+		return index.keys.map(getItem);
 	}
 };
 

--- a/lib/modules/contexts.js
+++ b/lib/modules/contexts.js
@@ -89,7 +89,8 @@ addModule('contexts', function (module, moduleID) {
 
 
 	function anyTogglesEnabled(toggles) {
-		var enabled = toggles.map(function(toggle) {
+		var enabled = [].concat(toggles)
+			.map(function(toggle) {
 				return toggle[1]; // enabled
 			});
 		var anyEnabled = enabled.reduce(function(previousEnabled, enabled) {
@@ -109,7 +110,7 @@ addModule('contexts', function (module, moduleID) {
 		var active = true;
 		if (module.isEnabled() && module.isMatchURL()) {
 			var toggles = getOptionByContext('toggle', context);
-			if (!anyTogglesEnabled(toggles)) {
+			if (toggles && !anyTogglesEnabled(toggles)) {
 				active = false;
 			}
 		}

--- a/lib/modules/contexts.js
+++ b/lib/modules/contexts.js
@@ -1,0 +1,189 @@
+addModule('contexts', function (module, moduleID) {
+	module.title = 'Contexts';
+	module.category = 'Filters';
+	module.description = 'Define certain contexts to allow actions on things like posts or comments.<br><br>\
+		Scenes can also be called contexts, profiles, states, schedules.<br>\
+		Actions include filtering, like hiding a subreddit between Friday and Tuesday to avoid spoilers.'
+
+	module.options.toggle = {
+		description: 'Enable or disable everything connected to a certain context, and provide a toggle in the RES gear dropdown menu',
+		type: 'table',
+		fields: [{
+			name: 'context',
+			type: 'text'
+		}, {
+			name: 'enabled',
+			type: 'boolean',
+			value: true,
+		}, {
+			name: 'menuItem',
+			type: 'text'
+		}]
+	};
+/*
+	module.options.schedule = {
+		type: 'table',
+		fields: [{
+			name: 'context',
+			type: 'text'
+		}, {
+			name: 'start/end'
+			type: 'enum',
+			values: [{
+				name: 'start',
+				value: 'start'
+			}, {
+				name: 'end',
+				name: 'end'
+			}]
+		}, {
+			name: 'time of day (0-2359)',
+			type: 'text',
+		}, {
+			name: 'day of month (1-31)',
+			type: 'text',
+		}, {
+			name: 'month (1-12)',
+			type: 'text',
+		}, {
+			name: 'day of week (1-7 Monday-Sunday)',
+			type: 'text'
+		}]
+	};
+	*/
+
+	var _getByContext = {};
+	function getOptionByContext(optionKey, context) {
+		if (!_getByContext[optionKey]) {
+			_getByContext[optionKey] = RESUtils.indexOptionTable(moduleID, optionKey, 0)
+		}
+
+		return _getByContext[optionKey](context);
+	}
+
+
+	var _getMenuItems;
+	function getMenuItems(menuItemID) {
+		if (!_getMenuItems) {
+			_getMenuItems = RESUtils.indexOptionTable(moduleID, 'toggle', 2, true)
+		}
+
+		if (typeof menuItemID === "undefined") {
+			return _getMenuItems;
+		} else {
+			return _getMenuItems(menuItemID);
+		}
+	};
+	function getAllMenuItems() {
+		return getMenuItems().all();
+	}
+
+	function getContextsForMenuItem(menuItemID) {
+		var menuItems = getMenuItems(menuItemID);
+		var contexts = menuItems
+			.map(function(menuItem) {
+				return menuItem[0]; // context
+			});
+		return contexts;
+	}
+
+
+	function anyTogglesEnabled(toggles) {
+		var enabled = toggles.map(function(toggle) {
+				return toggle[1]; // enabled
+			});
+		var anyEnabled = enabled.reduce(function(previousEnabled, enabled) {
+				// If any toggle is enabled, then collection is enabled.
+				// If all toggles are disabled, then collection is disabled
+				return previousEnabled || enabled;
+			}, false);
+		return anyEnabled;
+	};
+
+
+	module.go = function() {
+		createToggleMenuItems();
+	};
+
+	module.contextActive = function(context) {
+		var active = true;
+		if (module.isEnabled() && module.isMatchURL()) {
+			var toggles = getOptionByContext('toggle', context);
+			if (!anyTogglesEnabled(toggles)) {
+				active = false;
+			}
+		}
+
+
+		return active;
+	};
+
+	// var $menuItems = {};
+	function createToggleMenuItems() {
+		var menuItems = getAllMenuItems();
+		menuItems.forEach(function(menuItem) {
+			var menuItemID = menuItem[0][2];
+
+			var $element = RESTemplates.getSync('contextToggleMenu').html({
+				displayName: menuItemID,
+				enabled: anyTogglesEnabled(menuItem)
+			});
+			$element.data('res-context-menuitem', menuItemID);
+
+			$element.appendTo('#RESDropdownOptions');
+		});
+
+		$("#RESDropdownOptions").on('click', 'li', onClickToggleMenuItem);
+	}
+	function onClickToggleMenuItem() {
+		var menuItemID = $(this).data('res-context-menuitem');
+		if (typeof menuItemID === 'undefined') return;
+
+		var enabled = module.toggleMenuItem(menuItemID);
+		$(this).find(".toggleButton").toggleClass("enabled", enabled);
+	}
+
+
+	module.toggleMenuItem = function(menuItemID) {
+		var contexts = getContextsForMenuItem(menuItemID);
+		return module.toggleContexts(contexts);
+	};
+
+	module.toggleContexts = function(contexts) {
+		var toggles = [].concat(contexts)
+			.map(function(context) {
+				return getOptionByContext('toggle', context)
+			}).reduce(function(toggles, newToggles) {
+				return toggles.concat(newToggles);
+			}, []);
+
+		var newEnabled = !anyTogglesEnabled(toggles);
+
+		// Update cached settings
+		toggles.forEach(function(toggle) {
+			toggle[1] = newEnabled;
+		});
+
+		// Update settings in storage
+		module.options.toggle.value.filter(function(toggle) {
+			return contexts.indexOf(toggle[0]) !== -1;
+		}).forEach(function(toggle) {
+			toggle[1] = newEnabled;
+
+		});
+		RESUtils.setOption(moduleID, 'toggle', module.options.toggle.value);
+
+
+		// Notify listeners
+		toggles.forEach(function(toggle) {
+			var context = toggle[0];
+			if (newEnabled) {
+				$(module).trigger($.Event('activated', { target: context }));
+			} else {
+				$(module).trigger($.Event('deactivated', { target: context }));
+			}
+		});
+
+		return newEnabled;
+	};
+});

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -415,7 +415,7 @@ modules['filteReddit'] = {
 
 		if (this.allowAllNsfw == null && currSubreddit) {
 			var optionValue = this.subredditAllowNsfwOption(currSubreddit);
-			this.allowAllNsfw = (optionValue && optionValue[1] === 'visit') || false;
+			this.allowAllNsfw = (optionValue && optionValue[0][1] === 'visit') || false;
 		}
 		if (this.allowAllNsfw) {
 			return true;
@@ -425,7 +425,7 @@ modules['filteReddit'] = {
 		if (!postSubreddit) return false;
 		var optionValue = this.subredditAllowNsfwOption(postSubreddit);
 		if (optionValue) {
-			if (optionValue[1] === 'everywhere') {
+			if (optionValue[0][1] === 'everywhere') {
 				return true;
 			} else { // optionValue[1] == visit (subreddit or multisubreddit)
 				if (RESUtils.inList(postSubreddit, currSubreddit, '+')) {

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -263,6 +263,23 @@ modules['filteReddit'] = {
 				}
 			);
 
+			$(modules['contexts']).on('activated deactivated', function() {
+				var contexts = modules['filteReddit'].options.keywords.value
+					.map(function(value) { return value[4]; })
+					.filter(function(value) { return value; });
+				if (contexts.length) {
+					modules['notifications'].showNotification({
+						header: 'Filters toggled',
+						message: '<a href="' + window.location.href + '">Reload the page.</a>',
+						moduleID: 'contexts',
+						optionKey: 'toggle',
+						notificationID: 'contextToggled',
+						cooldown: 10000,
+						closeDelay: 1500
+					}, 600);
+				}
+			});
+
 		}
 	},
 	toggleNsfwFilter: function(toggle, notify) {

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -69,7 +69,12 @@ modules['filteReddit'] = {
 				{
 					name: 'unlessKeyword',
 					type: 'text'
-				} //,
+				},
+				{
+					name: 'context',
+					type: 'text'
+				}
+				 //,
 				/* { name: 'inclusions', type: 'list', source: location.protocol + '/api/search_reddit_names' } */
 			],
 			value: [],
@@ -459,7 +464,12 @@ modules['filteReddit'] = {
 			var exceptSearchString = obj[i][3];
 			var applyTo = obj[i][1];
 			var applyList = obj[i][2].toLowerCase().split(',');
+			var context = obj[i][4];
 			var skipCheck = false;
+
+			if (context && !modules['contexts'].contextActive(context)) {
+				skipCheck = true;
+			}
 			// we also want to know if we should be matching /r/all, because when getting
 			// listings on /r/all, each post has a subreddit (that does not equal "all")
 			var checkRAll = ((RESUtils.currentSubreddit() === 'all') && (applyList.indexOf('all') !== -1));


### PR DESCRIPTION
Certain functionality, such as filtering and night mode, are only active in certain contexts: the user is visiting a certain subreddit, frontpage, or all; a post/comment is from a particular subreddit or user; the time of day falls within a certain range, etc.  This PR is the stub of a utility module for centrally managing these contexts in order to address requests like "filter certain subreddits during spoiler-heavy days of the week" as well as adding requested functionality like "toggle switch for certain subreddits or filters".

---

If a context is active, the following must all be true:

1. that context has **at least one** associated toggle enabled.
1. FUTURE: the context is within the scheduled time for **all** associated schedules

---

Toggles can be associated with a new menu item in the dropdown. If any toggle is enabled, then that menu item is marked "active/on". 

---

I've only implemented "context" on keyword filters so far. Before I carry on with implementing it on other features (such as subreddit filters), I was hoping for feedback on the architecture and names (especially "contexts").


---

![screen shot 2014-12-06 at 11 11 38 am](https://cloud.githubusercontent.com/assets/455632/5328546/d332e460-7d38-11e4-9b10-5abb2ba61dd6.png)
![screen shot 2014-12-06 at 11 12 26 am](https://cloud.githubusercontent.com/assets/455632/5328547/d351b084-7d38-11e4-8c0d-67868f24b010.png)
![screen shot 2014-12-06 at 11 10 43 am](https://cloud.githubusercontent.com/assets/455632/5328548/d7c1109c-7d38-11e4-8d22-52dda6e920ae.png)
