### PR TITLE
Orangered, Floater

### DIFF
--- a/Chrome/background.js
+++ b/Chrome/background.js
@@ -301,6 +301,19 @@ chrome.runtime.onMessage.addListener(
 						break;
 				}
 				break;
+			case 'multicast':
+				var tabs = chrome.tabs.query({
+					status: 'complete',
+				}, function(tabs) {
+					tabs = tabs.filter(function(tab) {
+						return (sender.tab.id !== tab.id);
+					});
+
+					tabs.forEach(function(tab) {
+						chrome.tabs.sendMessage(tab.id, request, function(response) { });
+					});
+				});
+				break;
 			default:
 				sendResponse({status: 'unrecognized request type'});
 				break;

--- a/Chrome/browsersupport-chrome.js
+++ b/Chrome/browsersupport-chrome.js
@@ -45,6 +45,9 @@ chrome.runtime.onMessage.addListener(
 				var toggle = !modules['styleTweaks'].styleToggleCheckbox.checked;
 				modules['styleTweaks'].toggleSubredditStyle(toggle, RESUtils.currentSubreddit());
 				break;
+			case 'multicast':
+				RESUtils.rpc(request.moduleID, request.method, request.arguments);
+				break;
 			default:
 				// sendResponse({status: 'unrecognized request type'});
 				break;

--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -49,6 +49,7 @@
 				"modules/keyboardNav.js",
 				"modules/about.js",
 				"modules/commandLine.js",
+				"modules/floater.js",
 				"modules/orangered.js",
 				"modules/announcements.js",
 				"modules/selectedEntry.js",

--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -49,6 +49,7 @@
 				"modules/keyboardNav.js",
 				"modules/about.js",
 				"modules/commandLine.js",
+				"modules/orangered.js",
 				"modules/announcements.js",
 				"modules/selectedEntry.js",
 				"modules/settingsConsole.js",

--- a/Opera/browsersupport-opera.js
+++ b/Opera/browsersupport-opera.js
@@ -70,6 +70,9 @@ function operaMessageHandler(msgEvent) {
 				RESUtils.runtime._addURLToHistoryViaForeground(url);
 			}
 			break;
+		case 'multicast':
+			RESUtils.rpc(eventData.moduleID, eventData.method, eventData.arguments);
+			break;
 		default:
 			// console.log('unknown event type in operaMessageHandler');
 			break;

--- a/Opera/includes/loader.js
+++ b/Opera/includes/loader.js
@@ -54,6 +54,7 @@ window.addEventListener('DOMContentLoaded', function() {
 		'modules/accountSwitcher.js',
 		'modules/betteReddit.js',
 		'modules/commandLine.js',
+		'modules/floater.js',
 		'modules/orangered.js',
 		'modules/announcements.js',
 		'modules/selectedEntry.js',

--- a/Opera/includes/loader.js
+++ b/Opera/includes/loader.js
@@ -54,6 +54,7 @@ window.addEventListener('DOMContentLoaded', function() {
 		'modules/accountSwitcher.js',
 		'modules/betteReddit.js',
 		'modules/commandLine.js',
+		'modules/orangered.js',
 		'modules/announcements.js',
 		'modules/selectedEntry.js',
 		'modules/settingsConsole.js',

--- a/Opera/index.html
+++ b/Opera/index.html
@@ -301,6 +301,20 @@ opera.extension.addEventListener( 'message', function( event ) {
 				};
 				event.source.postMessage(passBack);
 				break;
+			case 'multicast':
+				var tabs = opera.extension.tabs.getAll();
+				tabs = tabs.filter(function(tab) {
+					return (event.source !== tab);
+				});
+
+				tabs.forEach(function(tab) {
+					tab.sendMessage(tab.id, {
+						msgType: 'multicast',
+						data: request
+					}, function(response) { });
+				});
+
+				break;
 			default:
 				passBack = {
 					msgType: '',

--- a/OperaBlink/background.js
+++ b/OperaBlink/background.js
@@ -302,6 +302,19 @@ chrome.runtime.onMessage.addListener(
 						break;
 				}
 				break;
+			case 'multicast':
+				var tabs = chrome.tabs.query({
+					status: 'complete',
+				}, function(tabs) {
+					tabs = tabs.filter(function(tab) {
+						return (sender.tab.id !== tab.id);
+					});
+
+					tabs.forEach(function(tab) {
+						chrome.tabs.sendMessage(tab.id, request, function(response) { });
+					});
+				});
+				break;
 			default:
 				sendResponse({status: 'unrecognized request type'});
 				break;

--- a/OperaBlink/manifest.json
+++ b/OperaBlink/manifest.json
@@ -48,6 +48,7 @@
 				"modules/keyboardNav.js",
 				"modules/about.js",
 				"modules/commandLine.js",
+				"modules/floater.js",
 				"modules/orangered.js",
 				"modules/announcements.js",
 				"modules/selectedEntry.js",

--- a/OperaBlink/manifest.json
+++ b/OperaBlink/manifest.json
@@ -48,6 +48,7 @@
 				"modules/keyboardNav.js",
 				"modules/about.js",
 				"modules/commandLine.js",
+				"modules/orangered.js",
 				"modules/announcements.js",
 				"modules/selectedEntry.js",
 				"modules/settingsConsole.js",

--- a/RES.safariextension/Info.plist
+++ b/RES.safariextension/Info.plist
@@ -58,6 +58,7 @@
 				<string>modules/userTagger.js</string>
 				<string>modules/keyboardNav.js</string>
 				<string>modules/commandLine.js</string>
+				<string>modules/floater.js</string>
 				<string>modules/orangered.js</string>
 				<string>modules/announcements.js</string>
 				<string>modules/selectedEntry.js</string>

--- a/RES.safariextension/Info.plist
+++ b/RES.safariextension/Info.plist
@@ -58,6 +58,7 @@
 				<string>modules/userTagger.js</string>
 				<string>modules/keyboardNav.js</string>
 				<string>modules/commandLine.js</string>
+				<string>modules/orangered.js</string>
 				<string>modules/announcements.js</string>
 				<string>modules/selectedEntry.js</string>
 				<string>modules/settingsConsole.js</string>

--- a/RES.safariextension/background-safari.html
+++ b/RES.safariextension/background-safari.html
@@ -266,6 +266,22 @@
 					sendResponse(passBack, msgEvent);
 				}
 				break;
+			case 'multicast':
+				(function () {
+					var tabs = Array.prototype.slice.call(safari.application.browserWindows)
+						.map(function(window) {
+							return Array.prototype.slice.call(window.tabs);
+						}).reduce(function(prev, next) {
+							return prev.concat(next);
+						}, []);
+					var sendTo = tabs.filter(function(tab) {
+							return msgEvent.target !== tab;
+						})
+					sendTo.forEach(function(tab) {
+						tab.page.dispatchMessage(request.requestType, request);
+					});
+				})();
+				break;
 			default:
 				sendResponse({status: 'unrecognized request type'}, msgEvent);
 		}

--- a/RES.safariextension/browsersupport-safari.js
+++ b/RES.safariextension/browsersupport-safari.js
@@ -2,18 +2,19 @@
 // This is the message handler for Safari - the background page calls this function with return data...
 
 function safariMessageHandler(msgEvent) {
+	var request = msgEvent.message;
 	switch (msgEvent.name) {
 		case 'ajax':
 			// Fire the appropriate onload function for this xmlhttprequest.
-			xhrQueue.onloads[msgEvent.message.XHRID](msgEvent.message);
+			xhrQueue.onloads[request.XHRID](request);
 			break;
 		case 'compareVersion':
 			var forceUpdate = false;
-			if (typeof msgEvent.message.forceUpdate !== 'undefined') forceUpdate = true;
-			RESUtils.compareVersion(msgEvent.message, forceUpdate);
+			if (typeof request.forceUpdate !== 'undefined') forceUpdate = true;
+			RESUtils.compareVersion(request, forceUpdate);
 			break;
 		case 'loadTweet':
-			var tweet = msgEvent.message;
+			var tweet = request;
 			var thisExpando = modules['styleTweaks'].tweetExpando;
 			$(thisExpando).html(tweet.html);
 			thisExpando.style.display = 'block';
@@ -22,7 +23,7 @@ function safariMessageHandler(msgEvent) {
 		case 'getLocalStorage':
 			// Does RESStorage have actual data in it?  If it doesn't, they're a legacy user, we need to copy
 			// old schol localStorage from the foreground page to the background page to keep their settings...
-			if (typeof msgEvent.message.importedFromForeground === 'undefined') {
+			if (typeof request.importedFromForeground === 'undefined') {
 				// it doesn't exist.. copy it over...
 				var ls = {};
 				for (var i = 0, len = localStorage.length; i < len; i++) {
@@ -36,21 +37,21 @@ function safariMessageHandler(msgEvent) {
 				};
 				safari.self.tab.dispatchMessage('saveLocalStorage', thisJSON);
 			} else {
-				setUpRESStorage(msgEvent.message);
+				setUpRESStorage(request);
 				//RESInit();
 			}
 			break;
 		case 'saveLocalStorage':
 			// Okay, we just copied localStorage from foreground to background, let's set it up...
-			setUpRESStorage(msgEvent.message);
+			setUpRESStorage(request);
 			//RESInit();
 			break;
 		case 'addURLToHistory':
-			var url = msgEvent.message.url;
+			var url = request.url;
 			RESUtils.runtime._addURLToHistoryViaForeground(url);
 			break;
 		case 'localStorage':
-			RESStorage.setItem(msgEvent.message.itemName, msgEvent.message.itemValue, true);
+			RESStorage.setItem(request.itemName, request.itemValue, true);
 			break;
 		default:
 			// console.log('unknown event type in safariMessageHandler');

--- a/RES.safariextension/browsersupport-safari.js
+++ b/RES.safariextension/browsersupport-safari.js
@@ -53,6 +53,9 @@ function safariMessageHandler(msgEvent) {
 		case 'localStorage':
 			RESStorage.setItem(request.itemName, request.itemValue, true);
 			break;
+		case 'multicast':
+			RESUtils.rpc(request.moduleID, request.method, request.arguments);
+			break;
 		default:
 			// console.log('unknown event type in safariMessageHandler');
 			break;

--- a/XPI/data/browsersupport-firefox.js
+++ b/XPI/data/browsersupport-firefox.js
@@ -1,21 +1,21 @@
 // if this is a jetpack addon, add an event listener like Safari's message handler...
-self.on('message', function(msgEvent) {
-	switch (msgEvent.name) {
+self.on('message', function(request) {
+	switch (request.requestType) {
 		case 'readResource':
-			window.RESLoadCallbacks[msgEvent.transaction](msgEvent.data);
-			delete window.RESLoadCallbacks[msgEvent.transaction];
+			window.RESLoadCallbacks[request.transaction](request.data);
+			delete window.RESLoadCallbacks[request.transaction];
 			break;
 		case 'ajax':
 			// Fire the appropriate onload function for this xmlhttprequest.
-			xhrQueue.onloads[msgEvent.XHRID](msgEvent.response);
+			xhrQueue.onloads[request.XHRID](request.response);
 			break;
 		case 'compareVersion':
 			var forceUpdate = false;
-			if (typeof msgEvent.message.forceUpdate !== 'undefined') forceUpdate = true;
-			RESUtils.compareVersion(msgEvent.message, forceUpdate);
+			if (typeof request.message.forceUpdate !== 'undefined') forceUpdate = true;
+			RESUtils.compareVersion(request.message, forceUpdate);
 			break;
 		case 'loadTweet':
-			var tweet = msgEvent.response;
+			var tweet = request.response;
 			var thisExpando = modules['styleTweaks'].tweetExpando;
 			$(thisExpando).html(tweet.html);
 			thisExpando.style.display = 'block';
@@ -24,7 +24,7 @@ self.on('message', function(msgEvent) {
 		case 'getLocalStorage':
 			// Does RESStorage have actual data in it?  If it doesn't, they're a legacy user, we need to copy
 			// old school localStorage from the foreground page to the background page to keep their settings...
-			if (typeof msgEvent.message.importedFromForeground === 'undefined') {
+			if (typeof request.message.importedFromForeground === 'undefined') {
 				// it doesn't exist.. copy it over...
 				var thisJSON = {
 					requestType: 'saveLocalStorage',
@@ -32,22 +32,22 @@ self.on('message', function(msgEvent) {
 				};
 				self.postMessage(thisJSON);
 			} else {
-				setUpRESStorage(msgEvent.message);
+				setUpRESStorage(request.message);
 				//RESInit();
 			}
 			break;
 		case 'saveLocalStorage':
 			// Okay, we just copied localStorage from foreground to background, let's set it up...
-			setUpRESStorage(msgEvent.message);
+			setUpRESStorage(request.message);
 			break;
 		case 'localStorage':
-			RESStorage.setItem(msgEvent.itemName, msgEvent.itemValue, true);
+			RESStorage.setItem(request.itemName, request.itemValue, true);
 			break;
 		case 'subredditStyle':
 			if (!modules['styleTweaks'].styleToggleCheckbox) {
 				return;
 			}
-			if (msgEvent.message === 'refreshState') {
+			if (request.message === 'refreshState') {
 				var toggle = modules['styleTweaks'].styleToggleCheckbox.checked,
 					currentSubreddit = RESUtils.currentSubreddit();
 
@@ -68,7 +68,7 @@ self.on('message', function(msgEvent) {
 			break;
 		default:
 			// console.log('unknown event type in self.on');
-			// console.log(msgEvent.toSource());
+			// console.log(request.toSource());
 			break;
 	}
 });

--- a/XPI/data/browsersupport-firefox.js
+++ b/XPI/data/browsersupport-firefox.js
@@ -66,6 +66,9 @@ self.on('message', function(request) {
 				}
 			}
 			break;
+		case 'multicast':
+			RESUtils.rpc(request.moduleID, request.method, request.args);
+			break;
 		default:
 			// console.log('unknown event type in self.on');
 			// console.log(request.toSource());

--- a/XPI/data/browsersupport-firefox.js
+++ b/XPI/data/browsersupport-firefox.js
@@ -67,7 +67,7 @@ self.on('message', function(request) {
 			}
 			break;
 		case 'multicast':
-			RESUtils.rpc(request.moduleID, request.method, request.args);
+			RESUtils.rpc(request.moduleID, request.method, request.arguments);
 			break;
 		default:
 			// console.log('unknown event type in self.on');

--- a/XPI/lib/main.js
+++ b/XPI/lib/main.js
@@ -175,6 +175,7 @@ pageMod.PageMod({
 		self.data.url('modules/userTagger.js'),
 		self.data.url('modules/keyboardNav.js'),
 		self.data.url('modules/commandLine.js'),
+		self.data.url('modules/orangered.js'),
 		self.data.url('modules/announcements.js'),
 		self.data.url('modules/selectedEntry.js'),
 		self.data.url('modules/settingsConsole.js'),

--- a/XPI/lib/main.js
+++ b/XPI/lib/main.js
@@ -117,8 +117,8 @@ tabs.on('activate', function() {
 	// find this worker...
 	let worker = getActiveWorker();
 	if (worker) {
-		worker.postMessage({ name: 'getLocalStorage', message: localStorage });
-		worker.postMessage({ name: 'subredditStyle', message: 'refreshState' });
+		worker.postMessage({ requestType: 'getLocalStorage', message: localStorage });
+		worker.postMessage({ requestType: 'subredditStyle', message: 'refreshState' });
 	}
 });
 
@@ -280,7 +280,7 @@ pageMod.PageMod({
 			switch (request.requestType) {
 				case 'readResource':
 					let fileData = self.data.load(request.filename);
-					worker.postMessage({ name: 'readResource', data: fileData, transaction: request.transaction });
+					worker.postMessage({ requestType: 'readResource', data: fileData, transaction: request.transaction });
 					break;
 				case 'deleteCookie':
 					cookieManager.remove('.reddit.com', request.cname, '/', false);
@@ -289,7 +289,7 @@ pageMod.PageMod({
 				case 'ajax':
 					let responseObj = {
 						XHRID: request.XHRID,
-						name: request.requestType
+						requestType: request.requestType
 					};
 					if (request.aggressiveCache || XHRCache.forceCache) {
 						let cachedResult = XHRCache.check(request.url);
@@ -386,7 +386,7 @@ pageMod.PageMod({
 						onComplete: function(response) {
 							let resp = JSON.parse(response.text);
 							let responseObj = {
-								name: 'loadTweet',
+								requestType: 'loadTweet',
 								response: resp
 							};
 							worker.postMessage(responseObj);
@@ -396,14 +396,14 @@ pageMod.PageMod({
 					}).get();
 					break;
 				case 'getLocalStorage':
-					worker.postMessage({ name: 'getLocalStorage', message: localStorage });
+					worker.postMessage({ requestType: 'getLocalStorage', message: localStorage });
 					break;
 				case 'saveLocalStorage':
 					for (let key in request.data) {
 						localStorage.setItem(key,request.data[key]);
 					}
 					localStorage.setItem('importedFromForeground', true);
-					worker.postMessage({ name: 'saveLocalStorage', message: localStorage });
+					worker.postMessage({ requestType: 'saveLocalStorage', message: localStorage });
 					break;
 				case 'localStorage':
 					switch (request.operation) {
@@ -443,7 +443,7 @@ pageMod.PageMod({
 									onChange: function(state) {
 										let worker = getActiveWorker();
 										worker.postMessage({
-											name: 'subredditStyle',
+											requestType: 'subredditStyle',
 											toggle: state.checked
 										});
 									}

--- a/XPI/lib/main.js
+++ b/XPI/lib/main.js
@@ -504,6 +504,14 @@ pageMod.PageMod({
 						}]
 					});
 					break;
+				case 'multicast':
+					workers
+						.filter(function(w) { return w !== worker; })
+						.forEach(function(worker) {
+							worker.postMessage(request);
+						});
+
+					break;
 				default:
 					worker.postMessage({status: 'unrecognized request type'});
 					break;

--- a/XPI/lib/main.js
+++ b/XPI/lib/main.js
@@ -175,6 +175,7 @@ pageMod.PageMod({
 		self.data.url('modules/userTagger.js'),
 		self.data.url('modules/keyboardNav.js'),
 		self.data.url('modules/commandLine.js'),
+		self.data.url('modules/floater.js'),
 		self.data.url('modules/orangered.js'),
 		self.data.url('modules/announcements.js'),
 		self.data.url('modules/selectedEntry.js'),

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -830,10 +830,17 @@ RESUtils.inArray = function(needle, haystacks, isCaseSensitive) {
 	}
 };
 RESUtils.rpc = function(moduleID, method, args) {
-	var module = modules[moduleID];
-	if (typeof module[method] === 'function') {
-		module[method].apply(method, [].concat(args).concat('rpc'));
+	if (args && args[args.length - 1] === 'rpc') {
+		console.warn('rpc warning: loop.', moduleID, method, args);
+		return;
 	}
+	var module = modules[moduleID];
+	if (!module || typeof module[method] !== 'function') {
+		console.warn('rpc error: could not find method.', moduleID, method, args);
+		return;
+	}
+
+	module[method].apply(method, [].concat(args).concat('rpc'));
 };
 RESUtils.firstRun = function() {
 	// if this is the first time this version has been run, pop open the what's new tab, background focused.

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -829,6 +829,12 @@ RESUtils.inArray = function(needle, haystacks, isCaseSensitive) {
 		}
 	}
 };
+RESUtils.rpc = function(moduleID, method, args) {
+	var module = modules[moduleID];
+	if (typeof module[method] === 'function') {
+		module[method].apply(method, [].concat(args).concat('rpc'));
+	}
+};
 RESUtils.firstRun = function() {
 	// if this is the first time this version has been run, pop open the what's new tab, background focused.
 	if (RESStorage.getItem('RES.firstRun.' + RESVersion) === null) {

--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -25,38 +25,6 @@ modules['betteReddit'] = {
 			value: true,
 			description: 'Changes "hide" links to read as "hide" or "unhide" depending on the hide state. Also adds a 5 second delay prior to hiding the link.'
 		},
-		showUnreadCount: {
-			type: 'boolean',
-			value: true,
-			description: 'Show unread message count next to orangereds?'
-		},
-		retroUnreadCount: {
-			type: 'boolean',
-			value: false,
-			description: 'If you dislike the unread count provided by native reddit, you can replace it with the RES-style bracketed unread count',
-			dependsOn: 'showUnreadCount'
-		},
-		showUnreadCountInTitle: {
-			type: 'boolean',
-			value: false,
-			description: 'Show unread message count in page/tab title?'
-		},
-		showUnreadCountInFavicon: {
-			type: 'boolean',
-			value: true,
-			description: 'Show unread message count in favicon?'
-		},
-		unreadLinksToInbox: {
-			type: 'boolean',
-			value: false,
-			description: 'Always go to the inbox, not unread messages, when clicking on orangered',
-			advanced: true
-		},
-		hideModMail: {
-			type: 'boolean',
-			value: false,
-			description: 'Hide the mod mail button in user bar.'
-		},
 		videoTimes: {
 			type: 'boolean',
 			value: true,
@@ -196,8 +164,6 @@ modules['betteReddit'] = {
 				}
 			}
 
-			this.setupFaviconBadge();
-
 			if ((modules['betteReddit'].options.showLastEditedTimestamp.value) && ((RESUtils.pageType() === 'linklist') || (RESUtils.pageType() === 'comments'))) {
 				RESUtils.addCSS('.edited-timestamp[title]:after{content:" (" attr(title) ")";font-size: 90%;}');
 			}
@@ -234,24 +200,6 @@ modules['betteReddit'] = {
 				// listen for new DOM nodes so that modules like autopager, river of reddit, etc still get l+c links...
 
 				RESUtils.watchForElement('siteTable', modules['betteReddit'].getVideoTimes);
-			}
-			if ((RESUtils.loggedInUser() !== null) && ((this.options.showUnreadCount.value) || (this.options.showUnreadCountInTitle.value) || (this.options.showUnreadCountInFavicon.value))) {
-				// Reddit CSS change broke this when they went to sprite sheets.. new CSS will fix the issue.
-				// removing text indent - on 11/14/11 reddit changed the mail sprites, so I have to change how this is handled..
-				RESUtils.addCSS('#mail { top: 2px; min-width: 16px !important; width: auto !important; background-repeat: no-repeat !important; line-height: 8px !important; }');
-				// RESUtils.addCSS('#mail.havemail { top: 2px !important; margin-right: 1px; }');
-				RESUtils.addCSS('#mail.havemail { top: 2px !important; }');
-				if ((BrowserDetect.isChrome()) || (BrowserDetect.isSafari())) {
-					// I hate that I have this conditional CSS in here but I can't figure out why it's needed for webkit and screws up firefox.
-					RESUtils.addCSS('#mail.havemail { top: 0; }');
-				}
-				this.showUnreadCount();
-			}
-			if ((RESUtils.loggedInUser() !== null) && !this.options.showUnreadCount.value) {
-				this.hideUnreadCount();
-			}
-			if (this.options.hideModMail.value) {
-				RESUtils.addCSS('#modmail, #modmail + .separator { display:none; }');
 			}
 			switch (this.options.pinHeader.value) {
 				case 'header':
@@ -346,119 +294,6 @@ modules['betteReddit'] = {
 				});
 			}
 			modules['betteReddit'].selfTextHash[thisID] = linkList[i].data.selftext_html;
-		}
-	},
-	getInboxLink: function(havemail) {
-		if (havemail && !modules['betteReddit'].options.unreadLinksToInbox.value) {
-			return '/message/unread/';
-		}
-
-		return '/message/inbox/';
-	},
-	showUnreadCount: function() {
-		if ((typeof this.mail === 'undefined') && this.options.showUnreadCount.value) {
-			// deprecate this feature once reddit's own goes live...
-			this.mail = document.getElementById('mail');
-			if (!document.querySelector('.message-count') || this.options.retroUnreadCount.value) {
-				if (this.mail) {
-					this.mailCount = RESUtils.createElementWithID('a', 'mailCount');
-					this.mailCount.display = 'none';
-					this.mailCount.setAttribute('href', this.getInboxLink(true));
-					RESUtils.insertAfter(this.mail, this.mailCount);
-				}
-				// since retroUnreadCount must be turned on (or the new one isn't active yet),
-				// add the CSS to hide the "new" unread count
-				this.hideUnreadCount();
-			} else {
-				this.deprecateMailCount = true;
-			}
-		}
-		if (this.mail) {
-			$(modules['betteReddit'].mail).html('');
-			var msgCountCacheKey = 'RESmodules.betteReddit.msgCount.' + RESUtils.loggedInUser();
-			if (this.mail.classList.contains('havemail')) {
-				this.mail.setAttribute('href', this.getInboxLink(true));
-				var countDiv = document.querySelector('.message-count'),
-					count;
-
-				// the new way of getting message count is right from reddit, as it will soon
-				// output the message count, replacing RES's check.
-				if (countDiv) {
-					count = countDiv.textContent;
-					modules['betteReddit'].setUnreadCount(count);
-				} else {
-					// if the countDiv doesn't exist, we still need to use the old way of polling
-					// reddit for unread count
-					RESUtils.cache.fetch({
-						key: msgCountCacheKey,
-						endpoint: 'message/unread/.json?mark=false',
-						handleData: function(response) {
-							return response.data.children.length;
-						},
-						callback: modules['betteReddit'].setUnreadCount.bind(modules['betteReddit'])
-					});
-				}
-			} else {
-				// console.log('no need to get count - no new mail. resetting lastCheck');
-				modules['betteReddit'].setUnreadCount(0);
-				RESUtils.cache.expire({ key: msgCountCacheKey });
-			}
-		}
-	},
-	hideUnreadCount: function() {
-		RESUtils.addCSS('.message-count { display: none; }');
-	},
-	setUnreadCount: function(count) {
-		if (count > 0) {
-			if (this.options.showUnreadCountInTitle.value) {
-				document.title = '[' + count + '] ' + document.title.replace(/^\[[\d]+\]\s/, '');
-			}
-			this.updateFaviconBadge(count);
-			if (this.options.showUnreadCount.value && !this.deprecateMailCount) {
-				modules['betteReddit'].mailCount.display = 'inline-block';
-				modules['betteReddit'].mailCount.textContent = '[' + count + ']';
-				if (modules['neverEndingReddit'].NREMailCount) {
-					modules['neverEndingReddit'].NREMailCount.display = 'inline-block';
-					modules['neverEndingReddit'].NREMailCount.textContent = '[' + count + ']';
-				}
-			}
-		} else {
-			document.title = document.title.replace(/^\[[\d]+\]\s/, '');
-			if (modules['betteReddit'].mailCount) {
-				modules['betteReddit'].mailCount.display = 'none';
-				$(modules['betteReddit'].mailCount).html('');
-				if (modules['neverEndingReddit'].NREMailCount) {
-					modules['neverEndingReddit'].NREMailCount.display = 'none';
-					$(modules['neverEndingReddit'].NREMailCount).html('');
-				}
-			}
-			this.updateFaviconBadge(0);
-		}
-	},
-	updateFaviconBadge: function(count) {
-		if (!(this.isEnabled() && this.isMatchURL())) return;
-		if (this.options.showUnreadCountInFavicon.value) {
-			this.setupFaviconBadge();
-
-			count = count || 0;
-			this.favicon.badge(count);
-		}
-	},
-	setupFaviconBadge: function() {
-		if (this.favicon) return;
-
-		if (this.options.showUnreadCountInFavicon.value) {
-			var faviconDataurl = 'data:image/x-icon;base64,AAABAAEAICAAAAAAIACoEAAAFgAAACgAAAAgAAAAQAAAAAEAIAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA///n///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb////n/wAAAAD/8Nb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv//8Nb/AAAAAP7u1f/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//ngyP//5s3//+3T///w1v//8Nb//u7V//7u1f/+7tX///DW//7u1f/+6M//+eDI//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//7u1f8AAAAA/u7V//bdxv/23cb/9t3G//bdxv/23cb/9t3G///mzf//8Nb//ePL/9O/qv+hkYL/eW1g/1pQRv9HPzf/Rz83/1VLQf91aV3/mYl6/8i1of/23cb//u7V//7p0P/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb//u7V/wAAAAD+7tX/9t3G//bdxv/23cb/9t3G//3jy///8Nb/2cax/3VpXf8fGxj/BAQE/xIUFv8sLzH/RkhK/1pcXf9bXV//TE5Q/zAzNf8WGBn/BAQE/xQRDv9cUkj/xbOg//7s0v/+6M//9t3G//bdxv/23cb/9t3G//bdxv/+7tX/AAAAAP/w1v/23cb/9t3G//bdxv//7dP/7NfA/2RbUf8CAQH/IyQm/4GDhP/Ozs//+Pj4//////////////////////////////////39/f/Z2dr/lZaW/zc5O/8AAAD/RDw1/9TBrf//8Nb/9t3G//bdxv/23cb/9t3G///w1v8AAAAA/u7V//bdxv/23cb//u7V/8Oyn/8TEA3/ICIk/6+vsP/+/v7//v7+//7+/v/+/v7//v7+//7+/v/29vb/8/P0//39/f/+/v7//v7+//7+/v/+/v7//v7+/8vLy/8/QUL/AAAA/52PgP/+8df/+N7G//bdxv/23cb//u7V/wAAAAD+7tX/9t3G//7u1f+/rZr/AAAA/2JjZP/6+vr//v7+//7+/v/+/v7//v7+/7Ozs/9RUVH/IyMj/xYWFv8UFBT/Ghoa/zg4OP+MjIz/+Pj4//7+/v/+/v7//v7+//7+/v+Pj4//AAAA/41/cv//8Nb/9t3G//bdxv/+7tX/AAAAAP7u1f/85c3/59G7/wUDAv9pamv//v7+//7+/v/+/v7//v7+//7+/v9dXV3/AAAA/1dXV/+bm5v/vb2+/8PDw/+tra3/dnZ2/xYWFv8lJSX/8fHx//7+/v/+/v7//v7+//7+/v+hoqL/AAAA/7+tmv/+7NL/9t3G//7u1f8AAAAA//DW///w1v9aUEb/IyQm/////////////////////////////////4+Pj//Ly8v/////////////////////////////////8PDw/4WFhf/w8PD///////////////////////////9WWFr/Ix8a//znzv/54Mj///DW/wAAAAD+9dv/6dK7/wIBAf+rrK3//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+/9/f4P8AAAD/w66b//7p0P/+7tX/AAAAAP784P+8qZb/BgcH/+vr6//+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+/yMkJv+CdGb//u7V//7u1f8AAAAA/v7j/76rmP8ODg//9PT1//7+/v/+/v7//v7+//7+/v/+/v7//v7+/9TY/v/z9f7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+/8vP/v/s7/7//v7+//7+/v/+/v7//v7+//7+/v/+/v7/LzEz/4J0Zv/+99z//u7V/wAAAAD//+X/b2NY/wAAAP/d3d3///////////////////////f5//9QVv//AAD//yUq///d4f////////////////////////f5//9KT///AAD//x0h///Y2/////////////////////////////8VFxj/Ni8o/+zZwv//+N3/AAAAALWjkf8DBQf/EBAQ/3R0dP/+/v7//v7+//7+/v/+/v7/xsv+/wAA//8AAP//AAD//4GH/v/+/v7//v7+//7+/v/+/v7/yM3+/wAA//8AAP//AAD//32D/v/+/v7//v7+//7+/v/+/v7/t7e3/wQEBP8jJCb/Miwn//7z2v8AAAAAQTgx/3p7ff+3t7f/AAAA/9LS0v/+/v7//v7+//7+/v/l6P7/Ehb+/wAA//8AAP//t7z+//7+/v/+/v7//v7+//7+/v/p7P7/GR7+/wAA//8AAP//ub7+//7+/v/+/v7//v7+//n5+f8WFhb/ZWVl//Pz9P8DBQf/t6KQ/wAAAAAxKiT/jI2P//7+/v9RUVH/Dg4P/9vb2//+/v7//v7+//7+/v/U2P7/fYP+/7G2/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/b3/7/iI3+/7m+/v/+/v7//v7+//7+/v/09PX/PDw8/xkZGf/x8fH//v7+/zAzNf+Ddmj/AAAAAH9wY/8XGhz/8PDw//////9XV1f/EhIS/6anp///////////////////////////////////////////////////////////////////////////////////////xcXG/ysrLP8vLy//8PDw///////q6ur/AQMF/7mkkv8AAAAA9+rS/y4pJf8QEhT/YGJj/0lLTf8AAAD/AAAA/zU3Of+vr7D/+Pj4//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7/xcXG/1JTVf8CAQH/AAAA/0JERv+1trf/nZ6e/xkbHf82MCr//vXb/wAAAAD/+N3/89vE/4l7bf9EPDX/WE5F/7+tmv/Ww6//Vk1E/wYFBP8SFBb/UlNV/5KTlP+9vb7/3d3d/+rq6v/r6+v/39/g/8vLy/+fn6D/X2Bi/x4gIv8CAQH/OzUu/8Gwnf/Rv6r/Rz83/w4MCf8TEA3/ZFpP/+/Zwv/+99z/AAAAAP7u1f/74sn//u7V//7u1f/+7tX//unQ//7oz//+7tX/4s23/5aHeP9JQTj/GxcT/wkIB/8GBwf/BwgJ/w4OD/8KCgr/BgUE/xMQDf8+Ny//g3Zo/9O/qv/+7NL//unQ//7oz//+6dD/79fA//PbxP/+7tX/++LJ//7u1f8AAAAA//DW//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/948v//u7V//7u1f/74sn/5s+5/9G9qP+olob/AAAA/5+QgP/iz7n/89vE///t0//+7tX//+bN//bdxv/23cb//+bN//7p0P//5s3/+eDI//bdxv/23cb///DW/wAAAAD+7tX/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//ngyP/948v//unQ///w1v8jIB3/hHdr///43f/54Mj/9t3G//bdxv/23cb/++LJ//7p0P/Tvan/w7Cc//PbxP/+6M//9tzE//bdxv/+7tX/AAAAAP7u1f/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb//vHX/21jWf8uKSX//unQ//bdxv/23cb/9t3G//ngyP/85c3/YllP/wMCAv8GBwf/IR0a/9TBrf/+6M//9t3G//7u1f8AAAAA/u7V//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/+6dD/vquY/wMCAv/iy7X//ePL//bdxv/74sn//vne/5SFdv8BAwX/wcLC/+Li4v9ERkj/KCMf//nlzP/54Mj//u7V/wAAAAD/8Nb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//viyf/z28T/DAsL/6GRgv///+X//+3T/+/Zwv/JvKj/Ix8a/2NlZv///////////9nZ2v8AAAD/3MWw///mzf//8Nb/AAAAAP7u1f/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G///w1v9PR0D/Mi0p/3l1af84My7/EBAQ/woKCv8PDQz/NDU2//v7+//+/v7/iYqL/wgGBP/v18D/++LJ//7u1f8AAAAA/u7V//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb//uzS/7Ggj/8UEhH/MCom/2phV/+omYj/4M23/9/Ltv8fGxj/Gx0f/zI0Nv8AAAD/mot9//7s0v/23cb//u7V/wAAAAD+7tX/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/+eDI/+/XwP/+6dD///DW//7s0v/948v//unQ/+fRu/+Ddmj/bmJW/8Gum//+7NL/9t3G//bdxv/+7tX/AAAAAP/w1v/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/43sb/++LJ//jexv/23cb/9t3G//bdxv/23cb//ePL//7u1f//8Nb//unQ//bdxv/23cb/9t3G///w1v8AAAAA///n///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb////n/wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAP////8=';
-			// Remove current favicons and replace accordingly, or Favico has a cross domain issue since the real favicon is on redditstatic.com.
-			$('head link[rel="shortcut icon"], head link[rel="icon"]').attr('href', faviconDataurl);
-
-			// Init Favico
-			this.favicon = new window.Favico();
-
-			// Prevent notification icon from showing up in bookmarks
-			$(window).on('beforeunload', function() {
-				modules['betteReddit'].favicon.reset();
-			});
 		}
 	},
 	toolbarFixLinks: [

--- a/lib/modules/floater.js
+++ b/lib/modules/floater.js
@@ -1,0 +1,91 @@
+addModule('floater', function(module, moduleID) {
+	module.category = 'About RES';
+	module.moduleName = 'Floating Islands';
+	module.description = 'Managing free-floating RES elements';
+	module.alwaysEnabled = true;
+
+	var defaultContainer = 'visibleAfterScroll';
+	var containers = {
+		visibleAfterScroll: {
+			renderElement: function() {
+				return RESUtils.createElementWithID('div', 'NREFloat');
+			},
+			css: function() {
+				var offset = this.getOffset();
+				var css = '#NREFloat { position: fixed; top: ' + offset + 'px; right: 8px; display: none; }';
+				return css;
+			},
+			go: function() {
+				window.addEventListener('scroll', RESUtils.debounce.bind(RESUtils, 'scroll.floater', 300, this.onScroll.bind(this)));
+				setTimeout(this.onScroll.bind(this), 500);
+			},
+			getOffset: function() {
+				if (typeof this._offset !== 'number') {
+					var offset = 4;
+					var pinHeader = modules['betteReddit'].options.pinHeader.value;
+					if (pinHeader === 'header') {
+						offset += document.getElementById('header').offsetHeight;
+					} else {
+						if (pinHeader.indexOf('sub') !== -1) {
+							offset += document.getElementById('sr-header-area').offsetHeight;
+						}
+						if (pinHeader.indexOf('user') !== -1) {
+							offset += document.getElementById('header-bottom-right').offsetHeight;
+						}
+					}
+
+					this._offset = offset;
+				}
+
+				return this._offset;
+			},
+			onScroll: function() {
+				var show = $(window).scrollTop() > this.getOffset();
+				$(this.element).toggle(show);
+			}
+		}
+	};
+
+	module.beforeLoad = function() {
+		$.each(containers, function(name, container) {
+			if (!container.element && typeof container.renderElement === 'function') {
+				container.element = container.renderElement();
+			}
+		});
+	}
+
+	module.go = function() {
+		var elements = $.map(containers, function(container) {
+			return container.element;
+		});
+		$(document.body).append(elements);
+
+		var css = $.map(containers, function(container) {
+			var currentCss;
+			if (typeof container.css === 'function') {
+				currentCss = container.css();
+			} else if (typeof container.css !== 'undefined') {
+				currentCss = container.css;
+			}
+
+			return currentCss;
+		}).filter(function(css) {
+			return !!css;
+		});
+		css.forEach(function(css) {
+			RESUtils.addCSS(css);
+		});
+
+		$.each(containers, function(name, container) {
+			if (typeof container.go === 'function') {
+				container.go();
+			}
+		});
+	}
+
+	module.addElement = function(element, containerName) {
+		var container = containers[containerName] || containers[defaultContainer];
+		$(container.element).append(element);
+	};
+
+});

--- a/lib/modules/floater.js
+++ b/lib/modules/floater.js
@@ -21,20 +21,7 @@ addModule('floater', function(module, moduleID) {
 			},
 			getOffset: function() {
 				if (typeof this._offset !== 'number') {
-					var offset = 4;
-					var pinHeader = modules['betteReddit'].options.pinHeader.value;
-					if (pinHeader === 'header') {
-						offset += document.getElementById('header').offsetHeight;
-					} else {
-						if (pinHeader.indexOf('sub') !== -1) {
-							offset += document.getElementById('sr-header-area').offsetHeight;
-						}
-						if (pinHeader.indexOf('user') !== -1) {
-							offset += document.getElementById('header-bottom-right').offsetHeight;
-						}
-					}
-
-					this._offset = offset;
+					this._offset = 5 + RESUtils.getHeaderOffset();
 				}
 
 				return this._offset;

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -62,7 +62,8 @@ modules['neverEndingReddit'] = {
 		'all'
 	],
 	exclude: [
-		'wiki'
+		'wiki',
+		'comments'
 	],
 	isMatchURL: function() {
 		return RESUtils.isMatchURL(this.moduleID);

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -174,7 +174,7 @@ modules['neverEndingReddit'] = {
 				this.NREFloat.appendChild(this.NREMail);
 				this.NREMailCount = RESUtils.createElementWithID('a', 'NREMailCount');
 				this.NREMailCount.display = 'none';
-				this.NREMailCount.setAttribute('href', modules['betteReddit'].getInboxLink(true));
+				this.NREMailCount.setAttribute('href', modules['orangered'].getInboxLink(true));
 				this.NREFloat.appendChild(this.NREMailCount);
 				var hasNew = false;
 				if ((typeof this.navMail !== 'undefined') && (this.navMail !== null)) {
@@ -353,17 +353,17 @@ modules['neverEndingReddit'] = {
 		if (newmail) {
 			modules['neverEndingReddit'].hasNewMail = true;
 			this.NREMail.classList.remove('nohavemail');
-			this.NREMail.setAttribute('href', modules['betteReddit'].getInboxLink(true));
+			this.NREMail.setAttribute('href', modules['orangered'].getInboxLink(true));
 			this.NREMail.setAttribute('title', 'new mail!');
 			this.NREMail.classList.add('havemail');
-			modules['betteReddit'].showUnreadCount();
+			modules['orangered'].showUnreadCount();
 		} else {
 			modules['neverEndingReddit'].hasNewMail = false;
 			this.NREMail.classList.add('nohavemail');
-			this.NREMail.setAttribute('href', modules['betteReddit'].getInboxLink(false));
+			this.NREMail.setAttribute('href', modules['orangered'].getInboxLink(false));
 			this.NREMail.setAttribute('title', 'no new mail');
 			this.NREMail.classList.remove('havemail');
-			modules['betteReddit'].setUnreadCount(0);
+			modules['orangered'].setUnreadCount(0);
 		}
 	},
 	attachModalWidget: function() {

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -150,7 +150,6 @@ modules['neverEndingReddit'] = {
 				}
 			}
 			// check if the user has new mail...
-			this.navMail = document.getElementById('mail');
 			this.NREPause = RESUtils.createElementWithID('div', 'NREPause');
 			this.NREPause.setAttribute('title', 'Pause / Restart Never Ending Reddit');
 			if (this.options.reversePauseIcon.value) this.NREPause.classList.add('reversePause');
@@ -158,28 +157,6 @@ modules['neverEndingReddit'] = {
 			if (this.isPaused) this.NREPause.classList.add('paused');
 			this.NREPause.addEventListener('click', modules['neverEndingReddit'].togglePause, false);
 			modules['floater'].addElement(this.NREPause);
-			var pinHeader = modules['betteReddit'].options.pinHeader.value;
-			if (pinHeader === 'sub' || pinHeader === 'none') {
-				this.NREMail = RESUtils.createElementWithID('a', 'NREMail');
-				RESUtils.addCSS('	\
-					#NREMail { width: 16px; height: 12px; float: left; margin-top: 4px; margin-left: 4px; background: center center no-repeat; }	\
-					#NREMail.nohavemail { background-image: url(https://redditstatic.s3.amazonaws.com/mailgray.png); }	\
-					#NREMail.havemail { background-image: url(https://redditstatic.s3.amazonaws.com/mail.png); }	\
-					.res-colorblind #NREMail.havemail { background-image: url(http://thumbs.reddit.com/t5_2s10b_5.png); }	\
-					');
-				modules['floater'].addElement(this.NREMail);
-				this.NREMailCount = RESUtils.createElementWithID('a', 'NREMailCount');
-				this.NREMailCount.display = 'none';
-				this.NREMailCount.setAttribute('href', modules['orangered'].getInboxLink(true));
-				modules['floater'].addElement(this.NREMailCount);
-				var hasNew = false;
-				if ((typeof this.navMail !== 'undefined') && (this.navMail !== null)) {
-					hasNew = this.navMail.classList.contains('havemail');
-				}
-				this.setMailIcon(hasNew);
-			} else {
-				this.NREMail = this.navMail;
-			}
 
 			if (this.options.showServerInfo.value) {
 				RESUtils.addCSS('	\
@@ -481,12 +458,8 @@ modules['neverEndingReddit'] = {
 						}
 						modules['neverEndingReddit'].duplicateCheck(newHTML);
 						// check for new mail
-						var hasNewMail = tempDiv.querySelector('#mail');
-						if ((typeof hasNewMail !== 'undefined') && (hasNewMail !== null) && (hasNewMail.classList.contains('havemail'))) {
-							modules['neverEndingReddit'].setMailIcon(true);
-						} else {
-							modules['neverEndingReddit'].setMailIcon(false);
-						}
+						modules['orangered'].updateFromPage(tempDiv);
+
 						// load up uppers and downers, if enabled...
 						// maybe not necessary anymore..
 						/*

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -162,7 +162,7 @@ modules['neverEndingReddit'] = {
 			if (pinHeader === 'sub' || pinHeader === 'none') {
 				this.NREMail = RESUtils.createElementWithID('a', 'NREMail');
 				RESUtils.addCSS('	\
-					#NREMail { width: 16px; height: 12px; float: left; margin-top: 4px; background: center center no-repeat; }	\
+					#NREMail { width: 16px; height: 12px; float: left; margin-top: 4px; margin-left: 4px; background: center center no-repeat; }	\
 					#NREMail.nohavemail { background-image: url(https://redditstatic.s3.amazonaws.com/mailgray.png); }	\
 					#NREMail.havemail { background-image: url(https://redditstatic.s3.amazonaws.com/mail.png); }	\
 					.res-colorblind #NREMail.havemail { background-image: url(http://thumbs.reddit.com/t5_2s10b_5.png); }	\

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -144,7 +144,9 @@ modules['neverEndingReddit'] = {
 
 				// watch for the user scrolling to the bottom of the page.  If they do it, load a new page.
 				if (this.options.autoLoad.value && nextLink) {
-					window.addEventListener('scroll', modules['neverEndingReddit'].handleScroll, false);
+					window.addEventListener('scroll',
+						RESUtils.debounce.bind(RESUtils, 'scroll.neverEndingReddit', 300, modules['neverEndingReddit'].handleScroll),
+						false);
 				}
 			}
 			// check if the user has new mail...
@@ -239,10 +241,6 @@ modules['neverEndingReddit'] = {
 		*/
 	},
 	handleScroll: function(e) {
-		if (modules['neverEndingReddit'].scrollTimer) clearTimeout(modules['neverEndingReddit'].scrollTimer);
-		modules['neverEndingReddit'].scrollTimer = setTimeout(modules['neverEndingReddit'].handleScrollAfterTimer, 300);
-	},
-	handleScrollAfterTimer: function(e) {
 		if (modules['settingsConsole'].isOpen) { // avoid console to close when scrolling
 			return;
 		}

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -161,10 +161,12 @@ modules['neverEndingReddit'] = {
 			var pinHeader = modules['betteReddit'].options.pinHeader.value;
 			if (pinHeader === 'sub' || pinHeader === 'none') {
 				this.NREMail = RESUtils.createElementWithID('a', 'NREMail');
-				RESUtils.addCSS('#NREMail { width: 16px; height: 12px; float: left; margin-top: 4px; background: center center no-repeat; }');
-				RESUtils.addCSS('#NREMail.nohavemail { background-image: url(https://redditstatic.s3.amazonaws.com/mailgray.png); }');
-				RESUtils.addCSS('#NREMail.havemail { background-image: url(https://redditstatic.s3.amazonaws.com/mail.png); }');
-				RESUtils.addCSS('.res-colorblind #NREMail.havemail { background-image: url(http://thumbs.reddit.com/t5_2s10b_5.png); }');
+				RESUtils.addCSS('	\
+					#NREMail { width: 16px; height: 12px; float: left; margin-top: 4px; background: center center no-repeat; }	\
+					#NREMail.nohavemail { background-image: url(https://redditstatic.s3.amazonaws.com/mailgray.png); }	\
+					#NREMail.havemail { background-image: url(https://redditstatic.s3.amazonaws.com/mail.png); }	\
+					.res-colorblind #NREMail.havemail { background-image: url(http://thumbs.reddit.com/t5_2s10b_5.png); }	\
+					');
 				modules['floater'].addElement(this.NREMail);
 				this.NREMailCount = RESUtils.createElementWithID('a', 'NREMailCount');
 				this.NREMailCount.display = 'none';
@@ -180,11 +182,13 @@ modules['neverEndingReddit'] = {
 			}
 
 			if (this.options.showServerInfo.value) {
-				RESUtils.addCSS('.debuginfo { position: fixed; bottom: 5px; right: 5px; }');
-				RESUtils.addCSS('.debuginfo { background: rgba(255,255,255,0.3); }');
-				RESUtils.addCSS('.debuginfo:hover { background: rgba(255,255,255,0.8); }');
-				RESUtils.addCSS('.res-nightmode .debuginfo { background: rgba(30,30,30,0.5); color: #ccc; }');
-				RESUtils.addCSS('.res-nightmode .debuginfo:hover { background: rgba(30,30,30,0.8); }');
+				RESUtils.addCSS('	\
+					.debuginfo { position: fixed; bottom: 5px; right: 5px; }	\
+					.debuginfo { background: rgba(255,255,255,0.3); }	\
+					.debuginfo:hover { background: rgba(255,255,255,0.8); }	\
+					.res-nightmode .debuginfo { background: rgba(30,30,30,0.5); color: #ccc; }	\
+					.res-nightmode .debuginfo:hover { background: rgba(30,30,30,0.8); }	\
+					');
 			}
 		}
 	},

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -149,13 +149,13 @@ modules['neverEndingReddit'] = {
 			}
 			// check if the user has new mail...
 			this.navMail = document.getElementById('mail');
-			this.NREFloat = RESUtils.createElementWithID('div', 'NREFloat');
 			this.NREPause = RESUtils.createElementWithID('div', 'NREPause');
 			this.NREPause.setAttribute('title', 'Pause / Restart Never Ending Reddit');
 			if (this.options.reversePauseIcon.value) this.NREPause.classList.add('reversePause');
 			this.isPaused = !!RESStorage.getItem('RESmodules.neverEndingReddit.isPaused');
 			if (this.isPaused) this.NREPause.classList.add('paused');
 			this.NREPause.addEventListener('click', modules['neverEndingReddit'].togglePause, false);
+			modules['floater'].addElement(this.NREPause);
 			var pinHeader = modules['betteReddit'].options.pinHeader.value;
 			if (pinHeader === 'sub' || pinHeader === 'none') {
 				this.NREMail = RESUtils.createElementWithID('a', 'NREMail');
@@ -163,11 +163,11 @@ modules['neverEndingReddit'] = {
 				RESUtils.addCSS('#NREMail.nohavemail { background-image: url(https://redditstatic.s3.amazonaws.com/mailgray.png); }');
 				RESUtils.addCSS('#NREMail.havemail { background-image: url(https://redditstatic.s3.amazonaws.com/mail.png); }');
 				RESUtils.addCSS('.res-colorblind #NREMail.havemail { background-image: url(http://thumbs.reddit.com/t5_2s10b_5.png); }');
-				this.NREFloat.appendChild(this.NREMail);
+				modules['floater'].addElement(this.NREMail);
 				this.NREMailCount = RESUtils.createElementWithID('a', 'NREMailCount');
 				this.NREMailCount.display = 'none';
 				this.NREMailCount.setAttribute('href', modules['orangered'].getInboxLink(true));
-				this.NREFloat.appendChild(this.NREMailCount);
+				modules['floater'].addElement(this.NREMailCount);
 				var hasNew = false;
 				if ((typeof this.navMail !== 'undefined') && (this.navMail !== null)) {
 					hasNew = this.navMail.classList.contains('havemail');
@@ -176,20 +176,6 @@ modules['neverEndingReddit'] = {
 			} else {
 				this.NREMail = this.navMail;
 			}
-			var offset = 4;
-			if (pinHeader === 'header') {
-				offset += document.getElementById('header').offsetHeight;
-			} else {
-				if (pinHeader.indexOf('sub') !== -1) {
-					offset += document.getElementById('sr-header-area').offsetHeight;
-				}
-				if (pinHeader.indexOf('user') !== -1) {
-					offset += document.getElementById('header-bottom-right').offsetHeight;
-				}
-			}
-			RESUtils.addCSS('#NREFloat { position: fixed; top: ' + offset + 'px; right: 8px; display: none; }');
-			this.NREFloat.appendChild(this.NREPause);
-			document.body.appendChild(this.NREFloat);
 
 			if (this.options.showServerInfo.value) {
 				RESUtils.addCSS('.debuginfo { position: fixed; bottom: 5px; right: 5px; }');
@@ -314,11 +300,6 @@ modules['neverEndingReddit'] = {
 				modules['neverEndingReddit'].loadNewPage();
 				modules['neverEndingReddit'].pauseAfter(thisPageNum);
 			}
-		}
-		if ($(window).scrollTop() > 30) {
-			modules['neverEndingReddit'].showFloat(true);
-		} else {
-			modules['neverEndingReddit'].showFloat(false);
 		}
 	},
 	pauseAfterPages: null,
@@ -620,13 +601,6 @@ modules['neverEndingReddit'] = {
 		if (modules['neverEndingReddit'].modalWidget) {
 			modules['neverEndingReddit'].modalWidget.style.display = 'none';
 			modules['neverEndingReddit'].modalContent.style.display = 'none';
-		}
-	},
-	showFloat: function(show) {
-		if (show) {
-			this.NREFloat.style.display = 'block';
-		} else {
-			this.NREFloat.style.display = 'none';
 		}
 	}
 };

--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -9,10 +9,20 @@ addModule('orangered', function(module, moduleID) {
 			type: 'enum',
 			value: false
 		},
+		updateCurrentTab: {
+			description: 'Update mail buttons on current tab when RES checks for orangereds',
+			type: 'boolean',
+			value: true,
+		},
 		updateOtherTabs: {
 			description: 'Update all open tabs when RES checks for orangereds',
 			type: 'boolean',
 			value: true,
+		},
+		showFloatingEnvelope: {
+			type: 'boolean',
+			value: true,
+			description: 'Show an envelope (inbox) icon in the top right corner'
 		},
 		showUnreadCount: {
 			type: 'boolean',
@@ -35,11 +45,17 @@ addModule('orangered', function(module, moduleID) {
 			value: true,
 			description: 'Show unread message count in favicon?'
 		},
+		resetFaviconOnLeave: {
+			type: 'boolean',
+			value: true,
+			description: 'Reset the favicon before leaving the page. \n\n This prevents the unread badge from appearing in bookmarks, but may hurt browser caching.'
+		},
 		unreadLinksToInbox: {
 			type: 'boolean',
 			value: false,
 			description: 'Always go to the inbox, not unread messages, when clicking on orangered',
-			advanced: true
+			advanced: true,
+			dependsOn: 'updateCurrentTab'
 		},
 		hideModMail: {
 			type: 'boolean',
@@ -48,6 +64,12 @@ addModule('orangered', function(module, moduleID) {
 		}
 	};
 
+	var favicon;
+	var mailButton, nativeMailCount;
+	var doHideUnreadCount;
+	var resMailCount;
+	var floatingInboxButton, floatingInboxCount;
+
 	module.go = function() {
 		if (!(module.isEnabled() && module.isMatchURL())) return;
 
@@ -55,167 +77,204 @@ addModule('orangered', function(module, moduleID) {
 			$('#mail, #modmail').attr('target', '_blank');
 		}
 
-		if ((RESUtils.loggedInUser() !== null) && ((module.options.showUnreadCount.value) || (module.options.showUnreadCountInTitle.value) || (module.options.showUnreadCountInFavicon.value))) {
-			module.setupFaviconBadge();
+		if (RESUtils.loggedInUser() !== null) {
+			setupFaviconBadge();
+			setupUnreadCount();
+			setupFloatingButtons();
 
-			// Reddit CSS change broke this when they went to sprite sheets.. new CSS will fix the issue.
-			// removing text indent - on 11/14/11 reddit changed the mail sprites, so I have to change how this is handled..
-			RESUtils.addCSS('#mail { top: 2px; min-width: 16px !important; width: auto !important; background-repeat: no-repeat !important; line-height: 8px !important; }');
-			// RESUtils.addCSS('#mail.havemail { top: 2px !important; margin-right: 1px; }');
-			RESUtils.addCSS('#mail.havemail { top: 2px !important; }');
-			if ((BrowserDetect.isChrome()) || (BrowserDetect.isSafari())) {
-				// I hate that I have this conditional CSS in here but I can't figure out why it's needed for webkit and screws up firefox.
-				RESUtils.addCSS('#mail.havemail { top: 0; }');
+			if (!module.options.showUnreadCount.value) {
+				hideUnreadCount();
 			}
-			module.showUnreadCount();
-		}
-		if ((RESUtils.loggedInUser() !== null) && !module.options.showUnreadCount.value) {
-			module.hideUnreadCount();
-		}
-		if (module.options.hideModMail.value) {
-			RESUtils.addCSS('#modmail, #modmail + .separator { display:none; }');
-		}
 
+			if (module.options.hideModMail.value) {
+				RESUtils.addCSS('#modmail, #modmail + .separator { display:none; }');
+			}
+
+			updateFromPage();
+		}
+	};
+
+	module.updateFromPage = updateFromPage;
+	function updateFromPage(doc) {
+		if (!module.options.updateCurrentTab.value) return;
+
+		var count = getUnreadCount(doc);
+
+		// the new way of getting message count is right from reddit, as it will soon
+		// output the message count, replacing RES's check.
+		if (typeof count !== 'undefined') {
+			setUnreadCount(count, doc && 'ner');
+		} else if (!doc) {
+			// if the countDiv doesn't exist, we still need to use the old way of polling
+			// reddit for unread count
+			var msgCountCacheKey = 'RESmodules.' + moduleID + '.msgCount.' + RESUtils.loggedInUser();
+			RESUtils.cache.fetch({
+				key: msgCountCacheKey,
+				endpoint: 'message/unread/.json?mark=false',
+				handleData: function(response) {
+					return response.data.children.length || 0;
+				},
+				callback: module.setUnreadCount.bind(module)
+			});
+		}
 	}
 
-	$.extend(true, module, {
-		getInboxLink: function(havemail) {
-			if (havemail && !module.options.unreadLinksToInbox.value) {
-				return '/message/unread/';
-			}
+	module.setUnreadCount = setUnreadCount;
+	function setUnreadCount(count, source) {
+		updateFaviconBadge(count);
+		updateTitle(count);
+		updateInboxElements(count, source);
+		updateMailCountElements(count, source);
 
-			return '/message/inbox/';
-		},
-		showUnreadCount: function(container) {
-			container = container || document;
-			if ((typeof module.mail === 'undefined') && module.options.showUnreadCount.value) {
-				// deprecate this feature once reddit's own goes live...
-				module.mail = document.getElementById('mail');
-				if (!document.querySelector('.message-count') || module.options.retroUnreadCount.value) {
-					if (module.mail) {
-						module.mailCount = RESUtils.createElementWithID('a', 'mailCount');
-						module.mailCount.display = 'none';
-						module.mailCount.setAttribute('href', module.getInboxLink(true));
-						RESUtils.insertAfter(module.mail, module.mailCount);
-					}
-					// since retroUnreadCount must be turned on (or the new one isn't active yet),
-					// add the CSS to hide the "new" unread count
-					module.hideUnreadCount();
-				} else {
-					module.deprecateMailCount = true;
+		if (module.options.updateOtherTabs.value && (source !== 'rpc') && typeof count !== 'undefined') {
+			RESUtils.runtime.sendMessage({
+				requestType: 'multicast',
+				moduleID: moduleID,
+				method: 'setUnreadCount',
+				arguments: [ count ]
+			});
+		}
+	}
+
+	function hideUnreadCount() {
+		RESUtils.addCSS('.message-count { display: none; }');
+	}
+	function updateTitle(count) {
+		if (!module.options.showUnreadCountInTitle.value) return;
+		if (count > 0) {
+			document.title = '[' + count + '] ' + document.title.replace(/^\[[\d]+\]\s/, '');
+		} else {
+			document.title = document.title.replace(/^\[[\d]+\]\s/, '');
+		}
+	}
+	function updateInboxElements(count, source) {
+		count = count || 0;
+		var $ele = $(floatingInboxButton);
+		if (module.options.updateCurrentTab.value && (source === 'rpc' || source === 'ner')) {
+			$ele = $ele.add(mailButton);
+		}
+
+		$ele.attr('title', count ? 'new mail!' : 'No new mail')
+			.toggleClass('havemail', !!count)
+			.toggleClass('nohavemail', !count)
+			.attr('href', getInboxLink(count));
+	}
+	function updateMailCountElements(count, source) {
+		if (!module.options.showUnreadCount.value) return;
+
+		if (module.options.updateCurrentTab && (source === 'rpc' || source === 'ner')) {
+			nativeMailCount.style.display = count && !resMailCount ? 'inline-block' : 'none';
+			nativeMailCount.textContent = count;
+		}
+
+		if (resMailCount) {
+			resMailCount.style.display = count ? 'inline-block' : 'none';
+			resMailCount.textContent = '[' + count + ']';
+		}
+
+		if (floatingInboxCount) {
+			floatingInboxCount.style.display = count ? 'inline-block' : 'none';
+			floatingInboxCount.textContent = '[' + count + ']';
+		}
+	}
+	function updateFaviconBadge(count) {
+		if (!module.options.showUnreadCountInFavicon.value) return;
+		setupFaviconBadge();
+
+		count = count || 0;
+		favicon.badge(count);
+	}
+	function setupFaviconBadge() {
+		if (favicon) return;
+		if (!module.options.showUnreadCountInFavicon.value) return;
+
+		var faviconDataurl = 'data:image/x-icon;base64,AAABAAEAICAAAAAAIACoEAAAFgAAACgAAAAgAAAAQAAAAAEAIAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA///n///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb////n/wAAAAD/8Nb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv//8Nb/AAAAAP7u1f/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//ngyP//5s3//+3T///w1v//8Nb//u7V//7u1f/+7tX///DW//7u1f/+6M//+eDI//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//7u1f8AAAAA/u7V//bdxv/23cb/9t3G//bdxv/23cb/9t3G///mzf//8Nb//ePL/9O/qv+hkYL/eW1g/1pQRv9HPzf/Rz83/1VLQf91aV3/mYl6/8i1of/23cb//u7V//7p0P/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb//u7V/wAAAAD+7tX/9t3G//bdxv/23cb/9t3G//3jy///8Nb/2cax/3VpXf8fGxj/BAQE/xIUFv8sLzH/RkhK/1pcXf9bXV//TE5Q/zAzNf8WGBn/BAQE/xQRDv9cUkj/xbOg//7s0v/+6M//9t3G//bdxv/23cb/9t3G//bdxv/+7tX/AAAAAP/w1v/23cb/9t3G//bdxv//7dP/7NfA/2RbUf8CAQH/IyQm/4GDhP/Ozs//+Pj4//////////////////////////////////39/f/Z2dr/lZaW/zc5O/8AAAD/RDw1/9TBrf//8Nb/9t3G//bdxv/23cb/9t3G///w1v8AAAAA/u7V//bdxv/23cb//u7V/8Oyn/8TEA3/ICIk/6+vsP/+/v7//v7+//7+/v/+/v7//v7+//7+/v/29vb/8/P0//39/f/+/v7//v7+//7+/v/+/v7//v7+/8vLy/8/QUL/AAAA/52PgP/+8df/+N7G//bdxv/23cb//u7V/wAAAAD+7tX/9t3G//7u1f+/rZr/AAAA/2JjZP/6+vr//v7+//7+/v/+/v7//v7+/7Ozs/9RUVH/IyMj/xYWFv8UFBT/Ghoa/zg4OP+MjIz/+Pj4//7+/v/+/v7//v7+//7+/v+Pj4//AAAA/41/cv//8Nb/9t3G//bdxv/+7tX/AAAAAP7u1f/85c3/59G7/wUDAv9pamv//v7+//7+/v/+/v7//v7+//7+/v9dXV3/AAAA/1dXV/+bm5v/vb2+/8PDw/+tra3/dnZ2/xYWFv8lJSX/8fHx//7+/v/+/v7//v7+//7+/v+hoqL/AAAA/7+tmv/+7NL/9t3G//7u1f8AAAAA//DW///w1v9aUEb/IyQm/////////////////////////////////4+Pj//Ly8v/////////////////////////////////8PDw/4WFhf/w8PD///////////////////////////9WWFr/Ix8a//znzv/54Mj///DW/wAAAAD+9dv/6dK7/wIBAf+rrK3//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+/9/f4P8AAAD/w66b//7p0P/+7tX/AAAAAP784P+8qZb/BgcH/+vr6//+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+/yMkJv+CdGb//u7V//7u1f8AAAAA/v7j/76rmP8ODg//9PT1//7+/v/+/v7//v7+//7+/v/+/v7//v7+/9TY/v/z9f7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+/8vP/v/s7/7//v7+//7+/v/+/v7//v7+//7+/v/+/v7/LzEz/4J0Zv/+99z//u7V/wAAAAD//+X/b2NY/wAAAP/d3d3///////////////////////f5//9QVv//AAD//yUq///d4f////////////////////////f5//9KT///AAD//x0h///Y2/////////////////////////////8VFxj/Ni8o/+zZwv//+N3/AAAAALWjkf8DBQf/EBAQ/3R0dP/+/v7//v7+//7+/v/+/v7/xsv+/wAA//8AAP//AAD//4GH/v/+/v7//v7+//7+/v/+/v7/yM3+/wAA//8AAP//AAD//32D/v/+/v7//v7+//7+/v/+/v7/t7e3/wQEBP8jJCb/Miwn//7z2v8AAAAAQTgx/3p7ff+3t7f/AAAA/9LS0v/+/v7//v7+//7+/v/l6P7/Ehb+/wAA//8AAP//t7z+//7+/v/+/v7//v7+//7+/v/p7P7/GR7+/wAA//8AAP//ub7+//7+/v/+/v7//v7+//n5+f8WFhb/ZWVl//Pz9P8DBQf/t6KQ/wAAAAAxKiT/jI2P//7+/v9RUVH/Dg4P/9vb2//+/v7//v7+//7+/v/U2P7/fYP+/7G2/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/b3/7/iI3+/7m+/v/+/v7//v7+//7+/v/09PX/PDw8/xkZGf/x8fH//v7+/zAzNf+Ddmj/AAAAAH9wY/8XGhz/8PDw//////9XV1f/EhIS/6anp///////////////////////////////////////////////////////////////////////////////////////xcXG/ysrLP8vLy//8PDw///////q6ur/AQMF/7mkkv8AAAAA9+rS/y4pJf8QEhT/YGJj/0lLTf8AAAD/AAAA/zU3Of+vr7D/+Pj4//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7/xcXG/1JTVf8CAQH/AAAA/0JERv+1trf/nZ6e/xkbHf82MCr//vXb/wAAAAD/+N3/89vE/4l7bf9EPDX/WE5F/7+tmv/Ww6//Vk1E/wYFBP8SFBb/UlNV/5KTlP+9vb7/3d3d/+rq6v/r6+v/39/g/8vLy/+fn6D/X2Bi/x4gIv8CAQH/OzUu/8Gwnf/Rv6r/Rz83/w4MCf8TEA3/ZFpP/+/Zwv/+99z/AAAAAP7u1f/74sn//u7V//7u1f/+7tX//unQ//7oz//+7tX/4s23/5aHeP9JQTj/GxcT/wkIB/8GBwf/BwgJ/w4OD/8KCgr/BgUE/xMQDf8+Ny//g3Zo/9O/qv/+7NL//unQ//7oz//+6dD/79fA//PbxP/+7tX/++LJ//7u1f8AAAAA//DW//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/948v//u7V//7u1f/74sn/5s+5/9G9qP+olob/AAAA/5+QgP/iz7n/89vE///t0//+7tX//+bN//bdxv/23cb//+bN//7p0P//5s3/+eDI//bdxv/23cb///DW/wAAAAD+7tX/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//ngyP/948v//unQ///w1v8jIB3/hHdr///43f/54Mj/9t3G//bdxv/23cb/++LJ//7p0P/Tvan/w7Cc//PbxP/+6M//9tzE//bdxv/+7tX/AAAAAP7u1f/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb//vHX/21jWf8uKSX//unQ//bdxv/23cb/9t3G//ngyP/85c3/YllP/wMCAv8GBwf/IR0a/9TBrf/+6M//9t3G//7u1f8AAAAA/u7V//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/+6dD/vquY/wMCAv/iy7X//ePL//bdxv/74sn//vne/5SFdv8BAwX/wcLC/+Li4v9ERkj/KCMf//nlzP/54Mj//u7V/wAAAAD/8Nb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//viyf/z28T/DAsL/6GRgv///+X//+3T/+/Zwv/JvKj/Ix8a/2NlZv///////////9nZ2v8AAAD/3MWw///mzf//8Nb/AAAAAP7u1f/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G///w1v9PR0D/Mi0p/3l1af84My7/EBAQ/woKCv8PDQz/NDU2//v7+//+/v7/iYqL/wgGBP/v18D/++LJ//7u1f8AAAAA/u7V//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb//uzS/7Ggj/8UEhH/MCom/2phV/+omYj/4M23/9/Ltv8fGxj/Gx0f/zI0Nv8AAAD/mot9//7s0v/23cb//u7V/wAAAAD+7tX/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/+eDI/+/XwP/+6dD///DW//7s0v/948v//unQ/+fRu/+Ddmj/bmJW/8Gum//+7NL/9t3G//bdxv/+7tX/AAAAAP/w1v/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/43sb/++LJ//jexv/23cb/9t3G//bdxv/23cb//ePL//7u1f//8Nb//unQ//bdxv/23cb/9t3G///w1v8AAAAA///n///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb////n/wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAP////8=';
+		// Remove current favicons and replace accordingly, or Favico has a cross domain issue since the real favicon is on redditstatic.com.
+		$('head link[rel="shortcut icon"], head link[rel="icon"]').attr('href', faviconDataurl);
+
+		// Init Favico
+		favicon = new window.Favico();
+
+		if (module.options.resetFaviconOnLeave.value) {
+			// Prevent notification icon from showing up in bookmarks
+			$(window).on('beforeunload', function() {
+				favicon.reset();
+			});
+		}
+	}
+
+	function setupUnreadCount() {
+		mailButton = document.getElementById('mail');
+		if (module.options.showUnreadCount.value) {
+			if (!resMailCount && module.options.retroUnreadCount.value) {
+				// Reddit CSS change broke this when they went to sprite sheets.. new CSS will fix the issue.
+				// removing text indent - on 11/14/11 reddit changed the mail sprites, so I have to change how this is handled..
+				RESUtils.addCSS('#mail { top: 2px; min-width: 16px !important; width: auto !important; background-repeat: no-repeat !important; line-height: 8px !important; }');
+				// RESUtils.addCSS('#mail.havemail { top: 2px !important; margin-right: 1px; }');
+				RESUtils.addCSS('#mail.havemail { top: 2px !important; }');
+				if ((BrowserDetect.isChrome()) || (BrowserDetect.isSafari())) {
+					// I hate that I have this conditional CSS in here but I can't figure out why it's needed for webkit and screws up firefox.
+					RESUtils.addCSS('#mail.havemail { top: 0; }');
 				}
-			}
-			if (module.mail) {
-				$(module.mail).html('');
-				var msgCountCacheKey = 'RESmodules.' + moduleID + '.msgCount.' + RESUtils.loggedInUser();
-				if (module.mail.classList.contains('havemail')) {
-					module.mail.setAttribute('href', module.getInboxLink(true));
-					var countDiv = container.querySelector('.message-count'),
-						count;
 
-					// the new way of getting message count is right from reddit, as it will soon
-					// output the message count, replacing RES's check.
-					if (countDiv) {
-						count = countDiv.textContent;
-						module.setUnreadCount(count || 0);
-					} else {
-						// if the countDiv doesn't exist, we still need to use the old way of polling
-						// reddit for unread count
-						RESUtils.cache.fetch({
-							key: msgCountCacheKey,
-							endpoint: 'message/unread/.json?mark=false',
-							handleData: function(response) {
-								return response.data.children.length || 0;
-							},
-							callback: module.setUnreadCount.bind(module)
-						});
-					}
-				} else {
-					// console.log('no need to get count - no new mail. resetting lastCheck');
-					module.setUnreadCount(0);
-					RESUtils.cache.expire({ key: msgCountCacheKey });
+				if (mailButton) {
+					resMailCount = RESUtils.createElementWithID('a', 'mailCount');
+					resMailCount.display = 'none';
+					resMailCount.setAttribute('href', module.getInboxLink(false));
+					RESUtils.insertAfter(mailButton, resMailCount);
 				}
+				// since retroUnreadCount must be turned on (or the new one isn't active yet),
+				// add the CSS to hide the "new" unread count
+				hideUnreadCount();
 			}
-		},
-		hideUnreadCount: function() {
-			RESUtils.addCSS('.message-count { display: none; }');
-		},
-		setUnreadCount: function(count, fromMessage) {
-			if (count > 0) {
-				if (module.options.showUnreadCountInTitle.value) {
-					document.title = '[' + count + '] ' + document.title.replace(/^\[[\d]+\]\s/, '');
+
+			nativeMailCount = document.querySelector('.message-count');
+			if (!nativeMailCount && !module.options.retroUnreadCount.value) {
+				if (mailButton) {
+					nativeMailCount = RESUtils.createElementWithID('a', null, 'message-count');
+					nativeMailCount.style.display = 'none';
+					nativeMailCount.setAttribute('href', getInboxLink(false));
+					RESUtils.insertAfter(mailButton, nativeMailCount);
 				}
-				module.updateFaviconBadge(count);
-				if (module.options.showUnreadCount.value && !module.deprecateMailCount) {
-					module.mailCount.display = 'inline-block';
-					module.mailCount.textContent = '[' + count + ']';
-					if (modules['neverEndingReddit'].NREMailCount) {
-						modules['neverEndingReddit'].NREMailCount.display = 'inline-block';
-						modules['neverEndingReddit'].NREMailCount.textContent = '[' + count + ']';
-					}
-				}
-			} else {
-				document.title = document.title.replace(/^\[[\d]+\]\s/, '');
-				if (module.mailCount) {
-					module.mailCount.display = 'none';
-					$(module.mailCount).html('');
-					if (modules['neverEndingReddit'].NREMailCount) {
-						modules['neverEndingReddit'].NREMailCount.display = 'none';
-						$(modules['neverEndingReddit'].NREMailCount).html('');
-					}
-				}
-				module.updateFaviconBadge(0);
-			}
-
-			if (fromMessage) {
-				module.updateMailElements(count);
-			}
-
-
-			if (module.options.updateOtherTabs.value && !fromMessage && typeof count !== 'undefined') {
-				RESUtils.runtime.sendMessage({
-					requestType: 'multicast',
-					moduleID: moduleID,
-					method: 'setUnreadCount',
-					arguments: Array.prototype.slice.call(arguments)
-				});
-			}
-
-		},
-		updateMailElements: function(count) {
-			count = count || 0;
-			var $ele = $(module.mail).add(modules['neverEndingReddit'].NREMail);
-
-			$ele.attr('title', count ? 'new mail!' : 'No new mail');
-			$ele.toggleClass('havemail', !!count);
-			$ele.toggleClass('nohavemail', !count);
-			$ele.attr('href', module.getInboxLink(count));
-		},
-		updateFaviconBadge: function(count) {
-			if (!(module.isEnabled() && module.isMatchURL())) return;
-			if (module.options.showUnreadCountInFavicon.value) {
-				module.setupFaviconBadge();
-
-				count = count || 0;
-				module.favicon.badge(count);
-			}
-		},
-		setupFaviconBadge: function() {
-			if (module.favicon) return;
-
-			if (module.options.showUnreadCountInFavicon.value) {
-				var faviconDataurl = 'data:image/x-icon;base64,AAABAAEAICAAAAAAIACoEAAAFgAAACgAAAAgAAAAQAAAAAEAIAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA///n///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb////n/wAAAAD/8Nb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv//8Nb/AAAAAP7u1f/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//ngyP//5s3//+3T///w1v//8Nb//u7V//7u1f/+7tX///DW//7u1f/+6M//+eDI//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//7u1f8AAAAA/u7V//bdxv/23cb/9t3G//bdxv/23cb/9t3G///mzf//8Nb//ePL/9O/qv+hkYL/eW1g/1pQRv9HPzf/Rz83/1VLQf91aV3/mYl6/8i1of/23cb//u7V//7p0P/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb//u7V/wAAAAD+7tX/9t3G//bdxv/23cb/9t3G//3jy///8Nb/2cax/3VpXf8fGxj/BAQE/xIUFv8sLzH/RkhK/1pcXf9bXV//TE5Q/zAzNf8WGBn/BAQE/xQRDv9cUkj/xbOg//7s0v/+6M//9t3G//bdxv/23cb/9t3G//bdxv/+7tX/AAAAAP/w1v/23cb/9t3G//bdxv//7dP/7NfA/2RbUf8CAQH/IyQm/4GDhP/Ozs//+Pj4//////////////////////////////////39/f/Z2dr/lZaW/zc5O/8AAAD/RDw1/9TBrf//8Nb/9t3G//bdxv/23cb/9t3G///w1v8AAAAA/u7V//bdxv/23cb//u7V/8Oyn/8TEA3/ICIk/6+vsP/+/v7//v7+//7+/v/+/v7//v7+//7+/v/29vb/8/P0//39/f/+/v7//v7+//7+/v/+/v7//v7+/8vLy/8/QUL/AAAA/52PgP/+8df/+N7G//bdxv/23cb//u7V/wAAAAD+7tX/9t3G//7u1f+/rZr/AAAA/2JjZP/6+vr//v7+//7+/v/+/v7//v7+/7Ozs/9RUVH/IyMj/xYWFv8UFBT/Ghoa/zg4OP+MjIz/+Pj4//7+/v/+/v7//v7+//7+/v+Pj4//AAAA/41/cv//8Nb/9t3G//bdxv/+7tX/AAAAAP7u1f/85c3/59G7/wUDAv9pamv//v7+//7+/v/+/v7//v7+//7+/v9dXV3/AAAA/1dXV/+bm5v/vb2+/8PDw/+tra3/dnZ2/xYWFv8lJSX/8fHx//7+/v/+/v7//v7+//7+/v+hoqL/AAAA/7+tmv/+7NL/9t3G//7u1f8AAAAA//DW///w1v9aUEb/IyQm/////////////////////////////////4+Pj//Ly8v/////////////////////////////////8PDw/4WFhf/w8PD///////////////////////////9WWFr/Ix8a//znzv/54Mj///DW/wAAAAD+9dv/6dK7/wIBAf+rrK3//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+/9/f4P8AAAD/w66b//7p0P/+7tX/AAAAAP784P+8qZb/BgcH/+vr6//+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+/yMkJv+CdGb//u7V//7u1f8AAAAA/v7j/76rmP8ODg//9PT1//7+/v/+/v7//v7+//7+/v/+/v7//v7+/9TY/v/z9f7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+/8vP/v/s7/7//v7+//7+/v/+/v7//v7+//7+/v/+/v7/LzEz/4J0Zv/+99z//u7V/wAAAAD//+X/b2NY/wAAAP/d3d3///////////////////////f5//9QVv//AAD//yUq///d4f////////////////////////f5//9KT///AAD//x0h///Y2/////////////////////////////8VFxj/Ni8o/+zZwv//+N3/AAAAALWjkf8DBQf/EBAQ/3R0dP/+/v7//v7+//7+/v/+/v7/xsv+/wAA//8AAP//AAD//4GH/v/+/v7//v7+//7+/v/+/v7/yM3+/wAA//8AAP//AAD//32D/v/+/v7//v7+//7+/v/+/v7/t7e3/wQEBP8jJCb/Miwn//7z2v8AAAAAQTgx/3p7ff+3t7f/AAAA/9LS0v/+/v7//v7+//7+/v/l6P7/Ehb+/wAA//8AAP//t7z+//7+/v/+/v7//v7+//7+/v/p7P7/GR7+/wAA//8AAP//ub7+//7+/v/+/v7//v7+//n5+f8WFhb/ZWVl//Pz9P8DBQf/t6KQ/wAAAAAxKiT/jI2P//7+/v9RUVH/Dg4P/9vb2//+/v7//v7+//7+/v/U2P7/fYP+/7G2/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/b3/7/iI3+/7m+/v/+/v7//v7+//7+/v/09PX/PDw8/xkZGf/x8fH//v7+/zAzNf+Ddmj/AAAAAH9wY/8XGhz/8PDw//////9XV1f/EhIS/6anp///////////////////////////////////////////////////////////////////////////////////////xcXG/ysrLP8vLy//8PDw///////q6ur/AQMF/7mkkv8AAAAA9+rS/y4pJf8QEhT/YGJj/0lLTf8AAAD/AAAA/zU3Of+vr7D/+Pj4//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7/xcXG/1JTVf8CAQH/AAAA/0JERv+1trf/nZ6e/xkbHf82MCr//vXb/wAAAAD/+N3/89vE/4l7bf9EPDX/WE5F/7+tmv/Ww6//Vk1E/wYFBP8SFBb/UlNV/5KTlP+9vb7/3d3d/+rq6v/r6+v/39/g/8vLy/+fn6D/X2Bi/x4gIv8CAQH/OzUu/8Gwnf/Rv6r/Rz83/w4MCf8TEA3/ZFpP/+/Zwv/+99z/AAAAAP7u1f/74sn//u7V//7u1f/+7tX//unQ//7oz//+7tX/4s23/5aHeP9JQTj/GxcT/wkIB/8GBwf/BwgJ/w4OD/8KCgr/BgUE/xMQDf8+Ny//g3Zo/9O/qv/+7NL//unQ//7oz//+6dD/79fA//PbxP/+7tX/++LJ//7u1f8AAAAA//DW//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/948v//u7V//7u1f/74sn/5s+5/9G9qP+olob/AAAA/5+QgP/iz7n/89vE///t0//+7tX//+bN//bdxv/23cb//+bN//7p0P//5s3/+eDI//bdxv/23cb///DW/wAAAAD+7tX/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//ngyP/948v//unQ///w1v8jIB3/hHdr///43f/54Mj/9t3G//bdxv/23cb/++LJ//7p0P/Tvan/w7Cc//PbxP/+6M//9tzE//bdxv/+7tX/AAAAAP7u1f/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb//vHX/21jWf8uKSX//unQ//bdxv/23cb/9t3G//ngyP/85c3/YllP/wMCAv8GBwf/IR0a/9TBrf/+6M//9t3G//7u1f8AAAAA/u7V//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/+6dD/vquY/wMCAv/iy7X//ePL//bdxv/74sn//vne/5SFdv8BAwX/wcLC/+Li4v9ERkj/KCMf//nlzP/54Mj//u7V/wAAAAD/8Nb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//viyf/z28T/DAsL/6GRgv///+X//+3T/+/Zwv/JvKj/Ix8a/2NlZv///////////9nZ2v8AAAD/3MWw///mzf//8Nb/AAAAAP7u1f/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G///w1v9PR0D/Mi0p/3l1af84My7/EBAQ/woKCv8PDQz/NDU2//v7+//+/v7/iYqL/wgGBP/v18D/++LJ//7u1f8AAAAA/u7V//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb//uzS/7Ggj/8UEhH/MCom/2phV/+omYj/4M23/9/Ltv8fGxj/Gx0f/zI0Nv8AAAD/mot9//7s0v/23cb//u7V/wAAAAD+7tX/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/+eDI/+/XwP/+6dD///DW//7s0v/948v//unQ/+fRu/+Ddmj/bmJW/8Gum//+7NL/9t3G//bdxv/+7tX/AAAAAP/w1v/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/43sb/++LJ//jexv/23cb/9t3G//bdxv/23cb//ePL//7u1f//8Nb//unQ//bdxv/23cb/9t3G///w1v8AAAAA///n///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb////n/wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAP////8=';
-				// Remove current favicons and replace accordingly, or Favico has a cross domain issue since the real favicon is on redditstatic.com.
-				$('head link[rel="shortcut icon"], head link[rel="icon"]').attr('href', faviconDataurl);
-
-				// Init Favico
-				this.favicon = new window.Favico();
-
-				// Prevent notification icon from showing up in bookmarks
-				$(window).on('beforeunload', function() {
-					module.favicon.reset();
-				});
 			}
 		}
-	});
+	}
+
+
+	function setupFloatingButtons() {
+		if (!module.options.showFloatingEnvelope.value) return;
+		if (floatingInboxCount) return;
+
+		var pinHeader = modules['betteReddit'].options.pinHeader.value;
+		if (pinHeader === 'sub' || pinHeader === 'none') {
+			floatingInboxButton = RESUtils.createElementWithID('a', 'NREMail');
+			RESUtils.addCSS('	\
+				#NREMail { width: 16px; height: 12px; float: left; margin-top: 4px; margin-left: 4px; background: center center no-repeat; }	\
+				#NREMail.nohavemail { background-image: url(https://redditstatic.s3.amazonaws.com/mailgray.png); }	\
+				#NREMail.havemail { background-image: url(https://redditstatic.s3.amazonaws.com/mail.png); }	\
+				.res-colorblind #NREMail.havemail { background-image: url(http://thumbs.reddit.com/t5_2s10b_5.png); }	\
+				');
+			modules['floater'].addElement(floatingInboxButton);
+
+			floatingInboxCount = RESUtils.createElementWithID('a', 'NREMailCount');
+			floatingInboxCount.display = 'none';
+			floatingInboxCount.setAttribute('href', getInboxLink(true));
+			modules['floater'].addElement(floatingInboxCount);
+		}
+	}
+
+	function getInboxLink(havemail) {
+		if (havemail && !module.options.unreadLinksToInbox.value) {
+			return '/message/unread/';
+		}
+
+		return '/message/inbox/';
+	}
+	function getUnreadCount(container) {
+		container = container || document.body;
+		var mailCount = container.querySelector('.message-count');
+		var value = mailCount && parseInt(mailCount.textContent, 0);
+
+		return value;
+	}
 });

--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -111,7 +111,7 @@ addModule('orangered', function(module, moduleID) {
 					// output the message count, replacing RES's check.
 					if (countDiv) {
 						count = countDiv.textContent;
-						module.setUnreadCount(count);
+						module.setUnreadCount(count || 0);
 					} else {
 						// if the countDiv doesn't exist, we still need to use the old way of polling
 						// reddit for unread count
@@ -119,7 +119,7 @@ addModule('orangered', function(module, moduleID) {
 							key: msgCountCacheKey,
 							endpoint: 'message/unread/.json?mark=false',
 							handleData: function(response) {
-								return response.data.children.length;
+								return response.data.children.length || 0;
 							},
 							callback: module.setUnreadCount.bind(module)
 						});
@@ -161,7 +161,7 @@ addModule('orangered', function(module, moduleID) {
 				module.updateFaviconBadge(0);
 			}
 
-			if (!fromMessage) {
+			if (!fromMessage && typeof count !== 'undefined') {
 				RESUtils.runtime.sendMessage({
 					requestType: 'multicast',
 					moduleID: moduleID,

--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -6,7 +6,7 @@ addModule('orangered', function(module, moduleID) {
 	module.options = {
 		openMailInNewTab: {
 			description: 'When clicking the mail envelope or modmail icon, open mail in a new tab?',
-			type: 'enum',
+			type: 'boolean',
 			value: false
 		},
 		updateCurrentTab: {
@@ -114,7 +114,7 @@ addModule('orangered', function(module, moduleID) {
 				handleData: function(response) {
 					return response.data.children.length || 0;
 				},
-				callback: module.setUnreadCount.bind(module)
+				callback: setUnreadCount
 			});
 		}
 	}
@@ -220,7 +220,7 @@ addModule('orangered', function(module, moduleID) {
 				if (mailButton) {
 					resMailCount = RESUtils.createElementWithID('a', 'mailCount');
 					resMailCount.display = 'none';
-					resMailCount.setAttribute('href', module.getInboxLink(false));
+					resMailCount.setAttribute('href', getInboxLink(false));
 					RESUtils.insertAfter(mailButton, resMailCount);
 				}
 				// since retroUnreadCount must be turned on (or the new one isn't active yet),

--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -3,10 +3,12 @@ addModule('orangered', function(module, moduleID) {
 	module.category = 'Comments';
 	module.description = 'Helping you get your daily dose of orangereds';
 
-	module.options.openMailInNewTab = {
-		description: 'When clicking the mail envelope or modmail icon, open mail in a new tab?',
-		type: 'enum',
-		value: false
+	module.options = {
+		openMailInNewTab: {
+			description: 'When clicking the mail envelope or modmail icon, open mail in a new tab?',
+			type: 'enum',
+			value: false
+		}
 	};
 
 	module.go = function() {

--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -8,12 +8,69 @@ addModule('orangered', function(module, moduleID) {
 			description: 'When clicking the mail envelope or modmail icon, open mail in a new tab?',
 			type: 'enum',
 			value: false
+		},
+		showUnreadCount: {
+			type: 'boolean',
+			value: true,
+			description: 'Show unread message count next to orangereds?'
+		},
+		retroUnreadCount: {
+			type: 'boolean',
+			value: false,
+			description: 'If you dislike the unread count provided by native reddit, you can replace it with the RES-style bracketed unread count',
+			dependsOn: 'showUnreadCount'
+		},
+		showUnreadCountInTitle: {
+			type: 'boolean',
+			value: false,
+			description: 'Show unread message count in page/tab title?'
+		},
+		showUnreadCountInFavicon: {
+			type: 'boolean',
+			value: true,
+			description: 'Show unread message count in favicon?'
+		},
+		unreadLinksToInbox: {
+			type: 'boolean',
+			value: false,
+			description: 'Always go to the inbox, not unread messages, when clicking on orangered',
+			advanced: true
+		},
+		hideModMail: {
+			type: 'boolean',
+			value: false,
+			description: 'Hide the mod mail button in user bar.'
 		}
 	};
 
 	module.go = function() {
+		if (!(this.isEnabled() && this.isMatchURL())) return;
+
 		if (module.options.openMailInNewTab.value) {
 			$('#mail, #modmail').attr('target', '_blank');
 		}
+
+		if ((RESUtils.loggedInUser() !== null) && ((this.options.showUnreadCount.value) || (this.options.showUnreadCountInTitle.value) || (this.options.showUnreadCountInFavicon.value))) {
+			// Reddit CSS change broke this when they went to sprite sheets.. new CSS will fix the issue.
+			// removing text indent - on 11/14/11 reddit changed the mail sprites, so I have to change how this is handled..
+			RESUtils.addCSS('#mail { top: 2px; min-width: 16px !important; width: auto !important; background-repeat: no-repeat !important; line-height: 8px !important; }');
+			// RESUtils.addCSS('#mail.havemail { top: 2px !important; margin-right: 1px; }');
+			RESUtils.addCSS('#mail.havemail { top: 2px !important; }');
+			if ((BrowserDetect.isChrome()) || (BrowserDetect.isSafari())) {
+				// I hate that I have this conditional CSS in here but I can't figure out why it's needed for webkit and screws up firefox.
+				RESUtils.addCSS('#mail.havemail { top: 0; }');
+			}
+			this.showUnreadCount();
+		}
+		if ((RESUtils.loggedInUser() !== null) && !this.options.showUnreadCount.value) {
+			this.hideUnreadCount();
+		}
+		if (this.options.hideModMail.value) {
+			RESUtils.addCSS('#modmail, #modmail + .separator { display:none; }');
+		}
 	}
+
+	module.updateUnreadCount = function(count) {
+
+	};
 });

--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -44,13 +44,15 @@ addModule('orangered', function(module, moduleID) {
 	};
 
 	module.go = function() {
-		if (!(this.isEnabled() && this.isMatchURL())) return;
+		if (!(module.isEnabled() && module.isMatchURL())) return;
 
 		if (module.options.openMailInNewTab.value) {
 			$('#mail, #modmail').attr('target', '_blank');
 		}
 
-		if ((RESUtils.loggedInUser() !== null) && ((this.options.showUnreadCount.value) || (this.options.showUnreadCountInTitle.value) || (this.options.showUnreadCountInFavicon.value))) {
+		if ((RESUtils.loggedInUser() !== null) && ((module.options.showUnreadCount.value) || (module.options.showUnreadCountInTitle.value) || (module.options.showUnreadCountInFavicon.value))) {
+			module.setupFaviconBadge();
+
 			// Reddit CSS change broke this when they went to sprite sheets.. new CSS will fix the issue.
 			// removing text indent - on 11/14/11 reddit changed the mail sprites, so I have to change how this is handled..
 			RESUtils.addCSS('#mail { top: 2px; min-width: 16px !important; width: auto !important; background-repeat: no-repeat !important; line-height: 8px !important; }');
@@ -60,17 +62,130 @@ addModule('orangered', function(module, moduleID) {
 				// I hate that I have this conditional CSS in here but I can't figure out why it's needed for webkit and screws up firefox.
 				RESUtils.addCSS('#mail.havemail { top: 0; }');
 			}
-			this.showUnreadCount();
+			module.showUnreadCount();
 		}
-		if ((RESUtils.loggedInUser() !== null) && !this.options.showUnreadCount.value) {
-			this.hideUnreadCount();
+		if ((RESUtils.loggedInUser() !== null) && !module.options.showUnreadCount.value) {
+			module.hideUnreadCount();
 		}
-		if (this.options.hideModMail.value) {
+		if (module.options.hideModMail.value) {
 			RESUtils.addCSS('#modmail, #modmail + .separator { display:none; }');
 		}
+
 	}
 
-	module.updateUnreadCount = function(count) {
+	$.extend(true, module, {
+		getInboxLink: function(havemail) {
+			if (havemail && !module.options.unreadLinksToInbox.value) {
+				return '/message/unread/';
+			}
 
-	};
+			return '/message/inbox/';
+		},
+		showUnreadCount: function() {
+			if ((typeof module.mail === 'undefined') && module.options.showUnreadCount.value) {
+				// deprecate this feature once reddit's own goes live...
+				module.mail = document.getElementById('mail');
+				if (!document.querySelector('.message-count') || module.options.retroUnreadCount.value) {
+					if (module.mail) {
+						module.mailCount = RESUtils.createElementWithID('a', 'mailCount');
+						module.mailCount.display = 'none';
+						module.mailCount.setAttribute('href', module.getInboxLink(true));
+						RESUtils.insertAfter(module.mail, module.mailCount);
+					}
+					// since retroUnreadCount must be turned on (or the new one isn't active yet),
+					// add the CSS to hide the "new" unread count
+					module.hideUnreadCount();
+				} else {
+					module.deprecateMailCount = true;
+				}
+			}
+			if (module.mail) {
+				$(module.mail).html('');
+				var msgCountCacheKey = 'RESmodules.' + moduleID + '.msgCount.' + RESUtils.loggedInUser();
+				if (module.mail.classList.contains('havemail')) {
+					module.mail.setAttribute('href', module.getInboxLink(true));
+					var countDiv = document.querySelector('.message-count'),
+						count;
+
+					// the new way of getting message count is right from reddit, as it will soon
+					// output the message count, replacing RES's check.
+					if (countDiv) {
+						count = countDiv.textContent;
+						module.setUnreadCount(count);
+					} else {
+						// if the countDiv doesn't exist, we still need to use the old way of polling
+						// reddit for unread count
+						RESUtils.cache.fetch({
+							key: msgCountCacheKey,
+							endpoint: 'message/unread/.json?mark=false',
+							handleData: function(response) {
+								return response.data.children.length;
+							},
+							callback: module.setUnreadCount.bind(module)
+						});
+					}
+				} else {
+					// console.log('no need to get count - no new mail. resetting lastCheck');
+					module.setUnreadCount(0);
+					RESUtils.cache.expire({ key: msgCountCacheKey });
+				}
+			}
+		},
+		hideUnreadCount: function() {
+			RESUtils.addCSS('.message-count { display: none; }');
+		},
+		setUnreadCount: function(count) {
+			if (count > 0) {
+				if (module.options.showUnreadCountInTitle.value) {
+					document.title = '[' + count + '] ' + document.title.replace(/^\[[\d]+\]\s/, '');
+				}
+				module.updateFaviconBadge(count);
+				if (module.options.showUnreadCount.value && !module.deprecateMailCount) {
+					module.mailCount.display = 'inline-block';
+					module.mailCount.textContent = '[' + count + ']';
+					if (modules['neverEndingReddit'].NREMailCount) {
+						modules['neverEndingReddit'].NREMailCount.display = 'inline-block';
+						modules['neverEndingReddit'].NREMailCount.textContent = '[' + count + ']';
+					}
+				}
+			} else {
+				document.title = document.title.replace(/^\[[\d]+\]\s/, '');
+				if (module.mailCount) {
+					module.mailCount.display = 'none';
+					$(module.mailCount).html('');
+					if (modules['neverEndingReddit'].NREMailCount) {
+						modules['neverEndingReddit'].NREMailCount.display = 'none';
+						$(modules['neverEndingReddit'].NREMailCount).html('');
+					}
+				}
+				module.updateFaviconBadge(0);
+			}
+		},
+		updateFaviconBadge: function(count) {
+			if (!(module.isEnabled() && module.isMatchURL())) return;
+			if (module.options.showUnreadCountInFavicon.value) {
+				module.setupFaviconBadge();
+
+				count = count || 0;
+				module.favicon.badge(count);
+			}
+		},
+		setupFaviconBadge: function() {
+			if (module.favicon) return;
+
+			if (module.options.showUnreadCountInFavicon.value) {
+				var faviconDataurl = 'data:image/x-icon;base64,AAABAAEAICAAAAAAIACoEAAAFgAAACgAAAAgAAAAQAAAAAEAIAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA///n///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb////n/wAAAAD/8Nb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv//8Nb/AAAAAP7u1f/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//ngyP//5s3//+3T///w1v//8Nb//u7V//7u1f/+7tX///DW//7u1f/+6M//+eDI//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//7u1f8AAAAA/u7V//bdxv/23cb/9t3G//bdxv/23cb/9t3G///mzf//8Nb//ePL/9O/qv+hkYL/eW1g/1pQRv9HPzf/Rz83/1VLQf91aV3/mYl6/8i1of/23cb//u7V//7p0P/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb//u7V/wAAAAD+7tX/9t3G//bdxv/23cb/9t3G//3jy///8Nb/2cax/3VpXf8fGxj/BAQE/xIUFv8sLzH/RkhK/1pcXf9bXV//TE5Q/zAzNf8WGBn/BAQE/xQRDv9cUkj/xbOg//7s0v/+6M//9t3G//bdxv/23cb/9t3G//bdxv/+7tX/AAAAAP/w1v/23cb/9t3G//bdxv//7dP/7NfA/2RbUf8CAQH/IyQm/4GDhP/Ozs//+Pj4//////////////////////////////////39/f/Z2dr/lZaW/zc5O/8AAAD/RDw1/9TBrf//8Nb/9t3G//bdxv/23cb/9t3G///w1v8AAAAA/u7V//bdxv/23cb//u7V/8Oyn/8TEA3/ICIk/6+vsP/+/v7//v7+//7+/v/+/v7//v7+//7+/v/29vb/8/P0//39/f/+/v7//v7+//7+/v/+/v7//v7+/8vLy/8/QUL/AAAA/52PgP/+8df/+N7G//bdxv/23cb//u7V/wAAAAD+7tX/9t3G//7u1f+/rZr/AAAA/2JjZP/6+vr//v7+//7+/v/+/v7//v7+/7Ozs/9RUVH/IyMj/xYWFv8UFBT/Ghoa/zg4OP+MjIz/+Pj4//7+/v/+/v7//v7+//7+/v+Pj4//AAAA/41/cv//8Nb/9t3G//bdxv/+7tX/AAAAAP7u1f/85c3/59G7/wUDAv9pamv//v7+//7+/v/+/v7//v7+//7+/v9dXV3/AAAA/1dXV/+bm5v/vb2+/8PDw/+tra3/dnZ2/xYWFv8lJSX/8fHx//7+/v/+/v7//v7+//7+/v+hoqL/AAAA/7+tmv/+7NL/9t3G//7u1f8AAAAA//DW///w1v9aUEb/IyQm/////////////////////////////////4+Pj//Ly8v/////////////////////////////////8PDw/4WFhf/w8PD///////////////////////////9WWFr/Ix8a//znzv/54Mj///DW/wAAAAD+9dv/6dK7/wIBAf+rrK3//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+/9/f4P8AAAD/w66b//7p0P/+7tX/AAAAAP784P+8qZb/BgcH/+vr6//+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+/yMkJv+CdGb//u7V//7u1f8AAAAA/v7j/76rmP8ODg//9PT1//7+/v/+/v7//v7+//7+/v/+/v7//v7+/9TY/v/z9f7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+/8vP/v/s7/7//v7+//7+/v/+/v7//v7+//7+/v/+/v7/LzEz/4J0Zv/+99z//u7V/wAAAAD//+X/b2NY/wAAAP/d3d3///////////////////////f5//9QVv//AAD//yUq///d4f////////////////////////f5//9KT///AAD//x0h///Y2/////////////////////////////8VFxj/Ni8o/+zZwv//+N3/AAAAALWjkf8DBQf/EBAQ/3R0dP/+/v7//v7+//7+/v/+/v7/xsv+/wAA//8AAP//AAD//4GH/v/+/v7//v7+//7+/v/+/v7/yM3+/wAA//8AAP//AAD//32D/v/+/v7//v7+//7+/v/+/v7/t7e3/wQEBP8jJCb/Miwn//7z2v8AAAAAQTgx/3p7ff+3t7f/AAAA/9LS0v/+/v7//v7+//7+/v/l6P7/Ehb+/wAA//8AAP//t7z+//7+/v/+/v7//v7+//7+/v/p7P7/GR7+/wAA//8AAP//ub7+//7+/v/+/v7//v7+//n5+f8WFhb/ZWVl//Pz9P8DBQf/t6KQ/wAAAAAxKiT/jI2P//7+/v9RUVH/Dg4P/9vb2//+/v7//v7+//7+/v/U2P7/fYP+/7G2/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/b3/7/iI3+/7m+/v/+/v7//v7+//7+/v/09PX/PDw8/xkZGf/x8fH//v7+/zAzNf+Ddmj/AAAAAH9wY/8XGhz/8PDw//////9XV1f/EhIS/6anp///////////////////////////////////////////////////////////////////////////////////////xcXG/ysrLP8vLy//8PDw///////q6ur/AQMF/7mkkv8AAAAA9+rS/y4pJf8QEhT/YGJj/0lLTf8AAAD/AAAA/zU3Of+vr7D/+Pj4//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7//v7+//7+/v/+/v7/xcXG/1JTVf8CAQH/AAAA/0JERv+1trf/nZ6e/xkbHf82MCr//vXb/wAAAAD/+N3/89vE/4l7bf9EPDX/WE5F/7+tmv/Ww6//Vk1E/wYFBP8SFBb/UlNV/5KTlP+9vb7/3d3d/+rq6v/r6+v/39/g/8vLy/+fn6D/X2Bi/x4gIv8CAQH/OzUu/8Gwnf/Rv6r/Rz83/w4MCf8TEA3/ZFpP/+/Zwv/+99z/AAAAAP7u1f/74sn//u7V//7u1f/+7tX//unQ//7oz//+7tX/4s23/5aHeP9JQTj/GxcT/wkIB/8GBwf/BwgJ/w4OD/8KCgr/BgUE/xMQDf8+Ny//g3Zo/9O/qv/+7NL//unQ//7oz//+6dD/79fA//PbxP/+7tX/++LJ//7u1f8AAAAA//DW//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/948v//u7V//7u1f/74sn/5s+5/9G9qP+olob/AAAA/5+QgP/iz7n/89vE///t0//+7tX//+bN//bdxv/23cb//+bN//7p0P//5s3/+eDI//bdxv/23cb///DW/wAAAAD+7tX/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//ngyP/948v//unQ///w1v8jIB3/hHdr///43f/54Mj/9t3G//bdxv/23cb/++LJ//7p0P/Tvan/w7Cc//PbxP/+6M//9tzE//bdxv/+7tX/AAAAAP7u1f/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb//vHX/21jWf8uKSX//unQ//bdxv/23cb/9t3G//ngyP/85c3/YllP/wMCAv8GBwf/IR0a/9TBrf/+6M//9t3G//7u1f8AAAAA/u7V//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/+6dD/vquY/wMCAv/iy7X//ePL//bdxv/74sn//vne/5SFdv8BAwX/wcLC/+Li4v9ERkj/KCMf//nlzP/54Mj//u7V/wAAAAD/8Nb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//viyf/z28T/DAsL/6GRgv///+X//+3T/+/Zwv/JvKj/Ix8a/2NlZv///////////9nZ2v8AAAD/3MWw///mzf//8Nb/AAAAAP7u1f/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G///w1v9PR0D/Mi0p/3l1af84My7/EBAQ/woKCv8PDQz/NDU2//v7+//+/v7/iYqL/wgGBP/v18D/++LJ//7u1f8AAAAA/u7V//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb//uzS/7Ggj/8UEhH/MCom/2phV/+omYj/4M23/9/Ltv8fGxj/Gx0f/zI0Nv8AAAD/mot9//7s0v/23cb//u7V/wAAAAD+7tX/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/+eDI/+/XwP/+6dD///DW//7s0v/948v//unQ/+fRu/+Ddmj/bmJW/8Gum//+7NL/9t3G//bdxv/+7tX/AAAAAP/w1v/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/23cb/9t3G//bdxv/43sb/++LJ//jexv/23cb/9t3G//bdxv/23cb//ePL//7u1f//8Nb//unQ//bdxv/23cb/9t3G///w1v8AAAAA///n///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb///DW///w1v//8Nb////n/wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAP////8=';
+				// Remove current favicons and replace accordingly, or Favico has a cross domain issue since the real favicon is on redditstatic.com.
+				$('head link[rel="shortcut icon"], head link[rel="icon"]').attr('href', faviconDataurl);
+
+				// Init Favico
+				this.favicon = new window.Favico();
+
+				// Prevent notification icon from showing up in bookmarks
+				$(window).on('beforeunload', function() {
+					module.favicon.reset();
+				});
+			}
+		}
+	});
 });

--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -134,7 +134,7 @@ addModule('orangered', function(module, moduleID) {
 		hideUnreadCount: function() {
 			RESUtils.addCSS('.message-count { display: none; }');
 		},
-		setUnreadCount: function(count) {
+		setUnreadCount: function(count, fromMessage) {
 			if (count > 0) {
 				if (module.options.showUnreadCountInTitle.value) {
 					document.title = '[' + count + '] ' + document.title.replace(/^\[[\d]+\]\s/, '');
@@ -160,6 +160,16 @@ addModule('orangered', function(module, moduleID) {
 				}
 				module.updateFaviconBadge(0);
 			}
+
+			if (!fromMessage) {
+				RESUtils.runtime.sendMessage({
+					requestType: 'multicast',
+					moduleID: moduleID,
+					method: 'setUnreadCount',
+					arguments: Array.prototype.slice.call(arguments)
+				});
+			}
+
 		},
 		updateFaviconBadge: function(count) {
 			if (!(module.isEnabled() && module.isMatchURL())) return;

--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -86,7 +86,8 @@ addModule('orangered', function(module, moduleID) {
 
 			return '/message/inbox/';
 		},
-		showUnreadCount: function() {
+		showUnreadCount: function(container) {
+			container = container || document;
 			if ((typeof module.mail === 'undefined') && module.options.showUnreadCount.value) {
 				// deprecate this feature once reddit's own goes live...
 				module.mail = document.getElementById('mail');
@@ -109,7 +110,7 @@ addModule('orangered', function(module, moduleID) {
 				var msgCountCacheKey = 'RESmodules.' + moduleID + '.msgCount.' + RESUtils.loggedInUser();
 				if (module.mail.classList.contains('havemail')) {
 					module.mail.setAttribute('href', module.getInboxLink(true));
-					var countDiv = document.querySelector('.message-count'),
+					var countDiv = container.querySelector('.message-count'),
 						count;
 
 					// the new way of getting message count is right from reddit, as it will soon
@@ -166,6 +167,11 @@ addModule('orangered', function(module, moduleID) {
 				module.updateFaviconBadge(0);
 			}
 
+			if (fromMessage) {
+				module.updateMailElements(count);
+			}
+
+
 			if (module.options.updateOtherTabs.value && !fromMessage && typeof count !== 'undefined') {
 				RESUtils.runtime.sendMessage({
 					requestType: 'multicast',
@@ -175,6 +181,15 @@ addModule('orangered', function(module, moduleID) {
 				});
 			}
 
+		},
+		updateMailElements: function(count) {
+			count = count || 0;
+			var $ele = $(module.mail).add(modules['neverEndingReddit'].NREMail);
+
+			$ele.attr('title', count ? 'new mail!' : 'No new mail');
+			$ele.toggleClass('havemail', !!count);
+			$ele.toggleClass('nohavemail', !count);
+			$ele.attr('href', module.getInboxLink(count));
 		},
 		updateFaviconBadge: function(count) {
 			if (!(module.isEnabled() && module.isMatchURL())) return;

--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -1,0 +1,17 @@
+addModule('orangered', function(module, moduleID) {
+	module.moduleName = 'Unread Messages'
+	module.category = 'Comments';
+	module.description = 'Helping you get your daily dose of orangereds';
+
+	module.options.openMailInNewTab = {
+		description: 'When clicking the mail envelope or modmail icon, open mail in a new tab?',
+		type: 'enum',
+		value: false
+	};
+
+	module.go = function() {
+		if (module.options.openMailInNewTab.value) {
+			$('#mail, #modmail').attr('target', '_blank');
+		}
+	}
+});

--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -9,6 +9,11 @@ addModule('orangered', function(module, moduleID) {
 			type: 'enum',
 			value: false
 		},
+		updateOtherTabs: {
+			description: 'Update all open tabs when RES checks for orangereds',
+			type: 'boolean',
+			value: true,
+		},
 		showUnreadCount: {
 			type: 'boolean',
 			value: true,
@@ -161,7 +166,7 @@ addModule('orangered', function(module, moduleID) {
 				module.updateFaviconBadge(0);
 			}
 
-			if (!fromMessage && typeof count !== 'undefined') {
+			if (module.options.updateOtherTabs.value && !fromMessage && typeof count !== 'undefined') {
 				RESUtils.runtime.sendMessage({
 					requestType: 'multicast',
 					moduleID: moduleID,

--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -162,7 +162,7 @@ addModule('orangered', function(module, moduleID) {
 	function updateMailCountElements(count, source) {
 		if (!module.options.showUnreadCount.value) return;
 
-		if (module.options.updateCurrentTab && (source === 'rpc' || source === 'ner')) {
+		if (module.options.updateCurrentTab.value && (source === 'rpc' || source === 'ner')) {
 			nativeMailCount.style.display = count && !resMailCount ? 'inline-block' : 'none';
 			nativeMailCount.textContent = count;
 		}


### PR DESCRIPTION
Unread messages/notifications/buttons

* update all tabs when RES sees a new notification: userbar mail icon, userbar mail count (adds if missing), userbar retro mail count, title, favicon, NRE mail icon and count  (where appropriate options are enabled)
* refactored modules.floater, for managing elements that need to float around -- particularly the NER pause button and floating orangered. fixes issue where floating buttons are invisible when betteReddit.pinHeader = fullHeader
* Refactored Never-Ending Reddit's floating inbox into orangered
* `RESUtils.rpc(moduleID, methodOnModule, [ 0, "or", "some", "args" ])` -- indirectly call a module method. future plans: call from RES command line and from messages from other extensions
* `RESUtils.sendMessage({ "multicast", moduleID: "someModule", method: "someMethodOnThatModule", arguments: [ 0, "or", "several", "parameters" ] })`

Might actually work in Opera12, who knows.  Seems to work generally well elsewhere.

Still doesn't check for orangereds in the background - only when loading page or NER-page