### PR TITLE
Macro default values, settings console fix

### DIFF
--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -756,10 +756,6 @@ modules['commentTools'] = {
 				this.macroSelection(box, '[Reddit Enhancement Suite](http://redditenhancementsuite.com/) ');
 			}));
 
-			this.addButtonToMacroGroup('', this.makeEditButton('&#3232;_&#3232;', 'Look of disaproval', null, 'btn-macro btn-lod', function(button, box) {
-				this.macroSelection(box, '&#3232;_&#3232;');
-			}));
-
 			this.addButtonToMacroGroup('', this.makeEditButton('Current timestamp', '', null, 'btn-macro btn-current-timestamp', function(button, box) {
 				var currentDate = new Date();
 				this.macroSelection(box, currentDate.toTimeString());

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -112,6 +112,7 @@ modules['commentTools'] = {
 				type: 'keycode'
 			}],
 			value: [
+				['Promote RES', '[Reddit Enhancement Suite(http://redditenhancementsuite.com "also /r/Enhancement") '],
 				['Current timestamp', '{{now}}']
 			],
 			description: 'Add buttons to insert frequently used snippets of text.'
@@ -744,18 +745,6 @@ modules['commentTools'] = {
 		if (this.options.macroButtons.value) {
 			this.addButtonToMacroGroup('', this.makeEditButton('reddiquette', '', null, 'btn-macro btn-rediquette', function(button, box) {
 				this.macroSelection(box, '[reddiquette](http://www.reddit.com/wiki/reddiquette) ', '');
-			}));
-
-			this.addButtonToMacroGroup('', this.makeEditButton('[Promote]', '', null, 'btn-macro btn-promote', function(button, box) {
-				var $button = $(button),
-					clickCount = $button.data('clickCount') || 0;
-				clickCount++;
-				$button.data('clickCount', clickCount);
-				if (clickCount > 2) {
-					$button.parent().hide();
-					modules['commentTools'].lod();
-				}
-				this.macroSelection(box, '[Reddit Enhancement Suite](http://redditenhancementsuite.com/) ');
 			}));
 
 			this.buildMacroDropdowns(wrappedEditBar);

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -111,7 +111,9 @@ modules['commentTools'] = {
 				name: 'key',
 				type: 'keycode'
 			}],
-			value: [],
+			value: [
+				['Current timestamp', '{{now}}']
+			],
 			description: 'Add buttons to insert frequently used snippets of text.'
 		},
 		keepMacroListOpen: {
@@ -754,11 +756,6 @@ modules['commentTools'] = {
 					modules['commentTools'].lod();
 				}
 				this.macroSelection(box, '[Reddit Enhancement Suite](http://redditenhancementsuite.com/) ');
-			}));
-
-			this.addButtonToMacroGroup('', this.makeEditButton('Current timestamp', '', null, 'btn-macro btn-current-timestamp', function(button, box) {
-				var currentDate = new Date();
-				this.macroSelection(box, currentDate.toTimeString());
 			}));
 
 			this.buildMacroDropdowns(wrappedEditBar);

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -113,7 +113,7 @@ modules['commentTools'] = {
 			}],
 			value: [
 				['reddiquette', '[reddiquette](/wiki/reddiquette) '],
-				['Promote RES', '[Reddit Enhancement Suite(http://redditenhancementsuite.com "also /r/Enhancement") '],
+				['Promote RES', '[Reddit Enhancement Suite](http://redditenhancementsuite.com "also /r/Enhancement") '],
 				['Current timestamp', '{{now}}']
 			],
 			description: 'Add buttons to insert frequently used snippets of text.'

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -114,7 +114,7 @@ modules['commentTools'] = {
 			value: [
 				['reddiquette', '[reddiquette](/wiki/reddiquette) '],
 				['Promote RES', '[Reddit Enhancement Suite](http://redditenhancementsuite.com "also /r/Enhancement") '],
-				['Current timestamp', '{{now}}']
+				['Current timestamp', '{{now}} ']
 			],
 			description: 'Add buttons to insert frequently used snippets of text.'
 		},

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -112,6 +112,7 @@ modules['commentTools'] = {
 				type: 'keycode'
 			}],
 			value: [
+				['reddiquette', '[reddiquette](/wiki/reddiquette) '],
 				['Promote RES', '[Reddit Enhancement Suite(http://redditenhancementsuite.com "also /r/Enhancement") '],
 				['Current timestamp', '{{now}}']
 			],
