### PR TITLE
Instagram expando support

### DIFF
--- a/lib/modules/hosts/instagram.js
+++ b/lib/modules/hosts/instagram.js
@@ -1,0 +1,14 @@
+export default {
+	moduleID: 'instagram',
+	name: 'Instagram',
+	domains: ['instagram.com', 'instagr.am'],
+	attribution: false,
+	detect: ({ pathname }) => (/^\/p\/([a-z0-9_\-]{10,})(?:\/|$)/i).exec(pathname),
+	handleLink: (href, [, id]) => ({
+		type: 'IFRAME',
+		expandoClass: 'image',
+		embed: `https://instagram.com/p/${id}/embed`,
+		width: '600px',
+		height: '680px',
+	}),
+};


### PR DESCRIPTION
Fixes #2126 

~~They do have an oembed API, but it doesn't seem to support CORS.
This means that instagram videos won't work, but it's better than having to add another permission.~~

Test links:
https://www.reddit.com/domain/instagr.am/
https://www.reddit.com/domain/instagram.com/