### PR TITLE
Align live preview and source stripes with the top left

### DIFF
--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -1796,7 +1796,7 @@ RESUtils.hashKeyArray = function(keyArray) {
 							return false;
 						}
 						var handled = obj.handleData(data, cache && cache.data);
-						cache.data = (typeof handled !== 'undefind') ? handled : data;
+						cache.data = (typeof handled !== 'undefined') ? handled : data;
 						cache.lastCheck = now;
 						RESStorage.setItem(obj.key, JSON.stringify(cache));
 						while (fetching[obj.key].length) {

--- a/lib/modules/commentPreview.js
+++ b/lib/modules/commentPreview.js
@@ -80,7 +80,7 @@ modules['commentPreview'] = {
 			RESUtils.addCSS('.ban-details { position: relative; }');
 			RESUtils.addCSS('#banned .RESBigEditorPop { float: none; left: 414px; bottom: -45px; position: absolute; }');
 			if (modules['commentPreview'].options.draftStyle.value) {
-				RESUtils.addCSS('.livePreview { background: repeating-linear-gradient(-45deg, transparent, transparent 40px, rgba(166,166,166,.07) 40px, rgba(166,166,166,.07) 80px); }');
+				RESUtils.addCSS('.livePreview { background: repeating-linear-gradient(-225deg, transparent, transparent 40px, rgba(166,166,166,.07) 40px, rgba(166,166,166,.07) 80px); }');
 			}
 
 		}

--- a/lib/modules/sourceSnudown.js
+++ b/lib/modules/sourceSnudown.js
@@ -11,8 +11,8 @@ addModule('sourceSnudown', function(module, moduleID) {
 	module.beforeLoad = function() {
 		if (module.isMatchURL() && module.isEnabled()) {
 			RESUtils.addCSS('.viewSource>.bottom-area:before{ display:none; }');
-			RESUtils.addCSS('.viewSource textarea{ background:repeating-linear-gradient(-45deg, transparent, transparent 40px, rgba(166,166,166,.05) 40px, rgba(166,166,166,.05) 80px), white; }');
-			RESUtils.addCSS('.viewSource textarea[readonly]{ background:repeating-linear-gradient(-45deg, transparent, transparent 40px, rgba(166,166,166,.1) 40px, rgba(166,166,166,.1) 80px), white; }');
+			RESUtils.addCSS('.viewSource textarea{ background:repeating-linear-gradient(-225deg, transparent, transparent 40px, rgba(166,166,166,.05) 40px, rgba(166,166,166,.05) 80px), white; }');
+			RESUtils.addCSS('.viewSource textarea[readonly]{ background:repeating-linear-gradient(-225deg, transparent, transparent 40px, rgba(166,166,166,.1) 40px, rgba(166,166,166,.1) 80px), white; }');
 		}
 	};
 


### PR DESCRIPTION
Fixes #2036 

Works for me in Chrome and Firefox, not sure which browser @andytuba was using when it didn't:

![test](https://cloud.githubusercontent.com/assets/7673145/6432071/d945d84a-c012-11e4-85be-f100042a12fc.gif)
(it's darkened in the .gif for visibility)