### PR TITLE
Allow table sorting in all markdown areas

### DIFF
--- a/lib/modules/tableTools.js
+++ b/lib/modules/tableTools.js
@@ -23,7 +23,7 @@
 		if ((this.isEnabled()) && (this.isMatchURL())) {
 			/* Add sorting styles if enabled */
 			if (modules['tableTools'].options.sort.value) {
-				RESUtils.addCSS('.usertext-body th { cursor: pointer; }');
+				RESUtils.addCSS('.md th { cursor: pointer; }');
 				RESUtils.addCSS('.sort-asc:after { content: "\u0020\u25B4" }');
 				RESUtils.addCSS('.sort-desc:after { content: "\u0020\u25BE" }');
 			}
@@ -32,7 +32,7 @@
 	go: function() {
 		if ((this.isEnabled()) && (this.isMatchURL())) {
 			if (modules['tableTools'].options.sort.value) {
-				$(document).on('click', '.usertext-body th', function(e) {
+				$(document).on('click', '.md th', function(e) {
 					modules['tableTools'].sortTableColumn(e.target);
 				});
 			}


### PR DESCRIPTION
Fixes #1917

Bonus: You can now sort tables in the live preview.
