### PR TITLE
KeyboardNav refactor

### DIFF
--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -49,6 +49,7 @@
 				"modules/keyboardNav.js",
 				"modules/about.js",
 				"modules/commandLine.js",
+				"modules/selectedEntry.js",
 				"modules/settingsConsole.js",
 				"modules/menu.js",
 				"modules/hover.js",

--- a/Opera/includes/loader.js
+++ b/Opera/includes/loader.js
@@ -54,6 +54,7 @@ window.addEventListener('DOMContentLoaded', function() {
 		'modules/accountSwitcher.js',
 		'modules/betteReddit.js',
 		'modules/commandLine.js',
+		'modules/selectedEntry.js',
 		'modules/settingsConsole.js',
 		'modules/menu.js',
 		'modules/commentHidePersistor.js',

--- a/OperaBlink/manifest.json
+++ b/OperaBlink/manifest.json
@@ -48,6 +48,7 @@
 				"modules/keyboardNav.js",
 				"modules/about.js",
 				"modules/commandLine.js",
+				"modules/selectedEntry.js",
 				"modules/settingsConsole.js",
 				"modules/menu.js",
 				"modules/hover.js",

--- a/RES.safariextension/Info.plist
+++ b/RES.safariextension/Info.plist
@@ -58,6 +58,7 @@
 				<string>modules/userTagger.js</string>
 				<string>modules/keyboardNav.js</string>
 				<string>modules/commandLine.js</string>
+				<string>modules/selectedEntry.js</string>
 				<string>modules/settingsConsole.js</string>
 				<string>modules/menu.js</string>
 				<string>modules/about.js</string>

--- a/XPI/lib/main.js
+++ b/XPI/lib/main.js
@@ -175,6 +175,7 @@ pageMod.PageMod({
 		self.data.url('modules/userTagger.js'),
 		self.data.url('modules/keyboardNav.js'),
 		self.data.url('modules/commandLine.js'),
+		self.data.url('modules/selectedEntry.js'),
 		self.data.url('modules/settingsConsole.js'),
 		self.data.url('modules/menu.js'),
 		self.data.url('modules/about.js'),

--- a/lib/core/migrate.js
+++ b/lib/core/migrate.js
@@ -105,6 +105,14 @@ var RESOptionsMigrate = {
 				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'mediaBrowseMode', 'showImages', 'mediaBrowseMode');
 				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'autoSelectOnScroll', 'selectedEntry', 'autoSelectOnScroll');
 				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'clickFocus', 'selectedEntry', 'selectOnClick');
+				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'addFocusBGColor', 'selectedEntry', 'addFocusBGColor');
+				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'focusBGColor', 'selectedEntry', 'focusBGColor');
+				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'focusBGColorNight', 'selectedEntry', 'focusBGColorNight');
+				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'focusFGColorNight', 'selectedEntry', 'focusFGColorNight');
+				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'addFocusBorder', 'selectedEntry', 'addFocusBorder');
+				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'focusBorder', 'selectedEntry', 'focusBorder');
+				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'focusBorderNight', 'selectedEntry', 'focusBorderNight');
+
 
 				// Minify existing options
 				for (var key in modules) {

--- a/lib/core/migrate.js
+++ b/lib/core/migrate.js
@@ -102,6 +102,7 @@ var RESOptionsMigrate = {
 				}
 				RESOptionsMigrate.migrators.generic.moveOption('betteReddit', 'uncheckSendRepliesToInbox', 'submitHelper', 'uncheckSendRepliesToInbox');
 				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'openBigEditor', 'commentPreview', 'openBigEditor');
+				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'mediaBrowseMode', 'showImages', 'mediaBrowseMode');
 				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'autoSelectOnScroll', 'selectedThings', 'autoSelectOnScroll');
 				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'clickFocus', 'selectedThings', 'selectOnClick');
 

--- a/lib/core/migrate.js
+++ b/lib/core/migrate.js
@@ -102,6 +102,8 @@ var RESOptionsMigrate = {
 				}
 				RESOptionsMigrate.migrators.generic.moveOption('betteReddit', 'uncheckSendRepliesToInbox', 'submitHelper', 'uncheckSendRepliesToInbox');
 				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'openBigEditor', 'commentPreview', 'openBigEditor');
+				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'autoSelectOnScroll', 'selectedThings', 'autoSelectOnScroll');
+				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'clickFocus', 'selectedThings', 'selectOnClick');
 
 				// Minify existing options
 				for (var key in modules) {

--- a/lib/core/migrate.js
+++ b/lib/core/migrate.js
@@ -102,7 +102,6 @@ var RESOptionsMigrate = {
 				}
 				RESOptionsMigrate.migrators.generic.moveOption('betteReddit', 'uncheckSendRepliesToInbox', 'submitHelper', 'uncheckSendRepliesToInbox');
 				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'openBigEditor', 'commentPreview', 'openBigEditor');
-				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'mediaBrowseMode', 'showImages', 'mediaBrowseMode');
 				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'autoSelectOnScroll', 'selectedEntry', 'autoSelectOnScroll');
 				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'clickFocus', 'selectedEntry', 'selectOnClick');
 				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'addFocusBGColor', 'selectedEntry', 'addFocusBGColor');

--- a/lib/core/migrate.js
+++ b/lib/core/migrate.js
@@ -103,8 +103,8 @@ var RESOptionsMigrate = {
 				RESOptionsMigrate.migrators.generic.moveOption('betteReddit', 'uncheckSendRepliesToInbox', 'submitHelper', 'uncheckSendRepliesToInbox');
 				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'openBigEditor', 'commentPreview', 'openBigEditor');
 				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'mediaBrowseMode', 'showImages', 'mediaBrowseMode');
