### PR TITLE
Settings staging / prompt before discard

### DIFF
--- a/lib/core/options.js
+++ b/lib/core/options.js
@@ -290,8 +290,8 @@ $.extend(RESUtils.options, {
 	}
 	function commitStagedOptions() {
 		$.each(stagedOptions, function (moduleID, module) {
-			$.each(module, function(optionName, optionValue) {
-				RESUtils.options.setOption(moduleID, optionName, optionValue);
+			$.each(module, function(optionName, option) {
+				RESUtils.options.setOption(moduleID, optionName, option.value);
 			});
 		});
 		clearStagedOptions();

--- a/lib/core/options.js
+++ b/lib/core/options.js
@@ -294,7 +294,7 @@ $.extend(RESUtils.options, {
 				RESUtils.options.setOption(moduleID, optionName, optionValue);
 			});
 		});
-		clearStage();
+		clearStagedOptions();
 	}
 	function clearStagedOptions() {
 		stagedOptions = {};

--- a/lib/core/options.js
+++ b/lib/core/options.js
@@ -276,3 +276,41 @@ $.extend(RESUtils.options, {
 		return modules[moduleID].options;
 	}
 });
+
+(function(module) {
+	var stagedOptions;
+
+	clearStagedOptions();
+
+	function stageOption(moduleID, optionName, optionValue) {
+		stageOptions[moduleID] = stagedOptions[moduleID] || {};
+		stageOptions[moduleID][optionName] = {
+			value: optionValue
+		};
+	}
+	function commitStagedOptions() {
+		$.each(stagedOptions, function (moduleID, module) {
+			$.each(module, function(optionName, optionValue) {
+				RESUtils.options.setOption(moduleID, optionName, optionValue);
+			});
+		});
+		clearStage();
+	}
+	function clearStagedOptions() {
+		stagedOptions = {};
+	}
+
+	function hasStagedOptions() {
+		return Object.getOwnPropertyNames(stagedOptions).length;
+	}
+
+	function getOptions(moduleID) {
+		return stagedOptions[moduleID];
+	}
+
+	module.reset = clearStagedOptions;
+	module.add = stageOption;
+	module.commit = commitStagedOptions;
+	module.isDirty = hasStagedOptions;
+	module.get = getOptions;
+})(RESUtils.options.stage = RESUtil.options.stage || {});

--- a/lib/core/options.js
+++ b/lib/core/options.js
@@ -313,4 +313,4 @@ $.extend(RESUtils.options, {
 	module.commit = commitStagedOptions;
 	module.isDirty = hasStagedOptions;
 	module.get = getOptions;
-})(RESUtils.options.stage = RESUtil.options.stage || {});
+})(RESUtils.options.stage = RESUtils.options.stage || {});

