### PR TITLE
Obviate calls to /subreddits/mine/moderator.json

### DIFF
--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -154,6 +154,10 @@ RESUtils.loggedInUser = function(tryingEarly) {
 	}
 	return this.loggedInUserCached;
 };
+RESUtils.isModeratorAnywhere = function() {
+	// I was given special permission to do this.
+	return !!document.getElementById("modmail");
+};
 RESUtils.loggedInUserHash = function() {
 	this.loggedInUser();
 	return this.loggedInUserHashCached;

--- a/lib/modules/quickMessage.js
+++ b/lib/modules/quickMessage.js
@@ -130,15 +130,16 @@ addModule('quickMessage', function(module, moduleID) {
 			return;
 		}
 
-		var cacheData = RESStorage.getItem('RESUtils.sendFromCache.' + username) || '{}',
+		var sendFromCacheKey = 'RESUtils.sendFromCache.' + username,
+			cacheData = RESStorage.getItem(sendFromCacheKey) || '{}',
 			sendFromCache = safeJSON.parse(cacheData),
 			lastCheck = (sendFromCache !== null) ? parseInt(sendFromCache.lastCheck, 10) || 0 : 0,
 			now = Date.now();
 
-		if ((now - lastCheck) > 300000 || lastCheck > now) {
-			sendFromCache.senders = [];
-			sendFromCache.senders.push('/u/' + username);
+		var senders = ['/u/' + username];
 
+		// We moderate a subreddit and the cache is stale
+		if (RESUtils.isModeratorAnywhere() && ((now - lastCheck) > 300000 || lastCheck > now)) {
 			BrowserStrategy.ajax({
 				method: 'GET',
 				url: location.protocol + '//' + location.hostname + '/subreddits/mine/moderator.json?app=res',
@@ -154,13 +155,20 @@ addModule('quickMessage', function(module, moduleID) {
 					}
 					sendFromCache.lastCheck = now;
 					thisResponse.data.children.forEach(function(elem) {
-						sendFromCache.senders.push(elem.data.url.slice(0, -1));
+						senders.push(elem.data.url.slice(0, -1));
 					});
-
-					RESStorage.setItem('RESUtils.sendFromCache.' + username, JSON.stringify(sendFromCache));
+					sendFromCache.senders = senders;
+					RESStorage.setItem(sendFromCacheKey, JSON.stringify(sendFromCache));
 					callback(sendFromCache.senders);
 				}
 			});
+		// We don't moderate anything
+		} else if (!RESUtils.isModeratorAnywhere()) {
+			// Mark the cache as stale so it'll update as soon as me start moderating something
+			sendFromCache.lastCheck = 0;
+			sendFromCache.senders = senders;
+			RESStorage.setItem(sendFromCacheKey, JSON.stringify(sendFromCache));
+			callback(sendFromCache.senders);
 		} else {
 			callback(sendFromCache.senders);
 		}


### PR DESCRIPTION
This is the second most common API call that RES makes to the API, and it's unnecessary for the average user. Change it so we don't check for subreddits we moderate if we're sure we don't moderate any :sun_with_face: 