### PR TITLE
quickMessage: use addModule() properly

### DIFF
--- a/lib/modules/quickMessage.js
+++ b/lib/modules/quickMessage.js
@@ -19,6 +19,9 @@ addModule('quickMessage', function(module, moduleID) {
 			description: 'Open the quick message dialog when clicking on "message the moderators" instead of going straight to reddit\'s message page.'
 		}
 	};
+
+	var quickMessageDialog;
+
 	module.beforeLoad = function() {
 		if ((module.isEnabled()) && (module.isMatchURL())) {
 			RESTemplates.load('quickMessageCSS', function(template) {
@@ -28,11 +31,11 @@ addModule('quickMessage', function(module, moduleID) {
 	};
 	module.go = function() {
 		if ((module.isEnabled()) && (module.isMatchURL())) {
-			module.quickMessageDialog = RESUtils.createElementWithID('div', 'quickMessage');
-			$(module.quickMessageDialog).html(RESTemplates.getSync('quickMessage').html());
-			document.body.appendChild(module.quickMessageDialog);
+			quickMessageDialog = RESUtils.createElementWithID('div', 'quickMessage');
+			$(quickMessageDialog).html(RESTemplates.getSync('quickMessage').html());
+			document.body.appendChild(quickMessageDialog);
 
-			module.attachEventListeners();
+			attachEventListeners();
 
 			var subreddit = RESUtils.currentSubreddit(),
 				messageTheMods = document.querySelector('.side a.helplink');
@@ -47,7 +50,7 @@ addModule('quickMessage', function(module, moduleID) {
 
 			modules['commandLine'].registerCommand('qm', 'qm [recipient [message]] - open quick message dialog',
 				function(command, val, match) {
-					var message = module.parseCommandLine(val);
+					var message = parseCommandLine(val);
 					if (message.body) {
 						return 'quick message to ' + message.to + ': ' + message.body;
 					} else if (message.to) {
@@ -55,13 +58,13 @@ addModule('quickMessage', function(module, moduleID) {
 					}
 					return 'quick message';
 				}, function(command, val, match, e) {
-					var message = module.parseCommandLine(val);
+					var message = parseCommandLine(val);
 					module.openQuickMessageDialog(message);
 				}
 			);
 		}
 	};
-	module.parseCommandLine = function(val) {
+	function parseCommandLine(val) {
 		var parts = {};
 		var vals = val.match(/^([^\s]+)(?:\s(.*))?$/);
 
@@ -71,8 +74,8 @@ addModule('quickMessage', function(module, moduleID) {
 		}
 
 		return parts;
-	};
-	module.attachEventListeners = function() {
+	}
+	function attachEventListeners() {
 		//keyboard shortcut
 		window.addEventListener('keydown', function(e) {
 			if (RESUtils.checkKeysForEvent(e, module.options.openQuickMessage.value)) {
@@ -82,12 +85,12 @@ addModule('quickMessage', function(module, moduleID) {
 		}, true);
 
 		// close dialog with "x" button
-		module.quickMessageDialog.querySelector('#quickMessageDialogClose').addEventListener('click', function(e) {
+		quickMessageDialog.querySelector('#quickMessageDialogClose').addEventListener('click', function(e) {
 			e.preventDefault();
 			module.closeQuickMessageDialog();
 		}, false);
 		// close dialog with escape key
-		module.quickMessageDialog.addEventListener('keydown', function(e) {
+		quickMessageDialog.addEventListener('keydown', function(e) {
 			if (e.keyCode === modules['commentTools'].KEYS.ESCAPE) {
 				e.preventDefault();
 				module.closeQuickMessageDialog();
@@ -95,33 +98,33 @@ addModule('quickMessage', function(module, moduleID) {
 		}, true);
 
 		// send with "send message" button (we would use a 'submit' event listener, but then the user could accidentally send the message by pressing enter)
-		module.quickMessageDialog.querySelector('#quickMessageDialogSend').addEventListener('click', function(e) {
+		quickMessageDialog.querySelector('#quickMessageDialogSend').addEventListener('click', function(e) {
 			e.preventDefault();
-			module.sendMessage();
+			sendMessage();
 		}, true);
 		// send with control-enter
 		modules['commentTools'].onCtrlEnter(
 			'#quickMessageDialog',
-			module.sendMessage
+			sendMessage
 		);
 
 		// open full message form
-		var fullMessageForm = module.quickMessageDialog.querySelector('a.fullMessageForm');
+		var fullMessageForm = quickMessageDialog.querySelector('a.fullMessageForm');
 		fullMessageForm.addEventListener('mousedown', function(e) {
 			// For accessibility reasons, update the link instead of simulating browser behavior with JavaScript
-			this.href = module.getFullMessageFormUrl();
+			this.href = getFullMessageFormUrl();
 		});
 		fullMessageForm.addEventListener('click', function(e) {
 			module.closeQuickMessageDialog();
 		});
 
-		$(module.quickMessageDialog).find('a').on('keypress', function(e) {
+		$(quickMessageDialog).find('a').on('keypress', function(e) {
 			if ((e.keyCode || e.which) === 13) {
 				$(e.target).trigger('click');
 			}
 		});
-	};
-	module.getValidSendFrom = function(callback) {
+	}
+	function getValidSendFrom(callback) {
 		var username = RESUtils.loggedInUser();
 		if (username) {
 			callback(['/u/' + username]);
@@ -143,13 +146,13 @@ addModule('quickMessage', function(module, moduleID) {
 		} else {
 			callback([]);
 		}
-	};
+	}
 	var setUpSendFromDropdownDone = false;
-	module.setUpSendFromDropdown = function() {
+	function setUpSendFromDropdown() {
 		if (setUpSendFromDropdownDone) return;
 		setUpSendFromDropdownDone = true;
-		module.getValidSendFrom(function(senders) {
-			var selectElement = module.quickMessageDialog.querySelector('select#quickMessageDialogFrom'),
+		getValidSendFrom(function(senders) {
+			var selectElement = quickMessageDialog.querySelector('select#quickMessageDialogFrom'),
 				currentOption;
 			senders.forEach(function(elem) {
 				currentOption = document.createElement('option');
@@ -157,16 +160,16 @@ addModule('quickMessage', function(module, moduleID) {
 				selectElement.add(currentOption);
 			});
 		});
-	};
-	module.focusFirstEmpty = function() {
-		var elems = module.quickMessageDialog.querySelectorAll('input, textarea');
+	}
+	function focusFirstEmpty() {
+		var elems = quickMessageDialog.querySelectorAll('input, textarea');
 		for(var len = elems.length, i = 0; i < len; i++) {
 			if (!elems[i].value || i === len - 1) {
 				elems[i].focus();
 				break;
 			}
 		}
-	};
+	}
 	module.openQuickMessageDialog = function(fields) {
 		if (!RESUtils.loggedInUser()) {
 			modules['notifications'].showNotification({
@@ -179,13 +182,13 @@ addModule('quickMessage', function(module, moduleID) {
 			return;
 		}
 
-		module.setUpSendFromDropdown();
+		setUpSendFromDropdown();
 
 		if (!fields) {
 			fields = {};
 		}
 
-		var quickMessageDialogFrom = module.quickMessageDialog.querySelector('select#quickMessageDialogFrom'),
+		var quickMessageDialogFrom = quickMessageDialog.querySelector('select#quickMessageDialogFrom'),
 			indexToSelect = 0;
 		for(var i = 0, len = quickMessageDialogFrom.options.length; i < len; i++) {
 			if (quickMessageDialogFrom.options[i].textContent === fields.from) {
@@ -195,49 +198,49 @@ addModule('quickMessage', function(module, moduleID) {
 		}
 		quickMessageDialogFrom.selectedIndex = indexToSelect;
 
-		module.quickMessageDialog.querySelector('input#quickMessageDialogTo').value = fields.to || '';
-		module.quickMessageDialog.querySelector('input#quickMessageDialogSubject').value = fields.subject || module.options.defaultSubject.value;
-		module.quickMessageDialog.querySelector('textarea#quickMessageDialogBody').value = fields.body || '';
+		quickMessageDialog.querySelector('input#quickMessageDialogTo').value = fields.to || '';
+		quickMessageDialog.querySelector('input#quickMessageDialogSubject').value = fields.subject || module.options.defaultSubject.value;
+		quickMessageDialog.querySelector('textarea#quickMessageDialogBody').value = fields.body || '';
 
-		RESUtils.fadeElementIn(module.quickMessageDialog, 0.3);
+		RESUtils.fadeElementIn(quickMessageDialog, 0.3);
 		modules['styleTweaks'].setSRStyleToggleVisibility(false, 'quickMessage');
 
-		module.focusFirstEmpty();
+		focusFirstEmpty();
 	};
 	module.closeQuickMessageDialog = function() {
-		RESUtils.fadeElementOut(module.quickMessageDialog, 0.3);
+		RESUtils.fadeElementOut(quickMessageDialog, 0.3);
 		modules['styleTweaks'].setSRStyleToggleVisibility(true, 'quickMessage');
 
 		if (modules['keyboardNav'].isEnabled()) {
-			var inputs = module.quickMessageDialog.querySelectorAll('INPUT, TEXTAREA, BUTTON');
+			var inputs = quickMessageDialog.querySelectorAll('INPUT, TEXTAREA, BUTTON');
 			// remove focus from any input fields from the prompt so that keyboard navigation works again...
 			for (var i = 0, len = inputs.length; i < len; i++) {
 				inputs[i].blur();
 			}
 		}
 	};
-	module.getCurrentFieldValues = function() {
+	function getCurrentFieldValues() {
 		return {
-			from: module.quickMessageDialog.querySelector('select#quickMessageDialogFrom').value,
-			to: module.quickMessageDialog.querySelector('input#quickMessageDialogTo').value,
-			subject: module.quickMessageDialog.querySelector('input#quickMessageDialogSubject').value,
-			body: module.quickMessageDialog.querySelector('textarea#quickMessageDialogBody').value
+			from: quickMessageDialog.querySelector('select#quickMessageDialogFrom').value,
+			to: quickMessageDialog.querySelector('input#quickMessageDialogTo').value,
+			subject: quickMessageDialog.querySelector('input#quickMessageDialogSubject').value,
+			body: quickMessageDialog.querySelector('textarea#quickMessageDialogBody').value
 		};
-	};
-	module.getFullMessageFormUrl = function() {
-		var fields = module.getCurrentFieldValues(),
+	}
+	function getFullMessageFormUrl() {
+		var fields = getCurrentFieldValues(),
 			subreddit = (fields.from.substring(0, 3) === '/r/') ? fields.from : '';
 		return location.protocol + '//' + location.hostname + subreddit + '/message/compose?to=' + encodeURIComponent(fields.to) + '&subject=' + encodeURIComponent(fields.subject) + '&message=' + encodeURIComponent(fields.body);
-	};
-	module.presetSendErrors = {
+	}
+	var presetSendErrors = {
 		'NO_USER': 'No recipient specified.',
 		'NO_SUBJECT': 'No subject specified.',
 		'NO_TEXT': 'Message body is empty.',
 		'BAD_CAPTCHA': '<p>Sorry, reddit requires you to enter a captcha to send messages. This is usually because your account is brand new or has low karma.</p><b>Click on "open full message form" and try again (your message will be preserved).</b>',
 		'TOO_LONG': 'Either your subject (max 100 characters) or body (max 10,000 characters) is too long.'
 	};
-	module.sendMessage = function() {
-		var fields = module.getCurrentFieldValues(),
+	function sendMessage() {
+		var fields = getCurrentFieldValues(),
 			fromSubreddit = (fields.from.substring(0, 3) === '/r/') ? ('&from_sr=' + fields.from.substring(3)) : '';
 		RESUtils.runtime.ajax({
 			method: 'POST',
@@ -259,7 +262,7 @@ addModule('quickMessage', function(module, moduleID) {
 							notificationID: 'quickMessageSendError',
 							header: 'Message not sent.',
 							closeDelay: 15000,
-							message: module.presetSendErrors[data.errors[0][0]] || (data.errors[0][0] + ' : ' + data.errors[0][1]) // errors[0][0] is the error name, [1] is reddit's description of the error
+							message: presetSendErrors[data.errors[0][0]] || (data.errors[0][0] + ' : ' + data.errors[0][1]) // errors[0][0] is the error name, [1] is reddit's description of the error
 						});
 					} else {
 						module.closeQuickMessageDialog();
@@ -277,5 +280,5 @@ addModule('quickMessage', function(module, moduleID) {
 				}
 			}
 		});
-	};
+	}
 });


### PR DESCRIPTION
Only expose what's necessary, instead of everything.
I guess the 6th (?) time's the charm.