### PR TITLE
Show expandos for twitter's alternate image resolutions

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -110,6 +110,7 @@
 				"modules/modhelper.js",
 				"modules/quickMessage.js",
 				"modules/hosts/imgur.js",
+				"modules/hosts/twimg.js",
 				"modules/hosts/xkcd.js",
 				"modules/hosts/dailymotion.js",
 				"modules/hosts/jsfiddle.js",

--- a/firefox/index.js
+++ b/firefox/index.js
@@ -564,6 +564,7 @@ PageMod({
 		self.data.url('modules/modhelper.js'),
 		self.data.url('modules/quickMessage.js'),
 		self.data.url('modules/hosts/imgur.js'),
+		self.data.url('modules/hosts/twimg.js'),
 		self.data.url('modules/hosts/xkcd.js'),
 		self.data.url('modules/hosts/dailymotion.js'),
 		self.data.url('modules/hosts/jsfiddle.js'),

--- a/lib/modules/hosts/twimg.js
+++ b/lib/modules/hosts/twimg.js
@@ -1,0 +1,9 @@
+addLibrary('mediaHosts', 'twimg', {
+	domains: ['twimg.com'],
+	logo: 'https://twitter.com/favicon.ico',
+	detect: href => (/^https?:\/\/pbs\.twimg\.com\/media\/[\w\-]+\.\w+/i).test(href),
+	handleLink(elem) {
+		elem.type = 'IMAGE';
+		elem.src = elem.href;
+	}
+});

--- a/node/files.json
+++ b/node/files.json
@@ -78,6 +78,7 @@
 	],
 	"libraries": [
 		"modules/hosts/imgur.js",
+		"modules/hosts/twimg.js",
 		"modules/hosts/xkcd.js",
 		"modules/hosts/dailymotion.js",
 		"modules/hosts/jsfiddle.js",

--- a/safari/Info.plist
+++ b/safari/Info.plist
@@ -117,6 +117,7 @@
 				<string>modules/modhelper.js</string>
 				<string>modules/quickMessage.js</string>
 				<string>modules/hosts/imgur.js</string>
+				<string>modules/hosts/twimg.js</string>
 				<string>modules/hosts/xkcd.js</string>
 				<string>modules/hosts/dailymotion.js</string>
 				<string>modules/hosts/jsfiddle.js</string>


### PR DESCRIPTION
Fixes #913.

~~I can't imagine it's very likely that `img.<png/jpg/gif>:<something>` wouldn't be an image, so I think it would be fine to do this instead of adding a special case for Twitter.~~