### PR TITLE
Images to batch icons

### DIFF
--- a/lib/core/console.js
+++ b/lib/core/console.js
@@ -885,7 +885,7 @@ var RESConsole = {
 			var thisHandle = document.createElement('div');
 			$(thisHandle)
 			.addClass('res-icon-button res-icon handle')
-				.html('&#xF0B5;')
+				.html('&#xF0AA;')
 				.attr('title', 'drag and drop to move this row')
 
 			thisTD.appendChild(thisHandle);

--- a/lib/core/res.css
+++ b/lib/core/res.css
@@ -819,11 +819,15 @@ p.moduleListing {
 	padding: 10px;
 	width: 26px;
 	height: 22px;
-	background: no-repeat center center;
-	background-image: url(https://s3.amazonaws.com/b.thumbs.redditmedia.com/bQYQXsuPzDmLh8iW7Nnfhq0zBczl5V6ek9Oi17rZ9mE.png);
-	display: none;
+	visibility: hidden;
 }
-#SearchRES-results li:hover .SearchRES-result-copybutton { display: block; }
+#SearchRES-results li:hover .SearchRES-result-copybutton {
+	visibility: visible;
+}
+#SearchRES-results .SearchRES-result-copybutton:hover {
+	color: #888;
+}
+
 #SearchRES-input-submit {
 	margin-left: 8px;
 }

--- a/lib/core/res.css
+++ b/lib/core/res.css
@@ -1126,16 +1126,12 @@ body.RESScrollLock {
 
 .content .RESBigEditorPop {
 	float: right;
-	margin: 3px 0 0 12px;
+	margin: 3px 0 0 0;
 	color: #333;
 	background-color: #fff;
 	border: 1px solid #ccc;
 	cursor: pointer;
-	text-indent: 20px;
 	padding: 5px 3px;
-	background-repeat: no-repeat;
-	background-position: 4px 50%;
-	background-image: url(https://b.thumbs.redditmedia.com/KGwj6faDlmPlGvWMZf2i9gn9CpnY__eZlqhdyU8b9gQ.png);
 }
 button.RESBigEditorPop:hover {
 	background-color: #ddd;

--- a/lib/modules/commentPreview.js
+++ b/lib/modules/commentPreview.js
@@ -236,7 +236,7 @@ modules['commentPreview'] = {
 		}
 	},
 	makeBigEditorButton: function() {
-		return $('<button type="button" class="RESBigEditorPop" tabIndex="3">big editor</button>');
+		return $('<button type="button" class="RESBigEditorPop" tabIndex="3"><span class="res-icon">&#xF0A4;</span> big editor</button>');
 	},
 	attachPreview: function(usertext) {
 		if (usertext == null) {

--- a/lib/modules/settingsNavigation.js
+++ b/lib/modules/settingsNavigation.js
@@ -477,8 +477,8 @@ addModule('search', function(module, moduleID) {
 
 
 			$('<span>', {
-				class: 'SearchRES-result-copybutton'
-			})
+				class: 'SearchRES-result-copybutton res-icon'
+			}).html('&#xF159')
 				.appendTo(element)
 				.attr('title', 'copy this for a comment');
 


### PR DESCRIPTION
Swapped out a few icon images for batch font icons.  This should supersede some of the "move icons from `url(https://aws...)` to `uri(data:...)`" PR

thanks to @erikdesjardins for suggestions.

Still need to do gear dropdown search button