### PR TITLE
qm: add a bit of padding, fix alignment.

### DIFF
--- a/lib/core/templates.html
+++ b/lib/core/templates.html
@@ -187,7 +187,8 @@
 			#quickMessage { display: none; position: fixed; top: 0; bottom: 0; left: 0; right: 0; background-color: rgba(0, 0, 0, 0.74902); z-index: 2000; }
 			#quickMessageDialog { position: fixed; top: 20%; left: 25%; width: 50%; z-index: 100001 }
 			#quickMessageDialog label { margin-top: 5px; clear: both; float: left; }
-			#quickMessageDialog input[type=text], #quickMessageDialog select, #quickMessageDialog textarea { margin-top: 5px; width: calc(100% - 70px); float: right; border: 1px solid #c7c7c7; border-radius: 3px; margin-bottom: 6px; }
+			#quickMessageDialog input[type=text], #quickMessageDialog select, #quickMessageDialog textarea { margin-top: 5px; width: calc(100% - 70px); float: right; border: 1px solid #c7c7c7; border-radius: 3px; margin-bottom: 6px; padding: 3px; }
+			#quickMessageDialog select { margin-top: 5px; width: calc(100% - 63px); float: right; border: 1px solid #c7c7c7; border-radius: 3px; margin-bottom: 6px; padding: 3px; }
 			#quickMessageDialog textarea { resize: vertical; min-height: 100px; }
 			#quickMessageDialog input[type=button] { cursor: pointer; position: absolute; right: 16px; bottom: 16px; padding: 3px 5px; font-size: 12px; color: #fff; border: 1px solid #636363; border-radius: 3px; background-color: #5cc410; }
 			#quickMessageDialog .clear { margin-bottom: 10px; }


### PR DESCRIPTION
3px padding to the form fields for quick message make it much more inviting.
The select element was also out of alignment, this is no longer the case.
