### PR TITLE
submitHelper module

### DIFF
--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -83,6 +83,7 @@
 				"modules/context.js",
 				"modules/noParticipation.js",
 				"modules/searchHelper.js",
+				"modules/submitHelper.js",
 				"modules/logoLink.js",
 				"modules/voteEnhancements.js",
 				"modules/tableTools.js",

--- a/Opera/includes/loader.js
+++ b/Opera/includes/loader.js
@@ -73,6 +73,7 @@ window.addEventListener('DOMContentLoaded', function() {
 		'modules/RESTips.js',
 		'modules/saveComments.js',
 		'modules/searchHelper.js',
+		'modules/submitHelper.js',
 		'modules/settingsNavigation.js',
 		'modules/showImages.js',
 		'modules/showKarma.js',

--- a/OperaBlink/manifest.json
+++ b/OperaBlink/manifest.json
@@ -82,6 +82,7 @@
 				"modules/context.js",
 				"modules/noParticipation.js",
 				"modules/searchHelper.js",
+				"modules/submitHelper.js",
 				"modules/logoLink.js",
 				"modules/voteEnhancements.js",
 				"modules/tableTools.js",

--- a/RES.safariextension/Info.plist
+++ b/RES.safariextension/Info.plist
@@ -93,6 +93,7 @@
 				<string>modules/context.js</string>
 				<string>modules/noParticipation.js</string>
 				<string>modules/searchHelper.js</string>
+				<string>modules/submitHelper.js</string>
 				<string>modules/logoLink.js</string>
 				<string>modules/voteEnhancements.js</string>
 				<string>modules/tableTools.js</string>

--- a/XPI/lib/main.js
+++ b/XPI/lib/main.js
@@ -210,6 +210,7 @@ pageMod.PageMod({
 		self.data.url('modules/context.js'),
 		self.data.url('modules/noParticipation.js'),
 		self.data.url('modules/searchHelper.js'),
+		self.data.url('modules/submitHelper.js'),
 		self.data.url('modules/logoLink.js'),
 		self.data.url('modules/voteEnhancements.js'),
 		self.data.url('modules/tableTools.js'),

--- a/lib/core/migrate.js
+++ b/lib/core/migrate.js
@@ -84,6 +84,7 @@ var RESOptionsMigrate = {
 				RESOptionsMigrate.migrators.generic.updateOption('searchHelper', 'addSubmitButton', true, false);
 				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'save', 'keyboardNav', 'savePost');
 				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'save', 'keyboardNav', 'saveRES');
+				RESOptionsMigrate.migrators.generic.moveOption('betteReddit', 'uncheckSendRepliesToInbox', 'submitHelper', 'uncheckSendRepliesToInbox');
 			}
 		}
 	],

--- a/lib/core/templates.html
+++ b/lib/core/templates.html
@@ -192,7 +192,7 @@
 			#quickMessageDialog input[type=button] { cursor: pointer; position: absolute; right: 16px; bottom: 16px; padding: 3px 5px; font-size: 12px; color: #fff; border: 1px solid #636363; border-radius: 3px; background-color: #5cc410; }
 			#quickMessageDialog .clear { margin-bottom: 10px; }
 		</style>
-		<div id="quickMessage">
+		<div id="quickMessage" type="application/x-template">
 			<div id="quickMessageDialog" class="RESDialogSmall">
 				<h3>Send Message</h3>
 				<div id="quickMessageDialogContents" class="RESDialogContents clear">
@@ -214,6 +214,16 @@
 			</div>
 		</div>
 		<!-- /Quick Message Dialog -->
+
+		<!-- Submit Page Repost Warning -->
+		<div id="repostWarning" type="application/x-template">
+			<div class="spacer" style="display: none">
+				<div style="display: block;" class="roundfield info-notice res-repost">
+					<p>This link was submitted to <a class="subredditLink" href="#"></a>:<span class="time"></span><a class="seeMore" href="#">(see more)</a></p>
+				</div>
+			</div>
+		</div>
+		<!-- /Submit Page Repost Warning -->
 
 		<!--VideoUI-->
 		<!--Adapted from MediaCrush video player-->

--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -52,11 +52,6 @@ modules['betteReddit'] = {
 			description: 'Always go to the inbox, not unread messages, when clicking on orangered',
 			advanced: true
 		},
-		uncheckSendRepliesToInbox: {
-			type: 'boolean',
-			value: false,
-			description: 'Uncheck "send replies to my inbox" by default, when submitting a new post'
-		},
 		hideModMail: {
 			type: 'boolean',
 			value: false,
@@ -260,9 +255,6 @@ modules['betteReddit'] = {
 					break;
 				default:
 					break;
-			}
-			if (this.options.uncheckSendRepliesToInbox.value) {
-				this.uncheckSendRepliesToInbox();
 			}
 		}
 	},
