### PR TITLE
Added a module to configure entry click behavior (EntryTitleAction) -- fixed

### DIFF
--- a/Chrome/background.js
+++ b/Chrome/background.js
@@ -157,6 +157,14 @@ chrome.runtime.onMessage.addListener(
 				}
 				sendResponse({status: 'success'});
 				break;
+			case 'entryTitleAction':
+				var focus = !(request.isBackground);
+				// Get the selected tab so we can get the index of it.  This allows us to open our new tab as the "next" tab.
+				var newIndex = sender.tab.index+1;
+				// handle requests from entryTitleAction module
+				chrome.tabs.create({url: request.linkURL, selected: focus, index: newIndex, openerTabId: sender.tab.id});
+				sendResponse({status: "success"});
+				break;
 			case 'keyboardNav':
 				button = (request.button !== 1);
 				// handle requests from keyboardNav module

--- a/Opera/index.html
+++ b/Opera/index.html
@@ -166,6 +166,18 @@ opera.extension.addEventListener( 'message', function( event ) {
 				};
 				event.source.postMessage(passBack);
 				break;
+			case 'entryTitleAction':
+				var focus = !(request.isBackground);
+
+				// handle requests from entryTitleAction module
+				opera.extension.tabs.create({url: request.linkURL, focused: focus});
+
+				var passBack = {
+					msgType: 'entryTitleAction',
+					data: { status: 'success' }
+				}
+				event.source.postMessage(passBack);
+				break;
 			case 'keyboardNav':
 				button = (request.button !== 1);
 				// handle requests from keyboardNav module

--- a/OperaBlink/background.js
+++ b/OperaBlink/background.js
@@ -157,6 +157,16 @@ chrome.runtime.onMessage.addListener(
 				}
 				sendResponse({status: 'success'});
 				break;
+			case 'entryTitleAction':
+				var focus = !(request.isBackground);
+				// Get the selected tab so we can get the index of it.  This allows us to open our new tab as the "next" tab.
+				var newIndex = sender.tab.index+1;
+
+				// handle requests from entryTitleAction module
+				opera.extension.tabs.create({url: request.linkURL, selected: focus, index: newIndex, openerTabId: sender.tab.id});
+
+				sendResponse({status: "success"});
+				break;
 			case 'keyboardNav':
 				button = (request.button !== 1);
 				// handle requests from keyboardNav module

--- a/RES.safariextension/background-safari.html
+++ b/RES.safariextension/background-safari.html
@@ -152,6 +152,15 @@
 				}
 				sendResponse({status: 'success'}, msgEvent);
 				break;
+			case 'entryTitleAction':
+				(request.isBackground) ? focus = 'background' : focus = 'foreground';
+
+				// handle requests from entryTitleAction module
+				var linkTab = safari.application.activeBrowserWindow.openTab(focus);
+				linkTab.url = request.linkURL;
+
+				sendResponse({status: "success"}, msgEvent);
+				break;
 			case 'keyboardNav':
 				button = (request.button === 1) ? 'background' : 'foreground';
 				// handle requests from keyboardNav module

