### PR TITLE
gear icon font size 15px -> 14px

### DIFF
--- a/lib/core/res.css
+++ b/lib/core/res.css
@@ -108,6 +108,7 @@ body.res-console-open {
 	font-family: Batch;
 	line-height: 15px;
 	font-size: 14px;
+	vertical-align: middle;
 }
 .gearIcon::after {
 	content: '\F04D';

--- a/lib/core/res.css
+++ b/lib/core/res.css
@@ -107,7 +107,7 @@ body.res-console-open {
 .gearIcon::before, .gearIcon::after {
 	font-family: Batch;
 	line-height: 15px;
-	font-size: 15px;
+	font-size: 14px;
 }
 .gearIcon::after {
 	content: '\F04D';

--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -78,7 +78,6 @@ modules['accountSwitcher'] = {
 	},
 	beforeLoad: function() {
 		if ((this.isEnabled()) && (this.isMatchURL())) {
-			RESUtils.addCSS('#header-bottom-right { height: auto; padding: 4px 4px 7px }');
 			RESUtils.addCSS('#RESAccountSwitcherDropdown { min-width: 110px; width: auto; display: none; position: absolute; z-index: 1000; }');
 			RESUtils.addCSS('#RESAccountSwitcherDropdown li { height: auto; line-height: 20px; padding: 2px 10px; }');
 			RESUtils.addCSS('#RESAccountSwitcherDropdown li span { margin-left: 8px; }');


### PR DESCRIPTION
For better alignment:
(original / 15px / 14px - Chrome without notifications, FF with) - *now with valign:middle it's 2px lower than this image*
![image](https://cloud.githubusercontent.com/assets/7673145/6805278/7ccc8330-d218-11e4-9f00-8598e1a78575.png)

Also removes the 3px extra padding-bottom from the userbar - here's how it looks now:
![image](https://cloud.githubusercontent.com/assets/7673145/6813897/f0a9e57c-d24f-11e4-9697-9e55a8cffff3.png)