### PR TITLE
Remove RESUtils.sendMessage (alias of BrowserStrategy.sendMessage)

### DIFF
--- a/XPI/data/browsersupport-firefox.js
+++ b/XPI/data/browsersupport-firefox.js
@@ -52,7 +52,7 @@ self.on('message', function(msgEvent) {
 					currentSubreddit = RESUtils.currentSubreddit();
 
 				if (currentSubreddit) {
-					RESUtils.sendMessage({
+					BrowserStrategy.sendMessage({
 						requestType: 'pageAction',
 						action: 'stateChange',
 						visible: toggle
@@ -210,7 +210,7 @@ BrowserStrategy.deleteCookie = function(cookieName) {
 		host: location.protocol + '//' + location.host,
 		cname: cookieName
 	};
-	
+
 	self.on('message', function receiveMessage(message) {
 		if (message && message.removedCookie && message.removedCookie === cookieName) {
 			self.removeListener('message', receiveMessage);

--- a/lib/core/storage.js
+++ b/lib/core/storage.js
@@ -31,7 +31,7 @@ function setUpRESStorage(response) {
 			};
 
 			if (!fromBG) {
-				RESUtils.sendMessage(thisJSON);
+				BrowserStrategy.sendMessage(thisJSON);
 			}
 		}
 	};
@@ -48,7 +48,7 @@ function setUpRESStorage(response) {
 			itemName: key
 		};
 
-		RESUtils.sendMessage(thisJSON);
+		BrowserStrategy.sendMessage(thisJSON);
 	};
 
 	RESStorage.isReady = true;

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -1351,9 +1351,6 @@ RESUtils.isEmpty = function(obj) {
 	}
 	return true;
 };
-RESUtils.sendMessage = function(thisJSON) {
-	BrowserStrategy.sendMessage(thisJSON);
-};
 
 RESUtils.openLinkInNewTab = function(url, focus) {
 	var thisJSON = {
@@ -1362,7 +1359,7 @@ RESUtils.openLinkInNewTab = function(url, focus) {
 		button: focus
 	};
 
-	RESUtils.sendMessage(thisJSON);
+	BrowserStrategy.sendMessage(thisJSON);
 };
 RESUtils.toggleButton = function(moduleID, fieldID, enabled, onText, offText, isTable) {
 	var checked, thisToggle,
@@ -1445,7 +1442,7 @@ RESUtils.xhrCache = function(operation) {
 		operation: operation
 	};
 
-	RESUtils.sendMessage(thisJSON);
+	BrowserStrategy.sendMessage(thisJSON);
 };
 RESUtils.initObservers = function() {
 	var siteTable, observer;

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -937,7 +937,7 @@ modules['keyboardNav'] = {
 				button: button
 			};
 
-			RESUtils.sendMessage(thisJSON);
+			BrowserStrategy.sendMessage(thisJSON);
 		} else {
 			location.href = this.getAttribute('href');
 		}
@@ -1498,7 +1498,7 @@ modules['keyboardNav'] = {
 						button: button
 					};
 
-				RESUtils.sendMessage(thisJSON);
+				BrowserStrategy.sendMessage(thisJSON);
 			} else {
 				location.href = thisHREF;
 			}
@@ -1834,7 +1834,7 @@ modules['keyboardNav'] = {
 					button: button
 				};
 
-			RESUtils.sendMessage(thisJSON);
+			BrowserStrategy.sendMessage(thisJSON);
 		} else {
 			location.href = thisHREF;
 		}
@@ -1850,7 +1850,7 @@ modules['keyboardNav'] = {
 					button: button
 				};
 
-			RESUtils.sendMessage(thisJSON);
+			BrowserStrategy.sendMessage(thisJSON);
 		} else {
 			location.href = thisHREF;
 		}
@@ -1866,7 +1866,7 @@ modules['keyboardNav'] = {
 				button: button
 			};
 
-			RESUtils.sendMessage(thisJSON);
+			BrowserStrategy.sendMessage(thisJSON);
 		} else {
 			location.href = thisHREF;
 		}

--- a/lib/modules/singleClick.js
+++ b/lib/modules/singleClick.js
@@ -100,7 +100,7 @@ modules['singleClick'] = {
 								ctrl: e.ctrlKey
 							};
 
-							RESUtils.sendMessage(thisJSON);
+							BrowserStrategy.sendMessage(thisJSON);
 						}
 					}, false);
 				}

--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -224,7 +224,7 @@ modules['styleTweaks'] = {
 		var me = this;
 		if (BrowserDetect.isChrome()) {
 			if (!RESUtils.currentSubreddit() || !modules['styleTweaks'].options.subredditStyleBrowserToolbarButton.value) {
-					RESUtils.sendMessage({
+					BrowserStrategy.sendMessage({
 						requestType: 'pageAction',
 						action: 'hide'
 					});
@@ -234,7 +234,7 @@ modules['styleTweaks'] = {
 				// has been created yet, and if not, wait a bit and try again. There is a miniscule
 				// likelihood of ever having to wait, but it is nonzero.
 				if (me.styleToggleCheckbox) {
-					RESUtils.sendMessage({
+					BrowserStrategy.sendMessage({
 						requestType: 'pageAction',
 						action: 'show',
 						visible: me.styleToggleCheckbox.checked
@@ -301,12 +301,12 @@ modules['styleTweaks'] = {
 			}
 			if (BrowserDetect.isFirefox()) {
 				if (!modules['styleTweaks'].options.subredditStyleBrowserToolbarButton.value) {
-					RESUtils.sendMessage({
+					BrowserStrategy.sendMessage({
 						requestType: 'pageAction',
 						action: 'hide'
 					});
 				} else if (!RESUtils.currentSubreddit()) {
-					RESUtils.sendMessage({
+					BrowserStrategy.sendMessage({
 						requestType: 'pageAction',
 						action: 'disable'
 					});
@@ -315,7 +315,7 @@ modules['styleTweaks'] = {
 					// has been created yet, and if not, wait a bit and try again. There is a miniscule
 					// likelihood of ever having to wait, but it is nonzero.
 					if (this.styleToggleCheckbox) {
-						RESUtils.sendMessage({
+						BrowserStrategy.sendMessage({
 							requestType: 'pageAction',
 							action: 'show',
 							visible: this.styleToggleCheckbox.checked
@@ -753,7 +753,7 @@ modules['styleTweaks'] = {
 			if (this.styleToggleCheckbox) {
 				this.styleToggleCheckbox.checked = true;
 			}
-			RESUtils.sendMessage({
+			BrowserStrategy.sendMessage({
 				requestType: 'pageAction',
 				action: 'stateChange',
 				visible: true
@@ -790,7 +790,7 @@ modules['styleTweaks'] = {
 			if (this.styleToggleCheckbox) {
 				this.styleToggleCheckbox.checked = false;
 			}
-			RESUtils.sendMessage({
+			BrowserStrategy.sendMessage({
 				requestType: 'pageAction',
 				action: 'stateChange',
 				visible: false


### PR DESCRIPTION
I'm guessing that `RESUtils.sendMessage` was created first, before browser-dependant behavior was moved into separate files.
