### PR TITLE
Add global spoiler tags module

### DIFF
--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -42,6 +42,7 @@
 				"vendor/gifyoutube.js",
 				"vendor/imgurgifv.js",
 				"reddit_enhancement_suite.user.js",
+				"modules/spoilerTags.js",
 				"modules/submitIssue.js",
 				"modules/betteReddit.js",
 				"modules/userTagger.js",

--- a/OperaBlink/manifest.json
+++ b/OperaBlink/manifest.json
@@ -41,6 +41,7 @@
 				"vendor/gifyoutube.js",
 				"vendor/imgurgifv.js",
 				"reddit_enhancement_suite.user.js",
+				"modules/spoilerTags.js",
 				"modules/submitIssue.js",
 				"modules/betteReddit.js",
 				"modules/userTagger.js",

--- a/RES.safariextension/Info.plist
+++ b/RES.safariextension/Info.plist
@@ -52,6 +52,7 @@
 				<string>vendor/gifyoutube.js</string>
 				<string>vendor/imgurgifv.js</string>
 				<string>reddit_enhancement_suite.user.js</string>
+				<string>modules/spoilerTags.js</string>
 				<string>modules/submitIssue.js</string>
 				<string>modules/betteReddit.js</string>
 				<string>modules/userTagger.js</string>

--- a/XPI/lib/main.js
+++ b/XPI/lib/main.js
@@ -169,6 +169,7 @@ pageMod.PageMod({
 		self.data.url('vendor/imgurgifv.js'),
 		self.data.url('vendor/hogan-3.0.2.js'),
 		self.data.url('reddit_enhancement_suite.user.js'),
+		self.data.url('modules/spoilerTags.js'),
 		self.data.url('modules/submitIssue.js'),
 		self.data.url('modules/betteReddit.js'),
 		self.data.url('modules/userTagger.js'),

--- a/lib/core/templates.html
+++ b/lib/core/templates.html
@@ -28,6 +28,18 @@
 			</div>
 		</div>
 
+		<style type="text/css" id="spoiler-styles">
+			a[href="/s"], a[href="/spoiler"], a[href="#s"], a[href="#spoiler"] {
+				color: #000;
+				background-color: #000;
+				cursor: default;
+			}
+
+			a[href="/s"]:hover, a[href="/spoiler"]:hover, a[href="#s"]:hover, a[href="#spoiler"]:hover {
+				color: #fff;
+			}
+		</style>
+
 		<!-- Submit issues wizard -->
 		<style type="text/css" id="submitWizardCSS">
 		#submittingToEnhancement { display: none; min-height: 300px; font-size: 14px; line-height: 15px; margin-top: 10px; width: 518px; position: absolute; z-index: 999; } #submittingToEnhancement ol { margin-left: 10px; margin-top: 15px; list-style-type: decimal; } #submittingToEnhancement li { margin-left: 25px; }

--- a/lib/modules/spoilerTags.js
+++ b/lib/modules/spoilerTags.js
@@ -1,0 +1,28 @@
+modules['spoilerTags'] = {
+	moduleID: 'spoilerTags',
+	moduleName: 'Global Spoiler Tags',
+	category: 'UI',
+	options: { },
+	description: 'Hides spoiler-tagged comments globally across Reddit',
+	isEnabled: function() {
+		return RESConsole.getModulePrefs(this.moduleID);
+	},
+	include: [
+		/^https?:\/\/([a-z]+)\.reddit\.com\/user\/.*/i
+	],
+	exclude: [ ],
+	isMatchURL: function() {
+		return RESUtils.isMatchURL(this.moduleID);
+	},
+	go: function() {
+		if (!this.isEnabled() || !this.isMatchURL()) {
+			return;
+		}
+		var styles = RESTemplates.getSync('spoiler-styles');
+		var tag = document.createElement('style');
+		tag.setAttribute('type', 'text/css');
+		tag.innerHTML = styles.text(); // Security note: not user input
+		document.head.appendChild(tag);
+	},
+	hosts: {}
+};

--- a/lib/modules/spoilerTags.js
+++ b/lib/modules/spoilerTags.js
@@ -3,12 +3,12 @@ modules['spoilerTags'] = {
 	moduleName: 'Global Spoiler Tags',
 	category: 'UI',
 	options: { },
-	description: 'Hides spoiler-tagged comments globally across Reddit',
+	description: 'Hides spoiler-tagged comments on user profiles.',
 	isEnabled: function() {
 		return RESConsole.getModulePrefs(this.moduleID);
 	},
 	include: [
-		/^https?:\/\/([a-z]+)\.reddit\.com\/user\/.*/i
+		"profile"
 	],
 	exclude: [ ],
 	isMatchURL: function() {

--- a/lib/modules/spoilerTags.js
+++ b/lib/modules/spoilerTags.js
@@ -23,6 +23,5 @@ modules['spoilerTags'] = {
 		tag.setAttribute('type', 'text/css');
 		tag.innerHTML = styles.text(); // Security note: not user input
 		document.head.appendChild(tag);
-	},
-	hosts: {}
+	}
 };


### PR DESCRIPTION
This adds support for common spoiler tag formats on user pages.

![2015-01-14_16 27 10](https://cloud.githubusercontent.com/assets/1310872/5749848/45a7e4a6-9c0a-11e4-828e-4cb9bbff66d2.png)
