### PR TITLE
JSFiddle Expandos

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -112,6 +112,7 @@
 				"modules/hosts/imgur.js",
 				"modules/hosts/xkcd.js",
 				"modules/hosts/dailymotion.js",
+				"modules/hosts/jsfiddle.js",
 				"modules/hosts/pornbot.js",
 				"modules/hosts/coub.js",
 				"modules/hosts/uploadly.js",

--- a/firefox/index.js
+++ b/firefox/index.js
@@ -566,6 +566,7 @@ PageMod({
 		self.data.url('modules/hosts/imgur.js'),
 		self.data.url('modules/hosts/xkcd.js'),
 		self.data.url('modules/hosts/dailymotion.js'),
+		self.data.url('modules/hosts/jsfiddle.js'),
 		self.data.url('modules/hosts/pornbot.js'),
 		self.data.url('modules/hosts/coub.js'),
 		self.data.url('modules/hosts/uploadly.js'),

--- a/lib/modules/hosts/jsfiddle.js
+++ b/lib/modules/hosts/jsfiddle.js
@@ -1,0 +1,12 @@
+addLibrary('mediaHosts', 'jsfiddle', {
+	domains: ['jsfiddle.net'],
+	logo: 'https://jsfiddle.net/favicon.png',
+	detect: href => (/^https?:\/\/jsfiddle.net(\/(?:\w+\/(?!embedded\/))?[a-z0-9]{5,}(?:\/\d+)?(?=\/|$))(\/embedded\/[\w,]+\/)?/i).exec(href),
+	handleLink(elem, [, path, categories]) {
+		elem.type = 'IFRAME';
+		elem.expandoClass = 'selftext';
+		elem.setAttribute('data-embed', `//jsfiddle.net${path}${categories || '/embedded/result,js,resources,html,css/'}`);
+		elem.setAttribute('data-width', '100%');
+		elem.setAttribute('data-height', '500px');
+	}
+});

--- a/node/files.json
+++ b/node/files.json
@@ -80,6 +80,7 @@
 		"modules/hosts/imgur.js",
 		"modules/hosts/xkcd.js",
 		"modules/hosts/dailymotion.js",
+		"modules/hosts/jsfiddle.js",
 		"modules/hosts/pornbot.js",
 		"modules/hosts/coub.js",
 		"modules/hosts/uploadly.js",

--- a/safari/Info.plist
+++ b/safari/Info.plist
@@ -119,6 +119,7 @@
 				<string>modules/hosts/imgur.js</string>
 				<string>modules/hosts/xkcd.js</string>
 				<string>modules/hosts/dailymotion.js</string>
+				<string>modules/hosts/jsfiddle.js</string>
 				<string>modules/hosts/pornbot.js</string>
 				<string>modules/hosts/coub.js</string>
 				<string>modules/hosts/uploadly.js</string>


### PR DESCRIPTION
This is the final part of, and closes #1352.

~~Unfortunately, jsFiddle insists on loading 3rd-party scripts over HTTP, so functionality is broken in many fiddles.~~

~~Update (2016-03-13): They still load dependencies over HTTP. *Why?*~~

Actually, seems like it's just for old ones, new ones seem to work fine.

![image](https://cloud.githubusercontent.com/assets/7673145/6435343/9b8240c2-c06a-11e4-880e-e899639980d1.png)