@@ -743,10 +744,6 @@ modules['commentTools'] = {
 		}
 
 		if (this.options.macroButtons.value) {
-			this.addButtonToMacroGroup('', this.makeEditButton('reddiquette', '', null, 'btn-macro btn-rediquette', function(button, box) {
-				this.macroSelection(box, '[reddiquette](http://www.reddit.com/wiki/reddiquette) ', '');
-			}));
-
 			this.buildMacroDropdowns(wrappedEditBar);
 
 			var addMacroButton = modules['commentTools'].makeEditButton(modules['commentTools'].options.macros.addRowText, null, null, 'btn-macro btn-macro-add', function() {

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -221,7 +221,9 @@ addModule('settingsConsole', function(module, moduleID) {
 					thisOptionFormEle.setAttribute('type', 'text');
 					thisOptionFormEle.setAttribute('moduleID', moduleID);
 					thisOptionFormEle.setAttribute('placeHolder', optionObject.placeHolder || '');
-					thisOptionFormEle.setAttribute('value', optionObject.value);
+					if (typeof optionObject.value !== 'undefined') {
+						thisOptionFormEle.setAttribute('value', optionObject.value);
+					}
 					break;
 				case 'color':
 					// color...
@@ -229,7 +231,9 @@ addModule('settingsConsole', function(module, moduleID) {
 					thisOptionFormEle.setAttribute('type', 'color');
 					thisOptionFormEle.setAttribute('moduleID', moduleID);
 					// thisOptionFormEle.setAttribute('value', optionObject.value); // didn't work on chrome, need to work with .value
-					thisOptionFormEle.value = optionObject.value;
+					if (typeof optionObject.value !== 'undefined') {
+						thisOptionFormEle.value = optionObject.value;
+					}
 					break;
 				case 'button':
 					// button...
@@ -237,7 +241,9 @@ addModule('settingsConsole', function(module, moduleID) {
 					thisOptionFormEle.classList.add('RESConsoleButton');
 					thisOptionFormEle.setAttribute('moduleID', moduleID);
 					thisOptionFormEle.textContent = optionObject.text;
-					thisOptionFormEle.addEventListener('click', optionObject.callback, false);
+					if (typeof optionObject.callback === 'function') {
+						thisOptionFormEle.addEventListener('click', optionObject.callback, false);
+					}
 					break;
 				case 'list':
 					// list...
@@ -280,7 +286,9 @@ addModule('settingsConsole', function(module, moduleID) {
 					thisOptionFormEle = RESUtils.createElement('input', optionName);
 					thisOptionFormEle.setAttribute('type', 'password');
 					thisOptionFormEle.setAttribute('moduleID', moduleID);
-					thisOptionFormEle.setAttribute('value', optionObject.value);
+					if (typeof optionObject.value !== 'undefined') {
+						thisOptionFormEle.setAttribute('value', optionObject.value);
+					}
 					break;
 				case 'boolean':
 					// checkbox


### PR DESCRIPTION
Move boilerplate macros into macro default values so that users can customize them better and not have to put up with defaults they don't want.

Not bothering to add migration to add default macros because anyone who cares can probably do it themselves or ask for help.

Removed look of disapproval. It's stale. 

---

I fixed settings console showing "undefined" in table options when a value is missing (like when a new field is added)

---

P.S. I left the LOD modal in in case somebody wants to add an autodetect in for "user has pasted a hundred [R..E..S]()".