### PR TITLE
GitHub gist expandos

### DIFF
--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -126,6 +126,7 @@
 				"modules/hosts/giphy.js",
 				"modules/hosts/streamable.js",
 				"modules/hosts/raddit.js",
+				"modules/hosts/github.js",
 				"core/init.js"
 			],
 			"css": [

--- a/Opera/includes/loader.js
+++ b/Opera/includes/loader.js
@@ -132,6 +132,7 @@ window.addEventListener('DOMContentLoaded', function() {
 		'modules/hosts/giphy.js',
 		'modules/hosts/streamable.js',
 		'modules/hosts/raddit.js',
+		'modules/hosts/github.js',
 
 		'core/init.js',
 

--- a/OperaBlink/manifest.json
+++ b/OperaBlink/manifest.json
@@ -125,6 +125,7 @@
 				"modules/hosts/giphy.js",
 				"modules/hosts/streamable.js",
 				"modules/hosts/raddit.js",
+				"modules/hosts/github.js",
 				"core/init.js"
 			],
 			"css": [

--- a/RES.safariextension/Info.plist
+++ b/RES.safariextension/Info.plist
@@ -136,6 +136,7 @@
 				<string>modules/hosts/giphy.js</string>
 				<string>modules/hosts/streamable.js</string>
 				<string>modules/hosts/raddit.js</string>
+				<string>modules/hosts/github.js</string>
 				<string>core/init.js</string>
 			</array>
 		</dict>

--- a/XPI/lib/main.js
+++ b/XPI/lib/main.js
@@ -253,6 +253,7 @@ pageMod.PageMod({
 		self.data.url('modules/hosts/giphy.js'),
 		self.data.url('modules/hosts/streamable.js'),
 		self.data.url('modules/hosts/raddit.js'),
+		self.data.url('modules/hosts/github.js'),
 		self.data.url('core/init.js')
 	],
 	contentStyleFile: [

--- a/lib/modules/hosts/github.js
+++ b/lib/modules/hosts/github.js
@@ -11,6 +11,7 @@ modules['showImages'].siteModules['github'] = {
 			RESUtils.runtime.ajax({
 				method: 'GET',
 				url: 'https://api.github.com/gists/' + groups[1],
+				aggressiveCache: true,
 				onload: function(response) {
 					if (response.status === 200) {
 						try {

--- a/lib/modules/hosts/github.js
+++ b/lib/modules/hosts/github.js
@@ -19,9 +19,10 @@ modules['showImages'].siteModules['github'] = {
 						} catch (error) {
 							def.reject();
 						}
-					} else if (response.status === 403 && response.responseText.indexOf('rate limit') !== -1) {
-						console.error('GitHub API limit reached');
 					} else {
+						if (response.status === 403 && response.responseText.indexOf('rate limit') !== -1) {
+							console.error('GitHub API limit reached');
+						}
 						def.reject();
 					}
 				},

--- a/lib/modules/hosts/github.js
+++ b/lib/modules/hosts/github.js
@@ -1,0 +1,57 @@
+modules['showImages'].siteModules['github'] = {
+	domains: ['gist.github.com'],
+	name: 'github gists',
+	detect: function(href, elem) {
+		return href.indexOf('gist.github.com/') !== -1;
+	},
+	handleLink: function(elem) {
+		var def = $.Deferred(),
+			groups = (/^https?:\/\/gist\.github\.com\/(?:[\w-]+\/)?([a-z0-9]{20,}|\d+)/i).exec(elem.href);
+		if (groups) {
+			BrowserStrategy.ajax({
+				method: 'GET',
+				url: 'https://api.github.com/gists/' + groups[1],
+				onload: function(response) {
+					if (response.status === 200) {
+						try {
+							var json = JSON.parse(response.responseText);
+							def.resolve(elem, json);
+						} catch (error) {
+							def.reject();
+						}
+					} else if(response.status === 403 && response.responseText.indexOf('rate limit') !== -1) {
+						console.error('github api limit reached');
+					} else {
+						def.reject();
+					}
+				},
+				onerror: function(error) {
+					def.reject();
+				}
+			});
+		} else {
+			def.reject();
+		}
+		return def.promise();
+	},
+	handleInfo: function(elem, info) {
+		var def = $.Deferred();
+		elem.type = 'TEXT';
+		elem.imageTitle = info.description;
+		elem.src = '';
+		for (var filename in info.files) {
+			var file = info.files[filename];
+			elem.src += '<h5>' + filename + ':</h5>';
+			if (file.language === 'Markdown') {
+				elem.src += window.SnuOwnd.getParser().render(file.content);
+			} else {
+				elem.src += '<pre><code>' + escapeHTML(file.content) + '</code></pre>';
+			}
+			if (file.truncated) {
+				elem.src += '<p>&lt;file truncated&gt;</p>';
+			}
+		}
+		def.resolve(elem);
+		return def.promise();
+	}
+};

--- a/lib/modules/hosts/github.js
+++ b/lib/modules/hosts/github.js
@@ -8,7 +8,7 @@ modules['showImages'].siteModules['github'] = {
 		var def = $.Deferred(),
 			groups = (/^https?:\/\/gist\.github\.com\/(?:[\w-]+\/)?([a-z0-9]{20,}|\d+)/i).exec(elem.href);
 		if (groups) {
-			BrowserStrategy.ajax({
+			RESUtils.runtime.ajax({
 				method: 'GET',
 				url: 'https://api.github.com/gists/' + groups[1],
 				onload: function(response) {
@@ -19,8 +19,8 @@ modules['showImages'].siteModules['github'] = {
 						} catch (error) {
 							def.reject();
 						}
-					} else if(response.status === 403 && response.responseText.indexOf('rate limit') !== -1) {
-						console.error('github api limit reached');
+					} else if (response.status === 403 && response.responseText.indexOf('rate limit') !== -1) {
+						console.error('GitHub API limit reached');
 					} else {
 						def.reject();
 					}


### PR DESCRIPTION
There are a few rendering glitches in `.md` files due to differences between Snudown and Markdown, but it's definitely better than the raw text.

---
![image](https://cloud.githubusercontent.com/assets/7673145/6434119/b1e4064a-c04f-11e4-8556-3766483b6f5e.png)

---
how2loop.js just happens to be the name of the gist, if you're wondering why it's duplicated
![image](https://cloud.githubusercontent.com/assets/7673145/6434141/246470c4-c050-11e4-9862-614c732c882b.png)
