### PR TITLE
Prevent quick messages from being truncated on some characters + more

### DIFF
--- a/lib/modules/quickMessage.js
+++ b/lib/modules/quickMessage.js
@@ -249,7 +249,8 @@ addModule('quickMessage', function(module, moduleID) {
 		'NO_USER': 'No recipient specified.',
 		'NO_SUBJECT': 'No subject specified.',
 		'NO_TEXT': 'Message body is empty.',
-		'BAD_CAPTCHA': '<p>Sorry, reddit requires you to enter a captcha to send messages. This is usually because your account is brand new or has low karma.</p><b>Click on "open full message form" and try again (your message will be preserved).</b>'
+		'BAD_CAPTCHA': '<p>Sorry, reddit requires you to enter a captcha to send messages. This is usually because your account is brand new or has low karma.</p><b>Click on "open full message form" and try again (your message will be preserved).</b>',
+		'TOO_LONG': 'Either your subject (max 100 characters) or body (max 10,000 characters) is too long.'
 	};
 	module.sendMessage = function() {
 		var fields = module.getCurrentFieldValues(),
@@ -257,7 +258,7 @@ addModule('quickMessage', function(module, moduleID) {
 		BrowserStrategy.ajax({
 			method: 'POST',
 			url: 'https://' + location.hostname + '/api/compose',
-			data: 'api_type=json' + fromSubreddit + '&subject=' + encodeURIComponent(fields.subject.substring(0, 100)) + '&text=' + encodeURIComponent(fields.body) + '&to=' + encodeURIComponent(fields.to), // subject is max 100 characters
+			data: 'api_type=json' + fromSubreddit + '&subject=' + encodeURIComponent(fields.subject) + '&text=' + encodeURIComponent(fields.body) + '&to=' + encodeURIComponent(fields.to),
 			headers: {
 				'Content-Type': 'application/x-www-form-urlencoded',
 				'X-Modhash': RESUtils.loggedInUserHash()

--- a/lib/modules/quickMessage.js
+++ b/lib/modules/quickMessage.js
@@ -257,7 +257,7 @@ addModule('quickMessage', function(module, moduleID) {
 		BrowserStrategy.ajax({
 			method: 'POST',
 			url: 'https://' + location.hostname + '/api/compose',
-			data: 'api_type=json' + fromSubreddit + '&subject=' + fields.subject.substring(0, 100) + '&text=' + fields.body + '&to=' + fields.to, // subject is max 100 characters
+			data: 'api_type=json' + fromSubreddit + '&subject=' + encodeURIComponent(fields.subject.substring(0, 100)) + '&text=' + encodeURIComponent(fields.body) + '&to=' + encodeURIComponent(fields.to), // subject is max 100 characters
 			headers: {
 				'Content-Type': 'application/x-www-form-urlencoded',
 				'X-Modhash': RESUtils.loggedInUserHash()


### PR DESCRIPTION
Fixes [a bug reported on reddit.](https://www.reddit.com/r/RESissues/comments/2qypen/bug_private_message_get_truncated_when_is_used/) (Would you prefer that I create an issue on github, even if it'll be immediately resolved?)

Also, stop silently shortening the subject to 100 characters and add an error message for it.