### PR TITLE
Change instances of "reddits" to "subreddits"

### DIFF
--- a/lib/modules/RESTips.js
+++ b/lib/modules/RESTips.js
@@ -249,7 +249,7 @@ modules['RESTips'] = {
 		},
 
 		{
-			message: 'Do you subscribe to a ton of reddits? Give the subreddit tagger a try; it can make your homepage a bit more readable.',
+			message: 'Do you subscribe to a ton of subreddits? Give the subreddit tagger a try; it can make your homepage a bit more readable.',
 			option: {
 				moduleID: 'subRedditTagger'
 			}

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -70,7 +70,7 @@ modules['filteReddit'] = {
 					description: 'Apply filter to:'
 				},
 				{
-					name: 'reddits',
+					name: 'subreddits',
 					type: 'list',
 					listType: 'subreddits',
 				},
@@ -118,7 +118,7 @@ modules['filteReddit'] = {
 					description: 'Apply filter to:'
 				},
 				{
-					name: 'reddits',
+					name: 'subreddits',
 					type: 'list',
 					listType: 'subreddits',
 				}
@@ -151,7 +151,7 @@ modules['filteReddit'] = {
 					description: 'Apply filter to:'
 				},
 				{
-					name: 'reddits',
+					name: 'subreddits',
 					type: 'list',
 					listType: 'subreddits',
 				}


### PR DESCRIPTION
Only 4 instances of "reddit(s)" when reffering to subreddits were found (at least in the UI). This changes them to the correct term.

Fixes #1838 
