### PR TITLE
Allow modmail keyboard shortcut to be saved properly

### DIFF
--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -96,8 +96,9 @@ addModule('settingsConsole', function(module, moduleID) {
 					} else {
 						keyArray = [e.keyCode, e.altKey, e.ctrlKey, e.shiftKey, e.metaKey];
 					}
-					document.getElementById(RESConsole.captureKeyID).value = keyArray.join(',');
-					document.getElementById(RESConsole.captureKeyID + '-display').value = RESUtils.niceKeyCode(keyArray);
+					// not using .getElementById here due to a collision with reddit's elements (i.e. #modmail)
+					RESConsole.RESConfigPanelOptions.querySelector('[id="' + RESConsole.captureKeyID + '"]').value = keyArray.join(',');
+					RESConsole.RESConfigPanelOptions.querySelector('[id="' + RESConsole.captureKeyID + '-display"]').value = RESUtils.niceKeyCode(keyArray);
 					RESConsole.keyCodeModal.style.display = 'none';
 					RESConsole.captureKey = false;
 				}


### PR DESCRIPTION
Fixes #1954

This occurred because the event handler to update the keycode for each shortcut used `.getElementById(optionKey)`, which would select the modmail icon (for users that have it) instead of the modmail option.

I'm not sure if it would be better to change our `id` naming scheme instead - it would make more sense but require more changes.

@andytuba I don't appear to have permission to make a PR from the issue; I imagine I might if I was the issue's creator.