@@ -752,12 +744,6 @@ modules['betteReddit'] = {
 	hideFader: function(ele) {
 		var parentThing = ele.parentNode.parentNode.parentNode.parentNode.parentNode.parentNode;
 		RESUtils.fadeElementOut(parentThing, 0.3);
-	},
-	uncheckSendRepliesToInbox: function () {
-		var sendReplies = document.body.querySelector('#sendreplies');
-		if (sendReplies) {
-			sendReplies.checked = false;
-		}
 	},
 	getVideoTimes: function(obj) {
 		obj = obj || document;

--- a/lib/modules/submitHelper.js
+++ b/lib/modules/submitHelper.js
@@ -1,0 +1,111 @@
+modules['submitHelper'] = {
+	moduleID: 'submitHelper',
+	moduleName: 'Submission Helper',
+	category: 'UI',
+	description: 'Provides utilities to help with submitting a post.',
+	options: {
+		warnAlreadySubmitted: {
+			type: 'boolean',
+			value: false,
+			description: 'Show a warning when the current URL has already been submitted to the selected subreddit. <p><i>Not 100% accurate, due to search limitations and different ways to format the same URL.</i></p>'
+		},
+		uncheckSendRepliesToInbox: {
+			type: 'boolean',
+			value: false,
+			description: 'Uncheck "send replies to my inbox" by default, when submitting a new post.'
+		}
+	},
+	isEnabled: function() {
+		return RESConsole.getModulePrefs(this.moduleID);
+	},
+	include: [
+		'submit'
+	],
+	isMatchURL: function() {
+		return RESUtils.isMatchURL(this.moduleID);
+	},
+	beforeLoad: function() {
+		if (this.isEnabled() && this.isMatchURL()) {
+			if (this.options.warnAlreadySubmitted.value) {
+				RESTemplates.load('repostWarning', function(template) {
+					modules['submitHelper'].repostWarning = template.html()[0];
+				});
+				RESUtils.addCSS('.res-repost::before { background-position: -44px -774px; }');
+			}
+		}
+	},
+	go: function() {
+		if (this.isEnabled() && this.isMatchURL()) {
+			if (this.options.warnAlreadySubmitted.value) {
+				var urlFieldDiv = document.body.querySelector('#url-field');
+				if (urlFieldDiv) {
+					$(urlFieldDiv).parent().after(this.repostWarning);
+					this.urlField = urlFieldDiv.querySelector('#url');
+					this.srField = document.body.querySelector('#sr-autocomplete');
+					$([this.srField, this.urlField]).on('input keydown', function() {
+						RESUtils.debounce('repostWarning', 300, modules['submitHelper'].updateRepostWarning);
+					});
+					// No event is fired when reddit's js changes the subreddit field, so update whenever the user clicks
+					$('#suggested-reddits a, #sr-drop-down').on('click', modules['submitHelper'].updateRepostWarning);
+					// We would allow reddit to show/hide the message for link/text posts with #link-desc
+					// but some subreddits hide this box, so we'll do it manually.
+					var linkButton = document.body.querySelector('a.link-button'),
+						textButton = document.body.querySelector('a.text-button');
+					if (linkButton && textButton) {
+						linkButton.addEventListener('click', function() {
+							modules['submitHelper'].repostWarning.querySelector('.res-repost').style.display = 'block';
+						});
+						textButton.addEventListener('click', function() {
+							modules['submitHelper'].repostWarning.querySelector('.res-repost').style.display = 'none';
+						});
+					}
+				}
+			}
+
+			if (this.options.uncheckSendRepliesToInbox.value) {
+				var sendReplies = document.body.querySelector('#sendreplies');
+				if (sendReplies) {
+					sendReplies.checked = false;
+				}
+			}
+		}
+	},
+	showRepostWarning: function(sr, url, date) {
+		var srLink = this.repostWarning.querySelector('.subredditLink');
+		srLink.href = '/r/' + sr;
+		$(srLink).text('/r/' + sr);
+		this.repostWarning.querySelector('.seeMore').href = '/r/' + sr + '/search?restrict_sr=on&sort=relevance&q=url%3A' + encodeURIComponent(url);
+		$(this.repostWarning).find('.time').text(' ' + RESUtils.niceDateDiff(date) + ' ago ');
+		RESUtils.fadeElementIn(this.repostWarning, 0.3);
+	},
+	hideRepostWarning: function() {
+		RESUtils.fadeElementOut(this.repostWarning, 0.3);
+	},
+	updateRepostWarning: function() {
+		var stripUrlRe = /^(?:https?:\/\/)?(?:(?:www|i|m)\.)?(.+?)\/?(?:\.\w+)?(?:#[^\/]*)?$/i,
+			subreddit = modules['submitHelper'].srField.value,
+			userUrl = modules['submitHelper'].urlField.value;
+		if (subreddit && userUrl) {
+			userUrl = userUrl.match(stripUrlRe)[1];
+			BrowserStrategy.ajax({
+				method: 'GET',
+				url: location.protocol + '//' + location.hostname + '/r/' + subreddit + '/search.json?restrict_sr=on&sort=relevance&limit=1&q=url%3A' + encodeURIComponent(userUrl),
+				onload: function(response) {
+					if (response.status == 200 && response.responseText) {
+						var data = safeJSON.parse(response.responseText).data;
+						if (data && data.children.length && data.children[0].data.url.match(stripUrlRe)[1] === userUrl) {
+							modules['submitHelper'].showRepostWarning(subreddit, userUrl, new Date(data.children[0].data.created * 1000));
+						} else {
+							modules['submitHelper'].hideRepostWarning();
+						}
+					} else {
+						console.log(response);
+						modules['submitHelper'].hideRepostWarning();
+					}
+				}
+			});
+		} else {
+			modules['submitHelper'].hideRepostWarning();
+		}
+	}
+};

--- a/lib/modules/submitHelper.js
+++ b/lib/modules/submitHelper.js
@@ -1,9 +1,8 @@
-modules['submitHelper'] = {
-	moduleID: 'submitHelper',
-	moduleName: 'Submission Helper',
-	category: 'UI',
-	description: 'Provides utilities to help with submitting a post.',
-	options: {
+addModule('submitHelper', function(module, moduleID) {
+	module.moduleName = 'Submission Helper';
+	module.category = 'UI';
+	module.description = 'Provides utilities to help with submitting a post.',
+	module.options = {
 		warnAlreadySubmitted: {
 			type: 'boolean',
 			value: false,
@@ -14,77 +13,71 @@ modules['submitHelper'] = {
 			value: false,
 			description: 'Uncheck "send replies to my inbox" by default, when submitting a new post.'
 		}
-	},
-	isEnabled: function() {
-		return RESConsole.getModulePrefs(this.moduleID);
-	},
-	include: [
+	};
+	module.include = [
 		'submit'
-	],
-	isMatchURL: function() {
-		return RESUtils.isMatchURL(this.moduleID);
-	},
-	beforeLoad: function() {
-		if (this.isEnabled() && this.isMatchURL()) {
-			if (this.options.warnAlreadySubmitted.value) {
+	];
+	module.beforeLoad = function() {
+		if (module.isEnabled() && module.isMatchURL()) {
+			if (module.options.warnAlreadySubmitted.value) {
 				RESTemplates.load('repostWarning', function(template) {
-					modules['submitHelper'].repostWarning = template.html()[0];
+					module.repostWarning = template.html()[0];
 				});
 				RESUtils.addCSS('.res-repost::before { background-position: -44px -774px; }');
 			}
 		}
-	},
-	go: function() {
-		if (this.isEnabled() && this.isMatchURL()) {
-			if (this.options.warnAlreadySubmitted.value) {
+	};
+	module.go = function() {
+		if (module.isEnabled() && module.isMatchURL()) {
+			if (module.options.warnAlreadySubmitted.value) {
 				var urlFieldDiv = document.body.querySelector('#url-field');
 				if (urlFieldDiv) {
-					$(urlFieldDiv).parent().after(this.repostWarning);
-					this.urlField = urlFieldDiv.querySelector('#url');
-					this.srField = document.body.querySelector('#sr-autocomplete');
-					$([this.srField, this.urlField]).on('input keydown', function() {
-						RESUtils.debounce('repostWarning', 300, modules['submitHelper'].updateRepostWarning);
+					$(urlFieldDiv).parent().after(module.repostWarning);
+					module.urlField = urlFieldDiv.querySelector('#url');
+					module.srField = document.body.querySelector('#sr-autocomplete');
+					$([module.srField, module.urlField]).on('input keydown', function() {
+						RESUtils.debounce('repostWarning', 300, module.updateRepostWarning);
 					});
 					// No event is fired when reddit's js changes the subreddit field, so update whenever the user clicks
-					$('#suggested-reddits a, #sr-drop-down').on('click', modules['submitHelper'].updateRepostWarning);
+					$('#suggested-reddits a, #sr-drop-down').on('click', module.updateRepostWarning);
 					// We would allow reddit to show/hide the message for link/text posts with #link-desc
 					// but some subreddits hide this box, so we'll do it manually.
 					var linkButton = document.body.querySelector('a.link-button'),
 						textButton = document.body.querySelector('a.text-button');
 					if (linkButton && textButton) {
 						linkButton.addEventListener('click', function() {
-							modules['submitHelper'].repostWarning.querySelector('.res-repost').style.display = 'block';
+							module.repostWarning.querySelector('.res-repost').style.display = 'block';
 						});
 						textButton.addEventListener('click', function() {
-							modules['submitHelper'].repostWarning.querySelector('.res-repost').style.display = 'none';
+							module.repostWarning.querySelector('.res-repost').style.display = 'none';
 						});
 					}
 				}
 			}
 
-			if (this.options.uncheckSendRepliesToInbox.value) {
+			if (module.options.uncheckSendRepliesToInbox.value) {
 				var sendReplies = document.body.querySelector('#sendreplies');
 				if (sendReplies) {
 					sendReplies.checked = false;
 				}
 			}
 		}
-	},
-	showRepostWarning: function(sr, url, date) {
-		var srLink = this.repostWarning.querySelector('.subredditLink');
+	};
+	module.showRepostWarning = function(sr, url, date) {
+		var srLink = module.repostWarning.querySelector('.subredditLink');
 		srLink.href = '/r/' + sr;
 		$(srLink).text('/r/' + sr);
-		this.repostWarning.querySelector('.seeMore').href = '/r/' + sr + '/search?restrict_sr=on&sort=relevance&q=url%3A' + encodeURIComponent(url);
-		$(this.repostWarning).find('.time').text(' ' + RESUtils.niceDateDiff(date) + ' ago ');
-		RESUtils.fadeElementIn(this.repostWarning, 0.3);
-	},
-	hideRepostWarning: function() {
-		RESUtils.fadeElementOut(this.repostWarning, 0.3);
-	},
-	updateRepostWarning: function() {
+		module.repostWarning.querySelector('.seeMore').href = '/r/' + sr + '/search?restrict_sr=on&sort=relevance&q=url%3A' + encodeURIComponent(url);
+		$(module.repostWarning).find('.time').text(' ' + RESUtils.niceDateDiff(date) + ' ago ');
+		RESUtils.fadeElementIn(module.repostWarning, 0.3);
+	};
+	module.hideRepostWarning = function() {
+		RESUtils.fadeElementOut(module.repostWarning, 0.3);
+	};
+	module.updateRepostWarning = function() {
 		var stripUrlRe = /^(?:https?:\/\/)?(?:(?:www|i|m)\.)?(.+?)\/?(?:\.\w+)?(?:#[^\/]*)?$/i,
-			subreddit = modules['submitHelper'].srField.value,
-			userUrl = modules['submitHelper'].urlField.value;
+			subreddit = module.srField.value,
+			userUrl = module.urlField.value;
 		if (subreddit && userUrl) {
 			userUrl = userUrl.match(stripUrlRe)[1];
 			BrowserStrategy.ajax({
@@ -94,18 +87,18 @@ modules['submitHelper'] = {
 					if (response.status == 200 && response.responseText) {
 						var data = safeJSON.parse(response.responseText).data;
 						if (data && data.children.length && data.children[0].data.url.match(stripUrlRe)[1] === userUrl) {
-							modules['submitHelper'].showRepostWarning(subreddit, userUrl, new Date(data.children[0].data.created * 1000));
+							module.showRepostWarning(subreddit, userUrl, new Date(data.children[0].data.created * 1000));
 						} else {
-							modules['submitHelper'].hideRepostWarning();
+							module.hideRepostWarning();
 						}
 					} else {
 						console.log(response);
-						modules['submitHelper'].hideRepostWarning();
+						module.hideRepostWarning();
 					}
 				}
 			});
 		} else {
-			modules['submitHelper'].hideRepostWarning();
+			module.hideRepostWarning();
 		}
-	}
-};
+	};
+});


### PR DESCRIPTION
Fixes #1830 

Takes over `uncheckSendRepliesToInbox` functionality from betteReddit.

Currently the repost warning box is styled with reddit's classes (so it could potentially be mistaken for native functionality). Is it enough to make the feature disabled by default, or should it be more obvious that it's a feature of RES and not reddit?
I also couldn't include the ability to search the text of self-posts (to reduce false negatives), but I don't think that's too big of a deal.
![image](https://cloud.githubusercontent.com/assets/7673145/5545630/fb7af4f0-8af6-11e4-86e9-8ac2a0e6f6c1.png)