--- a/XPI/lib/main.js
+++ b/XPI/lib/main.js
@@ -178,6 +178,7 @@ pageMod.PageMod({
 		self.data.url('modules/hover.js'),
 		self.data.url('modules/subredditTagger.js'),
 		self.data.url('modules/singleClick.js'),
+		self.data.url('modules/entryTitleAction.js'),
 		self.data.url('modules/commentPreview.js'),
 		self.data.url('modules/commentTools.js'),
 		self.data.url('modules/sourceSnudown.js'),
@@ -315,6 +316,15 @@ pageMod.PageMod({
 					}
 					worker.postMessage({status: 'success'});
 					break;
+			   case 'entryTitleAction':
+				   var isBackground = request.isBackground;
+				   var isPrivate = priv.isPrivate(windows.activeWindow);
+
+				   // handle requests from entryTitleAction module
+				   tabs.open({url: request.linkURL, inBackground: isBackground, isPrivate: isPrivate });
+
+				   worker.postMessage({status: "success"});
+				   break;
 				case 'keyboardNav':
 					inBackground = (request.button === 1);
 					isPrivate = priv.isPrivate(windows.activeWindow);

--- a/XPI/lib/main.js
+++ b/XPI/lib/main.js
@@ -321,7 +321,7 @@ pageMod.PageMod({
 				   var isPrivate = priv.isPrivate(windows.activeWindow);
 
 				   // handle requests from entryTitleAction module
-				   tabs.open({url: request.linkURL, inBackground: isBackground, isPrivate: isPrivate });
+				   openTab({url: request.linkURL, inBackground: isBackground, isPrivate: isPrivate });
 
 				   worker.postMessage({status: "success"});
 				   break;

--- a/lib/core/console.js
+++ b/lib/core/console.js
@@ -86,6 +86,7 @@ var RESConsole = {
 			'userTagger': true,
 			'betteReddit': true,
 			'singleClick': true,
+			'entryTitleAction': false,
 			'subRedditTagger': true,
 			'uppersAndDowners': true,
 			'keyboardNav': true,

--- a/lib/modules/entryTitleAction.js
+++ b/lib/modules/entryTitleAction.js
@@ -33,7 +33,7 @@ modules['entryTitleAction'] = {
 		'all'
 	],
 	exclude: [
-		'comments'
+		'comments' //, /^https?:\/\/(?:[-\w\.]+\.)?reddit\.com\/subreddits\/?/i
 	],
 	beforeLoad: function() {
 	},

--- a/lib/modules/entryTitleAction.js
+++ b/lib/modules/entryTitleAction.js
@@ -82,7 +82,7 @@ modules['entryTitleAction'] = {
 
 							// check if it's a relative link (no http://domain) because chrome barfs on these when creating a new tab...
 							if (!(thisLink.match(/^http/i))) {
-								thisLink = 'http://' + document.domain + thisLink;
+								thisLink = location.protocol + '//' + document.domain + thisLink;
 							}
 
 							var thisJSON = {

--- a/lib/modules/entryTitleAction.js
+++ b/lib/modules/entryTitleAction.js
@@ -93,36 +93,11 @@ modules['entryTitleAction'] = {
 							};
 
 							// Post the action.
-							var foundBrowserType = modules['entryTitleAction'].postMessageJSON(thisJSON);
-
-							// If can't find browser type, just try to open the url.
-							if (!foundBrowserType) {
-								// Foreground/background setting doesn't matter here.
-								window.open(thisLink);
-							}
+							BrowserStrategy.sendMessage(thisJSON);
 						}
 					}, false);
 				}
 			}
 		}
-	},
-	postMessageJSON: function(aJSON) {
-		if (BrowserDetect.isChrome()) {
-			chrome.extension.sendMessage(aJSON);
-		}
-		else if (BrowserDetect.isSafari()) {
-			safari.self.tab.dispatchMessage("entryTitleAction", aJSON);
-		}
-		else if (BrowserDetect.isOpera()) {
-			opera.extension.postMessage(JSON.stringify(aJSON));
-		}
-		else if (BrowserDetect.isFirefox()) {
-			self.postMessage(aJSON);
-		}
-		else {
-			return false;
-		}
-
-		return true;
 	}
 };