-				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'autoSelectOnScroll', 'selectedThings', 'autoSelectOnScroll');
-				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'clickFocus', 'selectedThings', 'selectOnClick');
+				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'autoSelectOnScroll', 'selectedEntry', 'autoSelectOnScroll');
+				RESOptionsMigrate.migrators.generic.moveOption('keyboardNav', 'clickFocus', 'selectedEntry', 'selectOnClick');
 
 				// Minify existing options
 				for (var key in modules) {

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -398,6 +398,19 @@ RESUtils.elementInViewport = function(obj) {
 		return false;
 	}
 	// check the headerOffset - if we've pinned the subreddit bar, we need to add some pixels so the "visible" stuff is lower down the page.
+
+	var element = RESUtils.getDimensions(obj);
+	var viewport = RESUtils.getViewportDimensions();
+
+	var contained = (
+		viewport.top <= element.top  &&
+		viewport.left <= element.left  &&
+		element.bottom <= viewport.bottom &&
+		element.right <= viewport.right
+	);
+	return contained;
+};
+RESUtils.getDimensions = function(obj) {
 	var headerOffset = this.getHeaderOffset();
 	var top = obj.offsetTop - headerOffset;
 	var left = obj.offsetLeft;
@@ -408,12 +421,39 @@ RESUtils.elementInViewport = function(obj) {
 		top += obj.offsetTop;
 		left += obj.offsetLeft;
 	}
-	return (
-		top >= window.pageYOffset &&
-		left >= window.pageXOffset &&
-		(top + height) <= (window.pageYOffset + window.innerHeight - headerOffset) &&
-		(left + width) <= (window.pageXOffset + window.innerWidth)
-	);
+	var bottom = top + height;
+	var right = left + width;
+
+	return {
+		yOffset: headerOffset,
+		x: top,
+		y: left,
+		top: top,
+		left: left,
+		bottom: bottom,
+		right: right,
+		width: width,
+		height: height
+	};
+
+}
+
+RESUtils.getViewportDimensions = function() {
+	var headerOffset = this.getHeaderOffset();
+
+	var dimensions = {
+		yOffset: headerOffset,
+		x: window.pageXOffset,
+		y: window.pageYOffset + headerOffset,
+		width: window.innerWidth,
+		height: window.innerHeight
+	};
+	dimensions.top = dimensions.y;
+	dimensions.left = dimensions.x;
+	dimensions.bottom = dimensions.top + dimensions.height;
+	dimensions.right = dimensions.left + dimensions.width;
+
+	return dimensions;
 };
 // Returns percentage of the element that is within the viewport along the y-axis
 // Note that it doesn't matter where the element is on the x-axis, it can be totally invisible to the user

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -1289,9 +1289,10 @@ RESUtils.initObservers = function() {
 				mutations.forEach(function(mutation) {
 
 					// handle comment listing pages (not within a post)
-					if (mutation.addedNodes[0].id.indexOf('siteTable') !== -1) {
+					var $container = $(mutation.addedNotes[0]);
+					if ($container.is('[id^="siteTable"]')) {
 						// when a new sitetable is loaded, we need to add new observers for selftexts within that sitetable...
-						$(mutation.addedNodes[0]).find('.entry div.expando').each(function() {
+						$container.find('.entry div.expando').each(function() {
 							RESUtils.addSelfTextObserver(this);
 						});
 						RESUtils.watchers.siteTable.forEach(function(callback) {

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -393,6 +393,7 @@ RESUtils.getXYpos = function(obj) {
 		'y': topValue
 	};
 };
+
 RESUtils.elementInViewport = function(obj) {
 	if (!obj) {
 		return false;
@@ -562,6 +563,40 @@ RESUtils.doElementsCollide = function(ele1, ele2, margin) {
 
 	return false;
 };
+RESUtils.scrollToElement = function(element, options) {
+	options = $.extend(true, {
+		makeVisible: undefined
+	}, options);
+
+	var elementXY = RESUtils.getXYpos(element);
+	var target = (options.makeVisible || element).getBoundingClientRect(); // top, right, bottom, left are relative to viewport
+	var viewport = RESUtils.getViewportDimensions();
+
+	if (0 <= target.top && target.bottom <= viewport.height) {
+		// Element is already completely inside viewport
+		// (remember, top and bottom are relative to viewport)
+		return;
+	}
+	else if (options.scrollToTop) {
+		RESUtils.scrollTo(0, viewport.y + target.top);
+	} else if (target.top < 0) {
+		// Element starts above viewport
+		// So, Align top of element to top of viewport
+		RESUtils.scrollTo(0, viewport.y + target.top);
+	}
+	else if (viewport.height < target.bottom &&
+			target.height < viewport.height) {
+		// Visible part of element starts or extends below viewport,
+		// So, align bottom of target to bottom of viewport
+		RESUtils.scrollTo(0, viewport.y + target.bottom - viewport.height);
+		return;
+	}
+	else {
+		// Visible part of element below the viewport but it'll fill the viewport, or fallback
+		// So, align top of element to top of viewport
+		RESUtils.scrollTo(0, viewport.y + target.top)
+	}
+}
 RESUtils.scrollTo = function(x, y) {
 	var headerOffset = this.getHeaderOffset();
 	window.scrollTo(x, y - headerOffset);

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -578,6 +578,9 @@ RESUtils.scrollToElement = function(element, options) {
 		// (remember, top and bottom are relative to viewport)
 		return;
 	}
+	else if (options.scrollStyle === 'none') {
+		return;
+	}
 	else if (options.scrollStyle === 'top') {
 		// Always scroll element to top of page
 		RESUtils.scrollTo(0, viewport.y + target.top - options.topOffset);

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -577,7 +577,7 @@ RESUtils.scrollToElement = function(element, options) {
 		// (remember, top and bottom are relative to viewport)
 		return;
 	}
-	else if (options.scrollToTop) {
+	else if (options.scrollToElement === 'top') {
 		RESUtils.scrollTo(0, viewport.y + target.top);
 	} else if (target.top < 0) {
 		// Element starts above viewport

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -565,6 +565,7 @@ RESUtils.doElementsCollide = function(ele1, ele2, margin) {
 };
 RESUtils.scrollToElement = function(element, options) {
 	options = $.extend(true, {
+		topOffset: 5,
 		makeVisible: undefined
 	}, options);
 
@@ -578,11 +579,12 @@ RESUtils.scrollToElement = function(element, options) {
 		return;
 	}
 	else if (options.scrollToElement === 'top') {
-		RESUtils.scrollTo(0, viewport.y + target.top);
+		// Always scroll element to top of page
+		RESUtils.scrollTo(0, viewport.y + target.top - options.topOffset);
 	} else if (target.top < 0) {
 		// Element starts above viewport
-		// So, Align top of element to top of viewport
-		RESUtils.scrollTo(0, viewport.y + target.top);
+		// So, align top of element to top of viewport
+		RESUtils.scrollTo(0, viewport.y + target.top - options.topOffset);
 	}
 	else if (viewport.height < target.bottom &&
 			target.height < viewport.height) {
@@ -594,7 +596,7 @@ RESUtils.scrollToElement = function(element, options) {
 	else {
 		// Visible part of element below the viewport but it'll fill the viewport, or fallback
 		// So, align top of element to top of viewport
-		RESUtils.scrollTo(0, viewport.y + target.top)
+		RESUtils.scrollTo(0, viewport.y + target.top - options.topOffset)
 	}
 }
 RESUtils.scrollTo = function(x, y) {

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -573,18 +573,20 @@ RESUtils.scrollToElement = function(element, options) {
 	var target = (options.makeVisible || element).getBoundingClientRect(); // top, right, bottom, left are relative to viewport
 	var viewport = RESUtils.getViewportDimensions();
 
-	if (0 <= target.top && target.bottom <= viewport.height) {
-		// Element is already completely inside viewport
-		// (remember, top and bottom are relative to viewport)
-		return;
-	}
-	else if (options.scrollStyle === 'none') {
+
+	if (options.scrollStyle === 'none') {
 		return;
 	}
 	else if (options.scrollStyle === 'top') {
 		// Always scroll element to top of page
 		RESUtils.scrollTo(0, viewport.y + target.top - options.topOffset);
-	} else if (target.top < 0) {
+	}
+	else if (0 <= target.top && target.bottom <= viewport.height) {
+		// Element is already completely inside viewport
+		// (remember, top and bottom are relative to viewport)
+		return;
+	}
+	else if (target.top < 0) {
 		// Element starts above viewport
 		// So, align top of element to top of viewport
 		RESUtils.scrollTo(0, viewport.y + target.top - options.topOffset);

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -578,7 +578,7 @@ RESUtils.scrollToElement = function(element, options) {
 		// (remember, top and bottom are relative to viewport)
 		return;
 	}
-	else if (options.scrollToElement === 'top') {
+	else if (options.scrollStyle === 'top') {
 		// Always scroll element to top of page
 		RESUtils.scrollTo(0, viewport.y + target.top - options.topOffset);
 	} else if (target.top < 0) {
@@ -588,9 +588,14 @@ RESUtils.scrollToElement = function(element, options) {
 	}
 	else if (viewport.height < target.bottom &&
 			target.height < viewport.height) {
-		// Visible part of element starts or extends below viewport,
-		// So, align bottom of target to bottom of viewport
-		RESUtils.scrollTo(0, viewport.y + target.bottom - viewport.height);
+		// Visible part of element starts or extends below viewport
+
+		if (options.scrollStyle === 'page') {
+			RESUtils.scrollTo(0, viewport.y + target.top - options.topOffset);
+		} else {
+			// So, align bottom of target to bottom of viewport
+			RESUtils.scrollTo(0, viewport.y + target.bottom - viewport.height);
+		}
 		return;
 	}
 	else {

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -1,7 +1,7 @@
 modules['commentTools'] = {
 	moduleID: 'commentTools',
 	moduleName: 'Comment Tools',
-	category: 'Editing',
+	category: [ 'Editing', 'Comments', 'Posts' ],
 	options: {
 		userAutocomplete: {
 			type: 'boolean',

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1169,7 +1169,7 @@ modules['keyboardNav'] = {
 
 		// find the [l+c] link and click it...
 		var lcLink = selected.entry.querySelector('.redditSingleClick');
-		RESUtils.mousedown(lcLink, background);
+		RESUtils.mousedown(lcLink, background && 1);
 
 	},
 	upVote: function(preventToggle) {

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -143,72 +143,72 @@ modules['keyboardNav'] = {
 			callback: function() { modules['commandLine'].toggleCmdLine() }
 		},
 		hide: {
-			includes: [ 'linklist', 'profile' ],
+			include: [ 'linklist', 'profile' ],
 			value: [72, false, false, false], // h
 			description: 'Hide link'
 		},
 		moveUp: {
-			includes: [ 'linklist', 'profile', 'comments' ],
+			include: [ 'linklist', 'profile', 'comments' ],
 			value: [75, false, false, false], // k
 			description: 'Move up (previous link or comment)'
 		},
 		moveDown: {
-			includes: [ 'linklist', 'profile', 'comments' ],
+			include: [ 'linklist', 'profile', 'comments' ],
 			value: [74, false, false, false], // j
 			description: 'Move down (next link or comment)'
 		},
 		moveTop: {
-			includes: [ 'linklist', 'profile' ],
+			include: [ 'linklist', 'profile' ],
 			value: [75, false, false, true], // shift-k
 			description: 'Move to top of list (on link pages)'
 		},
 		moveBottom: {
-			includes: [ 'linklist', 'profile' ],
+			include: [ 'linklist', 'profile' ],
 			value: [74, false, false, true], // shift-j
 			description: 'Move to bottom of list (on link pages)'
 		},
 		moveUpSibling: {
-			includes: [ 'comments' ],
+			include: [ 'comments' ],
 			value: [75, false, false, true], // shift-k
 			description: 'Move to previous sibling (in comments) - skips to previous sibling at the same depth.'
 		},
 		moveDownSibling: {
-			includes: [ 'comments' ],
+			include: [ 'comments' ],
 			value: [74, false, false, true], // shift-j
 			description: 'Move to next sibling (in comments) - skips to next sibling at the same depth.'
 		},
 		moveUpThread: {
-			includes: [ 'comments' ],
+			include: [ 'comments' ],
 			value: [75, true, false, true], // shift-alt-k
 			description: 'Move to the topmost comment of the previous thread (in comments).'
 		},
 		moveDownThread: {
-			includes: [ 'comments' ],
+			include: [ 'comments' ],
 			value: [74, true, false, true], // shift-alt-j
 			description: 'Move to the topmost comment of the next thread (in comments).'
 		},
 		moveToTopComment: {
-			includes: [ 'comments' ],
+			include: [ 'comments' ],
 			value: [84, false, false, false], // t
 			description: 'Move to the topmost comment of the current thread (in comments).'
 		},
 		moveToParent: {
-			includes: [ 'comments' ],
+			include: [ 'comments' ],
 			value: [80, false, false, false], // p
 			description: 'Move to parent (in comments).'
 		},
 		showParents: {
-			includes: [ 'comments' ],
+			include: [ 'comments' ],
 			value: [80, false, false, true], // p
 			description: 'Display parent comments.'
 		},
 		followLink: {
-			includes: [ 'linklist', 'profile' ],
+			include: [ 'linklist', 'profile' ],
 			value: [13, false, false, false], // enter
 			description: 'Follow link (hold shift to open it in a new tab) (link pages only)'
 		},
 		followLinkNewTab: {
-			includes: [ 'linklist', 'profile', 'comments' ],
+			include: [ 'linklist', 'profile', 'comments' ],
 			value: [13, false, false, true], // shift-enter
 			description: 'Follow link in new tab (link pages only)',
 			callback: function() {
@@ -275,95 +275,95 @@ modules['keyboardNav'] = {
 			description: 'Toggle "view images" button',
 		},
 		toggleChildren: {
-			includes: [ 'comments' ],
+			include: [ 'comments' ],
 			value: [13, false, false, false], // enter
 			description: 'Expand/collapse comments (comments pages only)'
 		},
 		followComments: {
-			includes: [ 'linklist', 'profile' ],
+			include: [ 'linklist', 'profile' ],
 			value: [67, false, false, false], // c
 			description: 'View comments for link (shift opens them in a new tab)'
 		},
 		followCommentsNewTab: {
-			includes: [ 'linklist', 'profile' ],
+			include: [ 'linklist', 'profile' ],
 			value: [67, false, false, true], // shift-c
 			description: 'View comments for link in a new tab',
 			callback: function() { modules['keyboardNav'].followComments(true); }
 		},
 		followLinkAndCommentsNewTab: {
-			includes: [ 'linklist', 'profile' ],
+			include: [ 'linklist', 'profile' ],
 			value: [76, false, false, false], // l
 			description: 'View link and comments in new tabs',
 			callback: function() { modules['keyboardNav'].followLinkAndComments(); }
 		},
 		followLinkAndCommentsNewTabBG: {
-			includes: [ 'linklist', 'profile' ],
+			include: [ 'linklist', 'profile' ],
 			value: [76, false, false, true], // shift-l
 			description: 'View link and comments in new background tabs',
 			callback: function() { modules['keyboardNav'].followLinkAndComments(true); }
 		},
 		upVote: {
-			includes: [ 'linklist', 'profile', 'comments' ],
+			include: [ 'linklist', 'profile', 'comments' ],
 			value: [65, false, false, false], // a
 			description: 'Upvote selected link or comment (or remove the upvote)'
 		},
 		downVote: {
-			includes: [ 'linklist', 'profile',  'comments' ],
+			include: [ 'linklist', 'profile',  'comments' ],
 			value: [90, false, false, false], // z
 			description: 'Downvote selected link or comment (or remove the downvote)'
 		},
 		upVoteWithoutToggling: {
-			includes: [ 'linklist', 'profile',  'comments' ],
+			include: [ 'linklist', 'profile',  'comments' ],
 			value: [65, false, false, true], // a
 			description: 'Upvote selected link or comment (but don\'t remove the upvote)',
 			callback: function() { modules['keyboardNav'].upVote(true); }
 		},
 		downVoteWithoutToggling: {
-			includes: [ 'linklist', 'profile', 'comments' ],
+			include: [ 'linklist', 'profile', 'comments' ],
 			value: [90, false, false, true], // z
 			description: 'Downvote selected link or comment (but don\'t remove the downvote)',
 			callback: function() { modules['keyboardNav'].downVote(true); }
 		},
 		savePost: {
-			includes: [ 'linklist', 'profile', 'comments' ],
+			include: [ 'linklist', 'profile', 'comments' ],
 			value: [83, false, false, false], // s
 			description: 'Save the current post to your reddit account. This is accessible from anywhere that you\'re logged in, but does not preserve the original text if it\'s edited or deleted.',
 			callback: function() { modules['keyboardNav'].saveLink(); }
 		},
 		saveComment: {
-			includes: [ 'comments' ],
+			include: [ 'comments' ],
 			value: [83, false, false, true], // shift-s
 			description: 'Save the current comment to your reddit account. This is accessible from anywhere that you\'re logged in, but does not preserve the original text if it\'s edited or deleted.'
 		},
 		saveRES: {
-			includes: [ 'comments', 'profile' ],
+			include: [ 'comments', 'profile' ],
 			value: [83, false, false, false], // s
 			description: 'Save the current comment with RES. This does preserve the original text of the comment, but is only saved locally.',
 			callback: function() { modules['keyboardNav'].saveCommentRES(); }
 		},
 		reply: {
-			includes: [ 'comments' ],
+			include: [ 'comments' ],
 			value: [82, false, false, false], // r
 			description: 'Reply to current comment (comment pages only)'
 		},
 		followPermalink: {
-			includes: [ 'comments' ],
+			include: [ 'comments' ],
 			value: [89, false, false, false], // y
 			description: 'Open the current comment\'s permalink (comment pages only)'
 		},
 		followPermalinkNewTab: {
-			includes: [ 'comments' ],
+			include: [ 'comments' ],
 			value: [89, false, false, true], // shift-y
 			description: 'Open the current comment\'s permalink in a new tab (comment pages only)',
 			callback: function() { modules['keyboardNav'].followPermalink(true); }
 		},
 		followSubreddit: {
-			includes: [ 'linklist', 'profile' ],
+			include: [ 'linklist', 'profile' ],
 			value: [82, false, false, false], // r
 			description: 'Go to subreddit of selected link (link pages only)'
 		},
 		followSubredditNewTab: {
-			includes: [ 'linklist', 'profile' ],
+			include: [ 'linklist', 'profile' ],
 			value: [82, false, false, true], // shift-r
 			description: 'Go to subreddit of selected link in a new tab (link pages only)',
 			callback: function() { modules['keyboardNav'].followPermalink(true); }
@@ -418,13 +418,13 @@ modules['keyboardNav'] = {
 			isGoTo : true
 		},
 		nextPage: {
-			includes: [ 'linklist', 'profile' ],
+			include: [ 'linklist', 'profile' ],
 			value: [78, false, false, false], // n
 			description: 'Go to next page (link list pages only)',
 			dependsOn: 'goMode'
 		},
 		prevPage: {
-			includes: [ 'linklist', 'profile' ],
+			include: [ 'linklist', 'profile' ],
 			value: [80, false, false, false], // p
 			description: 'Go to prev page (link list pages only)',
 			dependsOn: 'goMode'
@@ -550,17 +550,17 @@ modules['keyboardNav'] = {
 			callback: function() { modules['keyboardNav'].commentLink(9); }
 		},
 		toggleCommentNavigator: {
-			includes: 'comments',
+			include: 'comments',
 			value: [78, false, false, false], // N
 			description: 'Open Comment Navigator'
 		},
 		commentNavigatorMoveUp: {
-			includes: 'comments',
+			include: 'comments',
 			value: [38, false, false, true], // shift+up arrow
 			description: 'Move up using Comment Navigator'
 		},
 		commentNavigatorMoveDown: {
-			includes: 'comments',
+			include: 'comments',
 			value: [40, false, false, true], // shift+down arrow
 			description: 'Move down using Comment Navigator'
 		}

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -163,10 +163,10 @@ modules['keyboardNav'] = {
 			value: [13, false, false, true], // shift-enter
 			description: 'Follow link in new tab (link pages only)',
 			callback: function() {
-				var selectedThing = modules['selectedEntry'].selectedThing();
-				if (!selectedThing) return false;
+				var selected = modules['selectedEntry'].selected();
+				if (!selected) return;
 
-				if (!RESUtils.isPageType('comments') || selectedThing.classList.contains('link')) {
+				if (!RESUtils.isPageType('comments') || selected.thing.classList.contains('link')) {
 					modules['keyboardNav'].followLink(true);
 				}
 			}
@@ -575,9 +575,9 @@ modules['keyboardNav'] = {
 
 	registerSelectedThingWatcher: function() {
 		var module = this;
-		modules['selectedEntry'].addListener(function(newThing, lastThing) {
-			newThing && module.keyFocus(newThing);
-			lastThing && module.keyUnfocus(lastThing);
+		modules['selectedEntry'].addListener(function(selected, last) {
+			selected && module.keyFocus(selected.entry);
+			last && module.keyUnfocus(last.entry);
 		});
 	},
 
@@ -618,9 +618,9 @@ modules['keyboardNav'] = {
 			modules['keyboardNav'].recentKeyPress = false;
 		}, 1000);
 	},
-	keyFocus: function(obj) {
+	keyFocus: function(entry) {
 		if (RESUtils.isPageType('comments') && this.options.commentsLinkNumbers.value) {
-			var links = this.getCommentLinks(obj);
+			var links = this.getCommentLinks(entry);
 			var annotationCount = 0;
 			for (var i = 0, len = links.length; i < len; i++) {
 
@@ -668,9 +668,9 @@ modules['keyboardNav'] = {
 			location.href = this.getAttribute('href');
 		}
 	},
-	keyUnfocus: function (obj) {
+	keyUnfocus: function (entry) {
 		if (RESUtils.isPageType('comments')) {
-			var annotations = obj.querySelectorAll('div.md .keyNavAnnotation');
+			var annotations = entry.querySelectorAll('div.md .keyNavAnnotation');
 			for (var i = 0, len = annotations.length; i < len; i++) {
 				annotations[i].parentNode.removeChild(annotations[i]);
 			}
@@ -810,8 +810,20 @@ modules['keyboardNav'] = {
 		}
 	},
 
-	moveUp: function(obj) {
-		var current = obj.classList ? obj : modules['selectedEntry'].selectedThing();
+	moveUp: function() {
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+
+		modules['keyboardNav']._moveUp(selected.thing);
+	},
+	moveDown: function() {
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+
+		modules['keyboardNav']._moveDown(selected.thing);
+	},
+	_moveUp: function(fromThing) {
+		var current = fromThing;
 		var things = modules['selectedEntry'].selectableThings();
 		var index = things.index(current);
 
@@ -822,10 +834,8 @@ modules['keyboardNav'] = {
 
 		modules['keyboardNav'].recentKey();
 	},
-	moveDown: function(obj) {
-		var current = obj.classList ? obj : modules['selectedEntry'].selectedThing();
-
-		var current = modules['selectedEntry'].selectedThing();
+	_moveDown: function(fromThing) {
+		var current = fromThing;
 		var things = modules['selectedEntry'].selectableThings();
 		var index = things.index(current);
 
@@ -859,9 +869,10 @@ modules['keyboardNav'] = {
 		modules['keyboardNav'].recentKey();
 	},
 	moveDownSibling: function() {
-		var selected = modules['selectedEntry'].selectedThing();
+		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
-		var current = $(selected);
+
+		var current = $(selected.thing);
 
 		var target;
 		do {
@@ -875,9 +886,10 @@ modules['keyboardNav'] = {
 		modules['keyboardNav'].recentKey();
 	},
 	moveUpSibling: function() {
-		var selected = modules['selectedEntry'].selectedThing();
+		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
-		var current = $(selected);
+
+		var current = $(selected.thing);
 
 		var target = current.prevAll('.thing').last()[0];
 		if (!target) {
@@ -888,116 +900,110 @@ modules['keyboardNav'] = {
 		modules['keyboardNav'].recentKey();
 	},
 	moveUpThread: function() {
-		var selected = modules['selectedEntry'].selectedThing();
+		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
 
-		var current = $(selected).parents('.thing').last();
+		var current = $(selected.thing).parents('.thing').last();
 		if (!current.length) {
-			current = $(selected).closest('.thing');
+			current = $(selected.thing).closest('.thing');
 		}
 
 		var target = current.prevAll('.thing').last()[0];
 		if (!target) {
-			this.moveUp(current);
+			this._moveUp(current);
 		} else {
 			modules['selectedEntry'].select(target, { scrollToTop: true });
 			modules['keyboardNav'].recentKey();
 		}
 	},
 	moveDownThread: function() {
-		var selected = modules['selectedEntry'].selectedThing();
+		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
 
-		var current = $(selected).parents('.thing').last();
+		var current = $(selected.thing).parents('.thing').last();
 		if (!current.length) {
-			current = $(selected).closest('.thing');
+			current = $(selected.thing).closest('.thing');
 		}
 
 		var target = current.nextAll('.thing').first()[0];
 		if (!target) {
-			this.moveDown(current);
+			this._moveDown(current);
 		} else {
 			modules['selectedEntry'].select(target, { scrollToTop: true });
 			modules['keyboardNav'].recentKey();
 		}
 	},
 	moveToTopComment: function() {
-		var target = $(modules['selectedEntry'].selectedThing()).parents('.thing').last();
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+		var target = $(selected.thing).parents('.thing').last();
 
 		modules['selectedEntry'].select(target, { scrollToTop: true });
 		modules['keyboardNav'].recentKey();
 	},
 	moveToParent: function() {
-		var selected = modules['selectedEntry'].selectedThing();
-		var parent = $(selected).parent().closest('.thing');
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+
+		var target = $(selected.thing).parent().closest('.thing');
 		modules['selectedEntry'].select(parent);
 	},
 	showParents: function() {
-		var selected = modules['selectedEntry'].selectedThing();
-		var button = selected.querySelector('.entry').querySelector('.buttons .bylink[href^="#"]');
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+
+		var button = selected.entry.querySelector('.buttons .bylink[href^="#"]');
 		if (button) {
 			modules['hover'].begin(button, {}, modules['showParent'].showCommentHover, {});
 		}
 	},
 	toggleChildren: function() {
-		var selected = modules['selectedEntry'].selectedThing();
-		if (selected.classList.contains('link')) {
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+
+		if (selected.thing.classList.contains('link')) {
 			// Ahh, we're not in a comment, but in the main story... that key should follow the link.
 			this.followLink();
 			return;
 		} else {
 			// find out if this is a collapsed or uncollapsed view...
-			var thisCollapsed = selected.querySelector('div.collapsed'),
-				thisNonCollapsed = selected.querySelector('div.noncollapsed'),
-				thisToggle, moreComments, contThread;
+			var thisToggle, moreComments, contThread;
 
-			// Detecting and logic for new version of comment threads
-			if (!thisCollapsed && !thisNonCollapsed) {
-				thisToggle = selected.querySelector('a.expand');
+			thisToggle = selected.entry.querySelector('a.expand');
 
-				// check if this is a "show more comments" box, or just contracted content...
-				moreComments = selected.querySelector('span.morecomments > a');
-				if (moreComments) {
-					thisToggle = moreComments;
-				}
-
-				// 'continue this thread' links
-				contThread = selected.querySelector('span.deepthread > a');
-				if (contThread) {
-					thisToggle = contThread;
-				}
-			} else if (thisCollapsed.style.display !== 'none') {
-				thisToggle = thisCollapsed.querySelector('a.expand');
-			} else {
-				// check if this is a "show more comments" box, or just contracted content...
-				moreComments = thisNonCollapsed.querySelector('span.morecomments > a');
-				if (moreComments) {
-					thisToggle = moreComments;
-				} else {
-					thisToggle = thisNonCollapsed.querySelector('a.expand');
-				}
-				// 'continue this thread' links
-				contThread = thisNonCollapsed.querySelector('span.deepthread > a');
-				if (contThread) {
-					thisToggle = contThread;
-				}
+			// check if this is a "show more comments" box, or just contracted content...
+			moreComments = selected.entry.querySelector('span.morecomments > a');
+			if (moreComments) {
+				thisToggle = moreComments;
 			}
+
+			// 'continue this thread' links
+			contThread = selected.entry.querySelector('span.deepthread > a');
+			if (contThread) {
+				thisToggle = contThread;
+			}
+
 			RESUtils.click(thisToggle);
 		}
 	},
 	toggleExpando: function() {
-		var selectedThing = modules['selectedEntry'].selectedThing();
-		var thisExpando = selectedThing && selectedThing.querySelector('.expando-button');
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+
+		var thisExpando = selected.entry.querySelector('.expando-button');
 		if (thisExpando) {
 			RESUtils.click(thisExpando);
 			if (this.options.scrollOnExpando.value) {
-				var thisXY = RESUtils.getXYpos(selectedThing);
+				var thisXY = RESUtils.getXYpos(selected.thing);
 				RESUtils.scrollTo(0, thisXY.y);
 			}
 		}
 	},
 	imageResize: function(factor) {
-		var images = $(modules['selectedEntry'].selectedThing()).find('.RESImage, .madeVisible video'),
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+
+		var images = $(selected.entry).find('.RESImage, .madeVisible video'),
 			thisWidth;
 
 		for (var i = 0, len = images.length; i < len; i++) {
@@ -1046,13 +1052,19 @@ modules['keyboardNav'] = {
 		modules['showImages'].moveMedia(images[mostVisible], deltaX, deltaY);
 	},
 	previousGalleryImage: function() {
-		var previousButton = modules['selectedEntry'].selected().querySelector('.RESGalleryControls .previous');
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+
+		var previousButton = selected.entry.querySelector('.RESGalleryControls .previous');
 		if (previousButton) {
 			RESUtils.click(previousButton);
 		}
 	},
 	nextGalleryImage: function() {
-		var nextButton = modules['selectedEntry'].selected().querySelector('.RESGalleryControls .next');
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+
+		var nextButton = selected.entry.querySelector('.RESGalleryControls .next');
 		if (nextButton) {
 			RESUtils.click(nextButton);
 		}
@@ -1064,7 +1076,10 @@ modules['keyboardNav'] = {
 		}
 	},
 	toggleAllExpandos: function() {
-		var thisExpandos = modules['selectedEntry'].selected().querySelectorAll('.expando-button');
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+
+		var thisExpandos = selected.entry.querySelectorAll('.expando-button');
 		if (thisExpandos) {
 			for (var i = 0, len = thisExpandos.length; i < len; i++) {
 				RESUtils.click(thisExpandos[i]);
@@ -1072,7 +1087,10 @@ modules['keyboardNav'] = {
 		}
 	},
 	followLink: function(newWindow) {
-		var thisA = modules['selectedEntry'].selected().querySelector('a.title');
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+
+		var thisA = selected.entry.querySelector('a.title');
 		var thisHREF = thisA.href;
 		if (thisHREF.substring(0, 2) === '//') {
 			thisHREF = location.protocol + thisHREF;
@@ -1101,7 +1119,8 @@ modules['keyboardNav'] = {
 	followPermalink: function(newWindow) {
 		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
-		var thisA = selected.querySelector('a.bylink');
+
+		var thisA = selected.entry.querySelector('a.bylink');
 		var thisHREF = thisA.getAttribute('href');
 		if (newWindow) {
 			var button = (this.options.followLinkNewTabFocus.value) ? 0 : 1,
@@ -1119,7 +1138,8 @@ modules['keyboardNav'] = {
 	followComments: function(newWindow) {
 		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
-		var thisA = selected.querySelector('a.comments'),
+
+		var thisA = selected.entry.querySelector('a.comments'),
 			thisHREF = thisA.getAttribute('href');
 		if (newWindow) {
 			var button = (this.options.followLinkNewTabFocus.value) ? 0 : 1,
@@ -1139,20 +1159,19 @@ modules['keyboardNav'] = {
 		if (!selected) return;
 
 		// find the [l+c] link and click it...
-		var lcLink = selected.querySelector('.redditSingleClick');
+		var lcLink = selected.entry.querySelector('.redditSingleClick');
 		RESUtils.mousedown(lcLink, background);
 
 	},
 	upVote: function(preventToggle) {
 		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
-		// TODO
 
 		var upVoteButton;
 		if (selected.previousSibling.tagName === 'A') {
-			upVoteButton = selected.previousSibling.previousSibling.querySelector('div.up') || this.keyboardLinks[this.activeIndex].previousSibling.previousSibling.querySelector('div.upmod');
+			upVoteButton = selected.entry.previousSibling.previousSibling.querySelector('div.up') || this.keyboardLinks[this.activeIndex].previousSibling.previousSibling.querySelector('div.upmod');
 		} else {
-			upVoteButton = selected.previousSibling.querySelector('div.up') || this.keyboardLinks[this.activeIndex].previousSibling.querySelector('div.upmod');
+			upVoteButton = selected.entry.previousSibling.querySelector('div.up') || this.keyboardLinks[this.activeIndex].previousSibling.querySelector('div.upmod');
 		}
 
 		if (!upVoteButton) {
@@ -1167,7 +1186,7 @@ modules['keyboardNav'] = {
 			}
 		}
 
-		var link = RESUtils.isPageType('linklisting', 'profile');
+		var link = RESUtils.isPageType('linklist', 'profile');
 		if (link && this.options.onVoteMoveDown.value || !link && this.options.onVoteCommentMoveDown.value) {
 			this.moveDown();
 		}
@@ -1179,9 +1198,9 @@ modules['keyboardNav'] = {
 		//TODO
 		var downVoteButton;
 		if (selected.previousSibling.tagName === 'A') {
-			downVoteButton = selected.previousSibling.previousSibling.querySelector('div.down') || this.keyboardLinks[this.activeIndex].previousSibling.previousSibling.querySelector('div.downmod');
+			downVoteButton = selected.entry.previousSibling.previousSibling.querySelector('div.down') || this.keyboardLinks[this.activeIndex].previousSibling.previousSibling.querySelector('div.downmod');
 		} else {
-			downVoteButton = selected.previousSibling.querySelector('div.down') || this.keyboardLinks[this.activeIndex].previousSibling.querySelector('div.downmod');
+			downVoteButton = selected.entry.previousSibling.querySelector('div.down') || this.keyboardLinks[this.activeIndex].previousSibling.querySelector('div.downmod');
 		}
 
 		if (!downVoteButton) {
@@ -1196,7 +1215,7 @@ modules['keyboardNav'] = {
 			}
 		}
 
-		var link = RESUtils.isPageType('linklisting', 'profile');
+		var link = RESUtils.isPageType('linklist', 'profile');
 		if (link && this.options.onVoteMoveDown.value || !link && this.options.onVoteCommentMoveDown.value) {
 			this.moveDown();
 		}
@@ -1205,7 +1224,7 @@ modules['keyboardNav'] = {
 		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
 
-		var saveLink = selected.querySelector('.link-save-button a') || selected.querySelector('.link-unsave-button a');
+		var saveLink = selected.event.querySelector('.link-save-button a') || selected.querySelector('.link-unsave-button a');
 		if (saveLink) {
 			RESUtils.click(saveLink);
 		}
@@ -1214,7 +1233,7 @@ modules['keyboardNav'] = {
 		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
 
-		var saveComment = selected.querySelector('.comment-save-button > a');
+		var saveComment = selected.event.querySelector('.comment-save-button > a');
 		if (saveComment) {
 			RESUtils.click(saveComment);
 		}
@@ -1223,7 +1242,7 @@ modules['keyboardNav'] = {
 		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
 
-		var saveComment = selected.querySelector('.saveComments, .unsaveComments');
+		var saveComment = selected.event.querySelector('.saveComments, .unsaveComments');
 		if (saveComment) {
 			RESUtils.click(saveComment);
 			modules['saveComments'].showEducationalNotification();
@@ -1232,13 +1251,12 @@ modules['keyboardNav'] = {
 	reply: function() {
 		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
-		var selectedThing = modules['selectedEntry'].selectedThing();
 
-		if (selectedThing.classList.contains('link') || (!RESUtils.isPageType('comments'))) {
-			if (RESUtils.isPageType('comments') && selectedThing.classList.contains('link') && (location.href.indexOf('/message/') === -1)) {
+		if (selected.thing.classList.contains('link') || (!RESUtils.isPageType('comments'))) {
+			if (RESUtils.isPageType('comments') && selected.thing.classList.contains('link') && (location.href.indexOf('/message/') === -1)) {
 				$('.usertext-edit textarea:first').focus();
 			} else {
-				var commentButtons = selected.querySelectorAll('ul.buttons > li > a');
+				var commentButtons = selected.entry.querySelectorAll('ul.buttons > li > a');
 				for (var i = 0, len = commentButtons.length; i < len; i++) {
 					if (commentButtons[i].textContent === 'reply') {
 						RESUtils.click(commentButtons[i]);
@@ -1251,7 +1269,7 @@ modules['keyboardNav'] = {
 				firstCommentBox.focus();
 			} else {
 				// uh oh, we must be in a subpage, there is no first comment box. The user probably wants to reply to the OP. Let's take them to the comments page.
-				var commentButton = selected.querySelector('ul.buttons > li > a.comments');
+				var commentButton = selected.entry.querySelector('ul.buttons > li > a.comments');
 				location.href = commentButton.getAttribute('href');
 			}
 		}
@@ -1383,11 +1401,14 @@ modules['keyboardNav'] = {
 			}
 		}
 	},
-	getCommentLinks: function(obj) {
-		if (!obj) {
-			obj = modules['selectedEntry'].selected();
+	getCommentLinks: function(entry) {
+		if (!entry) {
+			var selected = modules['selectedEntry'].selected();
+			if (!selected) return;
+
+			entry = selected && selected.entry;
 		}
-		var links = obj.querySelectorAll('div.md a:not(.expando-button):not(.madeVisible):not(.toggleImage):not(.noKeyNav):not([href^="javascript:"]):not([href="#"])');
+		var links = entry.querySelectorAll('div.md a:not(.expando-button):not(.madeVisible):not(.toggleImage):not(.noKeyNav):not([href^="javascript:"]):not([href="#"])');
 
 		links = Array.prototype.filter.call(links, function(link) { return !RESUtils.isCommentCode(link); });
 

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -794,6 +794,8 @@ modules['keyboardNav'] = {
 		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
 
+		newWindow = typeof newWindow === "boolean" ? newWindow : undefined;
+
 		// find the subreddit link and click it...
 		var srLink = selected.entry.querySelector('A.subreddit');
 		if (srLink) {
@@ -1015,10 +1017,12 @@ modules['keyboardNav'] = {
 		}
 	},
 	imageSizeUp: function(fineControl) {
+		fineControl = typeof fineControl === "boolean" ? background : undefined;
 		var factor = (fineControl) ? 50 : 150;
 		this.imageResize(factor);
 	},
 	imageSizeDown: function(fineControl) {
+		fineControl = typeof fineControl === "boolean" ? background : undefined;
 		var factor = (fineControl) ? -50 : -150;
 		this.imageResize(factor);
 	},
@@ -1092,6 +1096,7 @@ modules['keyboardNav'] = {
 	followLink: function(newWindow) {
 		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
+		newWindow = typeof newWindow === "boolean" ? newWindow : undefined;
 
 		var thisA = selected.entry.querySelector('a.title');
 		var thisHREF = thisA.href;
@@ -1160,6 +1165,7 @@ modules['keyboardNav'] = {
 	followLinkAndComments: function(background) {
 		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
+		background = typeof background === "boolean" ? background : undefined;
 
 		// find the [l+c] link and click it...
 		var lcLink = selected.entry.querySelector('.redditSingleClick');
@@ -1169,6 +1175,7 @@ modules['keyboardNav'] = {
 	upVote: function(preventToggle) {
 		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
+		preventToggle = typeof preventToggle === "boolean" ? preventToggle : undefined;
 
 		var upVoteButton;
 		if (selected.entry.previousSibling.tagName === 'A') {
@@ -1197,6 +1204,7 @@ modules['keyboardNav'] = {
 	downVote: function(preventToggle) {
 		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
+		preventToggle = typeof preventToggle === "boolean" ? preventToggle : undefined;
 
 		var downVoteButton;
 		if (selected.entry.previousSibling.tagName === 'A') {
@@ -1331,6 +1339,7 @@ modules['keyboardNav'] = {
 		if ((this.options.useGoMode.value) && (!this.goModeActive)) {
 			return;
 		}
+		newWindow = typeof newWindow === "boolean" ? newWindow : undefined;
 		this.hideGoModePanel();
 		var thisHREF = location.protocol + '//' + location.hostname + '/message/inbox/';
 		modules['keyboardNav'].navigateTo(newWindow, thisHREF);
@@ -1339,6 +1348,7 @@ modules['keyboardNav'] = {
 		if ((this.options.useGoMode.value) && (!this.goModeActive)) {
 			return;
 		}
+		newWindow = typeof newWindow === "boolean" ? newWindow : undefined;
 		this.hideGoModePanel();
 		var thisHREF = location.protocol + '//' + location.hostname + '/message/moderator/';
 		modules['keyboardNav'].navigateTo(newWindow, thisHREF);
@@ -1347,6 +1357,7 @@ modules['keyboardNav'] = {
 		if ((this.options.useGoMode.value) && (!this.goModeActive)) {
 			return;
 		}
+		newWindow = typeof newWindow === "boolean" ? newWindow : undefined;
 		this.hideGoModePanel();
 		var thisHREF = location.protocol + '//' + location.hostname + '/user/' + RESUtils.loggedInUser();
 		modules['keyboardNav'].navigateTo(newWindow, thisHREF);
@@ -1355,6 +1366,7 @@ modules['keyboardNav'] = {
 		if ((this.options.useGoMode.value) && (!this.goModeActive)) {
 			return;
 		}
+		subreddit = typeof subreddit === "boolean" ? subreddit : undefined;
 		this.hideGoModePanel();
 
 		if (subreddit && !RESUtils.currentSubreddit()) {
@@ -1368,6 +1380,7 @@ modules['keyboardNav'] = {
 		location.href = newhref;
 	},
 	nextPage: function(override) {
+		override = typeof override === "boolean" ? override : undefined;
 		if (override !== true && this.options.useGoMode.value && !this.goModeActive) {
 			return;
 		}

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1047,8 +1047,8 @@ modules['keyboardNav'] = {
 		if ((document.activeElement.tagName === 'BODY') && (konamitest)) {
 			var callbacks = modules['keyboardNav'].getCommandsForKeyEvent(e);
 			if (callbacks) {
-				e.preventDefault();
 				callbacks.fire(e);
+				return true;
 			}
 		}
 	},

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -52,11 +52,6 @@ modules['keyboardNav'] = {
 			advanced: true,
 			dependsOn: 'addFocusBorder'
 		},
-		mediaBrowseMode: {
-			type: 'boolean',
-			value: true,
-			description: 'If media is open on the currently selected post when moving up/down one post, open media on the next post.'
-		},
 		scrollOnExpando: {
 			type: 'boolean',
 			value: true,

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -599,6 +599,16 @@ modules['keyboardNav'] = {
 			modules['keyboardNav'].options[commandName],
 			spec);
 	},
+	promptLogin: function() {
+		if (!RESUtils.loggedInUser()) {
+			var loginButton = document.querySelector('#header .login-required');
+			if (loginButton) {
+				RESUtils.click(loginButton);
+			}
+
+			return true;
+		}
+	},
 	updateKeyFocus: function(event) {
 		// we can't stop propagation because it breaks other buttons, so instead
 		// we will throttle this to only run once every 100ms. This prevents the
@@ -1178,6 +1188,7 @@ modules['keyboardNav'] = {
 
 	},
 	upVote: function(preventToggle) {
+		if (modules['keyboardNav'].promptLogin()) return;
 		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
 		preventToggle = typeof preventToggle === "boolean" ? preventToggle : undefined;
@@ -1207,6 +1218,7 @@ modules['keyboardNav'] = {
 		}
 	},
 	downVote: function(preventToggle) {
+		if (modules['keyboardNav'].promptLogin()) return;
 		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
 		preventToggle = typeof preventToggle === "boolean" ? preventToggle : undefined;
@@ -1236,6 +1248,7 @@ modules['keyboardNav'] = {
 		}
 	},
 	saveLink: function() {
+		if (modules['keyboardNav'].promptLogin()) return;
 		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
 
@@ -1245,6 +1258,7 @@ modules['keyboardNav'] = {
 		}
 	},
 	saveComment: function() {
+		if (modules['keyboardNav'].promptLogin()) return;
 		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
 
@@ -1264,6 +1278,8 @@ modules['keyboardNav'] = {
 		}
 	},
 	reply: function() {
+		if (modules['keyboardNav'].promptLogin()) return;
+
 		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
 

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -3,55 +3,6 @@ modules['keyboardNav'] = {
 	moduleName: 'Keyboard Navigation',
 	category: [ 'UI', 'Style' ],
 	options: {
-		// any configurable options you have go here...
-		// options must have a type and a value..
-		// valid types are: text, boolean (if boolean, value must be true or false)
-		// for example:
-		addFocusBGColor: {
-			type: 'boolean',
-			value: true,
-			description: 'Set a background color to highlight the currently focused element'
-		},
-		focusBGColor: {
-			type: 'color',
-			value: '#F0F3FC',
-			description: 'Background color of focused element',
-			advanced: true,
-			dependsOn: 'addFocusBGColor'
-		},
-		focusBGColorNight: {
-			type: 'color',
-			value: '#373737',
-			description: 'Background color of focused element in Night Mode',
-			advanced: true,
-			dependsOn: 'addFocusBGColor'
-		},
-		focusFGColorNight: {
-			type: 'color',
-			value: '#DDDDDD',
-			description: 'Foreground color of focused element in Night Mode',
-			advanced: true,
-			dependsOn: 'addFocusBGColor'
-		},
-		addFocusBorder: {
-			type: 'boolean',
-			value: true,
-			description: 'Set a border to highlight the currently focused element'
-		},
-		focusBorder: {
-			type: 'text',
-			value: '',
-			description: 'border style (e.g. 1px dashed gray) for focused element',
-			advanced: true,
-			dependsOn: 'addFocusBorder'
-		},
-		focusBorderNight: {
-			type: 'text',
-			value: '',
-			description: 'border style (e.g. 1px dashed gray) for focused element in Night Mode',
-			advanced: true,
-			dependsOn: 'addFocusBorder'
-		},
 		scrollOnExpando: {
 			type: 'boolean',
 			value: true,
@@ -583,15 +534,7 @@ modules['keyboardNav'] = {
 	},
 	beforeLoad: function() {
 		if ((this.isEnabled()) && (this.isMatchURL())) {
-			if (modules['keyboardNav'].options.addFocusBGColor.value) {
-				modules['keyboardNav'].addFocusBGColor();
-			}
-			if (modules['keyboardNav'].options.addFocusBorder.value) {
-				modules['keyboardNav'].addFocusBorder();
-			}
-
 			RESUtils.addCSS(' \
-				.entry { padding-right: 5px; } \
 				#keyHelp { display: none; position: fixed; height: 90%; overflow-y: auto; right: 20px; top: 20px; z-index: 1000; border: 2px solid #aaa; border-radius: 5px; width: 300px; padding: 5px; background-color: #fff; } \
 				#keyHelp th { font-weight: bold; padding: 2px; border-bottom: 1px dashed #ddd; } \
 				#keyHelp td { padding: 2px; border-bottom: 1px dashed #ddd; } \
@@ -656,62 +599,6 @@ modules['keyboardNav'] = {
 			modules['keyboardNav'].options[commandName],
 			spec);
 	},
-
-	// old style: .RES-keyNav-activeElement { '+borderType+': '+focusBorder+'; background-color: '+focusBGColor+'; } \
-	// this new pure CSS arrow will not work because to position it we must have .RES-keyNav-activeElement position relative, but that screws up image viewer's absolute positioning to
-	// overlay over the sidebar... yikes.
-	// .RES-keyNav-activeElement:after { content: ""; float: right; margin-right: -5px; border-color: transparent '+focusBorderColor+' transparent transparent; border-style: solid; border-width: 3px 4px 3px 0; } \
-
-	// why !important on .RES-keyNav-activeElement?  Because some subreddits are unfortunately using !important for no good reason on .entry divs...
-
-	addFocusBGColor: function() {
-		var focusFGColorNight, focusBGColor, focusBGColorNight;
-
-		if (typeof this.options.focusBGColor === 'undefined') {
-			focusBGColor = '#F0F3FC';
-		} else {
-			focusBGColor = this.options.focusBGColor.value;
-		}
-
-		if (!(this.options.focusBGColorNight.value)) {
-			focusBGColorNight = '#666';
-		} else {
-			focusBGColorNight = this.options.focusBGColorNight.value;
-		}
-		if (!(this.options.focusFGColorNight.value)) {
-			focusFGColorNight = '#DDD';
-		} else {
-			focusFGColorNight = this.options.focusFGColorNight.value;
-		}
-
-		RESUtils.addCSS('	\
-			.RES-keyNav-activeElement, .commentarea .RES-keyNav-activeElement .md, .commentarea .RES-keyNav-activeElement.entry .noncollapsed { background-color: ' + focusBGColor + ' !important; } \
-			.res-nightmode .RES-keyNav-activeElement, .res-nightmode .RES-keyNav-activeElement .usertext-body, .res-nightmode .RES-keyNav-activeElement .usertext-body .md, .res-nightmode .RES-keyNav-activeElement .usertext-body .md p, .res-nightmode .commentarea .RES-keyNav-activeElement .noncollapsed, .res-nightmode .RES-keyNav-activeElement .noncollapsed .md, .res-nightmode .RES-keyNav-activeElement .noncollapsed .md p { background-color: ' + focusBGColorNight + ' !important; color: ' + focusFGColorNight + ' !important;} \
-			.res-nightmode .RES-keyNav-activeElement a.title:first-of-type {color: ' + focusFGColorNight + ' !important; } \
-			');
-
-	},
-	addFocusBorder: function() {
-		var focusBorder, focusBorderNight;
-		var borderType = BrowserStrategy.getOutlineProperty() || 'outline';
-
-		if (typeof this.options.focusBorder === 'undefined') {
-			focusBorder = '';
-		} else {
-			focusBorder = borderType + ': ' + this.options.focusBorder.value + ';';
-		}
-		if (typeof this.options.focusBorderNight === 'undefined') {
-			focusBorderNight = '';
-		} else {
-			focusBorderNight = borderType + ': ' + this.options.focusBorderNight.value + ';';
-		}
-
-		RESUtils.addCSS('	\
-			.RES-keyNav-activeElement { ' + focusBorder + ' } \
-			.res-nightmode .RES-keyNav-activeElement { ' + focusBorderNight + ' } \
-			');
-	},
-
 	updateKeyFocus: function(event) {
 		// we can't stop propagation because it breaks other buttons, so instead
 		// we will throttle this to only run once every 100ms. This prevents the

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1035,6 +1035,8 @@ modules['keyboardNav'] = {
 				oldExpando.classList.contains('expanded') && !newExpando.classList.contains('expanded')) {
 				RESUtils.click(oldExpando);
 				RESUtils.click(newExpando);
+
+				return true;
 			}
 		}
 	},

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -325,7 +325,7 @@ modules['keyboardNav'] = {
 			include: [ 'linklist', 'profile' ],
 			value: [82, false, false, true], // shift-r
 			description: 'Go to subreddit of selected link in a new tab (link pages only)',
-			callback: function() { modules['keyboardNav'].followPermalink(true); }
+			callback: function() { modules['keyboardNav'].followSubreddit(true); }
 		},
 		inbox: {
 			value: [73, false, false, false], // i

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -174,12 +174,12 @@ modules['keyboardNav'] = {
 			description: 'Move down (next link or comment)'
 		},
 		moveTop: {
-			includes: [ 'linklist', 'profile', 'comments' ],
+			includes: [ 'linklist', 'profile' ],
 			value: [75, false, false, true], // shift-k
 			description: 'Move to top of list (on link pages)'
 		},
 		moveBottom: {
-			includes: [ 'linklist', 'profile', 'comments' ],
+			includes: [ 'linklist', 'profile' ],
 			value: [74, false, false, true], // shift-j
 			description: 'Move to bottom of list (on link pages)'
 		},
@@ -565,17 +565,17 @@ modules['keyboardNav'] = {
 			callback: function() { modules['keyboardNav'].commentLink(9); }
 		},
 		toggleCommentNavigator: {
-			include: 'comments',
+			includes: 'comments',
 			value: [78, false, false, false], // N
 			description: 'Open Comment Navigator'
 		},
 		commentNavigatorMoveUp: {
-			include: 'comments',
+			includes: 'comments',
 			value: [38, false, false, true], // shift+up arrow
 			description: 'Move up using Comment Navigator'
 		},
 		commentNavigatorMoveDown: {
-			include: 'comments',
+			includes: 'comments',
 			value: [40, false, false, true], // shift+down arrow
 			description: 'Move down using Comment Navigator'
 		}
@@ -1027,7 +1027,7 @@ modules['keyboardNav'] = {
 			var commands = $.each(this.options, function(name, option) {
 				if (option.type !== 'keycode') return;
 				if (!option.callback) return;
-				if (!RESUtils.matchesPageType(option.include, option.exclude)) return;
+				if (!RESUtils.matchesPageType(option.includes, option.excludes)) return;
 
 				var hash = RESUtils.hashKeyArray(option.value);
 				if (!lookup[hash]) {

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -296,7 +296,7 @@ modules['keyboardNav'] = {
 			callback: function() { modules['keyboardNav'].saveCommentRES(); }
 		},
 		reply: {
-			include: [ 'comments' ],
+			include: [ 'comments', 'inbox' ],
 			value: [82, false, false, false], // r
 			description: 'Reply to current comment (comment pages only)'
 		},
@@ -1267,26 +1267,26 @@ modules['keyboardNav'] = {
 		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
 
-		if (selected.thing.classList.contains('link') || (!RESUtils.isPageType('comments'))) {
-			if (RESUtils.isPageType('comments') && selected.thing.classList.contains('link') && (location.href.indexOf('/message/') === -1)) {
-				$('.usertext-edit textarea:first').focus();
-			} else {
-				var commentButtons = selected.entry.querySelectorAll('ul.buttons > li > a');
-				for (var i = 0, len = commentButtons.length; i < len; i++) {
-					if (commentButtons[i].textContent === 'reply') {
-						RESUtils.click(commentButtons[i]);
-					}
-				}
+		if (selected.thing.classList.contains('link') && RESUtils.isPageType('comments')) {
+			// Reply to OP, but only if a reply form is available
+			var target = $('.usertext-edit textarea[name=text]:first');
+			if (target.filter(':visible').length) {
+				target.focus();
+				return;
 			}
-		} else {
-			var firstCommentBox = document.querySelector('.commentarea textarea[name=text]');
-			if (firstCommentBox && $(firstCommentBox).is(':visible')) {
-				firstCommentBox.focus();
-			} else {
-				// uh oh, we must be in a subpage, there is no first comment box. The user probably wants to reply to the OP. Let's take them to the comments page.
-				var commentButton = selected.entry.querySelector('ul.buttons > li > a.comments');
-				location.href = commentButton.getAttribute('href');
-			}
+		}
+
+		// User can reply directly here, so open/focus the reply form
+		var replyButton = selected.entry.querySelector('.buttons a[onclick*=reply]');
+		if (replyButton) {
+			RESUtils.click(replyButton);
+			return;
+		}
+
+		// User cannot reply directly from this page, so go to where they can reply
+		var replyAt = selected.entry.querySelector('.buttons a.comments, .buttons a.bylink');
+		if (replyAt) {
+			RESUtils.click(replyAt);
 		}
 	},
 	navigateTo: function(newWindow, thisHREF) {

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -901,7 +901,7 @@ modules['keyboardNav'] = {
 
 		var current = $(selected.thing);
 
-		var target = current.prevAll('.thing').last()[0];
+		var target = current.prevAll('.thing').first()[0];
 		if (!target) {
 			target = current.parent().closest('.thing')[0];
 		}
@@ -918,7 +918,7 @@ modules['keyboardNav'] = {
 			current = $(selected.thing).closest('.thing');
 		}
 
-		var target = current.prevAll('.thing').last()[0];
+		var target = current.prevAll('.thing').first()[0];
 		if (!target) {
 			this._moveUp(current);
 		} else {

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -212,7 +212,10 @@ modules['keyboardNav'] = {
 			value: [13, false, false, true], // shift-enter
 			description: 'Follow link in new tab (link pages only)',
 			callback: function() {
-				if (!RESUtils.isPageType('comments') || modules['keyboardNav'].activeIndex === 0) {
+				var selectedThing = modules['selectedEntry'].selectedThing();
+				if (!selectedThing) return false;
+
+				if (!RESUtils.isPageType('comments') || selectedThing.classList.contains('link')) {
 					modules['keyboardNav'].followLink(true);
 				}
 			}
@@ -605,13 +608,6 @@ modules['keyboardNav'] = {
 					e.preventDefault();
 				}
 			}, true);
-			this.scanPageForKeyboardLinks();
-			// listen for new DOM nodes so that modules like autopager, never ending reddit, "load more comments" etc still get keyboard nav.
-			if (RESUtils.isPageType('comments')) {
-				RESUtils.watchForElement('newComments', modules['keyboardNav'].scanPageForNewKeyboardLinks);
-			} else {
-				RESUtils.watchForElement('siteTable', modules['keyboardNav'].scanPageForNewKeyboardLinks);
-			}
 
 			this.registerCommandLine();
 			this.registerSelectedThingWatcher();
@@ -622,14 +618,13 @@ modules['keyboardNav'] = {
 		modules['commandLine'].registerCommand(/\d+/, '[number] - navigates to the link with that number (comments pages) or rank (link pages)',
 			function(command, val, match) {},
 			function(command, val, match, e) {
+
 				if (RESUtils.isPageType('comments')) {
 					// comment link number? (integer)
 					modules['keyboardNav'].commentLink(parseInt(command, 10) - 1);
 				} else if (RESUtils.isPageType('linklist')) {
-					modules['keyboardNav'].keyUnfocus(modules['keyboardNav'].keyboardLinks[modules['keyboardNav'].activeIndex]);
-					modules['keyboardNav'].activeIndex = parseInt(command, 10) - 1;
-					modules['keyboardNav'].keyFocus(modules['keyboardNav'].keyboardLinks[modules['keyboardNav'].activeIndex]);
-					modules['keyboardNav'].followLink();
+					var targetRank = parseInt(command, 10);
+					modules['keyboardNav'].followLinkByRank(targetRank);
 				}
 			}
 		);
@@ -637,7 +632,7 @@ modules['keyboardNav'] = {
 
 	registerSelectedThingWatcher: function() {
 		var module = this;
-		modules['selectedThing'].addListener(function(newThing, lastThing) {
+		modules['selectedEntry'].addListener(function(newThing, lastThing) {
 			newThing && module.keyFocus(newThing);
 			lastThing && module.keyUnfocus(lastThing);
 		});
@@ -716,63 +711,7 @@ modules['keyboardNav'] = {
 			.res-nightmode .RES-keyNav-activeElement { ' + focusBorderNight + ' } \
 			');
 	},
-	scanPageForNewKeyboardLinks: function() {
-		modules['keyboardNav'].scanPageForKeyboardLinks(true);
-	},
 
-	scanPageForKeyboardLinks: function(isNew) {
-		if (typeof isNew === 'undefined') {
-			isNew = false;
-		}
-		var siteTable = document.getElementById('siteTable');
-		// check if we're on a link listing (regular page, subreddit page, etc) or comments listing...
-		var pageType = RESUtils.pageType();
-		switch (pageType) {
-			case 'linklist':
-			case 'profile':
-				// get all links into an array...
-				var stMultiCheck = document.querySelectorAll('#siteTable');
-				// stupid sponsored links create a second div with ID of sitetable (bad reddit! you should never have 2 IDs with the same name! naughty, naughty reddit!)
-				if (stMultiCheck.length === 2) {
-					siteTable = stMultiCheck[1];
-				}
-				if (siteTable) {
-					this.keyboardLinks = document.body.querySelectorAll('div.linklisting .entry');
-					if (!isNew) {
-						if ((this.keyboardNavLastIndexCache[location.href]) && (this.keyboardNavLastIndexCache[location.href].index > 0)) {
-							this.activeIndex = this.keyboardNavLastIndexCache[location.href].index;
-						} else {
-							this.activeIndex = 0;
-						}
-						if ((this.keyboardNavLastIndexCache[location.href]) && (this.keyboardNavLastIndexCache[location.href].index >= this.keyboardLinks.length)) {
-							this.activeIndex = 0;
-						}
-					}
-				}
-				break;
-			case 'comments':
-				// get all links into an array...
-				this.keyboardLinks = document.body.querySelectorAll('#siteTable .entry, div.content > div.commentarea .entry');
-				if (!isNew) {
-					this.activeIndex = 0;
-				}
-				break;
-			case 'inbox':
-				if (siteTable) {
-					this.keyboardLinks = siteTable.querySelectorAll('.entry');
-					this.activeIndex = 0;
-				}
-				break;
-		}
-		// wire up keyboard links for mouse clicky selecty goodness...
-		if ((typeof this.keyboardLinks !== 'undefined') && (this.options.clickFocus.value)) {
-			for (var i = 0, len = this.keyboardLinks.length; i < len; i++) {
-				$(this.keyboardLinks[i]).parent().data('keyIndex', i)
-					.on('click', modules['keyboardNav'].updateKeyFocus);
-			}
-			this.keyFocus(this.keyboardLinks[this.activeIndex]);
-		}
-	},
 	updateKeyFocus: function(event) {
 		// we can't stop propagation because it breaks other buttons, so instead
 		// we will throttle this to only run once every 100ms. This prevents the
@@ -782,7 +721,7 @@ modules['keyboardNav'] = {
 			modules['keyboardNav'].updateKeyFocusThrottle = setTimeout(function() {
 				delete modules['keyboardNav'].updateKeyFocusThrottle;
 			},100);
-			modules['selectedThing'].select(event.currentTarget);
+			modules['selectedEntry'].select(event.currentTarget);
 		}
 	},
 	recentKey: function() {
@@ -983,219 +922,164 @@ modules['keyboardNav'] = {
 			}
 		}
 	},
-	moveUp: function() {
-		if (this.activeIndex > 0) {
-			this.fromKey = true;
-			this.keyUnfocus(this.keyboardLinks[this.activeIndex]);
-			this.activeIndex--;
-			var thisXY = RESUtils.getXYpos(this.keyboardLinks[this.activeIndex]);
-			// skip over hidden elements...
-			while ((thisXY.x === 0) && (thisXY.y === 0) && (this.activeIndex > 0)) {
-				this.activeIndex--;
-				thisXY = RESUtils.getXYpos(this.keyboardLinks[this.activeIndex]);
-			}
-			this.keyFocus(this.keyboardLinks[this.activeIndex]);
-			if ((!(RESUtils.elementInViewport(this.keyboardLinks[this.activeIndex]))) || (this.options.scrollStyle.value === 'top')) {
-				RESUtils.scrollTo(0, thisXY.y);
-			}
 
-			modules['keyboardNav'].recentKey();
-		}
+	moveUp: function(obj) {
+		var current = obj.classList ? obj : modules['selectedEntry'].selectedThing();
+		var things = modules['selectedEntry'].selectableThings();
+		var index = things.index(current);
+
+		var targetIndex = Math.max(1, index) - 1;
+
+		var target = things[targetIndex];
+		modules['selectedEntry'].select(target);
+
+		modules['keyboardNav'].recentKey();
 	},
-	moveDown: function() {
-		if (this.activeIndex < this.keyboardLinks.length - 1) {
-			this.fromKey = true;
-			this.keyUnfocus(this.keyboardLinks[this.activeIndex]);
-			this.activeIndex++;
-			var thisXY = RESUtils.getXYpos(this.keyboardLinks[this.activeIndex]);
-			// skip over hidden elements...
-			while ((thisXY.x === 0) && (thisXY.y === 0) && (this.activeIndex < this.keyboardLinks.length - 1)) {
-				this.activeIndex++;
-				thisXY = RESUtils.getXYpos(this.keyboardLinks[this.activeIndex]);
-			}
-			this.keyFocus(this.keyboardLinks[this.activeIndex]);
-			/*
-			if ((!(RESUtils.elementInViewport(this.keyboardLinks[this.activeIndex]))) || (this.options.scrollTop.value)) {
-				RESUtils.scrollTo(0,thisXY.y);
-			}
-			*/
-			if (this.options.scrollStyle.value === 'top') {
-				RESUtils.scrollTo(0, thisXY.y);
-			} else if ((!(RESUtils.elementInViewport(this.keyboardLinks[this.activeIndex])))) {
-				var thisHeight = this.keyboardLinks[this.activeIndex].offsetHeight;
-				if (this.options.scrollStyle.value === 'page') {
-					RESUtils.scrollTo(0, thisXY.y);
-				} else {
-					RESUtils.scrollTo(0, thisXY.y - window.innerHeight + thisHeight + 5);
-				}
-			}
-			// note: we don't want to go to the next page if we're on the dashboard...
-			if (
-				(!RESUtils.currentSubreddit('dashboard')) &&
-				RESUtils.isPageType('linklist') &&
-				(this.activeIndex === (this.keyboardLinks.length - 1) &&
-				modules['neverEndingReddit'].isEnabled() &&
-				modules['neverEndingReddit'].options.autoLoad.value)
-			) {
-				this.nextPage(true);
-			}
-			modules['keyboardNav'].recentKey();
+	moveDown: function(obj) {
+		var current = obj.classList ? obj : modules['selectedEntry'].selectedThing();
+
+		var current = modules['selectedEntry'].selectedThing();
+		var things = modules['selectedEntry'].selectableThings();
+		var index = things.index(current);
+
+		var targetIndex = Math.min(index, things.length - 2) + 1;
+
+		var target = things[targetIndex];
+		modules['selectedEntry'].select(target);
+
+		// note: we don't want to go to the next page if we're on the dashboard...
+		if (
+			(!RESUtils.currentSubreddit('dashboard')) &&
+			RESUtils.isPageType('linklist') &&
+			$(target).is('.thing:nth-last-of-type(1), .thing:last-of-type') &&
+			modules['neverEndingReddit'].isEnabled() &&
+			modules['neverEndingReddit'].options.autoLoad.value
+		) {
+			this.nextPage(true);
 		}
+		modules['keyboardNav'].recentKey();
 	},
 	moveTop: function() {
-		this.keyUnfocus(this.keyboardLinks[this.activeIndex]);
-		this.activeIndex = 0;
-		this.keyFocus(this.keyboardLinks[this.activeIndex]);
-		var thisXY = RESUtils.getXYpos(this.keyboardLinks[this.activeIndex]);
-		if (!(RESUtils.elementInViewport(this.keyboardLinks[this.activeIndex]))) {
-			RESUtils.scrollTo(0, thisXY.y);
-		}
+		var things = modules['selectedEntry'].selectableThings();
+		var target = things.first();
+		modules['selectedEntry'].select(target);
 		modules['keyboardNav'].recentKey();
 	},
 	moveBottom: function() {
-		this.keyUnfocus(this.keyboardLinks[this.activeIndex]);
-		this.activeIndex = this.keyboardLinks.length - 1;
-		this.keyFocus(this.keyboardLinks[this.activeIndex]);
-		var thisXY = RESUtils.getXYpos(this.keyboardLinks[this.activeIndex]);
-		if (!(RESUtils.elementInViewport(this.keyboardLinks[this.activeIndex]))) {
-			RESUtils.scrollTo(0, thisXY.y);
-		}
+		var things = modules['selectedEntry'].selectableThings();
+		var target = things.last();
+		modules['selectedEntry'].select(target, { scrollToTop: true });
 		modules['keyboardNav'].recentKey();
 	},
 	moveDownSibling: function() {
-		if (this.activeIndex < this.keyboardLinks.length - 1) {
-			this.keyUnfocus(this.keyboardLinks[this.activeIndex]);
-			var thisParent = this.keyboardLinks[this.activeIndex].parentNode;
-			var childCount = thisParent.querySelectorAll('.entry').length;
-			this.activeIndex += childCount;
-			// skip over hidden elements...
-			var thisXY = RESUtils.getXYpos(this.keyboardLinks[this.activeIndex]);
-			while ((thisXY.x === 0) && (thisXY.y === 0) && (this.activeIndex < this.keyboardLinks.length - 1)) {
-				this.activeIndex++;
-				thisXY = RESUtils.getXYpos(this.keyboardLinks[this.activeIndex]);
+		var selected = modules['selectedEntry'].selectedThing();
+		if (!selected) return;
+		var current = $(selected);
+
+		var target;
+		do {
+			target = current.nextAll('.thing').first()[0];
+			if (!target) {
+				current = current.parent().closest('.thing');
 			}
-			if (RESUtils.isPageType('linklist', 'profile')) {
-				this.setKeyIndex();
-			}
-			this.keyFocus(this.keyboardLinks[this.activeIndex]);
-			if (!(RESUtils.elementInViewport(this.keyboardLinks[this.activeIndex]))) {
-				RESUtils.scrollTo(0, thisXY.y);
-			}
-		}
+		} while (!target && current.length);
+
+		modules['selectedEntry'].select(target, { scrollToTop: true });
 		modules['keyboardNav'].recentKey();
 	},
 	moveUpSibling: function() {
-		if (this.activeIndex < this.keyboardLinks.length - 1) {
-			this.keyUnfocus(this.keyboardLinks[this.activeIndex]);
-			var thisParent = this.keyboardLinks[this.activeIndex].parentNode,
-				childCount;
-			if (thisParent.previousSibling !== null) {
-				childCount = thisParent.previousSibling.previousSibling.querySelectorAll('.entry').length;
-			} else {
-				childCount = 1;
-			}
-			this.activeIndex -= childCount;
-			// skip over hidden elements...
-			var thisXY = RESUtils.getXYpos(this.keyboardLinks[this.activeIndex]);
-			while ((thisXY.x === 0) && (thisXY.y === 0) && (this.activeIndex < this.keyboardLinks.length - 1)) {
-				this.activeIndex++;
-				thisXY = RESUtils.getXYpos(this.keyboardLinks[this.activeIndex]);
-			}
-			if (RESUtils.isPageType('linklist', 'profile')) {
-				this.setKeyIndex();
-			}
-			this.keyFocus(this.keyboardLinks[this.activeIndex]);
-			if (!(RESUtils.elementInViewport(this.keyboardLinks[this.activeIndex]))) {
-				RESUtils.scrollTo(0, thisXY.y);
-			}
+		var selected = modules['selectedEntry'].selectedThing();
+		if (!selected) return;
+		var current = $(selected);
+
+		var target = current.prevAll('.thing').last()[0];
+		if (!target) {
+			target = current.parent().closest('.thing')[0];
 		}
+
+		modules['selectedEntry'].select(target, { scrollToTop: true });
 		modules['keyboardNav'].recentKey();
 	},
 	moveUpThread: function() {
-		if ((this.activeIndex < this.keyboardLinks.length - 1) && (this.activeIndex > 1)) {
-			this.moveToTopComment();
+		var selected = modules['selectedEntry'].selectedThing();
+		if (!selected) return;
+
+		var current = $(selected).parents('.thing').last();
+		if (!current.length) {
+			current = $(selected).closest('.thing');
 		}
-		this.moveUpSibling();
+
+		var target = current.prevAll('.thing').last()[0];
+		if (!target) {
+			this.moveUp(current);
+		} else {
+			modules['selectedEntry'].select(target, { scrollToTop: true });
+			modules['keyboardNav'].recentKey();
+		}
 	},
 	moveDownThread: function() {
-		if ((this.activeIndex < this.keyboardLinks.length - 1) && (this.activeIndex > 1)) {
-			this.moveToTopComment();
+		var selected = modules['selectedEntry'].selectedThing();
+		if (!selected) return;
+
+		var current = $(selected).parents('.thing').last();
+		if (!current.length) {
+			current = $(selected).closest('.thing');
 		}
-		this.moveDownSibling();
+
+		var target = current.nextAll('.thing').first()[0];
+		if (!target) {
+			this.moveDown(current);
+		} else {
+			modules['selectedEntry'].select(target, { scrollToTop: true });
+			modules['keyboardNav'].recentKey();
+		}
 	},
 	moveToTopComment: function() {
-		if ((this.activeIndex < this.keyboardLinks.length - 1) && (this.activeIndex > 1)) {
-			var firstParent = this.keyboardLinks[this.activeIndex].parentNode;
-			//goes up to the root of the current thread
-			while (!firstParent.parentNode.parentNode.parentNode.classList.contains('content') && (firstParent !== null)) {
-				this.moveToParent();
-				firstParent = this.keyboardLinks[this.activeIndex].parentNode;
-			}
-		}
-	},
-	moveToParent: function() {
-		if ((this.activeIndex < this.keyboardLinks.length - 1) && (this.activeIndex > 1)) {
-			var firstParent = this.keyboardLinks[this.activeIndex].parentNode;
-			// check if we're at the top parent, first... if the great grandparent has a class of content, do nothing.
-			if (!firstParent.parentNode.parentNode.parentNode.classList.contains('content')) {
-				if (firstParent !== null) {
-					this.keyUnfocus(this.keyboardLinks[this.activeIndex]);
-					var $thisParent = $(firstParent).parent().parent().prev().parent();
-					var newKeyIndex = parseInt($thisParent.data('keyIndex'), 10);
-					this.activeIndex = newKeyIndex;
-					this.keyFocus(this.keyboardLinks[this.activeIndex]);
-					var thisXY = RESUtils.getXYpos(this.keyboardLinks[this.activeIndex]);
-					if (!(RESUtils.elementInViewport(this.keyboardLinks[this.activeIndex]))) {
-						RESUtils.scrollTo(0, thisXY.y);
-					}
-				}
-			}
-		}
+		var target = $(modules['selectedEntry'].selectedThing()).parents('.thing').last();
+
+		modules['selectedEntry'].select(target, { scrollToTop: true });
 		modules['keyboardNav'].recentKey();
 	},
+	moveToParent: function() {
+		var selected = modules['selectedEntry'].selectedThing();
+		var parent = $(selected).parent().closest('.thing');
+		modules['selectedEntry'].select(parent);
+	},
 	showParents: function() {
-		if ((this.activeIndex < this.keyboardLinks.length - 1) && (this.activeIndex > 1)) {
-			var firstParent = this.keyboardLinks[this.activeIndex].parentNode;
-			if (firstParent !== null) {
-				var button = $(this.keyboardLinks[this.activeIndex]).find('.buttons :not(:first-child) .bylink:first').get(0);
-				modules['hover'].begin(button, {}, modules['showParent'].showCommentHover, {});
-			}
+		var selected = modules['selectedEntry'].selectedThing();
+		var button = selected.querySelector('.entry').querySelector('.buttons .bylink[href^="#"]');
+		if (button) {
+			modules['hover'].begin(button, {}, modules['showParent'].showCommentHover, {});
 		}
 	},
 	toggleChildren: function() {
-		if (this.activeIndex === 0) {
+		var selected = modules['selectedEntry'].selectedThing();
+		if (selected.classList.contains('link')) {
 			// Ahh, we're not in a comment, but in the main story... that key should follow the link.
 			this.followLink();
+			return;
 		} else {
 			// find out if this is a collapsed or uncollapsed view...
-			var thisCollapsed = this.keyboardLinks[this.activeIndex].querySelector('div.collapsed'),
-				thisNonCollapsed = this.keyboardLinks[this.activeIndex].querySelector('div.noncollapsed'),
+			var thisCollapsed = selected.querySelector('div.collapsed'),
+				thisNonCollapsed = selected.querySelector('div.noncollapsed'),
 				thisToggle, moreComments, contThread;
 
 			// Detecting and logic for new version of comment threads
 			if (!thisCollapsed && !thisNonCollapsed) {
-				var currentLink = this.keyboardLinks[this.activeIndex];
-				var comment = this.keyboardLinks[this.activeIndex].parentNode;
-
-				thisToggle = comment.querySelector('a.expand');
+				thisToggle = selected.querySelector('a.expand');
 
 				// check if this is a "show more comments" box, or just contracted content...
-				moreComments = currentLink.querySelector('span.morecomments > a');
+				moreComments = selected.querySelector('span.morecomments > a');
 				if (moreComments) {
 					thisToggle = moreComments;
 				}
 
 				// 'continue this thread' links
-				contThread = currentLink.querySelector('span.deepthread > a');
+				contThread = selected.querySelector('span.deepthread > a');
 				if (contThread) {
 					thisToggle = contThread;
 				}
-
-				RESUtils.click(thisToggle);
-				return;
-			}
-
-			if (thisCollapsed.style.display !== 'none') {
+			} else if (thisCollapsed.style.display !== 'none') {
 				thisToggle = thisCollapsed.querySelector('a.expand');
 			} else {
 				// check if this is a "show more comments" box, or just contracted content...
@@ -1215,17 +1099,18 @@ modules['keyboardNav'] = {
 		}
 	},
 	toggleExpando: function() {
-		var thisExpando = this.keyboardLinks[this.activeIndex].querySelector('.expando-button');
+		var selectedThing = modules['selectedEntry'].selectedThing();
+		var thisExpando = selectedThing && selectedThing.querySelector('.expando-button');
 		if (thisExpando) {
 			RESUtils.click(thisExpando);
 			if (this.options.scrollOnExpando.value) {
-				var thisXY = RESUtils.getXYpos(this.keyboardLinks[this.activeIndex]);
+				var thisXY = RESUtils.getXYpos(selectedThing);
 				RESUtils.scrollTo(0, thisXY.y);
 			}
 		}
 	},
 	imageResize: function(factor) {
-		var images = $(this.activeElement).find('.RESImage, .madeVisible video'),
+		var images = $(modules['selectedEntry'].selectedThing()).find('.RESImage, .madeVisible video'),
 			thisWidth;
 
 		for (var i = 0, len = images.length; i < len; i++) {
@@ -1274,13 +1159,13 @@ modules['keyboardNav'] = {
 		modules['showImages'].moveMedia(images[mostVisible], deltaX, deltaY);
 	},
 	previousGalleryImage: function() {
-		var previousButton = this.keyboardLinks[this.activeIndex].querySelector('.RESGalleryControls .previous');
+		var previousButton = modules['selectedEntry'].selected().querySelector('.RESGalleryControls .previous');
 		if (previousButton) {
 			RESUtils.click(previousButton);
 		}
 	},
 	nextGalleryImage: function() {
-		var nextButton = this.keyboardLinks[this.activeIndex].querySelector('.RESGalleryControls .next');
+		var nextButton = modules['selectedEntry'].selected().querySelector('.RESGalleryControls .next');
 		if (nextButton) {
 			RESUtils.click(nextButton);
 		}
@@ -1292,7 +1177,7 @@ modules['keyboardNav'] = {
 		}
 	},
 	toggleAllExpandos: function() {
-		var thisExpandos = this.keyboardLinks[this.activeIndex].querySelectorAll('.expando-button');
+		var thisExpandos = modules['selectedEntry'].selected().querySelectorAll('.expando-button');
 		if (thisExpandos) {
 			for (var i = 0, len = thisExpandos.length; i < len; i++) {
 				RESUtils.click(thisExpandos[i]);
@@ -1300,7 +1185,7 @@ modules['keyboardNav'] = {
 		}
 	},
 	followLink: function(newWindow) {
-		var thisA = this.keyboardLinks[this.activeIndex].querySelector('a.title');
+		var thisA = modules['selectedEntry'].selected().querySelector('a.title');
 		var thisHREF = thisA.href;
 		if (thisHREF.substring(0, 2) === '//') {
 			thisHREF = location.protocol + thisHREF;
@@ -1318,8 +1203,18 @@ modules['keyboardNav'] = {
 			location.href = thisHREF;
 		}
 	},
+	followLinkByRank: function(num) {
+		var target = modules['selectableEntry'].selectableThings().filter(function() {
+			var rank = (rank = this.querySelector('.rank')) && parseInt(rank.textContent, 10);
+			return rank === num;
+		});
+		modules['keyboardNav'].select(target);
+		modules['keyboardNav'].followLink();
+	},
 	followPermalink: function(newWindow) {
-		var thisA = this.keyboardLinks[this.activeIndex].querySelector('a.bylink');
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+		var thisA = selected.querySelector('a.bylink');
 		var thisHREF = thisA.getAttribute('href');
 		if (newWindow) {
 			var button = (this.options.followLinkNewTabFocus.value) ? 0 : 1,
@@ -1335,7 +1230,9 @@ modules['keyboardNav'] = {
 		}
 	},
 	followComments: function(newWindow) {
-		var thisA = this.keyboardLinks[this.activeIndex].querySelector('a.comments'),
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+		var thisA = selected.querySelector('a.comments'),
 			thisHREF = thisA.getAttribute('href');
 		if (newWindow) {
 			var button = (this.options.followLinkNewTabFocus.value) ? 0 : 1,
@@ -1351,20 +1248,24 @@ modules['keyboardNav'] = {
 		}
 	},
 	followLinkAndComments: function(background) {
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+
 		// find the [l+c] link and click it...
-		var lcLink = this.keyboardLinks[this.activeIndex].querySelector('.redditSingleClick');
+		var lcLink = selected.querySelector('.redditSingleClick');
 		RESUtils.mousedown(lcLink, background);
+
 	},
 	upVote: function(preventToggle) {
-		if (typeof this.keyboardLinks[this.activeIndex] === 'undefined') {
-			return false;
-		}
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+		// TODO
 
 		var upVoteButton;
-		if (this.keyboardLinks[this.activeIndex].previousSibling.tagName === 'A') {
-			upVoteButton = this.keyboardLinks[this.activeIndex].previousSibling.previousSibling.querySelector('div.up') || this.keyboardLinks[this.activeIndex].previousSibling.previousSibling.querySelector('div.upmod');
+		if (selected.previousSibling.tagName === 'A') {
+			upVoteButton = selected.previousSibling.previousSibling.querySelector('div.up') || this.keyboardLinks[this.activeIndex].previousSibling.previousSibling.querySelector('div.upmod');
 		} else {
-			upVoteButton = this.keyboardLinks[this.activeIndex].previousSibling.querySelector('div.up') || this.keyboardLinks[this.activeIndex].previousSibling.querySelector('div.upmod');
+			upVoteButton = selected.previousSibling.querySelector('div.up') || this.keyboardLinks[this.activeIndex].previousSibling.querySelector('div.upmod');
 		}
 
 		if (!upVoteButton) {
@@ -1385,15 +1286,15 @@ modules['keyboardNav'] = {
 		}
 	},
 	downVote: function(preventToggle) {
-		if (typeof this.keyboardLinks[this.activeIndex] === 'undefined') {
-			return false;
-		}
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
 
+		//TODO
 		var downVoteButton;
-		if (this.keyboardLinks[this.activeIndex].previousSibling.tagName === 'A') {
-			downVoteButton = this.keyboardLinks[this.activeIndex].previousSibling.previousSibling.querySelector('div.down') || this.keyboardLinks[this.activeIndex].previousSibling.previousSibling.querySelector('div.downmod');
+		if (selected.previousSibling.tagName === 'A') {
+			downVoteButton = selected.previousSibling.previousSibling.querySelector('div.down') || this.keyboardLinks[this.activeIndex].previousSibling.previousSibling.querySelector('div.downmod');
 		} else {
-			downVoteButton = this.keyboardLinks[this.activeIndex].previousSibling.querySelector('div.down') || this.keyboardLinks[this.activeIndex].previousSibling.querySelector('div.downmod');
+			downVoteButton = selected.previousSibling.querySelector('div.down') || this.keyboardLinks[this.activeIndex].previousSibling.querySelector('div.downmod');
 		}
 
 		if (!downVoteButton) {
@@ -1414,31 +1315,43 @@ modules['keyboardNav'] = {
 		}
 	},
 	saveLink: function() {
-		var saveLink = this.keyboardLinks[this.activeIndex].querySelector('.link-save-button a') || this.keyboardLinks[this.activeIndex].querySelector('.link-unsave-button a');
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+
+		var saveLink = selected.querySelector('.link-save-button a') || selected.querySelector('.link-unsave-button a');
 		if (saveLink) {
 			RESUtils.click(saveLink);
 		}
 	},
 	saveComment: function() {
-		var saveComment = this.keyboardLinks[this.activeIndex].querySelector('.comment-save-button > a');
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+
+		var saveComment = selected.querySelector('.comment-save-button > a');
 		if (saveComment) {
 			RESUtils.click(saveComment);
 		}
 	},
 	saveCommentRES: function() {
-		var saveComment = this.keyboardLinks[this.activeIndex].querySelector('.saveComments, .unsaveComments');
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+
+		var saveComment = selected.querySelector('.saveComments, .unsaveComments');
 		if (saveComment) {
 			RESUtils.click(saveComment);
 			modules['saveComments'].showEducationalNotification();
 		}
 	},
 	reply: function() {
-		// activeIndex = 0 means we're at the original post, not a comment
-		if ((this.activeIndex > 0) || (!RESUtils.isPageType('comments'))) {
-			if (RESUtils.isPageType('comments') && (this.activeIndex === 0) && (location.href.indexOf('/message/') === -1)) {
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+		var selectedThing = modules['selectedEntry'].selectedThing();
+
+		if (selectedThing.classList.contains('link') || (!RESUtils.isPageType('comments'))) {
+			if (RESUtils.isPageType('comments') && selectedThing.classList.contains('link') && (location.href.indexOf('/message/') === -1)) {
 				$('.usertext-edit textarea:first').focus();
 			} else {
-				var commentButtons = this.keyboardLinks[this.activeIndex].querySelectorAll('ul.buttons > li > a');
+				var commentButtons = selected.querySelectorAll('ul.buttons > li > a');
 				for (var i = 0, len = commentButtons.length; i < len; i++) {
 					if (commentButtons[i].textContent === 'reply') {
 						RESUtils.click(commentButtons[i]);
@@ -1451,7 +1364,7 @@ modules['keyboardNav'] = {
 				firstCommentBox.focus();
 			} else {
 				// uh oh, we must be in a subpage, there is no first comment box. The user probably wants to reply to the OP. Let's take them to the comments page.
-				var commentButton = this.keyboardLinks[this.activeIndex].querySelector('ul.buttons > li > a.comments');
+				var commentButton = selected.querySelector('ul.buttons > li > a.comments');
 				location.href = commentButton.getAttribute('href');
 			}
 		}
@@ -1585,7 +1498,7 @@ modules['keyboardNav'] = {
 	},
 	getCommentLinks: function(obj) {
 		if (!obj) {
-			obj = this.keyboardLinks[this.activeIndex];
+			obj = modules['selectedEntry'].selected();
 		}
 		var links = obj.querySelectorAll('div.md a:not(.expando-button):not(.madeVisible):not(.toggleImage):not(.noKeyNav):not([href^="javascript:"]):not([href="#"])');
 

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -575,10 +575,7 @@ modules['keyboardNav'] = {
 
 	registerSelectedThingWatcher: function() {
 		var module = this;
-		modules['selectedEntry'].addListener(function(selected, last) {
-			selected && module.keyFocus(selected.entry);
-			last && module.keyUnfocus(last.entry);
-		});
+		modules['selectedEntry'].addListener(module.updateAnnotations.bind(module));
 	},
 
 	registerCommand: function(commandName, spec) {
@@ -628,9 +625,9 @@ modules['keyboardNav'] = {
 			modules['keyboardNav'].recentKeyPress = false;
 		}, 1000);
 	},
-	keyFocus: function(entry) {
-		if (RESUtils.isPageType('comments') && this.options.commentsLinkNumbers.value) {
-			var links = this.getCommentLinks(entry);
+	updateAnnotations: function(selected, last) {
+		if (selected && RESUtils.isPageType('comments') && this.options.commentsLinkNumbers.value) {
+			var links = this.getCommentLinks(selected.entry);
 			var annotationCount = 0;
 			for (var i = 0, len = links.length; i < len; i++) {
 
@@ -654,6 +651,11 @@ modules['keyboardNav'] = {
 				}
 			}
 		}
+
+		if (last && RESUtils.isPageType('comments')) {
+			var annotations = last.entry.querySelectorAll('div.md .keyNavAnnotation');
+			$(annotations).remove();
+		}
 	},
 	handleKeyLink: function(link) {
 		var button = 0;
@@ -676,14 +678,6 @@ modules['keyboardNav'] = {
 			BrowserStrategy.sendMessage(thisJSON);
 		} else {
 			location.href = this.getAttribute('href');
-		}
-	},
-	keyUnfocus: function (entry) {
-		if (RESUtils.isPageType('comments')) {
-			var annotations = entry.querySelectorAll('div.md .keyNavAnnotation');
-			for (var i = 0, len = annotations.length; i < len; i++) {
-				annotations[i].parentNode.removeChild(annotations[i]);
-			}
 		}
 	},
 	drawHelp: function() {

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -655,7 +655,7 @@ modules['keyboardNav'] = {
 			}, true);
 			this.scanPageForKeyboardLinks();
 			// listen for new DOM nodes so that modules like autopager, never ending reddit, "load more comments" etc still get keyboard nav.
-			if (RESUtils.pageType() === 'comments') {
+			if (RESUtils.isPageType('comments')) {
 				RESUtils.watchForElement('newComments', modules['keyboardNav'].scanPageForNewKeyboardLinks);
 			} else {
 				RESUtils.watchForElement('siteTable', modules['keyboardNav'].scanPageForNewKeyboardLinks);
@@ -669,10 +669,10 @@ modules['keyboardNav'] = {
 		modules['commandLine'].registerCommand(/\d+/, '[number] - navigates to the link with that number (comments pages) or rank (link pages)',
 			function(command, val, match) {},
 			function(command, val, match, e) {
-				if (RESUtils.pageType() === 'comments') {
+				if (RESUtils.isPageType('comments')) {
 					// comment link number? (integer)
 					modules['keyboardNav'].commentLink(parseInt(command, 10) - 1);
-				} else if (RESUtils.pageType() === 'linklist') {
+				} else if (RESUtils.isPageType('linklist')) {
 					modules['keyboardNav'].keyUnfocus(modules['keyboardNav'].keyboardLinks[modules['keyboardNav'].activeIndex]);
 					modules['keyboardNav'].activeIndex = parseInt(command, 10) - 1;
 					modules['keyboardNav'].keyFocus(modules['keyboardNav'].keyboardLinks[modules['keyboardNav'].activeIndex]);
@@ -799,8 +799,8 @@ modules['keyboardNav'] = {
 		}
 		var siteTable = document.getElementById('siteTable');
 		// check if we're on a link listing (regular page, subreddit page, etc) or comments listing...
-		this.pageType = RESUtils.pageType();
-		switch (this.pageType) {
+		var pageType = RESUtils.pageType();
+		switch (pageType) {
 			case 'linklist':
 			case 'profile':
 				// get all links into an array...
@@ -893,10 +893,10 @@ modules['keyboardNav'] = {
 
 			obj.classList.add('RES-keyNav-activeElement');
 			this.activeElement = obj;
-			if ((this.pageType === 'linklist') || (this.pageType === 'profile')) {
+			if (RESUtils.isPageType('linklist', 'profile')) {
 				this.setKeyIndex();
 			}
-			if ((this.pageType === 'comments') && (this.options.commentsLinkNumbers.value)) {
+			if (RESUtils.isPageType('comments') && this.options.commentsLinkNumbers.value) {
 				var links = this.getCommentLinks(obj);
 				var annotationCount = 0;
 				for (var i = 0, len = links.length; i < len; i++) {
@@ -959,7 +959,7 @@ modules['keyboardNav'] = {
 			}
 		}
 		obj.classList.remove('RES-keyNav-activeElement');
-		if (this.pageType === 'comments') {
+		if (RESUtils.isPageType('comments')) {
 			var annotations = obj.querySelectorAll('div.md .keyNavAnnotation');
 			for (var i = 0, len = annotations.length; i < len; i++) {
 				annotations[i].parentNode.removeChild(annotations[i]);
@@ -1023,7 +1023,6 @@ modules['keyboardNav'] = {
 		var module = this;
 		if (!module._commandLookup) {
 			var lookup = {};
-			var pageType = RESUtils.pageType();
 			var commands = $.each(this.options, function(name, option) {
 				if (option.type !== 'keycode') return;
 				if (!option.callback) return;
@@ -1150,7 +1149,7 @@ modules['keyboardNav'] = {
 			// note: we don't want to go to the next page if we're on the dashboard...
 			if (
 				(!RESUtils.currentSubreddit('dashboard')) &&
-				(RESUtils.pageType() === 'linklist') &&
+				RESUtils.isPageType('linklist') &&
 				(this.activeIndex === (this.keyboardLinks.length - 1) &&
 				modules['neverEndingReddit'].isEnabled() &&
 				modules['neverEndingReddit'].options.autoLoad.value)
@@ -1192,7 +1191,7 @@ modules['keyboardNav'] = {
 				this.activeIndex++;
 				thisXY = RESUtils.getXYpos(this.keyboardLinks[this.activeIndex]);
 			}
-			if ((this.pageType === 'linklist') || (this.pageType === 'profile')) {
+			if (RESUtils.isPageType('linklist', 'profile')) {
 				this.setKeyIndex();
 			}
 			this.keyFocus(this.keyboardLinks[this.activeIndex]);
@@ -1219,7 +1218,7 @@ modules['keyboardNav'] = {
 				this.activeIndex++;
 				thisXY = RESUtils.getXYpos(this.keyboardLinks[this.activeIndex]);
 			}
-			if ((this.pageType === 'linklist') || (this.pageType === 'profile')) {
+			if (RESUtils.isPageType('linklist', 'profile')) {
 				this.setKeyIndex();
 			}
 			this.keyFocus(this.keyboardLinks[this.activeIndex]);
@@ -1552,8 +1551,8 @@ modules['keyboardNav'] = {
 	},
 	reply: function() {
 		// activeIndex = 0 means we're at the original post, not a comment
-		if ((this.activeIndex > 0) || (RESUtils.pageType() !== 'comments')) {
-			if ((RESUtils.pageType() === 'comments') && (this.activeIndex === 0) && (location.href.indexOf('/message/') === -1)) {
+		if ((this.activeIndex > 0) || (!RESUtils.isPageType('comments'))) {
+			if (RESUtils.isPageType('comments') && (this.activeIndex === 0) && (location.href.indexOf('/message/') === -1)) {
 				$('.usertext-edit textarea:first').focus();
 			} else {
 				var commentButtons = this.keyboardLinks[this.activeIndex].querySelectorAll('ul.buttons > li > a');

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -782,8 +782,11 @@ modules['keyboardNav'] = {
 		modules['styleTweaks'].setSRStyleToggleVisibility(true, 'keyboardnavhelp');
 	},
 	hide: function() {
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+
 		// find the hide link and click it...
-		var hideLink = this.keyboardLinks[this.activeIndex].querySelector('form.hide-button > span > a');
+		var hideLink = selected.entry.querySelector('form.hide-button > span > a');
 		RESUtils.click(hideLink);
 		// if ((this.options.onHideMoveDown.value) && (!modules['betteReddit'].options.fixHideLink.value)) {
 		if (this.options.onHideMoveDown.value) {
@@ -1179,9 +1182,9 @@ modules['keyboardNav'] = {
 
 		var upVoteButton;
 		if (selected.entry.previousSibling.tagName === 'A') {
-			upVoteButton = selected.entry.previousSibling.previousSibling.querySelector('div.up') || this.keyboardLinks[this.activeIndex].previousSibling.previousSibling.querySelector('div.upmod');
+			upVoteButton = selected.entry.previousSibling.previousSibling.querySelector('div.up') || selected.entry.previousSibling.previousSibling.querySelector('div.upmod');
 		} else {
-			upVoteButton = selected.entry.previousSibling.querySelector('div.up') || this.keyboardLinks[this.activeIndex].previousSibling.querySelector('div.upmod');
+			upVoteButton = selected.entry.previousSibling.querySelector('div.up') || selected.entry.previousSibling.querySelector('div.upmod');
 		}
 
 		if (!upVoteButton) {
@@ -1208,9 +1211,9 @@ modules['keyboardNav'] = {
 
 		var downVoteButton;
 		if (selected.entry.previousSibling.tagName === 'A') {
-			downVoteButton = selected.entry.previousSibling.previousSibling.querySelector('div.down') || this.keyboardLinks[this.activeIndex].previousSibling.previousSibling.querySelector('div.downmod');
+			downVoteButton = selected.entry.previousSibling.previousSibling.querySelector('div.down') || selected.entry.previousSibling.previousSibling.querySelector('div.downmod');
 		} else {
-			downVoteButton = selected.entry.previousSibling.querySelector('div.down') || this.keyboardLinks[this.activeIndex].previousSibling.querySelector('div.downmod');
+			downVoteButton = selected.entry.previousSibling.querySelector('div.down') || selected.entry.previousSibling.querySelector('div.downmod');
 		}
 
 		if (!downVoteButton) {

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1,7 +1,7 @@
 modules['keyboardNav'] = {
 	moduleID: 'keyboardNav',
 	moduleName: 'Keyboard Navigation',
-	category: [ 'UI', 'Style' ],
+	category: [ 'UI' ],
 	options: {
 		scrollOnExpando: {
 			type: 'boolean',

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -791,8 +791,11 @@ modules['keyboardNav'] = {
 		}
 	},
 	followSubreddit: function(newWindow) {
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+
 		// find the subreddit link and click it...
-		var srLink = this.keyboardLinks[this.activeIndex].querySelector('A.subreddit');
+		var srLink = selected.entry.querySelector('A.subreddit');
 		if (srLink) {
 			var thisHREF = srLink.getAttribute('href');
 			if (newWindow) {

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -936,9 +936,7 @@ modules['keyboardNav'] = {
 		}
 
 		var target = current.nextAll('.thing').first()[0];
-		if (!target) {
-			this._moveDown(current);
-		} else {
+		if (target) {
 			modules['selectedEntry'].select(target, { scrollStyle: 'top' });
 			modules['keyboardNav'].recentKey();
 		}

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -369,7 +369,7 @@ modules['keyboardNav'] = {
 		random: {
 			value: [89, true, false, false], // alt-y   SO RANDOM
 			description: 'Go to a random subreddit',
-			isGoTo : true
+			dependsOn: 'goMode'
 		},
 		nextPage: {
 			include: [ 'linklist', 'profile' ],

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1151,11 +1151,11 @@ modules['keyboardNav'] = {
 		}
 	},
 	followLinkByRank: function(num) {
-		var target = modules['selectableEntry'].selectableThings().filter(function() {
+		var target = modules['selectedEntry'].selectableThings().filter(function() {
 			var rank = (rank = this.querySelector('.rank')) && parseInt(rank.textContent, 10);
 			return rank === num;
 		});
-		modules['keyboardNav'].select(target);
+		modules['selectedEntry'].select(target);
 		modules['keyboardNav'].followLink();
 	},
 	followPermalink: function(newWindow) {

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1366,7 +1366,7 @@ modules['keyboardNav'] = {
 		location.href = newhref;
 	},
 	nextPage: function(override) {
-		if (!override && this.options.useGoMode.value && !this.goModeActive) {
+		if (override !== true && this.options.useGoMode.value && !this.goModeActive) {
 			return;
 		}
 		this.hideGoModePanel();

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -946,7 +946,7 @@ modules['keyboardNav'] = {
 		if (!selected) return;
 
 		var target = $(selected.thing).parent().closest('.thing');
-		modules['selectedEntry'].select(parent);
+		modules['selectedEntry'].select(target);
 	},
 	showParents: function() {
 		var selected = modules['selectedEntry'].selected();

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -598,6 +598,9 @@ modules['keyboardNav'] = {
 				#keyHelp td:first-child { width: 70px; } \
 				.keyNavAnnotation { font-size: 9px; position: relative; top: -6px; } \
 			');
+
+			this.registerCommandLine();
+			this.registerSelectedThingWatcher();
 		}
 	},
 	go: function() {
@@ -608,9 +611,6 @@ modules['keyboardNav'] = {
 					e.preventDefault();
 				}
 			}, true);
-
-			this.registerCommandLine();
-			this.registerSelectedThingWatcher();
 		}
 	},
 

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1597,7 +1597,7 @@ modules['keyboardNav'] = {
 				$contents = $('<div class="RESDialogContents"></div>');
 				$shortCutList = $('<table>');
 				for (var key in modules['keyboardNav'].options) {
-					if (modules['keyboardNav'].options[key].isGoTo) {
+					if (modules['keyboardNav'].options[key].dependsOn === 'goMode') {
 						niceKeyCode = modules['keyboardNav'].getNiceKeyCode(key);
 						$shortCutList.append('<tr><td>'+niceKeyCode+'</td><td class="arrow">&rarr;</td><td>'+key+'</td></tr>');
 					}

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -90,7 +90,7 @@ modules['keyboardNav'] = {
 		},
 		toggleCmdLine: {
 			value: [190, false, false, false], // .
-			description: 'Show/hide commandline box',
+			description: 'Launch RES command line',
 			callback: function() { modules['commandLine'].toggleCmdLine() }
 		},
 		hide: {

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -838,7 +838,9 @@ modules['keyboardNav'] = {
 		var targetIndex = Math.max(1, index) - 1;
 
 		var target = things[targetIndex];
-		modules['selectedEntry'].select(target);
+		modules['selectedEntry'].select(target, {
+			scrollStyle: modules['keyboardNav'].options.scrollStyle.value
+		});
 
 		modules['keyboardNav'].recentKey();
 	},
@@ -873,7 +875,7 @@ modules['keyboardNav'] = {
 	moveBottom: function() {
 		var things = modules['selectedEntry'].selectableThings();
 		var target = things.last();
-		modules['selectedEntry'].select(target, { scrollToTop: true });
+		modules['selectedEntry'].select(target, { scrollStyle: 'top' });
 		modules['keyboardNav'].recentKey();
 	},
 	moveDownSibling: function() {
@@ -890,7 +892,7 @@ modules['keyboardNav'] = {
 			}
 		} while (!target && current.length);
 
-		modules['selectedEntry'].select(target, { scrollToTop: true });
+		modules['selectedEntry'].select(target, { scrollStyle: 'top' });
 		modules['keyboardNav'].recentKey();
 	},
 	moveUpSibling: function() {
@@ -904,7 +906,7 @@ modules['keyboardNav'] = {
 			target = current.parent().closest('.thing')[0];
 		}
 
-		modules['selectedEntry'].select(target, { scrollToTop: true });
+		modules['selectedEntry'].select(target, { scrollStyle: 'top' });
 		modules['keyboardNav'].recentKey();
 	},
 	moveUpThread: function() {
@@ -920,7 +922,7 @@ modules['keyboardNav'] = {
 		if (!target) {
 			this._moveUp(current);
 		} else {
-			modules['selectedEntry'].select(target, { scrollToTop: true });
+			modules['selectedEntry'].select(target, { scrollStyle: 'top' });
 			modules['keyboardNav'].recentKey();
 		}
 	},
@@ -937,7 +939,7 @@ modules['keyboardNav'] = {
 		if (!target) {
 			this._moveDown(current);
 		} else {
-			modules['selectedEntry'].select(target, { scrollToTop: true });
+			modules['selectedEntry'].select(target, { scrollStyle: 'top' });
 			modules['keyboardNav'].recentKey();
 		}
 	},
@@ -946,7 +948,7 @@ modules['keyboardNav'] = {
 		if (!selected) return;
 		var target = $(selected.thing).parents('.thing').last();
 
-		modules['selectedEntry'].select(target, { scrollToTop: true });
+		modules['selectedEntry'].select(target, { scrollStyle: 'top' });
 		modules['keyboardNav'].recentKey();
 	},
 	moveToParent: function() {

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -275,6 +275,7 @@ modules['keyboardNav'] = {
 			description: 'Toggle "view images" button',
 		},
 		toggleChildren: {
+			includes: [ 'comments' ],
 			value: [13, false, false, false], // enter
 			description: 'Expand/collapse comments (comments pages only)'
 		},

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -852,7 +852,9 @@ modules['keyboardNav'] = {
 		var targetIndex = Math.min(index, things.length - 2) + 1;
 
 		var target = things[targetIndex];
-		modules['selectedEntry'].select(target);
+		modules['selectedEntry'].select(target, {
+			scrollStyle: modules['keyboardNav'].options.scrollStyle.value
+		});
 
 		// note: we don't want to go to the next page if we're on the dashboard...
 		if (

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -3,6 +3,11 @@ modules['keyboardNav'] = {
 	moduleName: 'Keyboard Navigation',
 	category: [ 'UI' ],
 	options: {
+		mediaBrowseMode: {
+			type: 'boolean',
+			value: true,
+			description: 'If media is open on the currently selected post when moving up/down one post, open media on the next post.'
+		},
 		scrollOnExpando: {
 			type: 'boolean',
 			value: true,
@@ -836,9 +841,13 @@ modules['keyboardNav'] = {
 		var targetIndex = Math.max(1, index) - 1;
 
 		var target = things[targetIndex];
-		modules['selectedEntry'].select(target, {
-			scrollStyle: modules['keyboardNav'].options.scrollStyle.value
-		});
+		if (modules['keyboardNav'].mediaBrowseMode(target, fromThing)) {
+			modules['selectedEntry'].select(target, { scrollStyle: 'top' });
+		} else {
+			modules['selectedEntry'].select(target, {
+				scrollStyle: modules['keyboardNav'].options.scrollStyle.value
+			});
+		}
 
 		modules['keyboardNav'].recentKey();
 	},
@@ -856,9 +865,14 @@ modules['keyboardNav'] = {
 		var targetIndex = Math.min(index, things.length - 2) + 1;
 
 		var target = things[targetIndex];
-		modules['selectedEntry'].select(target, {
-			scrollStyle: modules['keyboardNav'].options.scrollStyle.value
-		});
+
+		if (modules['keyboardNav'].mediaBrowseMode(target, fromThing)) {
+			modules['selectedEntry'].select(target, { scrollStyle: 'top' });
+		} else {
+			modules['selectedEntry'].select(target, {
+				scrollStyle: modules['keyboardNav'].options.scrollStyle.value
+			});
+		}
 
 		// note: we don't want to go to the next page if we're on the dashboard...
 		if (
@@ -1008,8 +1022,19 @@ modules['keyboardNav'] = {
 		if (thisExpando) {
 			RESUtils.click(thisExpando);
 			if (this.options.scrollOnExpando.value) {
-				var thisXY = RESUtils.getXYpos(selected.thing);
-				RESUtils.scrollTo(0, thisXY.y);
+				RESUtils.scrollToElement(selected.thing, { scrollStyle: 'top' });
+			}
+		}
+	},
+	mediaBrowseMode: function (newThing, oldThing) {
+		if (!oldThing || !newThing) return;
+		if (modules['keyboardNav'].options.mediaBrowseMode.value && !modules['showImages'].haltMediaBrowseMode) {
+			var oldExpando = oldThing.querySelector('.entry').querySelector('.expando-button');
+			var newExpando = newThing.querySelector('.entry').querySelector('.expando-button');
+			if (oldExpando && newExpando &&
+				oldExpando.classList.contains('expanded') && !newExpando.classList.contains('expanded')) {
+				RESUtils.click(oldExpando);
+				RESUtils.click(newExpando);
 			}
 		}
 	},

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -824,12 +824,6 @@ modules['keyboardNav'] = {
 
 		modules['keyboardNav']._moveUp(selected.thing);
 	},
-	moveDown: function() {
-		var selected = modules['selectedEntry'].selected();
-		if (!selected) return;
-
-		modules['keyboardNav']._moveDown(selected.thing);
-	},
 	_moveUp: function(fromThing) {
 		var current = fromThing;
 		var things = modules['selectedEntry'].selectableThings();
@@ -843,6 +837,12 @@ modules['keyboardNav'] = {
 		});
 
 		modules['keyboardNav'].recentKey();
+	},
+	moveDown: function() {
+		var selected = modules['selectedEntry'].selected();
+		if (!selected) return;
+
+		modules['keyboardNav']._moveDown(selected.thing);
 	},
 	_moveDown: function(fromThing) {
 		var current = fromThing;

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1168,7 +1168,7 @@ modules['keyboardNav'] = {
 		if (!selected) return;
 
 		var upVoteButton;
-		if (selected.previousSibling.tagName === 'A') {
+		if (selected.entry.previousSibling.tagName === 'A') {
 			upVoteButton = selected.entry.previousSibling.previousSibling.querySelector('div.up') || this.keyboardLinks[this.activeIndex].previousSibling.previousSibling.querySelector('div.upmod');
 		} else {
 			upVoteButton = selected.entry.previousSibling.querySelector('div.up') || this.keyboardLinks[this.activeIndex].previousSibling.querySelector('div.upmod');
@@ -1195,9 +1195,8 @@ modules['keyboardNav'] = {
 		var selected = modules['selectedEntry'].selected();
 		if (!selected) return;
 
-		//TODO
 		var downVoteButton;
-		if (selected.previousSibling.tagName === 'A') {
+		if (selected.entry.previousSibling.tagName === 'A') {
 			downVoteButton = selected.entry.previousSibling.previousSibling.querySelector('div.down') || this.keyboardLinks[this.activeIndex].previousSibling.previousSibling.querySelector('div.downmod');
 		} else {
 			downVoteButton = selected.entry.previousSibling.querySelector('div.down') || this.keyboardLinks[this.activeIndex].previousSibling.querySelector('div.downmod');

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -793,31 +793,31 @@ modules['keyboardNav'] = {
 		}, 1000);
 	},
 	keyFocus: function(obj) {
-			if (RESUtils.isPageType('comments') && this.options.commentsLinkNumbers.value) {
-				var links = this.getCommentLinks(obj);
-				var annotationCount = 0;
-				for (var i = 0, len = links.length; i < len; i++) {
+		if (RESUtils.isPageType('comments') && this.options.commentsLinkNumbers.value) {
+			var links = this.getCommentLinks(obj);
+			var annotationCount = 0;
+			for (var i = 0, len = links.length; i < len; i++) {
 
-					var annotation = document.createElement('span');
-					annotationCount++;
-					$(annotation).text('[' + annotationCount + '] ');
-					if (annotationCount <= 9) {
-						annotation.title = 'press ' + annotationCount + ' to open link';
-					}
-					else if (annotationCount === 10) {
-						annotation.title = 'press 0 to open link';
-					}
-					else {
-						annotation.title = 'press ' + this.getNiceKeyCode('toggleCmdLine') + ' then ' +annotationCount + ' and Enter to open link';
-					}
-					annotation.classList.add('keyNavAnnotation');
-					if (modules['keyboardNav'].options.commentsLinkNumberPosition.value === 'right') {
-						RESUtils.insertAfter(links[i], annotation);
-					} else {
-						links[i].parentNode.insertBefore(annotation, links[i]);
-					}
+				var annotation = document.createElement('span');
+				annotationCount++;
+				annotation.textContent = '[' + annotationCount + '] ';
+				if (annotationCount <= 9) {
+					annotation.title = 'press ' + annotationCount + ' to open link';
+				}
+				else if (annotationCount === 10) {
+					annotation.title = 'press 0 to open link';
+				}
+				else {
+					annotation.title = 'press ' + this.getNiceKeyCode('toggleCmdLine') + ' then ' +annotationCount + ' and Enter to open link';
+				}
+				annotation.classList.add('keyNavAnnotation');
+				if (modules['keyboardNav'].options.commentsLinkNumberPosition.value === 'right') {
+					RESUtils.insertAfter(links[i], annotation);
+				} else {
+					links[i].parentNode.insertBefore(annotation, links[i]);
 				}
 			}
+		}
 	},
 	handleKeyLink: function(link) {
 		var button = 0;
@@ -842,7 +842,7 @@ modules['keyboardNav'] = {
 			location.href = this.getAttribute('href');
 		}
 	},
-	keyUnfocus: function(obj) {
+	keyUnfocus: function (obj) {
 		if (RESUtils.isPageType('comments')) {
 			var annotations = obj.querySelectorAll('div.md .keyNavAnnotation');
 			for (var i = 0, len = annotations.length; i < len; i++) {

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -909,7 +909,7 @@ modules['keyboardNav'] = {
 			var commands = $.each(this.options, function(name, option) {
 				if (option.type !== 'keycode') return;
 				if (!option.callback) return;
-				if (!RESUtils.matchesPageType(option.includes, option.excludes)) return;
+				if (!RESUtils.matchesPageType(option.include, option.exclude)) return;
 
 				var hash = RESUtils.hashKeyArray(option.value);
 				if (!lookup[hash]) {

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -52,11 +52,6 @@ modules['keyboardNav'] = {
 			advanced: true,
 			dependsOn: 'addFocusBorder'
 		},
-		autoSelectOnScroll: {
-			type: 'boolean',
-			value: false,
-			description: 'Automatically select the topmost element for keyboard navigation on window scroll'
-		},
 		mediaBrowseMode: {
 			type: 'boolean',
 			value: true,
@@ -106,12 +101,6 @@ modules['keyboardNav'] = {
 			type: 'boolean',
 			value: true,
 			description: 'Open number key links in a new tab',
-			advanced: true
-		},
-		clickFocus: {
-			type: 'boolean',
-			value: true,
-			description: 'Move keyboard focus to a link or comment when clicked with the mouse',
 			advanced: true
 		},
 		onHideMoveDown: {
@@ -614,40 +603,7 @@ modules['keyboardNav'] = {
 	},
 	go: function() {
 		if ((this.isEnabled()) && (this.isMatchURL())) {
-			// get rid of antequated option we've removed
-			this.keyboardNavLastIndexCache = safeJSON.parse(RESStorage.getItem('RESmodules.keyboardNavLastIndex'), false, true);
-			var idx, now = Date.now();
-			if (!this.keyboardNavLastIndexCache) {
-				// this is a one time function to delete old keyboardNavLastIndex junk.
-				this.keyboardNavLastIndexCache = {};
-				for (idx in RESStorage) {
-					if (/keyboardNavLastIndex/.test(idx)) {
-						var url = idx.replace('RESmodules.keyboardNavLastIndex.', '');
-						this.keyboardNavLastIndexCache[url] = {
-							index: RESStorage[idx],
-							updated: now
-						};
-						RESStorage.removeItem(idx);
-					}
-				}
-				this.keyboardNavLastIndexCache.lastScan = now;
-				RESStorage.setItem('RESmodules.keyboardNavLastIndex', JSON.stringify(this.keyboardNavLastIndexCache));
-			} else {
-				// clean cache every 6 hours - delete any urls that haven't been visited in an hour.
-				if ((typeof this.keyboardNavLastIndexCache.lastScan === 'undefined') || (now - this.keyboardNavLastIndexCache.lastScan > 21600000)) {
-					for (idx in this.keyboardNavLastIndexCache) {
-						if ((typeof this.keyboardNavLastIndexCache[idx] === 'object') && (now - this.keyboardNavLastIndexCache[idx].updated > 3600000)) {
-							delete this.keyboardNavLastIndexCache[idx];
-						}
-					}
-					this.keyboardNavLastIndexCache.lastScan = now;
-					RESStorage.setItem('RESmodules.keyboardNavLastIndex', JSON.stringify(this.keyboardNavLastIndexCache));
-				}
-			}
 
-			if (this.options.autoSelectOnScroll.value) {
-				window.addEventListener('scroll', modules['keyboardNav'].handleScroll, false);
-			}
 			window.addEventListener('keydown', function(e) {
 				if (modules['keyboardNav'].handleKeyPress(e)) {
 					e.preventDefault();
@@ -757,40 +713,6 @@ modules['keyboardNav'] = {
 	},
 	scanPageForNewKeyboardLinks: function() {
 		modules['keyboardNav'].scanPageForKeyboardLinks(true);
-	},
-	setKeyIndex: function() {
-		var trimLoc = location.href;
-		// remove any trailing slash from the URL
-		if (trimLoc.substr(-1) === '/') {
-			trimLoc = trimLoc.substr(0, trimLoc.length - 1);
-		}
-		if (typeof this.keyboardNavLastIndexCache[trimLoc] === 'undefined') {
-			this.keyboardNavLastIndexCache[trimLoc] = {};
-		}
-		var now = Date.now();
-		this.keyboardNavLastIndexCache[trimLoc] = {
-			index: this.activeIndex,
-			updated: now
-		};
-		RESStorage.setItem('RESmodules.keyboardNavLastIndex', JSON.stringify(this.keyboardNavLastIndexCache));
-	},
-	handleScroll: function(e) {
-		if (modules['keyboardNav'].scrollTimer) {
-			clearTimeout(modules['keyboardNav'].scrollTimer);
-		}
-		modules['keyboardNav'].scrollTimer = setTimeout(modules['keyboardNav'].handleScrollAfterTimer, 300);
-	},
-	handleScrollAfterTimer: function() {
-		if ((!modules['keyboardNav'].recentKeyPress) && (!RESUtils.elementInViewport(modules['keyboardNav'].keyboardLinks[modules['keyboardNav'].activeIndex]))) {
-			for (var i = 0, len = modules['keyboardNav'].keyboardLinks.length; i < len; i++) {
-				if (RESUtils.elementInViewport(modules['keyboardNav'].keyboardLinks[i])) {
-					modules['keyboardNav'].keyUnfocus(modules['keyboardNav'].keyboardLinks[modules['keyboardNav'].activeIndex]);
-					modules['keyboardNav'].activeIndex = i;
-					modules['keyboardNav'].keyFocus(modules['keyboardNav'].keyboardLinks[modules['keyboardNav'].activeIndex]);
-					break;
-				}
-			}
-		}
 	},
 
 	scanPageForKeyboardLinks: function(isNew) {

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1049,7 +1049,7 @@ modules['keyboardNav'] = {
 			var callbacks = modules['keyboardNav'].getCommandsForKeyEvent(e);
 			if (callbacks) {
 				e.preventDefault();
-				callbacks.fire();
+				callbacks.fire(e);
 			}
 		}
 	},

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -614,6 +614,7 @@ modules['keyboardNav'] = {
 			}
 
 			this.registerCommandLine();
+			this.registerSelectedThingWatcher();
 		}
 	},
 
@@ -632,6 +633,14 @@ modules['keyboardNav'] = {
 				}
 			}
 		);
+	},
+
+	registerSelectedThingWatcher: function() {
+		var module = this;
+		modules['selectedThing'].addListener(function(newThing, lastThing) {
+			newThing && module.keyFocus(newThing);
+			lastThing && module.keyUnfocus(lastThing);
+		});
 	},
 
 	registerCommand: function(commandName, spec) {
@@ -773,19 +782,7 @@ modules['keyboardNav'] = {
 			modules['keyboardNav'].updateKeyFocusThrottle = setTimeout(function() {
 				delete modules['keyboardNav'].updateKeyFocusThrottle;
 			},100);
-			modules['keyboardNav'].doUpdateKeyFocus(event);
-		}
-	},
-	doUpdateKeyFocus: function(event) {
-		var thisIndex = parseInt($(event.currentTarget).data('keyIndex'), 10);
-		if (isNaN(thisIndex)) {
-			return;
-		}
-
-		if (modules['keyboardNav'].activeIndex !== thisIndex) {
-			modules['keyboardNav'].keyUnfocus(modules['keyboardNav'].keyboardLinks[modules['keyboardNav'].activeIndex]);
-			modules['keyboardNav'].activeIndex = thisIndex;
-			modules['keyboardNav'].keyFocus(modules['keyboardNav'].keyboardLinks[modules['keyboardNav'].activeIndex]);
+			modules['selectedThing'].select(event.currentTarget);
 		}
 	},
 	recentKey: function() {
@@ -796,24 +793,6 @@ modules['keyboardNav'] = {
 		}, 1000);
 	},
 	keyFocus: function(obj) {
-		if ((typeof obj !== 'undefined') && (obj.classList.contains('RES-keyNav-activeElement'))) {
-			return false;
-		} else if (typeof obj !== 'undefined') {
-			if (this.options.mediaBrowseMode.value && this.fromKey && !modules['showImages'].haltMediaBrowseMode) {
-				if (this.lastLinkExpanded === true) {
-					var $expando = $(obj).find('.expando-button:not(.expanded)');
-					if ($expando.length > 0) {
-						this.toggleExpando();
-					}
-				}
-			}
-			delete this.fromKey;
-
-			obj.classList.add('RES-keyNav-activeElement');
-			this.activeElement = obj;
-			if (RESUtils.isPageType('linklist', 'profile')) {
-				this.setKeyIndex();
-			}
 			if (RESUtils.isPageType('comments') && this.options.commentsLinkNumbers.value) {
 				var links = this.getCommentLinks(obj);
 				var annotationCount = 0;
@@ -839,7 +818,6 @@ modules['keyboardNav'] = {
 					}
 				}
 			}
-		}
 	},
 	handleKeyLink: function(link) {
 		var button = 0;
@@ -865,25 +843,12 @@ modules['keyboardNav'] = {
 		}
 	},
 	keyUnfocus: function(obj) {
-		if (this.options.mediaBrowseMode.value && this.fromKey && !modules['showImages'].haltMediaBrowseMode) {
-			var $expando = $(obj).children('.expando-button');
-			if ($expando.length > 0) {
-				if ($expando.hasClass('expanded')) {
-					this.lastLinkExpanded = true;
-					this.toggleExpando();
-				} else {
-					this.lastLinkExpanded = false;
-				}
-			}
-		}
-		obj.classList.remove('RES-keyNav-activeElement');
 		if (RESUtils.isPageType('comments')) {
 			var annotations = obj.querySelectorAll('div.md .keyNavAnnotation');
 			for (var i = 0, len = annotations.length; i < len; i++) {
 				annotations[i].parentNode.removeChild(annotations[i]);
 			}
 		}
-		modules['hover'].close(false);
 	},
 	drawHelp: function() {
 		this.keyHelp = RESUtils.createElementWithID('div', 'keyHelp');

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1165,6 +1165,7 @@ modules['keyboardNav'] = {
 		if (!selected) return;
 
 		var thisA = selected.entry.querySelector('a.bylink');
+		if (!thisA) return;
 		var thisHREF = thisA.getAttribute('href');
 		if (newWindow) {
 			var button = (this.options.followLinkNewTabFocus.value) ? 0 : 1,

--- a/lib/modules/saveComments.js
+++ b/lib/modules/saveComments.js
@@ -160,7 +160,7 @@ modules['saveComments'] = {
 		if (typeof this.storedComments[id] !== 'undefined') {
 			alert('comment already saved!');
 		} else {
-			var selectedThing = modules['selectedThing'].unselect(); // un-munge annotations or other mutilations
+			var selectedThing = modules['selectedEntry'].unselect(); // un-munge annotations or other mutilations
 
 			var comment = obj.parentNode.parentNode.querySelector('div.usertext-body > div.md');
 			if (comment !== null) {
@@ -181,7 +181,7 @@ modules['saveComments'] = {
 
 				$(obj).replaceWith($unsaveObj);
 			}
-			modules['selectedThings'].select(selectedThing); // restore munging
+			modules['selectedEntry'].select(selectedThing); // restore munging
 
 			if (RESUtils.proEnabled()) {
 				// add sync adds/deletes for RES Pro.

--- a/lib/modules/saveComments.js
+++ b/lib/modules/saveComments.js
@@ -160,10 +160,8 @@ modules['saveComments'] = {
 		if (typeof this.storedComments[id] !== 'undefined') {
 			alert('comment already saved!');
 		} else {
-			if (modules['keyboardNav'].isEnabled()) {
-				// unfocus it before we save it so we don't save the keyboard annotations...
-				modules['keyboardNav'].keyUnfocus(modules['keyboardNav'].keyboardLinks[modules['keyboardNav'].activeIndex]);
-			}
+			var selectedThing = modules['selectedThing'].unselect(); // un-munge annotations or other mutilations
+
 			var comment = obj.parentNode.parentNode.querySelector('div.usertext-body > div.md');
 			if (comment !== null) {
 				var commentHTML = comment.innerHTML.replace(/<script(.|\s)*?\/script>/g, ''),
@@ -183,9 +181,8 @@ modules['saveComments'] = {
 
 				$(obj).replaceWith($unsaveObj);
 			}
-			if (modules['keyboardNav'].isEnabled()) {
-				modules['keyboardNav'].keyFocus(modules['keyboardNav'].keyboardLinks[modules['keyboardNav'].activeIndex]);
-			}
+			modules['selectedThings'].select(selectedThing); // restore munging
+
 			if (RESUtils.proEnabled()) {
 				// add sync adds/deletes for RES Pro.
 				if (typeof this.storedComments.RESPro_add === 'undefined') {

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -16,14 +16,15 @@ addModule('selectedEntry', function(module, moduleID) {
 		advanced: true
 	};
 
-	module.go = function() {
+	addSelectListeners();
+	module.beforeLoad = function() {
 		if (!(module.isMatchURL() && module.isEnabled())) return;
 
-		setupLastSelectedCache();
-		selectLastSelected();
-
-		addSelectListeners();
 		addNewElementListeners();
+	}
+
+	module.go = function() {
+		if (!(module.isMatchURL() && module.isEnabled())) return;
 
 		if (module.options.autoSelectOnScroll.value) {
 			window.addEventListener('scroll', function(e) { RESUtils.debounce(moduleID + '.autoSelectOnScroll', 300, onScroll); });
@@ -38,6 +39,8 @@ addModule('selectedEntry', function(module, moduleID) {
 				}
 			});
 		}
+
+		setTimeout(selectLastSelected, 100);
 	}
 
 	var selectedEntry, selectedThing, selectedContainer;
@@ -64,7 +67,8 @@ addModule('selectedEntry', function(module, moduleID) {
 	};
 
 	var listeners;
-	module.addListener = function(callback) {
+	module.addListener = addListener;
+	function addListener(callback) {
 		if (!listeners) listeners = new $.Callbacks();
 		listeners.add(callback);
 	}
@@ -100,10 +104,11 @@ addModule('selectedEntry', function(module, moduleID) {
 	}
 
 	function addSelectListeners() {
-		module.addListener(scrollTo);
-		module.addListener(updateActiveElement);
-		module.addListener(updateLastSelectedCache);
-		module.addListener(function(selected, unselected) { if (unselected) modules['hover'].close(false); });
+		addListener(function(selected, unselected) { if (unselected) modules['hover'].close(false); });
+		addListener(updateActiveElement);
+		addListener(scrollTo);
+		addListener(updateLastSelectedCache);
+
 	}
 
 	function addNewElementListeners() {
@@ -148,6 +153,7 @@ addModule('selectedEntry', function(module, moduleID) {
 	var lastSelectedCache,
 		lastSelectedKey = 'RESmodules.selectedThing.lastSelectedCache';
 	function setupLastSelectedCache() {
+		if (lastSelectedCache) return;
 		lastSelectedCache = safeJSON.parse(RESStorage.getItem(lastSelectedKey), lastSelectedKey) || {};
 
 		// clean cache every so often and delete any urls that haven't been visited recently

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -1,6 +1,7 @@
 addModule('selectedEntry', function(module, moduleID) {
 	module.moduleName = 'Selected Entry';
 	module.category = [ 'Style', 'Comment', 'Post' ];
+	module.include = [ 'comments', 'linklisting', 'profile', 'inbox' ];
 	module.description = 'When a post or comment is selected, show extra styling and tools';
 
 	module.options.autoSelectOnScroll = {

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -98,7 +98,7 @@ addModule('selectedEntry', function(module, moduleID) {
 			addFocusBorder();
 		}
 
-		setTimeout(selectLastSelected, 100);
+		setTimeout(selectInitial, 100);
 	}
 
 	var selectedEntry, selectedThing, selectedContainer;
@@ -256,15 +256,24 @@ addModule('selectedEntry', function(module, moduleID) {
 		RESStorage.setItem('RESmodules.selectedThing.lastSelectedCache', JSON.stringify(lastSelectedCache));
 	}
 
-	function selectLastSelected() {
+	function selectInitial() {
+		var target = findLastSelectedThing();
+		if (!(target && target.length)) {
+			target = module.selectableThings().first();
+		}
+		select(target);
+	}
+
+	function findLastSelectedThing() {
 		setupLastSelectedCache();
+
 		var url = urlForSelectedCache();
 		var lastSelected = (lastSelected = lastSelectedCache[url]) && lastSelected.fullname;
 		if (lastSelected) {
-			var target = module.selectableThings().filter(function() {
+			target = module.selectableThings().filter(function() {
 				return this.getAttribute('data-fullname') === lastSelected;
 			});
-			select(target);
+			return target;
 		}
 	}
 

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -180,10 +180,11 @@ addModule('selectedEntry', function(module, moduleID) {
 
 	function scrollTo(selected, last, options) {
 		if (!selected) return;
-		RESUtils.scrollToElement(selected.thing, {
-			makeVisible: selected.entry,
-			scrollStyle: options.scrollStyle
-		});
+		options = $.extend(true, {}, {
+				makeVisible: selected.entry,
+			},
+			options);
+		RESUtils.scrollToElement(selected.thing, options);
 	}
 
 	function updateActiveElement(selected, last) {

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -209,7 +209,7 @@ addModule('selectedEntry', function(module, moduleID) {
 
 	function onClick(e) {
 		var thing = $(this).closest('.thing')[0];
-		select(thing);
+		select(thing, { scrollStyle: 'none' });
 	}
 
 	var lastSelectedCache,

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -15,6 +15,51 @@ addModule('selectedEntry', function(module, moduleID) {
 			value: true,
 			description: 'Select a link or comment when clicked with the mouse',
 			advanced: true
+		},
+		addFocusBGColor: {
+			type: 'boolean',
+			value: true,
+			description: 'Set a background color to highlight the currently focused element'
+		},
+		focusBGColor: {
+			type: 'color',
+			value: '#F0F3FC',
+			description: 'Background color of focused element',
+			advanced: true,
+			dependsOn: 'addFocusBGColor'
+		},
+		focusBGColorNight: {
+			type: 'color',
+			value: '#373737',
+			description: 'Background color of focused element in Night Mode',
+			advanced: true,
+			dependsOn: 'addFocusBGColor'
+		},
+		focusFGColorNight: {
+			type: 'color',
+			value: '#DDDDDD',
+			description: 'Foreground color of focused element in Night Mode',
+			advanced: true,
+			dependsOn: 'addFocusBGColor'
+		},
+		addFocusBorder: {
+			type: 'boolean',
+			value: true,
+			description: 'Set a border to highlight the currently focused element'
+		},
+		focusBorder: {
+			type: 'text',
+			value: '',
+			description: 'border style (e.g. 1px dashed gray) for focused element',
+			advanced: true,
+			dependsOn: 'addFocusBorder'
+		},
+		focusBorderNight: {
+			type: 'text',
+			value: '',
+			description: 'border style (e.g. 1px dashed gray) for focused element in Night Mode',
+			advanced: true,
+			dependsOn: 'addFocusBorder'
 		}
 	};
 
@@ -40,6 +85,17 @@ addModule('selectedEntry', function(module, moduleID) {
 					onClick.call(this, e);
 				}
 			});
+		}
+
+		RESUtils.addCSS(' \
+			.entry { padding-right: 5px; } \
+			');
+
+		if (module.options.addFocusBGColor.value) {
+			addFocusBGColor();
+		}
+		if (module.options.addFocusBorder.value) {
+			addFocusBorder();
 		}
 
 		setTimeout(selectLastSelected, 100);
@@ -206,5 +262,62 @@ addModule('selectedEntry', function(module, moduleID) {
 			select(target);
 		}
 	}
+
+
+	// old style: .RES-keyNav-activeElement { '+borderType+': '+focusBorder+'; background-color: '+focusBGColor+'; } \
+	// this new pure CSS arrow will not work because to position it we must have .RES-keyNav-activeElement position relative, but that screws up image viewer's absolute positioning to
+	// overlay over the sidebar... yikes.
+	// .RES-keyNav-activeElement:after { content: ""; float: right; margin-right: -5px; border-color: transparent '+focusBorderColor+' transparent transparent; border-style: solid; border-width: 3px 4px 3px 0; } \
+
+	// why !important on .RES-keyNav-activeElement?  Because some subreddits are unfortunately using !important for no good reason on .entry divs...
+
+	function addFocusBGColor() {
+		var focusFGColorNight, focusBGColor, focusBGColorNight;
+
+		if (typeof module.options.focusBGColor === 'undefined') {
+			focusBGColor = '#F0F3FC';
+		} else {
+			focusBGColor = module.options.focusBGColor.value;
+		}
+
+		if (!(module.options.focusBGColorNight.value)) {
+			focusBGColorNight = '#666';
+		} else {
+			focusBGColorNight = module.options.focusBGColorNight.value;
+		}
+		if (!(module.options.focusFGColorNight.value)) {
+			focusFGColorNight = '#DDD';
+		} else {
+			focusFGColorNight = module.options.focusFGColorNight.value;
+		}
+
+		RESUtils.addCSS('	\
+			.RES-keyNav-activeElement, .commentarea .RES-keyNav-activeElement .md, .commentarea .RES-keyNav-activeElement.entry .noncollapsed { background-color: ' + focusBGColor + ' !important; } \
+			.res-nightmode .RES-keyNav-activeElement, .res-nightmode .RES-keyNav-activeElement .usertext-body, .res-nightmode .RES-keyNav-activeElement .usertext-body .md, .res-nightmode .RES-keyNav-activeElement .usertext-body .md p, .res-nightmode .commentarea .RES-keyNav-activeElement .noncollapsed, .res-nightmode .RES-keyNav-activeElement .noncollapsed .md, .res-nightmode .RES-keyNav-activeElement .noncollapsed .md p { background-color: ' + focusBGColorNight + ' !important; color: ' + focusFGColorNight + ' !important;} \
+			.res-nightmode .RES-keyNav-activeElement a.title:first-of-type {color: ' + focusFGColorNight + ' !important; } \
+			');
+	}
+
+	function addFocusBorder() {
+		var focusBorder, focusBorderNight;
+		var borderType = BrowserStrategy.getOutlineProperty() || 'outline';
+
+		if (typeof module.options.focusBorder === 'undefined') {
+			focusBorder = '';
+		} else {
+			focusBorder = borderType + ': ' + module.options.focusBorder.value + ';';
+		}
+		if (typeof module.options.focusBorderNight === 'undefined') {
+			focusBorderNight = '';
+		} else {
+			focusBorderNight = borderType + ': ' + module.options.focusBorderNight.value + ';';
+		}
+
+		RESUtils.addCSS('	\
+			.RES-keyNav-activeElement { ' + focusBorder + ' } \
+			.res-nightmode .RES-keyNav-activeElement { ' + focusBorderNight + ' } \
+			');
+	}
+
 
 });

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -39,7 +39,7 @@ addModule('selectedEntry', function(module, moduleID) {
 		}
 	}
 
-	var selected = undefined;
+	var selectedEntry, selectedThing;
 	module.select = function(thing, scrollToTop) {
 		if (!thing || ('length' in thing && thing.length === 0)) return;
 		select(thing, scrollToTop);
@@ -51,7 +51,7 @@ addModule('selectedEntry', function(module, moduleID) {
 		return prevSelected;
 	};
 
-	module.selected = function() { return selected; };
+	module.selected = function() { return selectedEntry; };
 	module.selectedThing = function() { return selectedThing; };
 
 	module.selectableThings = function selectableThings() {
@@ -66,12 +66,19 @@ addModule('selectedEntry', function(module, moduleID) {
 
 
 
-	function select(thing, options) {
-		thing = $(thing).closest('.thing')[0];
-		if (thing === selected) return;
+	function select(thingOrEntry, options) {
+		var newThing = $(thingOrEntry).closest('.thing')[0];
+		if (newThing === selectedThing) return;
+
+		var oldSelected = selectedEntry;
+		var newEntry = newThing && newThing.querySelector('.entry');
+
 		options = options || {};
-		listeners && listeners.fire(thing, selected, options);
-		selected = thing;
+		listeners && listeners.fire(newEntry, oldSelected, options);
+
+		selectedEntry = newEntry;
+		selectedThing = newThing;
+
 	}
 
 
@@ -92,9 +99,9 @@ addModule('selectedEntry', function(module, moduleID) {
 
 	}
 
-	function updateActiveElement(thing, lastThing) {
-		thing && thing.querySelector('.entry').classList.add('RES-keyNav-activeElement');
-		lastThing && lastThing.querySelector('.entry').classList.remove('RES-keyNav-activeElement');
+	function updateActiveElement(newEntry, oldEntry) {
+		newEntry && newEntry.classList.add('RES-keyNav-activeElement');
+		oldEntry && oldEntry.classList.remove('RES-keyNav-activeElement');
 	}
 
 	function onScroll() {

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -1,6 +1,6 @@
 addModule('selectedEntry', function(module, moduleID) {
 	module.moduleName = 'Selected Entry';
-	module.category = [ 'Style', 'Comment', 'Post' ];
+	module.category = [ 'Style', 'Comments', 'Posts' ];
 	module.include = [ 'comments', 'linklist', 'profile', 'inbox' ];
 	module.description = 'When a post or comment is selected, show extra styling and tools';
 

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -1,7 +1,7 @@
 addModule('selectedEntry', function(module, moduleID) {
 	module.moduleName = 'Selected Entry';
 	module.category = [ 'Style', 'Comment', 'Post' ];
-	module.include = [ 'comments', 'linklisting', 'profile', 'inbox' ];
+	module.include = [ 'comments', 'linklist', 'profile', 'inbox' ];
 	module.description = 'When a post or comment is selected, show extra styling and tools';
 
 	module.options.autoSelectOnScroll = {

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -23,6 +23,7 @@ addModule('selectedEntry', function(module, moduleID) {
 		selectLastSelected();
 
 		addSelectListeners();
+		addNewElementListeners();
 
 		if (module.options.autoSelectOnScroll.value) {
 			window.addEventListener('scroll', function(e) { RESUtils.debounce(moduleID + '.autoSelectOnScroll', 300, onScroll); });
@@ -39,7 +40,7 @@ addModule('selectedEntry', function(module, moduleID) {
 		}
 	}
 
-	var selectedEntry, selectedThing;
+	var selectedEntry, selectedThing, selectedContainer;
 	module.select = function(thing, scrollToTop) {
 		if (!thing || ('length' in thing && thing.length === 0)) return;
 		select(thing, scrollToTop);
@@ -82,15 +83,31 @@ addModule('selectedEntry', function(module, moduleID) {
 
 		selectedEntry = newEntry;
 		selectedThing = newThing;
+		selectedContainer = newThing && $(newThing).parent().closest('.thing');
 
 	}
 
+	function onNewComments(entries) {
+		if (selectedThing && !selectedThing.parentNode) {
+			// Selected thing was replaced, so select the replacement
+			var newContainer = $(entries).closest('.thing').parent().closest('.thing')
+			if (newContainer.filter(selectedContainer).length) {
+				select(entries, {
+					replacement: true
+				});
+			}
+		}
+	}
 
 	function addSelectListeners() {
 		module.addListener(scrollTo);
 		module.addListener(updateActiveElement);
 		module.addListener(updateLastSelectedCache);
 		module.addListener(function(selected, unselected) { if (unselected) modules['hover'].close(false); });
+	}
+
+	function addNewElementListeners() {
+		RESUtils.watchForElement('newComments', onNewComments);
 	}
 
 	function scrollTo(thing, last, options) {

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -1,0 +1,173 @@
+addModule('selectedEntry', function(module, moduleID) {
+	module.moduleName = 'Selected Entry';
+	module.category = [ 'Style', 'Comment', 'Post' ];
+	module.description = 'When a post or comment is selected, show extra styling and tools';
+
+	module.options.autoSelectOnScroll = {
+		type: 'boolean',
+		value: false,
+		description: 'Automatically select the topmost element for keyboard navigation on window scroll'
+	};
+	module.options.selectOnClick = {
+		type: 'boolean',
+		value: true,
+		description: 'Select a link or comment when clicked with the mouse',
+		advanced: true
+	};
+
+	module.go = function() {
+		if (!(module.isMatchURL() && module.isEnabled())) return;
+
+		setupLastSelectedCache();
+		selectLastSelected();
+
+		addSelectListeners();
+
+		if (module.options.autoSelectOnScroll.value) {
+			window.addEventListener('scroll', function(e) { RESUtils.debounce(moduleID + '.autoSelectOnScroll', 300, onScroll); });
+		}
+		if (module.options.selectOnClick.value) {
+			var throttled;
+			$(document.body).on('click', '.thing', function(e) {
+				if (!throttled) {
+					throttled = true;
+					setTimeout(function() { throttled = false; }, 100);
+					onClick.call(this, e);
+				}
+			});
+		}
+	}
+
+	var selected = undefined;
+	module.select = function(thing, scrollToTop) {
+		if (!thing || ('length' in thing && thing.length === 0)) return;
+		select(thing, scrollToTop);
+	};
+
+	module.unselect = function() {
+		var prevSelected = selected;
+		select(undefined);
+		return prevSelected;
+	};
+
+	module.selected = function() { return selected; };
+	module.selectedThing = function() { return selectedThing; };
+
+	module.selectableThings = function selectableThings() {
+		return $('.linklisting .thing, .nestedlisting .thing');
+	};
+
+	var listeners;
+	module.addListener = function(callback) {
+		if (!listeners) listeners = new $.Callbacks();
+		listeners.add(callback);
+	}
+
+
+
+	function select(thing, options) {
+		thing = $(thing).closest('.thing')[0];
+		if (thing === selected) return;
+		options = options || {};
+		listeners && listeners.fire(thing, selected, options);
+		selected = thing;
+	}
+
+
+	function addSelectListeners() {
+		module.addListener(scrollTo);
+		module.addListener(updateActiveElement);
+		module.addListener(updateLastSelectedCache);
+		module.addListener(function(selected, unselected) { if (unselected) modules['hover'].close(false); });
+	}
+
+	function scrollTo(thing, last, options) {
+		if (!thing) return;
+		var entry = thing.querySelector('.entry');
+		RESUtils.scrollToElement(thing, {
+			makeVisible: entry,
+			scrollToTop: options.scrollToTop
+		});
+
+	}
+
+	function updateActiveElement(thing, lastThing) {
+		thing && thing.querySelector('.entry').classList.add('RES-keyNav-activeElement');
+		lastThing && lastThing.querySelector('.entry').classList.remove('RES-keyNav-activeElement');
+	}
+
+	function onScroll() {
+		if (modules['keyboardNav'].recentKeyPress) return;
+
+		var selected = module.selected();
+		if (selected && RESUtils.elementInViewport(selected)) return;
+
+
+		var things = $('.thing');
+		for (var i = 0, len = things.length; i < len; i++) {
+			if (RESUtils.elementInViewport(things[i])) {
+				select(things[i]);
+			}
+		}
+	}
+
+	function onClick(e) {
+		var thing = $(this).closest('.thing')[0];
+		select(thing);
+	}
+
+	var lastSelectedCache,
+		lastSelectedKey = 'RESmodules.selectedThing.lastSelectedCache';
+	function setupLastSelectedCache() {
+		lastSelectedCache = safeJSON.parse(RESStorage.getItem(lastSelectedKey), lastSelectedKey) || {};
+
+		// clean cache every so often and delete any urls that haven't been visited recently
+		var clearCachePeriod = 21600000; // 6 hours
+		var itemExpiration = 3600000; // 1 hour
+		var now = Date.now();
+		if (!lastSelectedCache.lastScan || (now - lastSelectedCache.lastScan > clearCachePeriod)) {
+			for (var idx in lastSelectedCache) {
+				if (lastSelectedCache[idx] && (now - lastSelectedCache[idx].updated > itemExpiration)) {
+					delete lastSelectedCache[idx];
+				}
+			}
+			lastSelectedCache.lastScan = now;
+			RESStorage.setItem(lastSelectedKey, JSON.stringify(lastSelectedCache));
+		}
+	}
+
+	function urlForSelectedCache() {
+		var url = document.location.pathname;
+		// remove any trailing slash from the URL
+		if (url.substr(-1) === '/') {
+			url = url.substr(0, url.length - 1);
+		}
+
+		return url;
+	}
+
+
+	function updateLastSelectedCache(thing) {
+		if (!RESUtils.isPageType('linklist', 'profile')) return;
+
+		var url = urlForSelectedCache();
+		var now = Date.now();
+		lastSelectedCache[url] = {
+			fullname: thing && thing.getAttribute('data-fullname'),
+			updated: now
+		};
+		RESStorage.setItem('RESmodules.selectedThing.lastSelectedCache', JSON.stringify(lastSelectedCache));
+	}
+
+	function selectLastSelected() {
+		var url = urlForSelectedCache();
+		var lastSelected = (lastSelected = lastSelectedCache[url]) && lastSelected.fullname;
+		if (lastSelected) {
+			var target = selectableThings().filter(function() {
+				return this.getAttribute('data-fullname') === lastSelected;
+			});
+			select(target);
+		}
+	}
+
+});

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -102,9 +102,9 @@ addModule('selectedEntry', function(module, moduleID) {
 	}
 
 	var selectedEntry, selectedThing, selectedContainer;
-	module.select = function(thing, scrollToTop) {
+	module.select = function(thing, options) {
 		if (!thing || ('length' in thing && thing.length === 0)) return;
-		select(thing, scrollToTop);
+		select(thing, options);
 	};
 
 	module.unselect = function() {
@@ -182,7 +182,7 @@ addModule('selectedEntry', function(module, moduleID) {
 		if (!selected) return;
 		RESUtils.scrollToElement(selected.thing, {
 			makeVisible: selected.entry,
-			scrollToTop: options.scrollToTop
+			scrollStyle: options.scrollStyle
 		});
 	}
 

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -4,16 +4,18 @@ addModule('selectedEntry', function(module, moduleID) {
 	module.include = [ 'comments', 'linklist', 'profile', 'inbox' ];
 	module.description = 'When a post or comment is selected, show extra styling and tools';
 
-	module.options.autoSelectOnScroll = {
-		type: 'boolean',
-		value: false,
-		description: 'Automatically select the topmost element for keyboard navigation on window scroll'
-	};
-	module.options.selectOnClick = {
-		type: 'boolean',
-		value: true,
-		description: 'Select a link or comment when clicked with the mouse',
-		advanced: true
+	module.options = {
+		autoSelectOnScroll: {
+			type: 'boolean',
+			value: false,
+			description: 'Automatically select the topmost element for keyboard navigation on window scroll'
+		},
+		selectOnClick: {
+			type: 'boolean',
+			value: true,
+			description: 'Select a link or comment when clicked with the mouse',
+			advanced: true
+		}
 	};
 
 	addSelectListeners();

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -51,8 +51,12 @@ addModule('selectedEntry', function(module, moduleID) {
 		return prevSelected;
 	};
 
-	module.selected = function() { return selectedEntry; };
-	module.selectedThing = function() { return selectedThing; };
+	module.selected = function() {
+		return selectedEntry;
+	};
+	module.selectedThing = function() {
+		return selectedThing;
+	};
 
 	module.selectableThings = function selectableThings() {
 		return $('.linklisting .thing, .nestedlisting .thing');

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -114,10 +114,10 @@ addModule('selectedEntry', function(module, moduleID) {
 	};
 
 	module.selected = function() {
-		return selectedEntry;
-	};
-	module.selectedThing = function() {
-		return selectedThing;
+		return selectedThing && {
+			entry: selectedEntry,	// DOMElement
+			thing: selectedThing	// DOMElement
+		};
 	};
 
 	module.selectableThings = function selectableThings() {
@@ -137,16 +137,21 @@ addModule('selectedEntry', function(module, moduleID) {
 		var newThing = $(thingOrEntry).closest('.thing')[0];
 		if (newThing === selectedThing) return;
 
-		var oldSelected = selectedEntry;
-		var newEntry = newThing && newThing.querySelector('.entry');
+		var newSelected = newThing && {
+			thing: newThing,
+			entry: newThing && newThing.querySelector('.entry')
+		};
+		var oldSelected = selectedThing && {
+			thing: selectedThing,
+			entry: selectedEntry
+		};
 
 		options = options || {};
-		listeners && listeners.fire(newEntry, oldSelected, options);
+		listeners && listeners.fire(newSelected, oldSelected, options);
 
-		selectedEntry = newEntry;
-		selectedThing = newThing;
-		selectedContainer = newThing && $(newThing).parent().closest('.thing');
-
+		selectedEntry = newSelected.entry;
+		selectedThing = newSelected.thing;
+		selectedContainer = $(newSelected.thing).parent().closest('.thing');
 	}
 
 	function onNewComments(entries) {
@@ -173,26 +178,24 @@ addModule('selectedEntry', function(module, moduleID) {
 		RESUtils.watchForElement('newComments', onNewComments);
 	}
 
-	function scrollTo(thing, last, options) {
-		if (!thing) return;
-		var entry = thing.querySelector('.entry');
-		RESUtils.scrollToElement(thing, {
-			makeVisible: entry,
+	function scrollTo(selected, last, options) {
+		if (!selected) return;
+		RESUtils.scrollToElement(selected.thing, {
+			makeVisible: selected.entry,
 			scrollToTop: options.scrollToTop
 		});
-
 	}
 
-	function updateActiveElement(newEntry, oldEntry) {
-		newEntry && newEntry.classList.add('RES-keyNav-activeElement');
-		oldEntry && oldEntry.classList.remove('RES-keyNav-activeElement');
+	function updateActiveElement(selected, last) {
+		selected && selected.entry.classList.add('RES-keyNav-activeElement');
+		last && last.entry.classList.remove('RES-keyNav-activeElement');
 	}
 
 	function onScroll() {
 		if (modules['keyboardNav'].recentKeyPress) return;
 
 		var selected = module.selected();
-		if (selected && RESUtils.elementInViewport(selected)) return;
+		if (selected && RESUtils.elementInViewport(selected.entry)) return;
 
 
 		var things = $('.thing');
@@ -240,23 +243,25 @@ addModule('selectedEntry', function(module, moduleID) {
 	}
 
 
-	function updateLastSelectedCache(thing) {
+	function updateLastSelectedCache(selected) {
 		if (!RESUtils.isPageType('linklist', 'profile')) return;
 
 		var url = urlForSelectedCache();
 		var now = Date.now();
+		var fullname = $(selected.thing).data('fullname');
 		lastSelectedCache[url] = {
-			fullname: thing && thing.getAttribute('data-fullname'),
+			fullname: fullname,
 			updated: now
 		};
 		RESStorage.setItem('RESmodules.selectedThing.lastSelectedCache', JSON.stringify(lastSelectedCache));
 	}
 
 	function selectLastSelected() {
+		setupLastSelectedCache();
 		var url = urlForSelectedCache();
 		var lastSelected = (lastSelected = lastSelectedCache[url]) && lastSelected.fullname;
 		if (lastSelected) {
-			var target = selectableThings().filter(function() {
+			var target = module.selectableThings().filter(function() {
 				return this.getAttribute('data-fullname') === lastSelected;
 			});
 			select(target);

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -496,11 +496,11 @@ modules['showImages'] = {
 	},
 	onSelectThing: function (selected, last) {
 		if (this.options.mediaBrowseMode.value && last && !modules['showImages'].haltMediaBrowseMode) {
-			if (this.lastLinkExpanded === true) {
-				var $expando = $(selected.entry).find('.expando-button:not(.expanded)');
-				if ($expando.length > 0) {
-					this.toggleExpando();
-				}
+			var lastExpando = (last && last.entry.querySelector('.expando-button'))
+			var selectedExpando = selected.entry.querySelector('.expando-button');
+			if (lastExpando.classList.contains('expanded') && !selectedExpando.classList.contains('expanded')) {
+				modules['showImages'].revealImage(lastExpando, false);
+				modules['showImages'].revealImage(selectedExpando, true);
 			}
 		}
 	},

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -214,6 +214,8 @@ modules['showImages'] = {
 			if (commentMaxHeight) {
 				RESUtils.addCSS('.comment .md { max-height: ' + commentMaxHeight + 'px; overflow-y: auto !important; position: relative; }');
 			}
+
+			modules['selectedEntry'].addListener(modules['showImages'].onSelectThing.bind(modules['showImages']));
 		}
 	},
 	go: function() {
@@ -247,7 +249,6 @@ modules['showImages'] = {
 			RESUtils.watchForElement('selfText', modules['showImages'].findAllImagesInSelfText);
 			RESUtils.watchForElement('newComments', modules['showImages'].findAllImagesInSelfText);
 
-			modules['selectedEntry'].addListener(modules['showImages'].onSelectThing.bind(modules['showImages']));
 			this.createImageButtons();
 			this.findAllImages();
 			document.addEventListener('dragstart', function() {

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -70,11 +70,6 @@ modules['showImages'] = {
 			value: false,
 			description: 'If checked, do not show images marked NSFW.'
 		},
-		mediaBrowseMode: {
-			type: 'boolean',
-			value: true,
-			description: 'If media is open on the currently selected post when moving up/down one post, open media on the next post.'
-		},
 		autoExpandSelfText: {
 			type: 'boolean',
 			value: true,
@@ -214,8 +209,6 @@ modules['showImages'] = {
 			if (commentMaxHeight) {
 				RESUtils.addCSS('.comment .md { max-height: ' + commentMaxHeight + 'px; overflow-y: auto !important; position: relative; }');
 			}
-
-			modules['selectedEntry'].addListener(modules['showImages'].onSelectThing.bind(modules['showImages']));
 		}
 	},
 	go: function() {
@@ -491,16 +484,6 @@ modules['showImages'] = {
 			var image = this.imageList[i];
 			if ($(image).hasClass(type) || image.imageLink.expandOnViewAll) {
 				this.revealImage(image, this.findImageFilter(image.imageLink));
-			}
-		}
-	},
-	onSelectThing: function (selected, last) {
-		if (this.options.mediaBrowseMode.value && last && !modules['showImages'].haltMediaBrowseMode) {
-			var lastExpando = (last && last.entry.querySelector('.expando-button'))
-			var selectedExpando = selected.entry.querySelector('.expando-button');
-			if (lastExpando.classList.contains('expanded') && !selectedExpando.classList.contains('expanded')) {
-				modules['showImages'].revealImage(lastExpando, false);
-				modules['showImages'].revealImage(selectedExpando, true);
 			}
 		}
 	},

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -494,10 +494,10 @@ modules['showImages'] = {
 			}
 		}
 	},
-	onSelectThing: function (obj, prevObj) {
-		if (this.options.mediaBrowseMode.value && prevObj && !modules['showImages'].haltMediaBrowseMode) {
+	onSelectThing: function (selected, last) {
+		if (this.options.mediaBrowseMode.value && last && !modules['showImages'].haltMediaBrowseMode) {
 			if (this.lastLinkExpanded === true) {
-				var $expando = $(obj).find('.expando-button:not(.expanded)');
+				var $expando = $(selected.entry).find('.expando-button:not(.expanded)');
 				if ($expando.length > 0) {
 					this.toggleExpando();
 				}

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -70,6 +70,11 @@ modules['showImages'] = {
 			value: false,
 			description: 'If checked, do not show images marked NSFW.'
 		},
+		mediaBrowseMode: {
+			type: 'boolean',
+			value: true,
+			description: 'If media is open on the currently selected post when moving up/down one post, open media on the next post.'
+		},
 		autoExpandSelfText: {
 			type: 'boolean',
 			value: true,
@@ -242,6 +247,7 @@ modules['showImages'] = {
 			RESUtils.watchForElement('selfText', modules['showImages'].findAllImagesInSelfText);
 			RESUtils.watchForElement('newComments', modules['showImages'].findAllImagesInSelfText);
 
+			modules['selectedThing'].addListener(modules['showImages'].onSelectThing.bind(modules['showImages']));
 			this.createImageButtons();
 			this.findAllImages();
 			document.addEventListener('dragstart', function() {
@@ -484,6 +490,16 @@ modules['showImages'] = {
 			var image = this.imageList[i];
 			if ($(image).hasClass(type) || image.imageLink.expandOnViewAll) {
 				this.revealImage(image, this.findImageFilter(image.imageLink));
+			}
+		}
+	},
+	onSelectThing: function (obj, prevObj) {
+		if (this.options.mediaBrowseMode.value && prevObj && !modules['showImages'].haltMediaBrowseMode) {
+			if (this.lastLinkExpanded === true) {
+				var $expando = $(obj).find('.expando-button:not(.expanded)');
+				if ($expando.length > 0) {
+					this.toggleExpando();
+				}
 			}
 		}
 	},

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -247,7 +247,7 @@ modules['showImages'] = {
 			RESUtils.watchForElement('selfText', modules['showImages'].findAllImagesInSelfText);
 			RESUtils.watchForElement('newComments', modules['showImages'].findAllImagesInSelfText);
 
-			modules['selectedThing'].addListener(modules['showImages'].onSelectThing.bind(modules['showImages']));
+			modules['selectedEntry'].addListener(modules['showImages'].onSelectThing.bind(modules['showImages']));
 			this.createImageButtons();
 			this.findAllImages();
 			document.addEventListener('dragstart', function() {

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -415,13 +415,8 @@ modules['userTagger'] = {
 		);
 
 		function getAuthorTagLink() {
-			var searchArea ;
-			if (modules['keyboardNav'].keyboardLinks && typeof modules['keyboardNav'].activeIndex !== 'undefined') {
-				searchArea = modules['keyboardNav'].keyboardLinks[modules['keyboardNav'].activeIndex];
-			}
-			if (!searchArea) {
-				searchArea = document.body;
-			}
+			var searchArea = modules['selectedEntry'].selected() || document.body;
+
 			var tagLink = searchArea.querySelector('a.userTagLink');
 			return tagLink;
 		}


### PR DESCRIPTION
## KeyboardNav 
* commands: name, default keycode, description, include/exclude, and callback (explicit or name matching a keyboardNav method)
* commands can be registered from other modules
* more efficient lookup for keyboard commands
* use SelectedEntry to manage which post/comment entry is active/selected
* commands for navigating link/comment listing traverse the DOM starting at Selected Entry
* KeyboardNav help panel shows GoMode prefix
* Shortcuts work in more edge places now: fixes #1097
* Migrate some options from keyboardNav into more relevant modules
* fixed segfault error on "move to entry"

## SelectedEntry

new module providing an interface for the currently selected post or comment.

## RESUtils, init, infrastructure

* RESUtils.IsMatchURL, .matchesPageType, .isPageType
*  Deferred fetching module option values until all modules have run .loadDynamicOptions. this enables `modules['keyboardNav'].registerCommand()` from other modules
* added RESUtils.hashKeyEvent, .hashKeyArray; .checkKeysForEvent uses hash for comparison
