### PR TITLE
Use batch icon for advanced options warning

### DIFF
--- a/lib/core/res.css
+++ b/lib/core/res.css
@@ -274,9 +274,11 @@ body.res-console-open {
 	display: none;
 }
 .optionContainer.advanced > label:after {
-	content: '\26A0';
+	content: '\F15A';
 	margin-left: 0.5em;
 	color: red;
+	font-family: 'Batch';
+	font-size: 11px;
 }
 .RESDialogSmall {
 	background-color: #fff;


### PR DESCRIPTION
I don't see the current one on Chrome (a browser specific issue that isn't FF? whaaat), I guess it doesn't choose fallback fonts as intelligently:
![image](https://cloud.githubusercontent.com/assets/7673145/6587261/6ade2b6c-c758-11e4-82ae-d1ca4a819a37.png)
Here's how it looks in Firefox, original / this PR:
![image](https://cloud.githubusercontent.com/assets/7673145/6587002/468fadd8-c755-11e4-9753-598e6468a5df.png)
![image](https://cloud.githubusercontent.com/assets/7673145/6587076/fb3295ca-c755-11e4-83b9-54c8904a6452.png)

Alternatively we could specify the font for the original icon, but I don't believe there's a single font that'll work on all platforms. (judging by [this site](http://www.fileformat.info/info/unicode/char/26a0/fontsupport.htm), whose trustworthiness is debatable, we'd have something like: `font-family: 'Segoe UI Symbol', FreeSans, STIXGeneral-Regular;`)