### PR TITLE
showImages: stop conserveMemory messing up albums

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -317,7 +317,7 @@ modules['showImages'] = {
 		if (ele.imageLink && ele.imageLink.image) {
 			$img = $(ele.imageLink.image);
 			src = $img.data('src');
-			if (src && ($img.attr('src') !== src)) {
+			if (src && ($img.attr('src') === this.transparentGif)) {
 				$img.attr('src',src);
 			}
 		}


### PR DESCRIPTION
Fixes #1494.

Originally, the image would be replaced if the current `src` was different from the stored source. This obviously causes problems in albums, resulting in the image getting reset after each scroll.

Instead, we can check that the image we're replacing is the `transparentGif` used as a substitute for the original image. As far as I can tell, conserveMemory still works properly after this change.