### PR TITLE
Lower RES Memory usage!

### DIFF
--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -27,6 +27,7 @@
 				"vendor/jquery.tokeninput.js",
 				"vendor/HTMLPasteurizer.js",
 				"vendor/snuownd.js",
+				"vendor/bloomfilter.js",
 				"core/utils.js",
 				"browsersupport.js",
 				"browsersupport-chrome.js",

--- a/Opera/includes/loader.js
+++ b/Opera/includes/loader.js
@@ -44,6 +44,7 @@ window.addEventListener('DOMContentLoaded', function() {
 		'vendor/konami.js',
 		'vendor/mediacrush.js',
 		'vendor/snuownd.js',
+		'vendor/bloomfilter.js',
 		'core/migrate.js',
 		'core/storage.js',
 		'core/template.js',

--- a/OperaBlink/manifest.json
+++ b/OperaBlink/manifest.json
@@ -40,6 +40,7 @@
 				"vendor/gfycat.js",
 				"vendor/gifyoutube.js",
 				"vendor/imgurgifv.js",
+				"vendor/bloomfilter.js",
 				"reddit_enhancement_suite.user.js",
 				"modules/submitIssue.js",
 				"modules/betteReddit.js",

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Thinking about contributing to RES? Awesome! We just ask that you follow a few s
 
 4. If you decide to add support for another media hosting site to RES, please be sure that they support [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing). This way, the sites do not need to be added as additional permissions, which has caused [headaches in the past](https://www.reddit.com/r/Enhancement/comments/1jskcm/announcement_chrome_users_did_your_res_turn_off/).
 
+## Third-party Scripts
+  - ./lib/vendor/bloomfilter.js – https://github.com/jasondavies/bloomfilter.js/blob/master/bloomfilter.js
 
 ## Project structure
 

--- a/RES.safariextension/Info.plist
+++ b/RES.safariextension/Info.plist
@@ -37,6 +37,7 @@
 				<string>vendor/jquery.tokeninput.js</string>
 				<string>vendor/HTMLPasteurizer.js</string>
 				<string>vendor/snuownd.js</string>
+				<string>vendor/bloomfilter.js</string>
 				<string>vendor/hogan-3.0.2.js</string>
 				<string>core/utils.js</string>
 				<string>browsersupport.js</string>

--- a/XPI/lib/main.js
+++ b/XPI/lib/main.js
@@ -168,6 +168,7 @@ pageMod.PageMod({
 		self.data.url('vendor/gifyoutube.js'),
 		self.data.url('vendor/imgurgifv.js'),
 		self.data.url('vendor/hogan-3.0.2.js'),
+		self.data.url('vendor/bloomfilter.js'),
 		self.data.url('reddit_enhancement_suite.user.js'),
 		self.data.url('modules/submitIssue.js'),
 		self.data.url('modules/betteReddit.js'),

--- a/lib/core/migrate.js
+++ b/lib/core/migrate.js
@@ -82,6 +82,7 @@ var RESOptionsMigrate = {
 			versionNumber: '4.5.3',
 			go: function() {
 				RESOptionsMigrate.migrators.generic.updateOption('searchHelper', 'addSubmitButton', true, false);
+				RESOptionsMigrate.migrators.generic.updateOption('neverEndingReddit', 'hideDupes', 'fade', 'remove');
 			}
 		}
 	],

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -97,6 +97,11 @@ modules['neverEndingReddit'] = {
 		if ((this.isEnabled()) && (this.isMatchURL())) {
 			// modified from a contribution by Peter Siewert, thanks Peter!
 			// bloom filter to store 100,000 elements with a .01 failure rate.
+			// http://0pointer.net/blog/projects/bloom.html
+			// m = -n*ln(p)/(ln(2)^2)
+			// m ~= 958505
+			// k = 0.7*m/n
+			// k ~= 7
 			if (typeof modules['neverEndingReddit'].dupeHash === 'undefined') modules['neverEndingReddit'].dupeHash = new BloomFilter(958505,7);
 			var entries = document.body.querySelectorAll('a.comments');
 			for (var i = entries.length - 1; i > -1; i--) {

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -54,6 +54,7 @@ modules['neverEndingReddit'] = {
 			description: 'Fade or completely remove duplicate posts from previous pages.'
 		}
 	},
+	filteredDupe: false,
 	description: 'Inspired by modules like River of Reddit and Auto Pager - gives you a never ending stream of reddit goodness.',
 	isEnabled: function() {
 		return RESConsole.getModulePrefs(this.moduleID);
@@ -102,10 +103,10 @@ modules['neverEndingReddit'] = {
 			// m ~= 958505
 			// k = 0.7*m/n
 			// k ~= 7
-			if (typeof modules['neverEndingReddit'].dupeHash === 'undefined') modules['neverEndingReddit'].dupeHash = new BloomFilter(958505,7);
+			if (typeof modules['neverEndingReddit'].bloomfilter === 'undefined') modules['neverEndingReddit'].bloomfilter = new BloomFilter(958505,7);
 			var entries = document.body.querySelectorAll('a.comments');
 			for (var i = entries.length - 1; i > -1; i--) {
-				modules['neverEndingReddit'].dupeHash.add(entries[i].href);
+				modules['neverEndingReddit'].bloomfilter.add(entries[i].href);
 			}
 
 			this.allLinks = document.body.querySelectorAll('#siteTable div.thing');
@@ -334,14 +335,26 @@ modules['neverEndingReddit'] = {
 		for (var i = newLinks.length - 1; i > -1; i--) {
 			var newLink = newLinks[i];
 			var thisCommentLink = newLink.querySelector('a.comments').href;
-			if (modules['neverEndingReddit'].dupeHash.test(thisCommentLink)) {
+			if (modules['neverEndingReddit'].bloomfilter.test(thisCommentLink)) {
 				if(this.options.hideDupes.value == 'remove'){
 					newLink.parentElement.removeChild(newLink);
+					//Tell the user if we filter a dupe.
+					if(! this.filteredDupe){
+						this.filteredDupe = true;
+						var notification = [];
+						notification.push('A duplicate post was filtered.');
+						notification.push('To show duplicates, modify the ' + modules['settingsNavigation'].makeUrlHashLink('neverEndingReddit', 'hideDupes', 'hideDupes option') + '.');
+						notification = notification.join('<br><br>');
+						modules['notifications'].showNotification({
+							moduleID: 'neverEndingReddit',
+							message: notification
+						});
+					}
 				}else{
 					newLink.classList.add('NERdupe');
 				}
 			} else {
-				modules['neverEndingReddit'].dupeHash.add(thisCommentLink);
+				modules['neverEndingReddit'].bloomfilter.add(thisCommentLink);
 			}
 		}
 		return newHTML;
@@ -468,6 +481,8 @@ modules['neverEndingReddit'] = {
 					if ((typeof modules['neverEndingReddit'].progressIndicator.parentNode !== 'undefined') && (modules['neverEndingReddit'].progressIndicator.parentNode !== null)) {
 						modules['neverEndingReddit'].progressIndicator.parentNode.removeChild(modules['neverEndingReddit'].progressIndicator);
 					}
+					// make sure this notification can only fire once per page-load.
+					this.filteredDupe = false;
 					// drop the HTML we got back into a div...
 					var thisHTML = response.responseText;
 					var tempDiv = document.createElement('div');

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -40,18 +40,18 @@ modules['neverEndingReddit'] = {
 		},
 		hideDupes: {
 			type: 'enum',
-			value: 'fade',
+			value: 'remove',
 			values: [{
 				name: 'Fade',
 				value: 'fade'
 			}, {
-				name: 'Hide',
-				value: 'hide'
+				name: 'Remove',
+				value: 'remove'
 			}, {
 				name: 'Do not hide',
 				value: 'none'
 			}],
-			description: 'Fade or completely hide duplicate posts from previous pages.'
+			description: 'Fade or completely remove duplicate posts from previous pages.'
 		}
 	},
 	description: 'Inspired by modules like River of Reddit and Auto Pager - gives you a never ending stream of reddit goodness.',
@@ -80,13 +80,8 @@ modules['neverEndingReddit'] = {
 			// hide next/prev page and random subreddit indicators
 			RESUtils.addCSS('.content div.nav-buttons { display: none; } ');
 			RESUtils.addCSS('.content .nav-buttons .nextprev { display: none; } ');
-			switch (this.options.hideDupes.value) {
-				case 'fade':
-					RESUtils.addCSS('.NERdupe { opacity: 0.3; }');
-					break;
-				case 'hide':
-					RESUtils.addCSS('.NERdupe { display: none; }');
-					break;
+			if(this.options.hideDupes.value == 'fade'){
+				RESUtils.addCSS('.NERdupe { opacity: 0.3; }');
 			}
 			// set the style for our little loader widget
 			RESUtils.addCSS('#progressIndicator { width: 95%; min-height: 20px; margin: 0 auto; font-size: 14px; border: 1px solid #999; border-radius: 10px; padding: 10px; text-align: center; background-color: #f0f3fc; cursor: pointer; } ');
@@ -101,10 +96,11 @@ modules['neverEndingReddit'] = {
 	go: function() {
 		if ((this.isEnabled()) && (this.isMatchURL())) {
 			// modified from a contribution by Peter Siewert, thanks Peter!
-			if (typeof modules['neverEndingReddit'].dupeHash === 'undefined') modules['neverEndingReddit'].dupeHash = {};
+			// bloom filter to store 100,000 elements with a .01 failure rate.
+			if (typeof modules['neverEndingReddit'].dupeHash === 'undefined') modules['neverEndingReddit'].dupeHash = new BloomFilter(958505,7);
 			var entries = document.body.querySelectorAll('a.comments');
 			for (var i = entries.length - 1; i > -1; i--) {
-				modules['neverEndingReddit'].dupeHash[entries[i].href] = 1;
+				modules['neverEndingReddit'].dupeHash.add(entries[i].href);
 			}
 
 			this.allLinks = document.body.querySelectorAll('#siteTable div.thing');
@@ -333,12 +329,14 @@ modules['neverEndingReddit'] = {
 		for (var i = newLinks.length - 1; i > -1; i--) {
 			var newLink = newLinks[i];
 			var thisCommentLink = newLink.querySelector('a.comments').href;
-			if (modules['neverEndingReddit'].dupeHash[thisCommentLink]) {
-				// let's not remove it altogether, but instead dim it...
-				// newLink.parentElement.removeChild(newLink);
-				newLink.classList.add('NERdupe');
+			if (modules['neverEndingReddit'].dupeHash.test(thisCommentLink)) {
+				if(this.options.hideDupes.value == 'remove'){
+					newLink.parentElement.removeChild(newLink);
+				}else{
+					newLink.classList.add('NERdupe');
+				}
 			} else {
-				modules['neverEndingReddit'].dupeHash[thisCommentLink] = 1;
+				modules['neverEndingReddit'].dupeHash.add(thisCommentLink);
 			}
 		}
 		return newHTML;

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -697,6 +697,7 @@ modules['showImages'] = {
 				});
 			}
 		} else if (!elem.classList.contains('imgScanned')) {
+			alert('dupe img');
 			var textFrag = document.createElement('span');
 			textFrag.setAttribute('class', 'RESdupeimg');
 			$(textFrag).html(' <a class="noKeyNav" href="#img' + parseInt(this.imagesRevealed[href], 10) + '" title="click to scroll to original">[RES ignored duplicate link]</a>');

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -697,7 +697,6 @@ modules['showImages'] = {
 				});
 			}
 		} else if (!elem.classList.contains('imgScanned')) {
-			alert('dupe img');
 			var textFrag = document.createElement('span');
 			textFrag.setAttribute('class', 'RESdupeimg');
 			$(textFrag).html(' <a class="noKeyNav" href="#img' + parseInt(this.imagesRevealed[href], 10) + '" title="click to scroll to original">[RES ignored duplicate link]</a>');

--- a/lib/vendor/bloomfilter.js
+++ b/lib/vendor/bloomfilter.js
@@ -1,0 +1,136 @@
+// From https://github.com/jasondavies/bloomfilter.js/blob/master/bloomfilter.js
+
+(function(exports) {
+  exports.BloomFilter = BloomFilter;
+  exports.fnv_1a = fnv_1a;
+  exports.fnv_1a_b = fnv_1a_b;
+
+  var typedArrays = typeof ArrayBuffer !== "undefined";
+
+  // Creates a new bloom filter.  If *m* is an array-like object, with a length
+  // property, then the bloom filter is loaded with data from the array, where
+  // each element is a 32-bit integer.  Otherwise, *m* should specify the
+  // number of bits.  Note that *m* is rounded up to the nearest multiple of
+  // 32.  *k* specifies the number of hashing functions.
+  function BloomFilter(m, k) {
+    var a;
+    if (typeof m !== "number") a = m, m = a.length * 32;
+
+    var n = Math.ceil(m / 32),
+        i = -1;
+    this.m = m = n * 32;
+    this.k = k;
+
+    if (typedArrays) {
+      var kbytes = 1 << Math.ceil(Math.log(Math.ceil(Math.log(m) / Math.LN2 / 8)) / Math.LN2),
+          array = kbytes === 1 ? Uint8Array : kbytes === 2 ? Uint16Array : Uint32Array,
+          kbuffer = new ArrayBuffer(kbytes * k),
+          buckets = this.buckets = new Int32Array(n);
+      if (a) while (++i < n) buckets[i] = a[i];
+      this._locations = new array(kbuffer);
+    } else {
+      var buckets = this.buckets = [];
+      if (a) while (++i < n) buckets[i] = a[i];
+      else while (++i < n) buckets[i] = 0;
+      this._locations = [];
+    }
+  }
+
+  // See http://willwhim.wordpress.com/2011/09/03/producing-n-hash-functions-by-hashing-only-once/
+  BloomFilter.prototype.locations = function(v) {
+    var k = this.k,
+        m = this.m,
+        r = this._locations,
+        a = fnv_1a(v),
+        b = fnv_1a_b(a),
+        i = -1,
+        x = a % m;
+    while (++i < k) {
+      r[i] = x < 0 ? (x + m) : x;
+      x = (x + b) % m;
+    }
+    return r;
+  };
+
+  BloomFilter.prototype.add = function(v) {
+    var l = this.locations(v + ""),
+        i = -1,
+        k = this.k,
+        buckets = this.buckets;
+    while (++i < k) buckets[Math.floor(l[i] / 32)] |= 1 << (l[i] % 32);
+  };
+
+  BloomFilter.prototype.test = function(v) {
+    var l = this.locations(v + ""),
+        i = -1,
+        k = this.k,
+        b,
+        buckets = this.buckets;
+    while (++i < k) {
+      b = l[i];
+      if ((buckets[Math.floor(b / 32)] & (1 << (b % 32))) === 0) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  // Estimated cardinality.
+  BloomFilter.prototype.size = function() {
+    var buckets = this.buckets,
+        bits = 0;
+    for (var i = 0, n = buckets.length; i < n; ++i) bits += popcnt(buckets[i]);
+    return -this.m * Math.log(1 - bits / this.m) / this.k;
+  };
+
+  // http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
+  function popcnt(v) {
+    v -= (v >> 1) & 0x55555555;
+    v = (v & 0x33333333) + ((v >> 2) & 0x33333333);
+    return ((v + (v >> 4) & 0xF0F0F0F) * 0x1010101) >> 24;
+  }
+
+  // Fowler/Noll/Vo hashing.
+  function fnv_1a(v) {
+    var n = v.length,
+        a = 2166136261,
+        c,
+        d,
+        i = -1;
+    while (++i < n) {
+      c = v.charCodeAt(i);
+      if (d = c & 0xff000000) {
+        a ^= d >> 24;
+        a += (a << 1) + (a << 4) + (a << 7) + (a << 8) + (a << 24);
+      }
+      if (d = c & 0xff0000) {
+        a ^= d >> 16;
+        a += (a << 1) + (a << 4) + (a << 7) + (a << 8) + (a << 24);
+      }
+      if (d = c & 0xff00) {
+        a ^= d >> 8;
+        a += (a << 1) + (a << 4) + (a << 7) + (a << 8) + (a << 24);
+      }
+      a ^= c & 0xff;
+      a += (a << 1) + (a << 4) + (a << 7) + (a << 8) + (a << 24);
+    }
+    // From http://home.comcast.net/~bretm/hash/6.html
+    a += a << 13;
+    a ^= a >> 7;
+    a += a << 3;
+    a ^= a >> 17;
+    a += a << 5;
+    return a & 0xffffffff;
+  }
+
+  // One additional iteration of FNV, given a hash.
+  function fnv_1a_b(a) {
+    a += (a << 1) + (a << 4) + (a << 7) + (a << 8) + (a << 24);
+    a += a << 13;
+    a ^= a >> 7;
+    a += a << 3;
+    a ^= a >> 17;
+    a += a << 5;
+    return a & 0xffffffff;
+  }
+})(typeof exports !== "undefined" ? exports : this);

--- a/lib/vendor/bloomfilter.js
+++ b/lib/vendor/bloomfilter.js
@@ -1,4 +1,3 @@
-// From https://github.com/jasondavies/bloomfilter.js/blob/master/bloomfilter.js
 
 (function(exports) {
   exports.BloomFilter = BloomFilter;


### PR DESCRIPTION
I got a new Microsoft Surface,  and the memory usage on RES is too much for the poor tablet.  So,  I decided to fork RES and see if I can reduce memory overhead for loading new pages.   If this patch goes well,  I'd like to further reduce RES's memory usage. 

This patch could use more testing.  Loading 10 pages with the current RES takes roughly 804M or ram,  after this patch the page consumed 764M with the same dataset.  Still needs more work,  but there is a noticeable reduction in memory usage with normal browsing habits.

Improvements:
- A bloomfilter is the most efficient way of keeping track of dupes.  A bloomfilter doesn't need to store the full string in order to keep track of uniqueness.  Additionally,  insertion into a bloom filter is always O(1), where as dictionaries need to be expanded when they become full.
-  "Hiding" elements with CSS doesn't make them go away.  These elements need to be deleted properly to free up memory. Hiding elements lead to a **nasty** memory leak.  Reddit has enough re-posts,  there is no need for RES to introduce duplicates to the feed.
