### PR TITLE
Regression in RESUtils.isMatchURL()

### DIFF
--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -83,18 +83,18 @@ RESUtils.isMatchURL = function(moduleID) {
 
 	var exclude = module.exclude,
 		include = module.include;
-	return RESUtils.matchesPageType(include, exclude);
+	return RESUtils.matchesPageLocation(include, exclude);
 };
 
-RESUtils.matchesPageType = function(includes, excludes) {
+RESUtils.matchesPageLocation = function(includes, excludes) {
 	var currURL = location.href,
 		pageType = RESUtils.pageType(),
 		includes = typeof includes === "undefined" ? [] : [].concat(includes),
 		excludes = typeof excludes === "undefined" ? [] : [].concat(excludes);
 
-	var excludesPageType = excludes.length && RESUtils.isPageType.apply(RESUtils, excludes);
+	var excludesPageType = excludes.length && (RESUtils.isPageType.apply(RESUtils, excludes) || RESUtils.matchesPageRegex.apply(RESUtils, excludes));
 	if (!excludesPageType) {
-		var includesPageType = !includes.length || RESUtils.isPageType.apply(RESUtils, includes);
+		var includesPageType = !includes.length || RESUtils.isPageType.apply(RESUtils, includes) || RESUtils.matchesPageRegex.apply(RESUtils, includes);
 		return includesPageType;
 	}
 };
@@ -220,6 +220,12 @@ RESUtils.isPageType = function(/*type1, type2, type3, ...*/) {
 		return (e === 'all') || (e === thisPage);
 	});
 };
+RESUtils.matchesPageRegex = function(/*type1, type2, type3, ...*/) {
+	var href = document.location.href;
+	return Array.prototype.slice.call(arguments).some(function(e) {
+		return e.test && e.test(href);
+	});
+}
 RESUtils.commentPermalinkRegex = /^https?:\/\/(?:[\-\w\.]+\.)?reddit\.com\/[\-\w\.\/]*comments\/[a-z0-9]+\/[^\/]+\/[a-z0-9]+$/i;
 RESUtils.isCommentPermalinkPage = function() {
 	if (typeof this.isCommentPermalinkSaved === 'undefined') {

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -745,7 +745,7 @@ modules['keyboardNav'] = {
 			var commands = $.each(this.options, function(name, option) {
 				if (option.type !== 'keycode') return;
 				if (!option.callback) return;
-				if (!RESUtils.matchesPageType(option.include, option.exclude)) return;
+				if (!RESUtils.matchesPageLocation(option.include, option.exclude)) return;
 
 				var hash = RESUtils.hashKeyArray(option.value);
 				if (!lookup[hash]) {


### PR DESCRIPTION


In https://github.com/honestbleeps/Reddit-Enhancement-Suite/commit/903c8a9553f1f46b63e9d65994b04da3dd6a728f, the behavor of RESUtils.isMatchURL() changed, probably unintentionally.  It more or less just checks isReddit() and then passes off all the work to matchesPageType().  

The old matchesPageType() did more than match the page type.  It would also see if the include/exclude was a regex and test it versus the URL (see old lines 96 and 108 in the diff above).  The new matchesPageType() does only what the name implies, and so, for example, filteReddit's regexes in its include list don't match things like "linklist" and so isMatchURL() will always be false.