### PR TITLE
Added subreddit hover feature for full links.

### DIFF
--- a/lib/modules/subredditInfo.js
+++ b/lib/modules/subredditInfo.js
@@ -61,7 +61,8 @@ modules['subredditInfo'] = {
 	srRe: /\/r\/(\w+)(?:\/(new|rising|controversial|top))?\/?$/i,
 	addListeners: function(ele) {
 		ele = ele || document.body;
-		var subredditLinks = document.body.querySelectorAll('.listing-page a.subreddit, .explore-page a.subreddit, .comment .md a[href^="/r/"], .side a[href^="/r/"], .usertext-body a[href^="/r/"], .trending-subreddits a[href^="/r/"]');
+        var querySelectors = ['.listing-page a.subreddit','.explore-page a.subreddit','.comment .md a[href^="/r/"]','.comment .md a[href*="reddit.com/r/"]','.side a[href^="/r/"]','.side a[href*="reddit.com/r/"]','.usertext-body a[href^="/r/"]','.usertext-body a[href*="reddit.com/r/"]','.trending-subreddits a[href^="/r/"]','.trending-subreddits a[href*="reddit.com/r/"]'];
+		var subredditLinks = document.body.querySelectorAll(querySelectors.join());
 		if (subredditLinks) {
 			var len = subredditLinks.length;
 			for (var i = 0; i < len; i++) {

--- a/lib/modules/subredditInfo.js
+++ b/lib/modules/subredditInfo.js
@@ -61,7 +61,7 @@ modules['subredditInfo'] = {
 	srRe: /\/r\/(\w+)(?:\/(new|rising|controversial|top))?\/?$/i,
 	addListeners: function(ele) {
 		ele = ele || document.body;
-        var querySelectors = ['.listing-page a.subreddit','.explore-page a.subreddit','.comment .md a[href^="/r/"]','.comment .md a[href*="reddit.com/r/"]','.side a[href^="/r/"]','.side a[href*="reddit.com/r/"]','.usertext-body a[href^="/r/"]','.usertext-body a[href*="reddit.com/r/"]','.trending-subreddits a[href^="/r/"]','.trending-subreddits a[href*="reddit.com/r/"]'];
+		var querySelectors = ['.listing-page a.subreddit','.explore-page a.subreddit','.comment .md a[href^="/r/"]','.comment .md a[href*="reddit.com/r/"]','.side a[href^="/r/"]','.side a[href*="reddit.com/r/"]','.usertext-body a[href^="/r/"]','.usertext-body a[href*="reddit.com/r/"]','.trending-subreddits a[href^="/r/"]','.trending-subreddits a[href*="reddit.com/r/"]'];
 		var subredditLinks = document.body.querySelectorAll(querySelectors.join());
 		if (subredditLinks) {
 			var len = subredditLinks.length;


### PR DESCRIPTION
Noticed that subreddit hovering doesn't work for full links, and that there's already an [issue ticket](https://github.com/honestbleeps/Reddit-Enhancement-Suite/issues/2021) open for it.  [edit: fixes #2021]

I originally thought it would be a lot trickier, as you would need to be able to accept all formats like:
- http://reddit.com/r/sub
- https://reddit.com/r/sub
- http://www.reddit.com/r/sub
- https://www.reddit.com/r/sub
- www.reddit.com/r/sub  

While also ignoring links over other protocols, like: 
- file://reddit.com/r/sub

However, it turns out RES automatically only links together proper Web URLS, so the issue was much simpler and complicated CSS selectors weren't needed.
I moved the selectors to an array (although I didn't space them out one per line) for better readability and modifiability.