### PR TITLE
fadeSpeed corrections

### DIFF
--- a/lib/core/migrate.js
+++ b/lib/core/migrate.js
@@ -102,6 +102,10 @@ var RESOptionsMigrate = {
 				}
 				RESOptionsMigrate.migrators.generic.moveOption('betteReddit', 'uncheckSendRepliesToInbox', 'submitHelper', 'uncheckSendRepliesToInbox');
 
+				RESOptionsMigrate.migrators.generic.forceUpdateOption('hover', 'fadeSpeed', RESOptionsMigrate.migrators.specific.updateFadeSpeed);
+				RESOptionsMigrate.migrators.generic.forceUpdateOption('showParent', 'fadeSpeed', RESOptionsMigrate.migrators.specific.updateFadeSpeed);
+				RESOptionsMigrate.migrators.generic.forceUpdateOption('subredditInfo', 'fadeSpeed', RESOptionsMigrate.migrators.specific.updateFadeSpeed);
+				RESOptionsMigrate.migrators.generic.forceUpdateOption('userTagger', 'fadeSpeed', RESOptionsMigrate.migrators.specific.updateFadeSpeed);
 
 				// Minify existing options
 				for (var key in modules) {
@@ -212,6 +216,13 @@ var RESOptionsMigrate = {
 				}
 
 				return values;
+			},
+			updateFadeSpeed: function(value) {
+				if (value < 0 || value > 1) {
+					return '0.7';
+				} else {
+					return (1 - value).toFixed(2);
+				}
 			}
 		}
 	},

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -619,7 +619,6 @@ RESUtils.fadeElementTo = function(el, speedInSeconds, finalOpacity, callback) {
 		if (typeof finalOpacity === 'undefined') {
 			finalOpacity = 1;
 		}
-		speedInSeconds = Math.max(speedInSeconds, 0.1); //set a minimum speed
 	}
 
 	function go() {

--- a/lib/modules/hover.js
+++ b/lib/modules/hover.js
@@ -13,7 +13,7 @@ addModule('hover', function(hover, moduleID) {
 			},
 			fadeSpeed: {
 				type: 'text',
-				value: 0.3
+				value: 0.7
 			},
 			width:  {
 				type: 'text',

--- a/lib/modules/showParent.js
+++ b/lib/modules/showParent.js
@@ -18,7 +18,7 @@ modules['showParent'] = {
 		fadeSpeed: {
 			type: 'text',
 			value: 0.3,
-			description: 'Fade animation\'s speed. Default is 0.3, the range is 0-1. Setting the speed to 1 will disable the animation.',
+			description: 'Fade animation\'s speed (in seconds). Default is 0.3.',
 			advanced: true
 		},
 		direction: {

--- a/lib/modules/showParent.js
+++ b/lib/modules/showParent.js
@@ -17,8 +17,8 @@ modules['showParent'] = {
 		},
 		fadeSpeed: {
 			type: 'text',
-			value: 0.3,
-			description: 'Fade animation\'s speed (in seconds). Default is 0.3.',
+			value: 0.7,
+			description: 'Fade animation\'s speed (in seconds). Default is 0.7.',
 			advanced: true
 		},
 		direction: {

--- a/lib/modules/subredditInfo.js
+++ b/lib/modules/subredditInfo.js
@@ -18,7 +18,7 @@ modules['subredditInfo'] = {
 		fadeSpeed: {
 			type: 'text',
 			value: 0.3,
-			description: 'Fade animation\'s speed. Default is 0.3, the range is 0-1. Setting the speed to 1 will disable the animation.',
+			description: 'Fade animation\'s speed (in seconds). Default is 0.3.',
 			advanced: true
 		},
 		USDateFormat: {

--- a/lib/modules/subredditInfo.js
+++ b/lib/modules/subredditInfo.js
@@ -17,8 +17,8 @@ modules['subredditInfo'] = {
 		},
 		fadeSpeed: {
 			type: 'text',
-			value: 0.3,
-			description: 'Fade animation\'s speed (in seconds). Default is 0.3.',
+			value: 0.7,
+			description: 'Fade animation\'s speed (in seconds). Default is 0.7.',
 			advanced: true
 		},
 		USDateFormat: {

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -60,8 +60,8 @@ modules['userTagger'] = {
 		},
 		fadeSpeed: {
 			type: 'text',
-			value: 0.3,
-			description: 'Fade animation\'s speed (in seconds). Default is 0.3.',
+			value: 0.7,
+			description: 'Fade animation\'s speed (in seconds). Default is 0.7.',
 			advanced: true,
 			dependsOn: 'hoverInfo'
 		},

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -61,7 +61,7 @@ modules['userTagger'] = {
 		fadeSpeed: {
 			type: 'text',
 			value: 0.3,
-			description: 'Fade animation\'s speed. Default is 0.3, the range is 0-1. Setting the speed to 1 will disable the animation.',
+			description: 'Fade animation\'s speed (in seconds). Default is 0.3.',
 			advanced: true,
 			dependsOn: 'hoverInfo'
 		},


### PR DESCRIPTION
Fixes this issue [(reddit post).](https://www.reddit.com/r/RESissues/comments/2vh45v/bug_cant_disable_fading_on_any_hover_popups)

`$.fadeTo` measures speed in seconds (instead of the fractional speed we used before), causing `fadeSpeed.value = 1` to fade things out over 1 second instead of instantly (as intended).