### PR TITLE
Stop the hover popup from appearing when it shouldn't

### DIFF
--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -645,52 +645,7 @@ RESUtils.firstValid = function() {
 	}
 };
 RESUtils.fadeElementTo = function(el, speed, finalOpacity, callback) {
-	if (el._resIsFading) {
-		return false;
-	}
-	if (finalOpacity === 0 && el.style.display === 'none') {
-		return false;
-	}
-	var initialOpacity;
-	if (el.style.display === 'none' || el.style.display === '') {
-		initialOpacity = 0;
-		el.style.display = 'block';
-	} else {
-		initialOpacity = parseFloat(el.style.opacity) || 1;
-	}
-
-	if (typeof finalOpacity === 'undefined') {
-		finalOpacity = 1;
-	}
-	speed = Math.max(speed, 0.1); //set a minimum speed
-	var opacityDelta = finalOpacity - initialOpacity;
-	var duration = Math.abs(opacityDelta) / speed * 100;
-	var startTime = Date.now();
-
-	el._resIsFading = true;
-
-	var fade = function () {
-		var t = (Date.now() - startTime)/duration; // 0 = start; 1 = end
-		//t = ease(t);//plug in any easing function here, if available
-		var currentOpacity = initialOpacity + opacityDelta * t;
-
-		el.style.opacity = Math.max(0, Math.min(1, currentOpacity));//keep opacity between 0 and 1
-
-		if (0 <= currentOpacity && currentOpacity <= 1) {
-			requestAnimationFrame(fade);
-		} else {
-			delete el._resIsFading;
-			if (currentOpacity <= 0) {
-				el.style.display = 'none';
-			}
-			if (callback && callback.call) {
-				callback();
-			}
-		}
-	};
-
-	fade();
-	return true;
+    $(ele).fadeTo(speed, finalOpacity, callback);
 };
 RESUtils.fadeElementOut = function(el, speed, callback) {
 	RESUtils.fadeElementTo(el, speed, 0, callback);


### PR DESCRIPTION
Resolves #1884 

This bug occurs because the callback is not executed (so the timeout is not removed) when `fadeElementTo` returns early (when fading is not necessary).

I think this change produces logical behavior, as we expect `RESUtils.fadeElementTo` to change the opacity and then execute the callback when it is completed (so it is still technically completed even if it didn't have to do anything).

User hover, subreddit hover, parents, and notifications seem to still work, also.
