### PR TITLE
Pastebin expando support

### DIFF
--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -126,6 +126,7 @@
 				"modules/hosts/giphy.js",
 				"modules/hosts/streamable.js",
 				"modules/hosts/raddit.js",
+				"modules/hosts/pastebin.js",
 				"core/init.js"
 			],
 			"css": [

--- a/Opera/includes/loader.js
+++ b/Opera/includes/loader.js
@@ -132,6 +132,7 @@ window.addEventListener('DOMContentLoaded', function() {
 		'modules/hosts/giphy.js',
 		'modules/hosts/streamable.js',
 		'modules/hosts/raddit.js',
+		'modules/hosts/pastebin.js',
 
 		'core/init.js',
 

--- a/OperaBlink/manifest.json
+++ b/OperaBlink/manifest.json
@@ -125,6 +125,7 @@
 				"modules/hosts/giphy.js",
 				"modules/hosts/streamable.js",
 				"modules/hosts/raddit.js",
+				"modules/hosts/pastebin.js",
 				"core/init.js"
 			],
 			"css": [

--- a/RES.safariextension/Info.plist
+++ b/RES.safariextension/Info.plist
@@ -136,6 +136,7 @@
 				<string>modules/hosts/giphy.js</string>
 				<string>modules/hosts/streamable.js</string>
 				<string>modules/hosts/raddit.js</string>
+				<string>modules/hosts/pastebin.js</string>
 				<string>core/init.js</string>
 			</array>
 		</dict>

--- a/XPI/lib/main.js
+++ b/XPI/lib/main.js
@@ -253,6 +253,7 @@ pageMod.PageMod({
 		self.data.url('modules/hosts/giphy.js'),
 		self.data.url('modules/hosts/streamable.js'),
 		self.data.url('modules/hosts/raddit.js'),
+		self.data.url('modules/hosts/pastebin.js'),
 		self.data.url('core/init.js')
 	],
 	contentStyleFile: [

--- a/lib/modules/hosts/pastebin.js
+++ b/lib/modules/hosts/pastebin.js
@@ -1,0 +1,34 @@
+modules['showImages'].siteModules['pastebin'] = {
+	domains: ['pastebin.com'],
+	detect: function(href, elem) {
+		return href.indexOf('pastebin.com/') !== -1;
+	},
+	handleLink: function(elem) {
+		var def = $.Deferred(),
+			groups = (/^https?:\/\/(?:www\.)?pastebin\.com\/(?:raw\.php\?i=|index\/)?([a-z0-9]{8})/i).exec(elem.href);
+		if (groups) {
+			def.resolve(elem, '//pastebin.com/embed_iframe.php?i=' + groups[1]);
+		} else {
+			def.reject();
+		}
+		return def.promise();
+	},
+	handleInfo: function(elem, info) {
+		var generate = function(options) {
+			var element = document.createElement('iframe');
+			element.src = info;
+			element.style.width = '80em';
+			element.style.maxWidth = 'calc(100% - 2px)';
+			element.style.height = '500px';
+			element.style.border = '1px solid #CCC';
+			return element;
+		};
+		elem.type = 'GENERIC_EXPANDO';
+		elem.expandoClass = ' selftext';
+		elem.expandoOptions = {
+			generate: generate,
+			media: info
+		};
+		return $.Deferred().resolve(elem).promise();
+	}
+};


### PR DESCRIPTION
Replaces would-be pastebin support in #1352, since it appears that their iframes work fine now, even with https.

![image](https://cloud.githubusercontent.com/assets/7673145/6433422/7c4dd366-c03c-11e4-8351-b2f7f8c906f5.png)
(might be too wide, i dunno)