--- a/lib/core/options.js
+++ b/lib/core/options.js
@@ -283,8 +283,8 @@ $.extend(RESUtils.options, {
 	clearStagedOptions();
 
 	function stageOption(moduleID, optionName, optionValue) {
-		stageOptions[moduleID] = stagedOptions[moduleID] || {};
-		stageOptions[moduleID][optionName] = {
+		stagedOptions[moduleID] = stagedOptions[moduleID] || {};
+		stagedOptions[moduleID][optionName] = {
 			value: optionValue
 		};
 	}

--- a/lib/core/templates.html
+++ b/lib/core/templates.html
@@ -210,7 +210,7 @@
 		</div>
 		<div id="aboutRESPanel">
 			<h3>RES Team</h3>
-			<p><a target="_blank" href="http://www.honestbleeps.com/">Steve Sobel</a> (<a target="_blank" href="http://www.reddit.com/user/honestbleeps/">/u/honestbleeps</a>) is the primary developer of RES.  Beyond that, there are a number of people who have contributed code, design and/or great ideas to RES.  <a target="_blank" href="http://redditenhancementsuite.com/about.html">Read more about the RES team.</a></p>
+			<p><a target="_blank" href="http://www.honestbleeps.com/">Steve Sobel</a> (<a target="_blank" href="http://www.reddit.com/user/honestbleeps/">/u/honestbleeps</a>) is the primary developer of RES.  Beyond that, there are a number of people who have contributed code, design and/or great ideas to RES.  <a target="_blank" href="/r/Enhancement/w/about/team">Read more about the RES team.</a></p>
 
 			<h3>What is RES?</h3>
 			<p>Reddit Enhancement Suite is a collection of modules that makes browsing reddit a whole lot easier.</p>

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -867,7 +867,7 @@ addModule('settingsConsole', function(module, moduleID) {
 			}
 		},
 		close: function(options) {
-			$.extend({
+			options = $.extend({
 				promptIfStagedOptions: true,
 				resetUrl: true
 			}, options);

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -860,7 +860,10 @@ addModule('settingsConsole', function(module, moduleID) {
 				RESConsole.close();
 			}
 		},
-		close: function(resetUrl) {
+		close: function(options) {
+			$.extend({
+				resetUrl: true
+			}, options);
 			$('#moduleOptionsSave').fadeOut();
 			this.isOpen = false;
 			$('body').off('keyup', RESConsole.handleEscapeKey);
@@ -887,12 +890,9 @@ addModule('settingsConsole', function(module, moduleID) {
 				RESConsole.captureKey = false;
 			}
 
-			// Closing should reset the URL by default
-			if (typeof resetUrl !== 'undefined' && !resetUrl) {
-				return;
+			if (options.resetUrl) {
+				modules['settingsNavigation'].resetUrlHash();
 			}
-
-			modules['settingsNavigation'].resetUrlHash();
 		},
 		openCategoryPanel: function(categories) {
 			var items = $(module.RESConsoleContainer).find('#RESConfigPanelModulesList .RESConfigPanelCategory');

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -862,8 +862,15 @@ addModule('settingsConsole', function(module, moduleID) {
 		},
 		close: function(options) {
 			$.extend({
+				promptIfStagedOptions: true,
 				resetUrl: true
 			}, options);
+
+			if (options.promptIfStagedOptions && hasStagedOptions()) {
+				var abandonChanges = confirm('You changed some options, but didn\'t save them. Do you want to abandon your changes?');
+				if (abandonChanges) return;
+			}
+
 			$('#moduleOptionsSave').fadeOut();
 			this.isOpen = false;
 			$('body').off('keyup', RESConsole.handleEscapeKey);
@@ -1017,6 +1024,10 @@ addModule('settingsConsole', function(module, moduleID) {
 			});
 		});
 		stagedOptions = {};
+	}
+
+	function hasStagedOptions() {
+		return Object.getOwnPropertyNames(stagedOptions).length;
 	}
 
 	function getOptions(moduleID) {

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -1017,7 +1017,8 @@ addModule('settingsConsole', function(module, moduleID) {
 		}
 	});
 
-	var stagedOptions = {};
+	var stagedOptions;
+	clearStagedOptions();
 	function stageOption(moduleID, optionName, optionValue) {
 		stageOptions[moduleID] = stagedOptions[moduleID] || {};
 		stageOptions[moduleID][optionName] = {
@@ -1030,6 +1031,9 @@ addModule('settingsConsole', function(module, moduleID) {
 				RESUtils.options.setOption(moduleID, optionName, optionValue);
 			});
 		});
+		clearStage();
+	}
+	function clearStagedOptions() {
 		stagedOptions = {};
 	}
 

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -851,6 +851,7 @@ addModule('settingsConsole', function(module, moduleID) {
 			}
 
 			$(document.body).on('keyup', RESConsole.handleEscapeKey);
+			$(window).on('beforeunload', RESConsole.handleBeforeUnload);
 			$(this.RESConsoleContainer).on('change', RESUtils.debounce.bind(RESUtils, 'RESSettings.autostage', 800, module.stageCurrentModuleOptions.bind(module)));
 		},
 		handleEscapeKey: function(event) {
@@ -858,6 +859,11 @@ addModule('settingsConsole', function(module, moduleID) {
 			// because they probably just want to cancel the dropdown list
 			if (event.which === 27 && (document.activeElement.id.indexOf('token-input') === -1)) {
 				RESConsole.close();
+			}
+		},
+		handleBeforeUnload: function() {
+			if (hasStagedOptions()) {
+				return abandonChangesConfirmation;
 			}
 		},
 		close: function(options) {
@@ -874,6 +880,7 @@ addModule('settingsConsole', function(module, moduleID) {
 			$('#moduleOptionsSave').fadeOut();
 			this.isOpen = false;
 			$(document.body).off('keyup', RESConsole.handleEscapeKey);
+			$(beforeunload).on('beforeunload', RESConsole.handleBeforeUnload);
 			// Let's be nice to reddit and put their ad frame back now...
 			var adFrame = document.getElementById('ad-frame');
 			if ((typeof adFrame !== 'undefined') && (adFrame !== null)) {

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -692,7 +692,7 @@ addModule('settingsConsole', function(module, moduleID) {
 			var thisRow = e.target.parentNode.parentNode;
 			$(thisRow).remove();
 		},
-		saveCurrentModuleOptions: function() {
+		stageCurrentModuleOptions: function() {
 			var panelOptionsDiv = this.RESConfigPanelOptions;
 			// first, go through inputs that aren't a part of a "table of options"...
 			var inputs = panelOptionsDiv.querySelectorAll('input, textarea');
@@ -726,7 +726,7 @@ addModule('settingsConsole', function(module, moduleID) {
 						}
 					}
 					if (typeof optionValue !== 'undefined') {
-						RESUtils.options.setOption(moduleID, optionName, optionValue);
+						stageOption(moduleID, optionName, optionValue);
 					}
 				}
 			});
@@ -789,17 +789,15 @@ addModule('settingsConsole', function(module, moduleID) {
 							optionMulti.sort(modules[moduleID].options[optionName].sort);
 						}
 
-						RESUtils.options.setOption(moduleID, optionName, optionMulti);
+						stageOption(moduleID, optionName, optionMulti);
 					}
 				});
 			}
-
-			var statusEle = module.RESConsoleContainer.querySelector('#moduleOptionsSaveStatus');
-			if (statusEle) {
-				$(statusEle).text('Options have been saved...');
-				statusEle.setAttribute('style', 'display: block; opacity: 1');
-				setTimeout(RESUtils.fadeElementOut, 500, statusEle, 1.0);
-			}
+		},
+		saveCurrentModuleOptions: function() {
+			module.stageCurrentModuleOptions();
+			commitStagedOptions();
+			notifyOptionsSaved();
 		},
 		open: function(moduleIdOrCategory) {
 			var category, moduleID;
@@ -1003,4 +1001,29 @@ addModule('settingsConsole', function(module, moduleID) {
 			});
 		}
 	});
+
+	var stagedOptions = {};
+	function stageOption(moduleID, optionName, optionValue) {
+		stageOptions[moduleID] = stagedOptions[moduleID] || {};
+		stageOptions[moduleID][optionName] = {
+			value: optionValue
+		};
+	}
+	function commitStagedOptions() {
+		$.each(stagedOptions, function (moduleID, module) {
+			$.each(module, function(optionName, optionValue) {
+				RESUtils.options.setOption(moduleID, optionName, optionValue);
+			});
+		});
+		stagedOptions = {};
+	}
+
+	function notifyOptionsSaved() {
+		var statusEle = module.RESConsoleContainer.querySelector('#moduleOptionsSaveStatus');
+		if (statusEle) {
+			$(statusEle).text('Options have been saved...');
+			statusEle.setAttribute('style', 'display: block; opacity: 1');
+			setTimeout(RESUtils.fadeElementOut, 500, statusEle, 1.0);
+		}
+	}
 });

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -851,7 +851,7 @@ addModule('settingsConsole', function(module, moduleID) {
 			}
 
 			$('body').on('keyup', RESConsole.handleEscapeKey);
-			$(this.RESConsoleContainer).on('blur', module.stageCurrentModuleOptions.bind(module));
+			$(this.RESConsoleContainer).on('change', RESUtils.debounce.bind(RESUtils, 'RESSettings.autostage', 800, module.stageCurrentModuleOptions.bind(module)));
 		},
 		handleEscapeKey: function(event) {
 			// don't close if the user is in a token input field (e.g. adding subreddits to a list)

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -367,7 +367,7 @@ addModule('settingsConsole', function(module, moduleID) {
 		},
 		drawConfigOptions: function(moduleID) {
 			if (modules[moduleID] && modules[moduleID].hidden) return;
-			var thisOptions = RESUtils.options.getOptions(moduleID),
+			var thisOptions = getOptions(moduleID),
 				optCount = 0,
 				moduleNameSpan = RESUtils.createElementWithID('span', null, 'moduleName', modules[moduleID].moduleName),
 				toggleOn = RESUtils.createElementWithID('span', null, 'toggleOn noCtrlF', 'on'),
@@ -670,7 +670,7 @@ addModule('settingsConsole', function(module, moduleID) {
 			}
 		},
 		onOptionChange: function(moduleID, fieldID, oldValue, newValue) {
-			var thisOptions = RESUtils.options.getOptions(moduleID);
+			var thisOptions = getOptions(moduleID);
 
 			if (thisOptions[fieldID] && thisOptions[fieldID].dependents) {
 				thisOptions[fieldID].dependents.forEach(function(dep) {
@@ -1016,6 +1016,14 @@ addModule('settingsConsole', function(module, moduleID) {
 			});
 		});
 		stagedOptions = {};
+	}
+
+	function getOptions(moduleID) {
+		var stored = RESUtils.options.getOptions(moduleID);
+		var staged = stagedOptions[moduleID];
+
+		var merged = $.extend(true, {}, stored, staged);
+		return merged;
 	}
 
 	function notifyOptionsSaved() {

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -874,7 +874,7 @@ addModule('settingsConsole', function(module, moduleID) {
 
 			if (options.promptIfStagedOptions && RESUtils.options.stage.isDirty()) {
 				var abandonChanges = confirm(abandonChangesConfirmation);
-				if (abandonChanges) return;
+				if (!abandonChanges) return;
 			}
 
 			RESUtils.options.stage.reset();

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -851,6 +851,7 @@ addModule('settingsConsole', function(module, moduleID) {
 			}
 
 			$('body').on('keyup', RESConsole.handleEscapeKey);
+			$(this.RESConsoleContainer).on('blur', module.stageCurrentModuleOptions.bind(module));
 		},
 		handleEscapeKey: function(event) {
 			// don't close if the user is in a token input field (e.g. adding subreddits to a list)

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -852,7 +852,7 @@ addModule('settingsConsole', function(module, moduleID) {
 
 			$(document.body).on('keyup', RESConsole.handleEscapeKey);
 			$(window).on('beforeunload', RESConsole.handleBeforeUnload);
-			$(this.RESConsoleContainer).on('change', RESUtils.debounce.bind(RESUtils, 'RESSettings.autostage', 800, module.stageCurrentModuleOptions.bind(module)));
+			$(this.RESConsoleContainer).on('change', RESUtils.debounce.bind(RESUtils, 'RESSettings.autostage', 800, this.stageCurrentModuleOptions.bind(this)));
 		},
 		handleEscapeKey: function(event) {
 			// don't close if the user is in a token input field (e.g. adding subreddits to a list)

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -726,7 +726,7 @@ addModule('settingsConsole', function(module, moduleID) {
 						}
 					}
 					if (typeof optionValue !== 'undefined') {
-						stageOption(moduleID, optionName, optionValue);
+						RESUtils.options.stage.add(moduleID, optionName, optionValue);
 					}
 				}
 			});
@@ -789,14 +789,14 @@ addModule('settingsConsole', function(module, moduleID) {
 							optionMulti.sort(modules[moduleID].options[optionName].sort);
 						}
 
-						stageOption(moduleID, optionName, optionMulti);
+						RESUtils.options.stage.add(moduleID, optionName, optionMulti);
 					}
 				});
 			}
 		},
 		saveCurrentModuleOptions: function() {
 			module.stageCurrentModuleOptions();
-			commitStagedOptions();
+			RESUtils.options.stage.commit();
 			notifyOptionsSaved();
 		},
 		open: function(moduleIdOrCategory) {
@@ -862,7 +862,7 @@ addModule('settingsConsole', function(module, moduleID) {
 			}
 		},
 		handleBeforeUnload: function() {
-			if (hasStagedOptions()) {
+			if (RESUtils.options.stage.isDirty()) {
 				return abandonChangesConfirmation;
 			}
 		},
@@ -872,10 +872,12 @@ addModule('settingsConsole', function(module, moduleID) {
 				resetUrl: true
 			}, options);
 
-			if (options.promptIfStagedOptions && hasStagedOptions()) {
+			if (options.promptIfStagedOptions && RESUtils.options.stage.isDirty()) {
 				var abandonChanges = confirm(abandonChangesConfirmation);
 				if (abandonChanges) return;
 			}
+
+			RESUtils.options.stage.reset();
 
 			$('#moduleOptionsSave').fadeOut();
 			this.isOpen = false;
@@ -1017,33 +1019,9 @@ addModule('settingsConsole', function(module, moduleID) {
 		}
 	});
 
-	var stagedOptions;
-	clearStagedOptions();
-	function stageOption(moduleID, optionName, optionValue) {
-		stageOptions[moduleID] = stagedOptions[moduleID] || {};
-		stageOptions[moduleID][optionName] = {
-			value: optionValue
-		};
-	}
-	function commitStagedOptions() {
-		$.each(stagedOptions, function (moduleID, module) {
-			$.each(module, function(optionName, optionValue) {
-				RESUtils.options.setOption(moduleID, optionName, optionValue);
-			});
-		});
-		clearStage();
-	}
-	function clearStagedOptions() {
-		stagedOptions = {};
-	}
-
-	function hasStagedOptions() {
-		return Object.getOwnPropertyNames(stagedOptions).length;
-	}
-
 	function getOptions(moduleID) {
 		var stored = RESUtils.options.getOptions(moduleID);
-		var staged = stagedOptions[moduleID];
+		var staged = RESUtils.options.stage.get(moduleID);
 
 		var merged = $.extend(true, {}, stored, staged);
 		return merged;

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -858,12 +858,12 @@ addModule('settingsConsole', function(module, moduleID) {
 			// because they probably just want to cancel the dropdown list
 			if (event.which === 27 && (document.activeElement.id.indexOf('token-input') === -1)) {
 				RESConsole.close();
-				$('body').off('keyup', RESConsole.handleEscapeKey);
 			}
 		},
 		close: function(resetUrl) {
 			$('#moduleOptionsSave').fadeOut();
 			this.isOpen = false;
+			$('body').off('keyup', RESConsole.handleEscapeKey);
 			// Let's be nice to reddit and put their ad frame back now...
 			var adFrame = document.getElementById('ad-frame');
 			if ((typeof adFrame !== 'undefined') && (adFrame !== null)) {

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -867,7 +867,7 @@ addModule('settingsConsole', function(module, moduleID) {
 			}, options);
 
 			if (options.promptIfStagedOptions && hasStagedOptions()) {
-				var abandonChanges = confirm('You changed some options, but didn\'t save them. Do you want to abandon your changes?');
+				var abandonChanges = confirm(abandonChangesConfirmation);
 				if (abandonChanges) return;
 			}
 
@@ -1037,6 +1037,8 @@ addModule('settingsConsole', function(module, moduleID) {
 		var merged = $.extend(true, {}, stored, staged);
 		return merged;
 	}
+
+	var abandonChangesConfirmation = 'You changed some options, but didn\'t save them. Do you want to abandon your changes?';
 
 	function notifyOptionsSaved() {
 		var statusEle = module.RESConsoleContainer.querySelector('#moduleOptionsSaveStatus');

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -896,7 +896,7 @@ addModule('settingsConsole', function(module, moduleID) {
 			this.RESConsoleContainer.classList.add('slideOut');
 			setTimeout(function() {
 				// Main reason for timeout: https://bugzilla.mozilla.org/show_bug.cgi?id=625289
-				document.querySelector('body').classList.remove('res-console-open');
+				document.body.classList.remove('res-console-open');
 			}, 500);
 			// just in case the user was in the middle of setting a key and decided to close the dialog, clean that up.
 			if (typeof RESConsole.keyCodeModal !== 'undefined') {

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -882,7 +882,7 @@ addModule('settingsConsole', function(module, moduleID) {
 			$('#moduleOptionsSave').fadeOut();
 			this.isOpen = false;
 			$(document.body).off('keyup', RESConsole.handleEscapeKey);
-			$(beforeunload).on('beforeunload', RESConsole.handleBeforeUnload);
+			$(window).off('beforeunload', RESConsole.handleBeforeUnload);
 			// Let's be nice to reddit and put their ad frame back now...
 			var adFrame = document.getElementById('ad-frame');
 			if ((typeof adFrame !== 'undefined') && (adFrame !== null)) {

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -850,7 +850,7 @@ addModule('settingsConsole', function(module, moduleID) {
 				modules['settingsNavigation'].RESSearchBox.focus();
 			}
 
-			$('body').on('keyup', RESConsole.handleEscapeKey);
+			$(document.body).on('keyup', RESConsole.handleEscapeKey);
 			$(this.RESConsoleContainer).on('change', RESUtils.debounce.bind(RESUtils, 'RESSettings.autostage', 800, module.stageCurrentModuleOptions.bind(module)));
 		},
 		handleEscapeKey: function(event) {
@@ -873,7 +873,7 @@ addModule('settingsConsole', function(module, moduleID) {
 
 			$('#moduleOptionsSave').fadeOut();
 			this.isOpen = false;
-			$('body').off('keyup', RESConsole.handleEscapeKey);
+			$(document.body).off('keyup', RESConsole.handleEscapeKey);
 			// Let's be nice to reddit and put their ad frame back now...
 			var adFrame = document.getElementById('ad-frame');
 			if ((typeof adFrame !== 'undefined') && (adFrame !== null)) {

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -1045,7 +1045,7 @@ addModule('settingsConsole', function(module, moduleID) {
 		return merged;
 	}
 
-	var abandonChangesConfirmation = 'You changed some options, but didn\'t save them. Do you want to abandon your changes?';
+	var abandonChangesConfirmation = 'Abandon your changes to RES settings?';
 
 	function notifyOptionsSaved() {
 		var statusEle = module.RESConsoleContainer.querySelector('#moduleOptionsSaveStatus');

--- a/lib/modules/settingsNavigation.js
+++ b/lib/modules/settingsNavigation.js
@@ -133,7 +133,9 @@ modules['settingsNavigation'] = {
 			if (modules['settingsConsole'].isOpen) {
 				// Avoid adding a duplicate page to the browser history
 				var resetUrl = false;
-				modules['settingsConsole'].close(resetUrl);
+				modules['settingsConsole'].close({
+					resetUrl: resetUrl
+				});
 			}
 			return;
 		}


### PR DESCRIPTION
* stage options changed while console is open, so user can switch modules without losing changes
* before closing console/window, prompt user to discard unsaved changes (if any exist)
* some refactoring, of course

This could probably use another iteration for UX, such as autosave+revert, but this is a good incremental step.