--- a/lib/modules/entryTitleAction.js
+++ b/lib/modules/entryTitleAction.js
@@ -55,8 +55,8 @@ modules['entryTitleAction'] = {
 				entries[i].classList.add('entryTitleActionTagged')
 				var thisLA = entries[i].querySelector('A.title');
 				if (thisLA !== null) {
-					var thisLink = thisLA.getAttribute('href');
-					var thisComments = entries[i].querySelector('.comments');
+					var thisLink = thisLA.href;
+					var thisComments = (thisComments = entries[i].querySelector('.comments')) && thisComments.href;
 					if (!(thisLink.match(/^https?/i))) {
 						thisLink = location.protocol + '//' + document.domain + thisLink;
 					}

--- a/lib/modules/entryTitleAction.js
+++ b/lib/modules/entryTitleAction.js
@@ -30,11 +30,10 @@ modules['entryTitleAction'] = {
 		return RESUtils.isMatchURL(this.moduleID);
 	},
 	include: [
-		/^https?:\/\/([a-z]+)\.reddit\.com\/[\?]*/i,
-		/^https?:\/\/([a-z]+)\.reddit\.com\/r\/[-\w\._]*\//i
+		'all'
 	],
 	exclude: [
-		/^https?:\/\/([a-z]+)\.reddit\.com\/r\/[-\w\._\/\?]*\/comments[-\w\._\/\?=]*/i
+		'comments'
 	],
 	beforeLoad: function() {
 	},

--- a/lib/modules/entryTitleAction.js
+++ b/lib/modules/entryTitleAction.js
@@ -1,0 +1,129 @@
+modules['entryTitleAction'] = {
+	moduleID: 'entryTitleAction',
+	moduleName: 'Entry Title Action',
+	category: 'UI',
+	options: {
+		actionBehavior: {
+			type: 'enum',
+			values: [
+				{ name: 'Open the content (reddit\'s default action).', value: 'link' },
+				{ name: 'Open the comments.', value: 'comments' }
+			],
+			value: 'comments',
+			description: 'What action should take place when the entry is clicked.'
+		},
+		focusBehavior: {
+			type: 'enum',
+			values: [
+				{ name: 'Open in new tab and switch to that tab.', value: 'foreground' },
+				{ name: 'Open in new tab and don\'t switch tabs.', value: 'background' }
+			],
+			value: 'background',
+			description: 'Where the link opens.'
+		}
+	},
+	description: 'Adds the ability to modify the behavior when clicking the entry\'s title.<br /><br />Note: <b>This changes reddit\'s default behavior.</b>',
+	isEnabled: function() {
+		return RESConsole.getModulePrefs(this.moduleID);
+	},
+	isMatchURL: function() {
+		return RESUtils.isMatchURL(this.moduleID);
+	},
+	include: [
+		/^https?:\/\/([a-z]+)\.reddit\.com\/[\?]*/i,
+		/^https?:\/\/([a-z]+)\.reddit\.com\/r\/[-\w\._]*\//i
+	],
+	exclude: [
+		/^https?:\/\/([a-z]+)\.reddit\.com\/r\/[-\w\._\/\?]*\/comments[-\w\._\/\?=]*/i
+	],
+	beforeLoad: function() {
+	},
+	go: function() {
+		if ((this.isEnabled()) && (this.isMatchURL())) {
+			this.applyLinks();
+			// listen for new DOM nodes so that modules like autopager, river of reddit, etc still get affected.
+			RESUtils.watchForElement('siteTable', modules['entryTitleAction'].applyLinks);
+		}
+	},
+	applyLinks: function(ele) {
+		selector = '#siteTable .entry, #siteTable_organic .entry';
+
+		var ele = ele || document;
+		var entries = ele.querySelectorAll(selector);
+
+		for (var i=0, len=entries.length; i<len; i++) {
+			if ((typeof entries[i] !== 'undefined') && (!entries[i].classList.contains('entryTitleActionTagged'))) {
+				entries[i].classList.add('entryTitleActionTagged')
+				var thisLA = entries[i].querySelector('A.title');
+				if (thisLA !== null) {
+					var thisLink = thisLA.getAttribute('href');
+					var thisComments = entries[i].querySelector('.comments');
+					if (!(thisLink.match(/^https?/i))) {
+						thisLink = location.protocol + '//' + document.domain + thisLink;
+					}
+
+					// Set attributes for retrieval later based on settings.
+					thisLA.setAttribute('entryTitleActionLink', thisLA.href)
+					thisLA.setAttribute('entryTitleActionComments', thisComments.href)
+
+					// TODO: Webkit won't trigger click events on middle click using the 'click' event.  
+					// ?? We should still preventDefault on a click though, maybe?
+					thisLA.addEventListener('click', function(e) {
+						e.preventDefault();
+
+						if (e.button !== 2) {
+							// Retrieve attributes based on settings.
+							var thisLink = ''
+							if (modules['entryTitleAction'].options.actionBehavior.value == 'link') {
+								thisLink = $(this).parent().parent().parent().find('a.title').attr('entryTitleActionLink');
+							}
+							else if (modules['entryTitleAction'].options.actionBehavior.value == 'comments') {
+								thisLink = $(this).parent().parent().parent().find('a.title').attr('entryTitleActionComments');
+							}
+
+							// check if it's a relative link (no http://domain) because chrome barfs on these when creating a new tab...
+							if (!(thisLink.match(/^http/i))) {
+								thisLink = 'http://' + document.domain + thisLink;
+							}
+
+							var thisJSON = {
+								requestType: 'entryTitleAction',
+								linkURL: thisLink,
+								isBackground: (modules['entryTitleAction'].options.focusBehavior.value === 'background') ? true : false,
+								ctrl: e.ctrlKey
+							};
+
+							// Post the action.
+							var foundBrowserType = modules['entryTitleAction'].postMessageJSON(thisJSON);
+
+							// If can't find browser type, just try to open the url.
+							if (!foundBrowserType) {
+								// Foreground/background setting doesn't matter here.
+								window.open(thisLink);
+							}
+						}
+					}, false);
+				}
+			}
+		}
+	},
+	postMessageJSON: function(aJSON) {
+		if (BrowserDetect.isChrome()) {
+			chrome.extension.sendMessage(aJSON);
+		}
+		else if (BrowserDetect.isSafari()) {
+			safari.self.tab.dispatchMessage("entryTitleAction", aJSON);
+		}
+		else if (BrowserDetect.isOpera()) {
+			opera.extension.postMessage(JSON.stringify(aJSON));
+		}
+		else if (BrowserDetect.isFirefox()) {
+			self.postMessage(aJSON);
+		}
+		else {
+			return false;
+		}
+
+		return true;
+	}
+};

--- a/lib/modules/entryTitleAction.js
+++ b/lib/modules/entryTitleAction.js
@@ -63,11 +63,11 @@ modules['entryTitleAction'] = {
 					}
 
 					// Set attributes for retrieval later based on settings.
-					thisLA.setAttribute('entryTitleActionLink', thisLA.href)
-					thisLA.setAttribute('entryTitleActionComments', thisComments.href)
+					thisLA.setAttribute('entryTitleActionLink', thisLink)
+					thisLA.setAttribute('entryTitleActionComments', thisComments)
 
 					// TODO: Webkit won't trigger click events on middle click using the 'click' event.  
-					// ?? We should still preventDefault on a click though, maybe?
+					// FIXME: Should we should still preventDefault on a click?
 					thisLA.addEventListener('click', function(e) {
 						e.preventDefault();
 
@@ -75,10 +75,10 @@ modules['entryTitleAction'] = {
 							// Retrieve attributes based on settings.
 							var thisLink = ''
 							if (modules['entryTitleAction'].options.actionBehavior.value == 'link') {
-								thisLink = $(this).parent().parent().parent().find('a.title').attr('entryTitleActionLink');
+								thisLink = $(this).attr('entryTitleActionLink');
 							}
 							else if (modules['entryTitleAction'].options.actionBehavior.value == 'comments') {
-								thisLink = $(this).parent().parent().parent().find('a.title').attr('entryTitleActionComments');
+								thisLink = $(this).attr('entryTitleActionComments');
 							}
 
 							// check if it's a relative link (no http://domain) because chrome barfs on these when creating a new tab...

--- a/lib/modules/entryTitleAction.js
+++ b/lib/modules/entryTitleAction.js
@@ -33,7 +33,8 @@ modules['entryTitleAction'] = {
 		'all'
 	],
 	exclude: [
-		'comments' //, /^https?:\/\/(?:[-\w\.]+\.)?reddit\.com\/subreddits\/?/i
+		'comments',
+      /^https?:\/\/(?:[-\w\.]+\.)?reddit\.com\/subreddits\/?/i
 	],
 	beforeLoad: function() {
 	},

--- a/lib/modules/entryTitleAction.js
+++ b/lib/modules/entryTitleAction.js
@@ -58,7 +58,7 @@ modules['entryTitleAction'] = {
 				if (thisLA !== null) {
 					var thisLink = thisLA.href;
 					var thisComments = (thisComments = entries[i].querySelector('.comments')) && thisComments.href;
-					if (!(thisLink.match(/^https?/i))) {
+					if (!/^https?/i.test(thisLink)) {
 						thisLink = location.protocol + '//' + document.domain + thisLink;
 					}
 
@@ -82,7 +82,7 @@ modules['entryTitleAction'] = {
 							}
 
 							// check if it's a relative link (no http://domain) because chrome barfs on these when creating a new tab...
-							if (!(thisLink.match(/^http/i))) {
+							if (!/^https?/i.test(thisLink)) {
 								thisLink = location.protocol + '//' + document.domain + thisLink;
 							}
 

--- a/lib/modules/entryTitleAction.js
+++ b/lib/modules/entryTitleAction.js
@@ -48,7 +48,7 @@ modules['entryTitleAction'] = {
 	applyLinks: function(ele) {
 		selector = '#siteTable .entry, #siteTable_organic .entry';
 
-		var ele = ele || document;
+		ele = ele || document;
 		var entries = ele.querySelectorAll(selector);
 
 		for (var i=0, len=entries.length; i<len; i++) {


### PR DESCRIPTION
Added a module to configure entry click behavior (EntryTitleAction).

This allows clicking the main title of a link and opening either the link or the comments in a background tab.

This fixes the broken functionality and merge conflicts since the code refactor (replacing merge request #578).

### Options
* Action
  - open the content (reddit's default action)
  - open the comments
* Focus
  - open in foreground
  - open in background

### Testing
Fully tested on Firefox and Chrome. I appreciate any feedback for about its behavior on other browsers.

### Other
* This is similar to the SingleClickOpener module, but I felt it was different enough to warrant its own module.
* The module is disabled by default because **it changes reddit's default behavior**.
* My motivation for making this is the desire to only open the comments (since I can get to the content from there) and to have interaction remain as close to the normal flow as possible (left-clicking on the main link).

### Disclaimer
I am not a web developer and did a lot of copy-pasting based on the existing SingleClickOpener module.