### PR TITLE
Added steamusercontent.com domain support to showImages Steam module.

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -3074,7 +3074,7 @@ modules['showImages'] = {
 			name: 'steam',
 			domains: ['steampowered.com', 'steamusercontent.com'],
 			detect: function(href, elem) {
-				return (/^cloud(?:-\d)?.(?:steampowered|steamusercontent).com$/i).test(elem.host);
+				return (/^cloud(?:-\d)?\.(?:steampowered|steamusercontent)\.com$/i).test(elem.host);
 			},
 			handleLink: function(elem) {
 				return $.Deferred().resolve(elem, elem.href).promise();

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -3072,9 +3072,9 @@ modules['showImages'] = {
 		},
 		steampowered: {
 			name: 'steam',
-			domains: ['steampowered.com'],
+			domains: ['steampowered.com', 'steamusercontent.com'],
 			detect: function(href, elem) {
-				return (/^cloud(?:-\d)?.steampowered.com$/i).test(elem.host);
+				return (/^cloud(?:-\d)?.(?:steampowered|steamusercontent).com$/i).test(elem.host);
 			},
 			handleLink: function(elem) {
 				return $.Deferred().resolve(elem, elem.href).promise();


### PR DESCRIPTION
The steam module only support links on the steampowered.com domain but I'm seeing a lot of links coming out of steamusercontent.com now.

This updates the domains and the detection regex on this module.