### PR TITLE
Remove uneffective RESTemplates.load calls without callbacks

### DIFF
--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -167,8 +167,6 @@ function RESInit() {
 		};
 		konami.iphone.load = function() { }; // nix touch support; occasional false positives on touchscreen laptops
 		konami.load();
-
-		RESTemplates.load();
 	}
 
 	RESUtils.postLoad = true;

--- a/lib/modules/hosts/fitbamob.js
+++ b/lib/modules/hosts/fitbamob.js
@@ -53,7 +53,6 @@ modules['showImages'].siteModules['fitbamob'] = {
 		return def.promise();
 	},
 	handleInfo: function(elem, info) {
-		RESTemplates.load('VideoUI');
 		var generate = function(options) {
 			var template = RESTemplates.getSync('VideoUI');
 			var video = {

--- a/lib/modules/hosts/gfycat.js
+++ b/lib/modules/hosts/gfycat.js
@@ -47,9 +47,6 @@ modules['showImages'].siteModules['gfycat'] = {
 		return def.promise();
 	},
 	handleInfo: function(elem, info) {
-
-		RESTemplates.load('GfycatUI');
-
 		var generate = function(options) {
 			var template = RESTemplates.getSync('GfycatUI');
 			var video = {

--- a/lib/modules/hosts/gifyoutube.js
+++ b/lib/modules/hosts/gifyoutube.js
@@ -54,9 +54,6 @@ modules['showImages'].siteModules['gifyoutube'] = {
 		return def.promise();
 	},
 	handleInfo: function(elem, info) {
-
-		RESTemplates.load('gifyoutubeUI');
-
 		var generate = function(options) {
 			var template = RESTemplates.getSync('gifyoutubeUI');
 			var video = {

--- a/lib/modules/hosts/giphy.js
+++ b/lib/modules/hosts/giphy.js
@@ -25,8 +25,6 @@ modules['showImages'].siteModules['giphy'] = {
 		return def.promise();
 	},
 	handleInfo: function(elem, info) {
-		RESTemplates.load('GiphyUI');
-
 		if (info.isHtml5) {
 
 			// html5 video player

--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -199,8 +199,6 @@ modules['showImages'].siteModules['imgur'] = {
 		return $.Deferred().resolve(elem).promise();
 	},
 	handleGifv: function(elem, info) {
-		RESTemplates.load('imgurgifvUI');
-
 		var generate = function(options) {
 			var template = RESTemplates.getSync('imgurgifvUI');
 			var video = {

--- a/lib/modules/quickMessage.js
+++ b/lib/modules/quickMessage.js
@@ -21,7 +21,6 @@ addModule('quickMessage', function(module, moduleID) {
 	};
 	module.beforeLoad = function() {
 		if ((module.isEnabled()) && (module.isMatchURL())) {
-			RESTemplates.load('quickMessage');
 			RESTemplates.load('quickMessageCSS', function(template) {
 				RESUtils.addCSS(template.text());
 			});


### PR DESCRIPTION
Maybe they used to do something, I don't know.
But since `RESTemplates.load` does absolutely nothing [if the callback is falsy](https://github.com/honestbleeps/Reddit-Enhancement-Suite/blob/401b0b61363ae7921599c9939dcb68acf1127671/lib/core/template.js#L5), they don't do anything now.