### PR TITLE
SingleClickOpener can hijack post title link to open comments or l+c/l=c

### DIFF
--- a/Chrome/background.js
+++ b/Chrome/background.js
@@ -145,14 +145,14 @@ chrome.runtime.onMessage.addListener(
 				if (request.openOrder === 'commentsfirst') {
 					// only open a second tab if the link is different...
 					if (request.linkURL !== request.commentsURL) {
-						chrome.tabs.create({url: request.commentsURL, selected: button, index: newIndex, openerTabId: sender.tab.id});
+						chrome.tabs.create({url: request.commentsURL, selected: button, index: newIndex++, openerTabId: sender.tab.id});
 					}
-					chrome.tabs.create({url: request.linkURL, selected: button, index: newIndex+1, openerTabId: sender.tab.id});
+					chrome.tabs.create({url: request.linkURL, selected: button, index: newIndex++, openerTabId: sender.tab.id});
 				} else {
-					chrome.tabs.create({url: request.linkURL, selected: button, index: newIndex, openerTabId: sender.tab.id});
+					chrome.tabs.create({url: request.linkURL, selected: button, index: newIndex++, openerTabId: sender.tab.id});
 					// only open a second tab if the link is different...
 					if (request.linkURL !== request.commentsURL) {
-						chrome.tabs.create({url: request.commentsURL, selected: button, index: newIndex+1, openerTabId: sender.tab.id});
+						chrome.tabs.create({url: request.commentsURL, selected: button, index: newIndex++, openerTabId: sender.tab.id});
 					}
 				}
 				sendResponse({status: 'success'});

--- a/OperaBlink/background.js
+++ b/OperaBlink/background.js
@@ -145,14 +145,14 @@ chrome.runtime.onMessage.addListener(
 				if (request.openOrder === 'commentsfirst') {
 					// only open a second tab if the link is different...
 					if (request.linkURL !== request.commentsURL) {
-						chrome.tabs.create({url: request.commentsURL, selected: button, index: newIndex, openerTabId: sender.tab.id});
+						chrome.tabs.create({url: request.commentsURL, selected: button, index: newIndex++, openerTabId: sender.tab.id});
 					}
-					chrome.tabs.create({url: request.linkURL, selected: button, index: newIndex+1, openerTabId: sender.tab.id});
+					chrome.tabs.create({url: request.linkURL, selected: button, index: newIndex++, openerTabId: sender.tab.id});
 				} else {
-					chrome.tabs.create({url: request.linkURL, selected: button, index: newIndex, openerTabId: sender.tab.id});
+					chrome.tabs.create({url: request.linkURL, selected: button, index: newIndex++, openerTabId: sender.tab.id});
 					// only open a second tab if the link is different...
 					if (request.linkURL !== request.commentsURL) {
-						chrome.tabs.create({url: request.commentsURL, selected: button, index: newIndex+1, openerTabId: sender.tab.id});
+						chrome.tabs.create({url: request.commentsURL, selected: button, index: newIndex++, openerTabId: sender.tab.id});
 					}
 				}
 				sendResponse({status: 'success'});

--- a/lib/modules/singleClick.js
+++ b/lib/modules/singleClick.js
@@ -21,6 +21,21 @@ modules['singleClick'] = {
 			description: 'Hide the [l=c] when the link is the same as the comments page',
 			advanced: true
 		},
+		buttonLocation: {
+			type: 'enum',
+			value: 'addbutton',
+			description: 'Add the [l+c] button or apply single-click to the link title',
+			values: [{
+				value: 'addbutton',
+				name: 'add [l+c] button'
+			}, {
+				value: 'title-l+c',
+				name: 'post title opens link and comments'
+			}, {
+				value: 'title-comments',
+				name: 'post title opens comments'
+			}]
+		},
 		openBackground: {
 			type: 'boolean',
 			value: false,
@@ -42,15 +57,13 @@ modules['singleClick'] = {
 		/^https?:\/\/(?:[\-\w\.]+\.)?reddit\.com\/subreddits\/?/i
 	],
 	beforeLoad: function() {
-		if ((this.isEnabled()) && (this.isMatchURL())) {
+		if (this.isEnabled() && this.isMatchURL()) {
 			RESUtils.addCSS('.redditSingleClick { color: #888; font-weight: bold; cursor: pointer; padding: 0 1px; }');
 		}
 	},
 	go: function() {
-		if ((this.isEnabled()) && (this.isMatchURL())) {
-			// do stuff here!
+		if (this.isEnabled() && this.isMatchURL()) {
 			this.applyLinks();
-			// listen for new DOM nodes so that modules like autopager, river of reddit, etc still get l+c links...
 			RESUtils.watchForElement('siteTable', modules['singleClick'].applyLinks);
 		}
 	},
@@ -58,53 +71,91 @@ modules['singleClick'] = {
 		ele = ele || document;
 		var entries = ele.querySelectorAll('#siteTable .entry, #siteTable_organic .entry');
 		for (var i = 0, len = entries.length; i < len; i++) {
-			if ((typeof entries[i] !== 'undefined') && (!entries[i].classList.contains('lcTagged'))) {
-				entries[i].classList.add('lcTagged');
-				var thisLA = entries[i].querySelector('A.title');
-				if (thisLA !== null) {
-					var thisLink = thisLA.href;
-					var thisComments = (thisComments = entries[i].querySelector('.comments')) && thisComments.href;
-					var thisUL = entries[i].querySelector('ul.flat-list');
-					var singleClickLI = document.createElement('li');
-					// changed from a link to a span because you can't cancel a new window on middle click of a link during the mousedown event, and a click event isn't triggered.
-					var singleClickLink = document.createElement('span');
-					// singleClickLink.setAttribute('href','javascript:void(0);');
-					singleClickLink.setAttribute('class', 'redditSingleClick');
-					singleClickLink.setAttribute('thisLink', thisLink);
-					singleClickLink.setAttribute('thisComments', thisComments);
-					if (thisLink != thisComments) {
-						singleClickLink.textContent = '[l+c]';
-					} else if (!(modules['singleClick'].options.hideLEC.value)) {
-						singleClickLink.textContent = '[l=c]';
-					}
-					singleClickLI.appendChild(singleClickLink);
-					thisUL.appendChild(singleClickLI);
-					// we have to switch to mousedown because Webkit is being a douche and not triggering click events on middle click.
-					// ?? We should still preventDefault on a click though, maybe?
-					singleClickLink.addEventListener('mousedown', function(e) {
-						e.preventDefault();
-						var lcMouseBtn = (modules['singleClick'].options.openBackground.value) ? 1 : 0;
-						if (e.button !== 2) {
-							// check if it's a relative link (no http://domain) because chrome barfs on these when creating a new tab...
-							var thisLink = $(this).parent().parent().parent().find('a.title').attr('href');
-							if (!/^http/i.test(thisLink)) {
-								thisLink = location.protocol + '//' + document.domain + thisLink;
-							}
+			var entry = entries[i];
+			if (!entry || $(entry).data('lcTagged')) continue;
+			$(entry).data('lcTagged', true);
 
-							var thisJSON = {
-								requestType: 'singleClick',
-								linkURL: thisLink,
-								openOrder: modules['singleClick'].options.openOrder.value,
-								commentsURL: this.getAttribute('thisComments'),
-								button: lcMouseBtn,
-								ctrl: e.ctrlKey
-							};
+			var urls = modules['singleClick'].getThingUrls(entry);
+			if (!urls) continue;
 
-							BrowserStrategy.sendMessage(thisJSON);
-						}
-					}, false);
-				}
+			var singleClickLink;
+			switch (modules['singleClick'].options.buttonLocation.value) {
+				case 'title-l+c':
+				case 'title-comments':
+					singleClickLink = entry.querySelector('a.title');
+					break;
+				case 'addbutton':
+				default:
+					singleClickLink = modules['singleClick'].createButton(entry, urls);
+					break;
 			}
+
+			// we have to switch to mousedown because Webkit is being a douche and not triggering click events on middle click.
+			singleClickLink.addEventListener('mousedown', modules['singleClick'].onClickSingleElement);
+			// prevent clicks too
+			singleClickLink.addEventListener('click', modules['singleClick'].onClickSingleElement);
+
+		}
+	},
+	createButton: function (entry, urls) {
+		var thisUL = entry.querySelector('ul.flat-list');
+		var singleClickLI = document.createElement('li');
+		// changed from a link to a span because you can't cancel a new window on middle click of a link during the mousedown event, and a click event isn't triggered.
+		singleClickLink = document.createElement('span');
+		// singleClickLink.setAttribute('href','javascript:void(0);');
+		singleClickLink.setAttribute('class', 'redditSingleClick');
+		singleClickLink.textContent = urls.link ? '[l+c]' : '[l=c]';
+
+		singleClickLI.appendChild(singleClickLink);
+		thisUL.appendChild(singleClickLI);
+
+		return singleClickLink;
+	},
+	onClickSingleElement: function(e) {
+		if (e.button === 2) {
+			return;
+		}
+		e.preventDefault();
+		e.stopPropagation();
+
+		if (e.type === 'click') {
+			return;
+		}
+
+		var urls = modules['singleClick'].getThingUrls(e.target);
+
+		var thisJSON = {
+			requestType: 'singleClick',
+			linkURL: urls.link || urls.comments,
+			openOrder: modules['singleClick'].options.openOrder.value,
+			commentsURL: urls.comments,
+			button: (modules['singleClick'].options.openBackground.value) ? 1 : 0,
+			ctrl: e.ctrlKey
+		};
+
+		BrowserStrategy.sendMessage(thisJSON);
+	},
+	getThingUrls: function (ele) {
+		var thing = $(ele).closest('.thing')[0];
+		var thisLink = (thisLink = thing.querySelector('a.title')) && thisLink.href;
+		var thisComments = (thisComments = thing.querySelector('.comments')) && thisComments.href;
+		var domain = (domain = thing.querySelector('.domain a')) && domain.href;
+		if (!thisLink) return;
+
+		if ((thisLink === thisComments) && modules['singleClick'].options.hideLEC.value) return;
+
+		if (modules['singleClick'].options.buttonLocation === 'title-comments') {
+			thisLink = false;
+		} else if (RESUtils.subredditRegex.test(domain)) {
+			thisLink = false;
+		} else if (!/^http/i.test(thisLink)) {
+			// turn relative urls (no http://domain) into absolute because chrome barfs on creating new tabs with relative urls
+			thisLink = location.protocol + '//' + document.domain + thisLink;
+		}
+
+		return {
+			link: thisLink,
+			comments: thisComments
 		}
 	}
 };


### PR DESCRIPTION
also a good chunk of refactoring

also fixed bug in chrome/chropera where opening an l+c, then opening an l=c puts the second link's comments tab in between the first post's links and comments tabs.

closes #1961 