### PR TITLE
. command line for rpc-executing RES module methods

### DIFF
--- a/lib/modules/troubleshooter.js
+++ b/lib/modules/troubleshooter.js
@@ -54,6 +54,28 @@ addModule('troubleshooter', function(module, moduleID) {
 		module.options.clearTags.callback = module.clearTags;
 		module.options.resetToFactory.callback = module.resetToFactory;
 		module.options.disableRES.callback = module.disableRES;
+
+		modules['commandLine'].registerCommand('.', false, function() { },
+			function(command, val) {
+				var match = /(\w+)\.(\w+)(?:\((.*)\))?$/.exec(val);
+				if (!match) {
+					return false;
+				}
+				var moduleID = match[1];
+				var method = match[2]
+				var args;
+				try {
+					args = match[3] && JSON.parse('[' + match[3] + ']');
+				} catch(e) {
+					return 'Could not parse arguments';
+				}
+
+				var result = RESUtils.rpc(moduleID, method, args);
+				if (result) {
+					return result;
+				}
+			}
+		);
 	},
 	clearUICache: function() {
 		var user = RESUtils.loggedInUser();


### PR DESCRIPTION
For example,

    . troubleshooter.notification
    . troubleshooter.notification()

both invoke `modules['troubleshooter'].notification('rpc')` in the RES extension context

    . troubleshooter.notificiation(1, 2, 3)

invokes modules['troubleshooter'].notification(1, 2, 3, 'rpc') in the RES extension context



--

This is very useful for debugging and troubleshooting -- but is it safe for distribution?