### PR TITLE
lighten the background of uncolored tags in nightmode

### DIFF
--- a/lib/modules/nightmode.css
+++ b/lib/modules/nightmode.css
@@ -993,7 +993,7 @@ html.res-nightmode .multi-details .subreddits .remove-sr {
 }
 /* Neutral background colour for tags in nightmode */
 .res-nightmode .hasTag[style*="background-color: transparent"] {
-	background-color: #666 !important;
+	background-color: #999 !important;
 }
 /* Nightmode friendly snoo/balloons image */
 .res-nightmode .with-listing-chooser:not(.multi-page) .footer-parent {


### PR DESCRIPTION
Fixes #1334.

Before:
![image](https://cloud.githubusercontent.com/assets/7673145/6568636/67363ca4-c6b1-11e4-82b4-c04fd42ec3af.png)
After:
![image](https://cloud.githubusercontent.com/assets/7673145/6568658/c721c9b2-c6b1-11e4-832b-30b49e34ae3c.png)
