### PR TITLE
betteReddit: options to show full timestamps by default

### DIFF
--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -123,6 +123,31 @@ modules['betteReddit'] = {
 			value: true,
 			description: 'When hovering [score hidden] show time left instead of hide duration.'
 		},
+		showTimestampPosts: {
+			type: 'boolean',
+			value: false,
+			description: 'Show the precise date (Sun Nov 16 20:14:56 2014 UTC) instead of a relative date (7 days ago), for posts.'
+		},
+		showTimestampComments: {
+			type: 'boolean',
+			value: false,
+			description: 'Show the precise date for comments / messages.'
+		},
+		showTimestampSidebar: {
+			type: 'boolean',
+			value: false,
+			description: 'Show the precise date in the sidebar.'
+		},
+		showTimestampWiki: {
+			type: 'boolean',
+			value: false,
+			description: 'Show the precise date in the wiki.'
+		},
+		showTimestampModerationLog: {
+			type: 'boolean',
+			value: false,
+			description: 'Show the precise date in the moderation log (/r/mod/about/log).'
+		},
 		restoreSavedTab: {
 			type: 'boolean',
 			value: false,
@@ -204,6 +229,30 @@ modules['betteReddit'] = {
 						}
 					}
 				});
+			}
+			if (this.options.showTimestampPosts.value) {
+				RESUtils.addCSS('.thing.link time:not(.edited-timestamp)[title] { font-size: 0; }');
+				RESUtils.addCSS('.thing.link time:not(.edited-timestamp)[title]:after { font-size: x-small; content:attr(title); }');
+			}
+			if (this.options.showTimestampComments.value) {
+				RESUtils.addCSS('.thing.comment time:not(.edited-timestamp)[title], .thing.message time:not(.edited-timestamp)[title] { font-size: 0; }');
+				RESUtils.addCSS('.thing.comment time:not(.edited-timestamp)[title]:after, .thing.message time:not(.edited-timestamp)[title]:after { font-size: x-small; content:attr(title); }');
+			}
+			if (this.options.showTimestampSidebar.value) {
+				var subredditAge = document.body.querySelector('.side .age');
+				if (subredditAge) {
+					subredditAge.firstChild.data = 'a community since ';
+					RESUtils.addCSS('.side time[title] { font-size: 0; }');
+					RESUtils.addCSS('.side time[title]:after { font-size: x-small; content:attr(title); }');
+				}
+			}
+			if (this.options.showTimestampWiki.value) {
+				RESUtils.addCSS('.wiki-page-content time[title] { font-size: 0; }');
+				RESUtils.addCSS('.wiki-page-content time[title]:after { font-size: x-small; content:attr(title); }');
+			}
+			if (this.options.showTimestampModerationLog.value) {
+				RESUtils.addCSS('.modactionlisting time[title] { font-size: 0; }');
+				RESUtils.addCSS('.modactionlisting time[title]:after { font-size: small; content:attr(title); }');
 			}
 			if ((modules['betteReddit'].options.restoreSavedTab.value) && (RESUtils.loggedInUser() !== null) && document.querySelector('.with-listing-chooser:not(.profile-page)')) {
 				this.restoreSavedTab();


### PR DESCRIPTION
Fixes #1788
I'm not completely satisfied with the options (they take up a *lot* of space), nor the timestamps themselves (although it might be the best we can do with CSS alone).