### PR TITLE
Use Batch for user tagger icon

### DIFF
--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -152,7 +152,8 @@ modules['userTagger'] = {
 
 			css += '#benefits { width: 200px; margin-left: 0; }';
 			css += '#userTaggerToolTip #userTaggerVoteWeight { width: 30px; }';
-			css += '.RESUserTagImage { display: inline-block; width: 16px; height: 8px; background-image: url("https://s3.amazonaws.com/b.thumbs.redditmedia.com/tBwwK20XXxtpgudWx1L7bDXla-iotv-JA0jgA0Y-FVs.png"); background-repeat: no-repeat; background-position: -16px -137px; }';
+			css += '.userTagLink.RESUserTagImage:hover { text-decoration: none; }';
+			css += '.RESUserTagImage::after { content: "\\F0AC"; font-family: "Batch"; font-size: 14px; line-height: 8px; vertical-align: middle; color: #9BD }';
 			css += '.userTagLink { display: inline-block; }';
 			css += '.hoverHelp { margin-left: 3px; cursor: pointer; color: #369; text-decoration: underline; }';
 			css += '.userTagLink.hasTag, #userTaggerPreview { display: inline-block; padding: 0 4px; border: 1px solid #c7c7c7; border-radius: 3px; }';


### PR DESCRIPTION
One less icon relying on the spritesheet!
There are a few subreddit stylesheets that conflict (their icon overlaps) - but the button still works, and all they should have to do is add `.userTagLink.RESUserTagImage::after { content: ""; }` to hide ours.

Before/after:
![image](https://cloud.githubusercontent.com/assets/7673145/6604423/9f2e6b10-c7fe-11e4-80c0-836fb4bccaa6.png)
![image](https://cloud.githubusercontent.com/assets/7673145/6604466/e460077a-c7fe-11e4-978f-e34347c4f81c.png) ![image](https://cloud.githubusercontent.com/assets/7673145/6604493/1066d182-c7ff-11e4-8003-bc50572dccc3.png)