### PR TITLE
Stop changing expandos' link URLs

### DIFF
--- a/lib/modules/hosts/ctrlv.js
+++ b/lib/modules/hosts/ctrlv.js
@@ -24,7 +24,6 @@ modules['showImages'].siteModules['ctrlv'] = {
 
 		elem.type = info.type;
 		elem.src = info.src;
-		elem.href = info.href;
 
 		if (RESUtils.pageType() === 'linklist') {
 			$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);

--- a/lib/modules/hosts/deviantart.js
+++ b/lib/modules/hosts/deviantart.js
@@ -47,10 +47,8 @@ modules['showImages'].siteModules['deviantart'] = {
 				var original_url = elem.href;
 				if (imgRe.test(info.url)) {
 					elem.src = info.url;
-					// elem.href = info.url;
 				} else {
 					elem.src = info.thumbnail_url;
-					// elem.href = info.thumbnail_url;
 				}
 				if (RESUtils.pageType() === 'linklist') {
 					$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);

--- a/lib/modules/hosts/flickr.js
+++ b/lib/modules/hosts/flickr.js
@@ -45,10 +45,8 @@ modules['showImages'].siteModules['flickr'] = {
 			elem.imageTitle = info.title;
 			if (imgRe.test(info.media_url)) {
 				elem.src = info.media_url;
-				// elem.href = info.url;
 			} else {
 				elem.src = info.thumbnail_url;
-				// elem.href = info.thumbnail_url;
 			}
 			if (RESUtils.pageType() === 'linklist') {
 				$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);

--- a/lib/modules/hosts/futurism.js
+++ b/lib/modules/hosts/futurism.js
@@ -36,7 +36,6 @@ modules['showImages'].siteModules['futurism'] = {
 	handleInfo: function(elem, info) {
 		elem.type = 'IMAGE';
 		elem.src = info['data']['image_link']
-		elem.href = info['data']['routing_link']
 
 		return $.Deferred().resolve(elem).promise();
 	}

--- a/lib/modules/hosts/giphy.js
+++ b/lib/modules/hosts/giphy.js
@@ -64,7 +64,6 @@ modules['showImages'].siteModules['giphy'] = {
 			// gif
 			elem.type = 'IMAGE';
 			elem.src = info.gifUrl;
-			elem.href = info.gifUrl;
 		}
 
 		if (RESUtils.pageType() === 'linklist') {

--- a/lib/modules/hosts/imgflip.js
+++ b/lib/modules/hosts/imgflip.js
@@ -12,7 +12,6 @@ modules['showImages'].siteModules['imgflip'] = {
 	handleInfo: function(elem, info) {
 		elem.type = 'IMAGE';
 		elem.src = info;
-		elem.href = elem.src;
 		if (RESUtils.pageType() === 'linklist') {
 			$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
 		}

--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -159,7 +159,6 @@ modules['showImages'].siteModules['imgur'] = {
 			info.image.links.original = info.image.links.original.replace('http:','https:');
 		}
 		elem.src = info.image.links.original;
-		elem.href = info.image.links.original;
 		if (RESUtils.pageType() === 'linklist') {
 			$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
 		}

--- a/lib/modules/hosts/livememe.js
+++ b/lib/modules/hosts/livememe.js
@@ -17,7 +17,6 @@ modules['showImages'].siteModules['livememe'] = {
 	handleInfo: function(elem, info) {
 		elem.type = 'IMAGE';
 		elem.src = info;
-		elem.href = info;
 		if (RESUtils.pageType() === 'linklist') {
 			$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
 		}

--- a/lib/modules/hosts/makeameme.js
+++ b/lib/modules/hosts/makeameme.js
@@ -17,7 +17,6 @@ modules['showImages'].siteModules['makeameme'] = {
 	handleInfo: function(elem, info) {
 		elem.type = 'IMAGE';
 		elem.src = info;
-		elem.href = info;
 		if (RESUtils.pageType() === 'linklist') {
 			$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
 		}

--- a/lib/modules/hosts/memecrunch.js
+++ b/lib/modules/hosts/memecrunch.js
@@ -17,7 +17,6 @@ modules['showImages'].siteModules['memecrunch'] = {
 	handleInfo: function(elem, info) {
 		elem.type = 'IMAGE';
 		elem.src = info;
-		elem.href = info;
 		if (RESUtils.pageType() === 'linklist') {
 			$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
 		}

--- a/lib/modules/hosts/memedad.js
+++ b/lib/modules/hosts/memedad.js
@@ -17,7 +17,6 @@ modules['showImages'].siteModules['memedad'] = {
 	handleInfo: function(elem, info) {
 		elem.type = 'IMAGE';
 		elem.src = info;
-		elem.href = info;
 		if (RESUtils.pageType() === 'linklist') {
 			$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
 		}

--- a/lib/modules/hosts/memegen.js
+++ b/lib/modules/hosts/memegen.js
@@ -31,7 +31,6 @@ modules['showImages'].siteModules['memegen'] = {
 	handleInfo: function(elem, info) {
 		elem.type = 'IMAGE';
 		elem.src = info;
-		elem.href = info;
 		if (RESUtils.pageType() === 'linklist') {
 			$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
 		}

--- a/lib/modules/hosts/minus.js
+++ b/lib/modules/hosts/minus.js
@@ -68,7 +68,6 @@ modules['showImages'].siteModules['minus'] = {
 				};
 			} else {
 				elem.type = 'IMAGE';
-				elem.href = info.ITEMS_GALLERY[0];
 				if (RESUtils.pageType() === 'linklist') {
 					$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
 				}

--- a/lib/modules/hosts/onedrive.js
+++ b/lib/modules/hosts/onedrive.js
@@ -181,7 +181,6 @@ modules['showImages'].siteModules['onedrive'] = {
 			case 'image':
 				elem.type = 'IMAGE';
 				elem.src = info['@content.downloadUrl'];
-				elem.href = elem.src;
 
 				if (RESUtils.pageType() === 'linklist') {
 					$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
@@ -214,7 +213,6 @@ modules['showImages'].siteModules['onedrive'] = {
 			} else {
 				elem.type = 'IMAGE';
 				elem.src = gallery[0]["@content.downloadUrl"];
-				elem.href = gallery[0].webUrl;
 
 				if (RESUtils.pageType() === 'linklist') {
 					$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);

--- a/lib/modules/hosts/photobucket.js
+++ b/lib/modules/hosts/photobucket.js
@@ -48,10 +48,8 @@ modules['showImages'].siteModules['photobucket'] = {
 		elem.type = 'IMAGE';
 		if (info instanceof Object) {
 			elem.src = info.imageUrl;
-			elem.href = info.imageUrl;
 		} else {
 			elem.src = info;
-			elem.href = info;
 		}
 
 		if (RESUtils.pageType() === 'linklist') {

--- a/lib/modules/hosts/picshd.js
+++ b/lib/modules/hosts/picshd.js
@@ -17,7 +17,6 @@ modules['showImages'].siteModules['picshd'] = {
 	handleInfo: function(elem, info) {
 		elem.type = 'IMAGE';
 		elem.src = info;
-		elem.href = info;
 		if (RESUtils.pageType() === 'linklist') {
 			$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
 		}

--- a/lib/modules/hosts/snag.js
+++ b/lib/modules/hosts/snag.js
@@ -18,7 +18,6 @@ modules['showImages'].siteModules['snag'] = {
 	handleInfo: function(elem, info) {
 		elem.type = 'IMAGE';
 		elem.src = info.src;
-		elem.href = info.src;
 		if (RESUtils.pageType() === 'linklist') {
 			$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
 		}

--- a/lib/modules/hosts/steampowered.js
+++ b/lib/modules/hosts/steampowered.js
@@ -10,7 +10,6 @@ modules['showImages'].siteModules['steampowered'] = {
 	handleInfo: function(elem, info) {
 		elem.type = 'IMAGE';
 		elem.src = info;
-		elem.href = info;
 		if (RESUtils.pageType() === 'linklist') {
 			$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
 		}

--- a/lib/modules/hosts/vidble.js
+++ b/lib/modules/hosts/vidble.js
@@ -58,7 +58,6 @@ modules['showImages'].siteModules['vidble'] = {
 			// direct image link
 			elem.type = 'IMAGE';
 			elem.src = info;
-			elem.href = info;
 			if (RESUtils.pageType() === 'linklist') {
 				$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
 			}

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -947,7 +947,7 @@ modules['showImages'] = {
 
 			var imageAnchor = document.createElement('a');
 			imageAnchor.classList.add('madeVisible');
-			imageAnchor.href = sourceImage.href;
+			imageAnchor.href = sourceImage.src;
 			if (thisHandle.options.openInNewWindow.value) {
 				imageAnchor.target = '_blank';
 			}

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1920,7 +1920,6 @@ modules['showImages'] = {
 
 				elem.type = info.type;
 				elem.src = info.src;
-				elem.href = info.src;
 
 				if (RESUtils.pageType() === 'linklist' && elem.classList.contains('title')) {
 					$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);


### PR DESCRIPTION
This is no longer necessary, since we use [addUrlToHistory()](https://github.com/honestbleeps/Reddit-Enhancement-Suite/blob/8719cc456bce7ef6f338ad7c22f172c5873d3833/lib/modules/showImages.js#L1636).

Also, for single-image expandos, make the image link to its source URL (this basically preserves existing behavior, since it used to be set to the title URL, which used to be changed to the source URL).