### PR TITLE
pastebin.js: option for expando width

### DIFF
--- a/lib/modules/hosts/pastebin.js
+++ b/lib/modules/hosts/pastebin.js
@@ -1,5 +1,12 @@
 modules['showImages'].siteModules['pastebin'] = {
 	domains: ['pastebin.com'],
+	options: {
+		width: {
+			description: 'The maximum width of pastebin expandos. (any valid CSS width, default 80em)',
+			value: '80em',
+			type: 'text'
+		}
+	},
 	detect: function(href, elem) {
 		return href.indexOf('pastebin.com/') !== -1;
 	},
@@ -17,7 +24,7 @@ modules['showImages'].siteModules['pastebin'] = {
 		var generate = function(options) {
 			var element = document.createElement('iframe');
 			element.src = info;
-			element.style.width = '80em';
+			element.style.width = modules['showImages'].siteModules['pastebin'].options.width.value;
 			element.style.maxWidth = 'calc(100% - 2px)';
 			element.style.height = '500px';
 			element.style.border = '1px solid #CCC';


### PR DESCRIPTION
No `|| options.default` since it's not catastrophic if it's left blank, they can leave the width unspecified if they want.