### PR TITLE
notification title -> header

### DIFF
--- a/lib/modules/userbarHider.js
+++ b/lib/modules/userbarHider.js
@@ -62,7 +62,7 @@ addModule('userbarHider', function(module, moduleID) {
 					moduleID: moduleID,
 					optionKey: 'userbarState',
 					cooldown: 24 * 60 * 60 * 1000,
-					title: 'User Bar Hidden',
+					header: 'User Bar Hidden',
 					message: 'Your username, karma, preferences, <span class="gearIcon"></span> RES gear, and so on are hidden. You can show them again by clicking the &laquo; button in the top right corner.'
 				});
 			}


### PR DESCRIPTION
So I saw this a while ago and thought: "Why do we support both `header` and `title`?"
As it turns out, we don't!
