### PR TITLE
Inline expansion for Dropbox "shared" images

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1957,7 +1957,7 @@ modules['showImages'] = {
 		'default': {
 			domains: [],
 			acceptRegex: /^[^#]+?\.(gif|jpe?g|png)(?:[?&#_].*|$)/i,
-			rejectRegex: /(?:wikipedia\.org\/wiki|(?:i\.|m\.)?imgur\.com|photobucket\.com|gifsound\.com|mediacru\.sh|gfycat\.com|\/wiki\/File:.*|reddit\.com|onedrive\.live\.com|500px\.(?:com|net|org)|(?:www\.|share\.)?gifyoutube\.com)/i,
+			rejectRegex: /(?:wikipedia\.org\/wiki|(?:i\.|m\.)?imgur\.com|photobucket\.com|gifsound\.com|mediacru\.sh|gfycat\.com|\/wiki\/File:.*|reddit\.com|onedrive\.live\.com|500px\.(?:com|net|org)|(?:www\.|share\.)?gifyoutube\.com|dropbox\.com)/i,
 			detect: function(href, elem) {
 				var siteMod = modules['showImages'].siteModules['default'];
 				return (siteMod.acceptRegex.test(href) && !siteMod.rejectRegex.test(href));

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -3926,7 +3926,7 @@ modules['showImages'] = {
 			}
 		},
 		dropbox: {
-			//I think this should handle it. I'm not sure.
+			//This only handles dropbox images -- not other media. Although, if it's made to recognize video and audio (and differentiate them from images) those should work just as well
 			name: 'dropbox',
 			domains: ['dropbox.com'],
 			calls: {},

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -3935,15 +3935,14 @@ modules['showImages'] = {
 				return modules['showImages'].siteModules['dropbox'].matchRe.test(elem.href);
 			},
 			handleLink: function(elem) {
-				var def = $.Deferred();
-				var divided = elem.href.split('?');
-				divided[divided.length-1] = 'raw=1';
-				var finalUrl = divided.join('?');
-				if (groups) {
-					def.resolve(elem, finalUrl);
-				} else {
-					def.reject();
+				var def = $.Deferred(),
+					finalUrl = elem.href;
+				if (elem.href.indexOf('?raw=1') === -1){
+					var divided = elem.href.split('?');
+					divided[divided.length-1] = 'raw=1';
+					finalUrl = divided.join('?');
 				}
+				def.resolve(elem, finalUrl);
 				return def.promise();
 			},
 			handleInfo: function(elem, info) {

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -3924,6 +3924,37 @@ modules['showImages'] = {
 				}
 				return $.Deferred().resolve(elem).promise();
 			}
+		},
+		dropbox: {
+			//I think this should handle it. I'm not sure.
+			name: 'dropbox',
+			domains: ['dropbox.com'],
+			calls: {},
+			matchRe: /^https?:\/\/(www\.)?dropbox\.com\/s\/.*\/.*(gif|jpe?g|png)(\?(&*.*=.*))?/i,
+			detect: function(href, elem) {
+				return modules['showImages'].siteModules['dropbox'].matchRe.test(elem.href);
+			},
+			handleLink: function(elem) {
+				var def = $.Deferred();
+				var divided = elem.href.split('?');
+				divided[divided.length-1] = 'raw=1';
+				var finalUrl = divided.join('?');
+				if (groups) {
+					def.resolve(elem, finalUrl);
+				} else {
+					def.reject();
+				}
+				return def.promise();
+			},
+			handleInfo: function(elem, info) {
+				elem.type = 'IMAGE';
+				elem.src = info;
+				elem.href = info;
+				if (RESUtils.pageType() === 'linklist') {
+					$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
+				}
+				return $.Deferred().resolve(elem).promise();
+			}
 		}
 	}
 };


### PR DESCRIPTION
Adds a handler for dropbox "shared" image urls.

Requires no requests other than the fetching of the actual image.

Images shared from the "Public" folders of those who still have them will be unaffected as those are hosted on a different domain.