### PR TITLE
gulp overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,22 +160,28 @@ by itself will build all current browser versions of RES and will place them int
 
     gulp clean
 
-cleans out the 'dist' directory
+cleans out the `dist/` directory
 
-    gulp <browsername>
+    gulp <tasks> -b browser1 -b browser2
 
-Where <browsername> is either: chrome, firefox, safari, opera, oblink. This will build just one version of RES, based on what you enter. Run 'gulp clean' before running the above.
+can be used with any of the following tasks to specify individual browsers (chrome, firefox, safari, opera, or oblink), instead of performing the task(s) for all of them.
+
+    gulp build
+
+builds RES, copying the resultant files into the `dist/` directory. It is recommended to run `gulp clean` first.
 
     gulp add-module --file module.js
 
 adds module.js, a new module, to the manifest for each browser.
 
-  gulp add-file --file hostname.js
+	gulp add-file --file hostname.js
 
 adds hostname.js, a new media host, to the manifest for each browser.
 
     gulp watch
-    or
-    gulp watch-<browsername>
 
-copies the extension files when anything changes.
+rebuilds the extension when anything changes.
+
+    gulp zip --zipdir /path/to/zip/directory
+
+compresses the build folders in `dist/` into .zip files. If no `--zipdir` is specified, the .zip files will be placed in `dist/zip/`. You must run `gulp build` first, otherwise there will be no files to zip.

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ builds RES, copying the resultant files into the `dist/` directory. It is recomm
 
 adds module.js, a new module, to the manifest for each browser.
 
-	gulp add-file --file hostname.js
+	gulp add-host --file hostname.js
 
 adds hostname.js, a new media host, to the manifest for each browser.
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -211,5 +211,5 @@ gulp.task('opera-zip', function() {
 
 // Other
 gulp.task('clean', function(cb) {
-	del(['dist/**/*'], cb);
+	del(['dist/*'], cb);
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -98,16 +98,10 @@ gulp.task('zip', function(cb) {
 });
 
 gulp.task('watch', function() {
-	var sources = selectedBrowsers.reduce(function(previous, browser) { // combine the sources of each browser
-		return previous.concat(
-			config[browser].buildFiles.reduce(function(pre, cur) { // combine the sources within each browser
-				return pre.concat(
-					cur.src.filter(function(src) { // filter out repeated directories (i.e. commonFiles, chrome/oblink common files)
-						return previous.indexOf(src) == -1;
-					})
-				);
-			}, [])
-		);
+	var sources = selectedBrowsers.reduce(function(previous, browser) {
+		return previous.concat(config[browser].buildFiles.reduce(function(pre, cur) {
+			return pre.concat(cur.src);
+		}, []));
 	}, []);
 	gulp.watch(sources, [ 'build' ]);
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,42 +14,65 @@ gulp.task('default', ['clean'], function() {
 	gulp.start('chrome', 'safari', 'firefox', 'oblink', 'opera');
 });
 
+// Paths
+var zipDir = '../../../var/www/html/res/dl',
+	rootBuildDir = 'dist',
+	buildDir = {
+		chrome:  path.join(rootBuildDir, 'chrome'),
+		safari:  path.join(rootBuildDir, 'RES.safariextension'),
+		firefox: path.join(rootBuildDir, 'XPI'),
+		oblink:  path.join(rootBuildDir, 'oblink'),
+		opera:   path.join(rootBuildDir, 'opera')
+	},
+	libFiles = ['lib/**/*.js', 'lib/**/*.json', 'lib/**/*.css', 'lib/**/*.html'],
+	// dest is relative to the browser's buildDir, src is relative to the root of the project
+	browserSpecificFiles = {
+		chrome: [
+			{ dest: 'images', src: 'Chrome/images/*.png' },
+			{ dest: '/',      src: ['Chrome/*.js', 'Chrome/*.png', 'Chrome/*.html', 'package.json', 'Chrome/manifest.json'] },
+			{ dest: '/',      src: libFiles }
+		],
+		safari: [
+			{ dest: '/', src: ['RES.safariextension/*.js', 'RES.safariextension/*.png', 'RES.safariextension/*.html', 'package.json', 'RES.safariextension/info.plist'] },
+			{ dest: '/', src: libFiles }
+		],
+		firefox: [
+			{ dest: 'data', src: 'XPI/data/**/*' },
+			{ dest: 'data', src: libFiles },
+			{ dest: 'lib',  src: 'XPI/lib/**/*' },
+			{ dest: '/',    src: ['*.png', 'XPI/package.json'] }
+		],
+		oblink: [
+			{ dest: 'images', src: 'OperaBlink/images/*.png' },
+			{ dest: '/',      src: ['OperaBlink/*.js', 'Chrome/browsersupport-chrome.js', 'OperaBlink/*.png', 'OperaBlink/*.json', 'package.json'] },
+			{ dest: '/',      src: libFiles }
+		],
+		opera: [
+			{ dest: 'includes', src: 'Opera/includes/*.js' },
+			{ dest: '/',        src: ['Opera/*.js', 'OperaBlink/*.gif', 'Opera/*.html', 'Opera/*.xml', 'package.json'] },
+			{ dest: '/',        src: libFiles }
+		]
+	};
+
+function getBrowserSources(browser) {
+	return browserSpecificFiles[browser].reduce(function(pre, cur) {
+		return pre.concat(cur.src);
+	}, []);
+}
+
+function copyBrowserFiles(browser) {
+	browserSpecificFiles[browser].forEach(function(paths) {
+		gulp.src(paths.src)
+			.pipe(gulp.dest(path.join(buildDir[browser], paths.dest)));
+	});
+}
+
 // Browser task runs subtasks
-gulp.task('chrome', ['chrome-css', 'chrome-js', 'chrome-img', 'chrome-move']);
-gulp.task('safari', ['safari-css', 'safari-js', 'safari-img', 'safari-move']);
-gulp.task('firefox', ['firefox-css', 'firefox-js', 'firefox-img', 'firefox-move']);
-gulp.task('oblink', ['oblink-css', 'oblink-js', 'oblink-img', 'oblink-move']);
-gulp.task('opera', ['opera-css', 'opera-js', 'opera-img', 'opera-move']);
-
-// Chrome subtasks
-gulp.task('chrome-move', ['chrome-move-1', 'chrome-move-2', 'chrome-move-3', 'chrome-move-4']);
-gulp.task('chrome-css', ['module-css-chrome', 'core-css-chrome', 'vendor-css-chrome']);
-gulp.task('chrome-js', ['lib-js-chrome', 'chrome-js-chrome', 'vendor-js-chrome', 'core-js-chrome', 'modules-js-chrome']);
-gulp.task('chrome-img', ['root-images-chrome', 'images-images-chrome']);
-
-// Safari subtasks
-gulp.task('safari-css', ['module-css-safari', 'core-css-safari', 'vendor-css-safari']);
-gulp.task('safari-js', ['lib-js-safari', 'safari-js-safari', 'vendor-js-safari', 'core-js-safari', 'modules-js-safari']);
-gulp.task('safari-img', ['root-images-safari']);
-gulp.task('safari-move', ['safari-move-1', 'safari-move-2', 'safari-move-3', 'safari-move-4']);
-
-// Firefox subtasks
-gulp.task('firefox-css', ['module-css-firefox', 'core-css-firefox', 'vendor-css-firefox']);
-gulp.task('firefox-js', ['modules-js-firefox', 'core-js-firefox', 'vendor-js-firefox', 'data-js-firefox', 'lib-js-firefox-2', 'lib-js-firefox']);
-gulp.task('firefox-img', ['root-images-firefox']);
-gulp.task('firefox-move', ['firefox-move-1', 'firefox-move-2']);
-
-// OperaBlink subtasks
-gulp.task('oblink-css', ['module-css-oblink', 'core-css-oblink', 'vendor-css-oblink']);
-gulp.task('oblink-js', ['lib-js-oblink', 'vendor-js-oblink', 'core-js-oblink', 'modules-js-oblink', 'oblink-js-oblink']);
-gulp.task('oblink-img', ['root-images-oblink', 'images-images-oblink']);
-gulp.task('oblink-move', ['oblink-move-1', 'oblink-move-2', 'oblink-move-3']);
-
-// Opera subtasks
-gulp.task('opera-css', ['module-css-opera', 'core-css-opera', 'vendor-css-opera']);
-gulp.task('opera-js', ['lib-js-opera', 'vendor-js-opera', 'core-js-opera', 'modules-js-opera', 'opera-js-opera', 'includes-js-opera']);
-gulp.task('opera-img', ['root-images-opera']);
-gulp.task('opera-move', ['opera-move-1', 'opera-move-2', 'opera-move-3', 'opera-move-4']);
+gulp.task('chrome', function() { copyBrowserFiles('chrome'); });
+gulp.task('safari', function() { copyBrowserFiles('safari'); });
+gulp.task('firefox', function() { copyBrowserFiles('firefox'); });
+gulp.task('oblink', function() { copyBrowserFiles('oblink'); });
+gulp.task('opera', function() { copyBrowserFiles('opera'); });
 
 // This kills the CPU
 gulp.task('zipall', ['chrome-zip', 'safari-zip', 'firefox-zip', 'oblink-zip', 'opera-zip']);
@@ -62,35 +85,24 @@ gulp.task('add-host', [ 'add-host-chrome', 'add-host-safari', 'add-host-firefox'
 gulp.task('watch', [ 'watch-chrome', 'watch-safari', 'watch-firefox', 'watch-oblink', 'watch-opera' ]);
 
 gulp.task('watch-chrome', function() {
-	gulp.watch([ 'lib/**/*', 'Chrome/**/*' ], [ 'chrome' ]);
+	gulp.watch(getBrowserSources('chrome'), [ 'chrome' ]);
 });
 
 gulp.task('watch-safari', function() {
-	gulp.watch([ 'lib/**/*', 'RES.safariextension/**/*' ], [ 'safari' ]);
+	gulp.watch(getBrowserSources('safari'), [ 'safari' ]);
 });
 
 gulp.task('watch-firefox', function() {
-	gulp.watch([ 'lib/**/*', 'XPI/**/*' ], [ 'firefox' ]);
+	gulp.watch(getBrowserSources('firefox'), [ 'firefox' ]);
 });
 
 gulp.task('watch-oblink', function() {
-	gulp.watch([ 'lib/**/*', 'OperaBlink/**/*', 'Chrome/browsersupport-chrome.js' ], [ 'oblink' ]);
+	gulp.watch(getBrowserSources('oblink'), [ 'oblink' ]);
 });
-
 
 gulp.task('watch-opera', function() {
-	gulp.watch([ 'lib/**/*', 'Opera/**/*' ], [ 'opera' ]);
+	gulp.watch(getBrowserSources('opera'), [ 'opera' ]);
 });
-
-// Paths
-var buildDir = 'dist';
-var chromeBuildDir = path.join(buildDir, 'chrome');
-var safariBuildDir = path.join(buildDir, 'RES.safariextension');
-var firefoxBuildDir = path.join(buildDir, 'XPI');
-var oblinkBuildDir = path.join(buildDir, 'oblink');
-var operaBuildDir = path.join(buildDir, 'opera');
-var zipDir = '../../../var/www/html/res/dl';
-
 
 // "Add file to manifests" task support
 function addFileToManifest(manifest, pattern) {
@@ -134,148 +146,12 @@ gulp.task('add-host-chrome', function() {
 	return addHostToManifest('Chrome/manifest.json');
 });
 
-gulp.task('module-css-chrome', function() {
-	return gulp.src('lib/modules/*.css')
-		.pipe(gulp.dest(path.join(chromeBuildDir, 'modules')));
-});
-
-gulp.task('core-css-chrome', function() {
-	return gulp.src('lib/core/*.css')
-		.pipe(gulp.dest(path.join(chromeBuildDir, 'core')));
-});
-
-gulp.task('vendor-css-chrome', function() {
-	return gulp.src('lib/vendor/*.css')
-		.pipe(gulp.dest(path.join(chromeBuildDir, 'vendor')));
-});
-
-gulp.task('lib-js-chrome', function() {
-	return gulp.src('lib/*.js')
-		.pipe(gulp.dest(path.join(chromeBuildDir)));
-});
-
-gulp.task('chrome-js-chrome', function() {
-	return gulp.src('Chrome/*.js')
-		.pipe(gulp.dest(path.join(chromeBuildDir)));
-});
-
-gulp.task('vendor-js-chrome', function() {
-	return gulp.src('lib/vendor/*.js')
-		.pipe(gulp.dest(path.join(chromeBuildDir, 'vendor')));
-});
-
-gulp.task('core-js-chrome', function() {
-	return gulp.src('lib/core/*.js')
-		.pipe(gulp.dest(path.join(chromeBuildDir, 'core')));
-});
-
-gulp.task('modules-js-chrome', function() {
-	return gulp.src([ 'lib/modules/**/*.js' , 'lib/modules/**/*.json' ])
-		.pipe(gulp.dest(path.join(chromeBuildDir, 'modules')));
-});
-
-gulp.task('root-images-chrome', function() {
-	return gulp.src('Chrome/*.png')
-		.pipe(gulp.dest(path.join(chromeBuildDir)));
-});
-
-gulp.task('images-images-chrome', function() {
-	return gulp.src('Chrome/images/*.png')
-		.pipe(gulp.dest(path.join(chromeBuildDir, 'images')));
-});
-
-gulp.task('chrome-move-1', function() { // move other stuff that doesn't fit elsewhere
-	return gulp.src('lib/core/*.html')
-		.pipe(gulp.dest(path.join(chromeBuildDir, 'core')));
-});
-
-gulp.task('chrome-move-2', function() {
-	return gulp.src('Chrome/*.html')
-		.pipe(gulp.dest(path.join(chromeBuildDir)));
-});
-
-gulp.task('chrome-move-3', function() {
-	return gulp.src('package.json')
-		.pipe(gulp.dest(path.join(chromeBuildDir)));
-});
-
-gulp.task('chrome-move-4', function() {
-	return gulp.src('Chrome/manifest.json')
-		.pipe(gulp.dest(path.join(chromeBuildDir)));
-});
-
 // Safari low-level tasks
 gulp.task('add-module-safari', function() {
 	return addModuleToManifest('RES.safariextension/Info.plist');
 });
 gulp.task('add-host-safari', function() {
 	return addHostToManifest('RES.safariextension/Info.plist');
-});
-
-
-gulp.task('module-css-safari', function() {
-	return gulp.src('lib/modules/*.css')
-		.pipe(gulp.dest(path.join(safariBuildDir, 'modules')));
-});
-
-gulp.task('core-css-safari', function() {
-	return gulp.src('lib/core/*.css')
-		.pipe(gulp.dest(path.join(safariBuildDir, 'core')));
-});
-
-gulp.task('vendor-css-safari', function() {
-	return gulp.src('lib/vendor/*.css')
-		.pipe(gulp.dest(path.join(safariBuildDir, 'vendor')));
-});
-
-gulp.task('lib-js-safari', function() {
-	return gulp.src('lib/*.js')
-		.pipe(gulp.dest(path.join(safariBuildDir)));
-});
-
-gulp.task('safari-js-safari', function() {
-	return gulp.src('RES.safariextension/*.js')
-		.pipe(gulp.dest(path.join(safariBuildDir)));
-});
-
-gulp.task('vendor-js-safari', function() {
-	return gulp.src('lib/vendor/*.js')
-		.pipe(gulp.dest(path.join(safariBuildDir, 'vendor')));
-});
-
-gulp.task('core-js-safari', function() {
-	return gulp.src('lib/core/*.js')
-		.pipe(gulp.dest(path.join(safariBuildDir, 'core')));
-});
-
-gulp.task('modules-js-safari', function() {
-	return gulp.src([ 'lib/modules/**/*.js' , 'lib/modules/**/*.json' ])
-		.pipe(gulp.dest(path.join(safariBuildDir, 'modules')));
-});
-
-gulp.task('root-images-safari', function() {
-	return gulp.src('RES.safariextension/*.png')
-		.pipe(gulp.dest(path.join(safariBuildDir)));
-});
-
-gulp.task('safari-move-1', function() { // move other stuff that doesn't fit elsewhere
-	return gulp.src('lib/core/*.html')
-		.pipe(gulp.dest(path.join(safariBuildDir, 'core')));
-});
-
-gulp.task('safari-move-2', function() {
-	return gulp.src('RES.safariextension/*.html')
-		.pipe(gulp.dest(path.join(safariBuildDir)));
-});
-
-gulp.task('safari-move-3', function() {
-	return gulp.src('package.json')
-		.pipe(gulp.dest(path.join(safariBuildDir)));
-});
-
-gulp.task('safari-move-4', function() {
-	return gulp.src('RES.safariextension/info.plist')
-		.pipe(gulp.dest(path.join(safariBuildDir)));
 });
 
 // Firefox low-level tasks
@@ -286,137 +162,12 @@ gulp.task('add-host-firefox', function() {
 	return addHostToManifest('XPI/lib/main.js');
 });
 
-gulp.task('module-css-firefox', function() {
-	return gulp.src('lib/modules/*.css')
-		.pipe(gulp.dest(path.join(firefoxBuildDir, 'data', 'modules')));
-});
-
-gulp.task('core-css-firefox', function() {
-	return gulp.src('lib/core/*.css')
-		.pipe(gulp.dest(path.join(firefoxBuildDir, 'data', 'core')));
-});
-
-gulp.task('vendor-css-firefox', function() {
-	return gulp.src('lib/vendor/*.css')
-		.pipe(gulp.dest(path.join(firefoxBuildDir, 'data', 'vendor')));
-});
-
-gulp.task('lib-js-firefox', function() {
-	return gulp.src('lib/*.js')
-		.pipe(gulp.dest(path.join(firefoxBuildDir, 'data')));
-});
-
-gulp.task('lib-js-firefox-2', function() {
-	return gulp.src('XPI/lib/**/*')
-		.pipe(gulp.dest(path.join(firefoxBuildDir, 'lib')));
-});
-
-gulp.task('data-js-firefox', function() {
-	return gulp.src('XPI/data/**/*')
-		.pipe(gulp.dest(path.join(firefoxBuildDir, 'data')));
-});
-
-gulp.task('vendor-js-firefox', function() {
-	return gulp.src('lib/vendor/*.js')
-		.pipe(gulp.dest(path.join(firefoxBuildDir, 'data', 'vendor')));
-});
-
-gulp.task('core-js-firefox', function() {
-	return gulp.src('lib/core/*.js')
-		.pipe(gulp.dest(path.join(firefoxBuildDir, 'data', 'core')));
-});
-
-gulp.task('modules-js-firefox', function() {
-	return gulp.src([ 'lib/modules/**/*.js' , 'lib/modules/**/*.json' ])
-		.pipe(gulp.dest(path.join(firefoxBuildDir, 'data', 'modules')));
-});
-
-gulp.task('root-images-firefox', function() {
-	return gulp.src('*.png')
-		.pipe(gulp.dest(path.join(firefoxBuildDir)));
-});
-
-gulp.task('firefox-move-1', function() { // move other stuff that doesn't fit elsewhere
-	return gulp.src('lib/core/*.html')
-		.pipe(gulp.dest(path.join(firefoxBuildDir, 'data', 'core')));
-});
-
-gulp.task('firefox-move-2', function() {
-	return gulp.src('XPI/package.json')
-		.pipe(gulp.dest(path.join(firefoxBuildDir)));
-});
-
 // OperaBlink low-level tasks
 gulp.task('add-module-oblink', function() {
 	return addModuleToManifest('OperaBlink/manifest.json');
 });
 gulp.task('add-host-oblink', function() {
 	return addHostToManifest('OperaBlink/manifest.json');
-});
-
-gulp.task('module-css-oblink', function() {
-	return gulp.src('lib/modules/*.css')
-		.pipe(gulp.dest(path.join(oblinkBuildDir, 'modules')));
-});
-
-gulp.task('core-css-oblink', function() {
-	return gulp.src('lib/core/*.css')
-		.pipe(gulp.dest(path.join(oblinkBuildDir, 'core')));
-});
-
-gulp.task('vendor-css-oblink', function() {
-	return gulp.src('lib/vendor/*.css')
-		.pipe(gulp.dest(path.join(oblinkBuildDir, 'vendor')));
-});
-
-gulp.task('lib-js-oblink', function() {
-	return gulp.src('lib/*.js')
-		.pipe(gulp.dest(path.join(oblinkBuildDir)));
-});
-
-gulp.task('vendor-js-oblink', function() {
-	return gulp.src('lib/vendor/*.js')
-		.pipe(gulp.dest(path.join(oblinkBuildDir, 'vendor')));
-});
-
-gulp.task('core-js-oblink', function() {
-	return gulp.src('lib/core/*.js')
-		.pipe(gulp.dest(path.join(oblinkBuildDir, 'core')));
-});
-
-gulp.task('modules-js-oblink', function() {
-	return gulp.src([ 'lib/modules/**/*.js' , 'lib/modules/**/*.json' ])
-		.pipe(gulp.dest(path.join(oblinkBuildDir, 'modules')));
-});
-
-gulp.task('oblink-js-oblink', function() {
-	return gulp.src([ 'OperaBlink/*.js', 'Chrome/browsersupport-chrome.js' ])
-		.pipe(gulp.dest(path.join(oblinkBuildDir)));
-});
-
-gulp.task('root-images-oblink', function() {
-	return gulp.src('OperaBlink/*.png')
-		.pipe(gulp.dest(path.join(oblinkBuildDir)));
-});
-
-gulp.task('images-images-oblink', function() {
-	return gulp.src('OperaBlink/images/*.png')
-		.pipe(gulp.dest(path.join(oblinkBuildDir, 'images')));
-});
-
-gulp.task('oblink-move-1', function() { // move other stuff that doesn't fit elsewhere
-	return gulp.src('lib/core/*.html')
-		.pipe(gulp.dest(path.join(oblinkBuildDir, 'core')));
-});
-
-gulp.task('oblink-move-2', function() {
-	return gulp.src('OperaBlink/*.json')
-		.pipe(gulp.dest(path.join(oblinkBuildDir)));
-});
-
-gulp.task('oblink-move-3', function() {
-	return gulp.src('package.json')
-		.pipe(gulp.dest(path.join(oblinkBuildDir)));
 });
 
 // Opera low-level tasks
@@ -427,103 +178,33 @@ gulp.task('add-host-opera', function() {
 	return addHostToManifest('Opera/includes/loader.js');
 });
 
-gulp.task('module-css-opera', function() {
-	return gulp.src('lib/modules/*.css')
-		.pipe(gulp.dest(path.join(operaBuildDir, 'modules')));
-});
-
-gulp.task('core-css-opera', function() {
-	return gulp.src('lib/core/*.css')
-		.pipe(gulp.dest(path.join(operaBuildDir, 'core')));
-});
-
-gulp.task('vendor-css-opera', function() {
-	return gulp.src('lib/vendor/*.css')
-		.pipe(gulp.dest(path.join(operaBuildDir, 'vendor')));
-});
-
-gulp.task('lib-js-opera', function() {
-	return gulp.src('lib/*.js')
-		.pipe(gulp.dest(path.join(operaBuildDir)));
-});
-
-gulp.task('vendor-js-opera', function() {
-	return gulp.src('lib/vendor/*.js')
-		.pipe(gulp.dest(path.join(operaBuildDir, 'vendor')));
-});
-
-gulp.task('core-js-opera', function() {
-	return gulp.src('lib/core/*.js')
-		.pipe(gulp.dest(path.join(operaBuildDir, 'core')));
-});
-
-gulp.task('modules-js-opera', function() {
-	return gulp.src([ 'lib/modules/**/*.js' , 'lib/modules/**/*.json' ])
-		.pipe(gulp.dest(path.join(operaBuildDir, 'modules')));
-});
-
-gulp.task('opera-js-opera', function() {
-	return gulp.src('Opera/*.js')
-		.pipe(gulp.dest(path.join(operaBuildDir)));
-});
-
-gulp.task('includes-js-opera', function() {
-	return gulp.src('Opera/includes/*.js')
-		.pipe(gulp.dest(path.join(operaBuildDir, 'includes')));
-});
-
-gulp.task('root-images-opera', function() {
-	return gulp.src('OperaBlink/*.gif')
-		.pipe(gulp.dest(path.join(operaBuildDir)));
-});
-
-gulp.task('opera-move-1', function() { // move other stuff that doesn't fit elsewhere
-	return gulp.src('lib/core/*.html')
-		.pipe(gulp.dest(path.join(operaBuildDir, 'core')));
-});
-
-gulp.task('opera-move-2', function() {
-	return gulp.src('Opera/*.html')
-		.pipe(gulp.dest(path.join(operaBuildDir)));
-});
-
-gulp.task('opera-move-3', function() {
-	return gulp.src('Opera/*.xml')
-		.pipe(gulp.dest(path.join(operaBuildDir)));
-});
-
-gulp.task('opera-move-4', function() {
-	return gulp.src('package.json')
-		.pipe(gulp.dest(path.join(operaBuildDir)));
-});
-
 // Zip tasks
 gulp.task('chrome-zip', function() {
-	return gulp.src(path.join(chromeBuildDir, '**/*'))
+	return gulp.src(path.join(buildDir.chrome, '**/*'))
 		.pipe(zip('chrome.zip'))
 		.pipe(gulp.dest(zipDir));
 });
 
 gulp.task('safari-zip', function() {
-	return gulp.src(path.join(safariBuildDir, '**/*'))
+	return gulp.src(path.join(buildDir.safari, '**/*'))
 		.pipe(zip('safari.safariextension.zip'))
 		.pipe(gulp.dest(zipDir));
 });
 
 gulp.task('firefox-zip', function() {
-	return gulp.src(path.join(firefoxBuildDir, '**/*'))
+	return gulp.src(path.join(buildDir.firefox, '**/*'))
 		.pipe(zip('firefox.zip'))
 		.pipe(gulp.dest(zipDir));
 });
 
 gulp.task('oblink-zip', function() {
-	return gulp.src(path.join(oblinkBuildDir, '**/*'))
+	return gulp.src(path.join(buildDir.oblink, '**/*'))
 		.pipe(zip('operablink.zip'))
 		.pipe(gulp.dest(zipDir));
 });
 
 gulp.task('opera-zip', function() {
-	return gulp.src(path.join(operaBuildDir, '**/*'))
+	return gulp.src(path.join(buildDir.opera, '**/*'))
 		.pipe(zip('opera.zip'))
 		.pipe(gulp.dest(zipDir));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,19 +60,22 @@ function getBrowserSources(browser) {
 	}, []);
 }
 
-function copyBrowserFiles(browser) {
+function copyBrowserFiles(browser, callback) {
 	browserSpecificFiles[browser].forEach(function(paths) {
 		gulp.src(paths.src)
 			.pipe(gulp.dest(path.join(buildDir[browser], paths.dest)));
 	});
+	if (callback) {
+		callback();
+	}
 }
 
 // Browser task runs subtasks
-gulp.task('chrome', function() { copyBrowserFiles('chrome'); });
-gulp.task('safari', function() { copyBrowserFiles('safari'); });
-gulp.task('firefox', function() { copyBrowserFiles('firefox'); });
-gulp.task('oblink', function() { copyBrowserFiles('oblink'); });
-gulp.task('opera', function() { copyBrowserFiles('opera'); });
+gulp.task('chrome', function(callback) { copyBrowserFiles('chrome', callback); });
+gulp.task('safari', function(callback) { copyBrowserFiles('safari', callback); });
+gulp.task('firefox', function(callback) { copyBrowserFiles('firefox', callback); });
+gulp.task('oblink', function(callback) { copyBrowserFiles('oblink', callback); });
+gulp.task('opera', function(callback) { copyBrowserFiles('opera', callback); });
 
 // This kills the CPU
 gulp.task('zipall', ['chrome-zip', 'safari-zip', 'firefox-zip', 'oblink-zip', 'opera-zip']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,15 +16,15 @@ gulp.task('default', ['clean'], function() {
 
 // Paths
 var rootBuildDir = 'dist',
-	buildDir = {
-		chrome:  path.join(rootBuildDir, 'chrome'),
-		safari:  path.join(rootBuildDir, 'RES.safariextension'),
-		firefox: path.join(rootBuildDir, 'XPI'),
-		oblink:  path.join(rootBuildDir, 'oblink'),
-		opera:   path.join(rootBuildDir, 'opera')
+	buildFolder = {
+		chrome:  'chrome',
+		safari:  'RES.safariextension',
+		firefox: 'XPI',
+		oblink:  'oblink',
+		opera:   'opera'
 	},
 	libFiles = ['lib/**/*.js', 'lib/**/*.json', 'lib/**/*.css', 'lib/**/*.html'],
-	// dest is relative to the browser's buildDir, src is relative to the root of the project
+	// dest is relative to the browser's buildDir [i.e. getBuildDir(browser)], src is relative to the root of the project
 	buildFiles = {
 		chrome: [
 			{ dest: 'images', src: ['Chrome/images/*.png'] },
@@ -62,11 +62,15 @@ var rootBuildDir = 'dist',
 	// the specified `-b browser` or all browsers, if unspecified
 	selectedBrowsers = options.b ? [].concat(options.b) : Object.keys(buildFiles);
 
+function getBuildDir(browser) {
+	return path.join(rootBuildDir, buildFolder[browser]);
+}
+
 gulp.task('build', function(cb) {
 	selectedBrowsers.forEach(function(browser) {
 		buildFiles[browser].forEach(function(paths) {
 			gulp.src(paths.src)
-				.pipe(gulp.dest(path.join(buildDir[browser], paths.dest)));
+				.pipe(gulp.dest(path.join(getBuildDir(browser), paths.dest)));
 		});
 	});
 	cb();
@@ -75,8 +79,8 @@ gulp.task('build', function(cb) {
 gulp.task('zip', function(cb) {
 	var zipDir = options.zipdir || path.join(rootBuildDir, 'zip');
 	selectedBrowsers.forEach(function(browser) {
-		gulp.src(path.join(buildDir[browser], '**/*'))
-			.pipe(zip(browser + '.zip'))
+		gulp.src(path.join(getBuildDir(browser), '**/*'))
+			.pipe(zip(buildFolder[browser] + '.zip'))
 			.pipe(gulp.dest(zipDir));
 	});
 	cb();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,11 +18,15 @@ gulp.task('default', ['clean'], function() {
 var rootBuildDir = 'dist',
 	commonFiles = ['lib/**/*.js', 'lib/**/*.json', 'lib/**/*.css', 'lib/**/*.html'],
 	config = {
+		// The name used to refer to the browser from the command line, i.e. `gulp build -b chrome`
 		chrome: {
+			// Subfolder of rootBuildDir that the buildFiles will be copied to
 			buildFolder: 'chrome',
+			// The file for addFileToManifest to modify when adding new hosts/modules
 			manifest: 'Chrome/manifest.json',
-			// dest is relative to the browser's buildDir [i.e. getBuildDir(browser)], src is relative to the root of the project
+			// Files to be copied when building the extension
 			buildFiles: [
+				// dest is relative to the browser's buildFolder, src is relative to the project root
 				{ dest: 'images', src: ['Chrome/images/*.png'] },
 				{ dest: '/',      src: ['Chrome/*.js', 'Chrome/*.png', 'Chrome/*.html', 'package.json', 'Chrome/manifest.json'] },
 				{ dest: '/',      src: commonFiles }
@@ -65,7 +69,7 @@ var rootBuildDir = 'dist',
 			]
 		}
 	},
-// the `-b browser` argument(s) or all browsers, if unspecified
+	// the `-b browser` argument(s) or all browsers, if unspecified
 	selectedBrowsers = options.b ? [].concat(options.b) : Object.keys(config);
 
 function getBuildDir(browser) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -59,7 +59,7 @@ var rootBuildDir = 'dist',
 		oblink:  'OperaBlink/manifest.json',
 		opera:   'Opera/includes/loader.js'
 	},
-	// the specified `-b browser` or all of them. if unspecified
+	// the specified `-b browser` or all browsers, if unspecified
 	selectedBrowsers = options.b ? [].concat(options.b) : Object.keys(buildFiles);
 
 gulp.task('build', function(cb) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,59 +16,65 @@ gulp.task('default', ['clean'], function() {
 
 // Paths
 var rootBuildDir = 'dist',
-	buildFolder = {
-		chrome:  'chrome',
-		safari:  'RES.safariextension',
-		firefox: 'XPI',
-		oblink:  'oblink',
-		opera:   'opera'
+	commonFiles = ['lib/**/*.js', 'lib/**/*.json', 'lib/**/*.css', 'lib/**/*.html'],
+	config = {
+		chrome: {
+			buildFolder: 'chrome',
+			manifest: 'Chrome/manifest.json',
+			// dest is relative to the browser's buildDir [i.e. getBuildDir(browser)], src is relative to the root of the project
+			buildFiles: [
+				{ dest: 'images', src: ['Chrome/images/*.png'] },
+				{ dest: '/',      src: ['Chrome/*.js', 'Chrome/*.png', 'Chrome/*.html', 'package.json', 'Chrome/manifest.json'] },
+				{ dest: '/',      src: commonFiles }
+			]
+		},
+		safari: {
+			buildFolder: 'RES.safariextension',
+			manifest: 'RES.safariextension/Info.plist',
+			buildFiles: [
+				{ dest: '/', src: ['RES.safariextension/*.js', 'RES.safariextension/*.png', 'RES.safariextension/*.html', 'package.json', 'RES.safariextension/info.plist'] },
+				{ dest: '/', src: commonFiles }
+			]
+		},
+		firefox: {
+			buildFolder: 'XPI',
+			manifest: 'XPI/lib/main.js',
+			buildFiles: [
+				{ dest: 'data', src: ['XPI/data/**/*'] },
+				{ dest: 'data', src: commonFiles },
+				{ dest: 'lib',  src: ['XPI/lib/**/*'] },
+				{ dest: '/',    src: ['*.png', 'XPI/package.json'] }
+			]
+		},
+		oblink: {
+			buildFolder: 'oblink',
+			manifest: 'OperaBlink/manifest.json',
+			buildFiles: [
+				{ dest: 'images', src: ['OperaBlink/images/*.png'] },
+				{ dest: '/',      src: ['OperaBlink/*.js', 'Chrome/browsersupport-chrome.js', 'OperaBlink/*.png', 'OperaBlink/*.json', 'package.json'] },
+				{ dest: '/',      src: commonFiles }
+			]
+		},
+		opera: {
+			buildFolder: 'opera',
+			manifest: 'Opera/includes/loader.js',
+			buildFiles: [
+				{ dest: 'includes', src: ['Opera/includes/*.js'] },
+				{ dest: '/',        src: ['Opera/*.js', 'OperaBlink/*.gif', 'Opera/*.html', 'Opera/*.xml', 'package.json'] },
+				{ dest: '/',        src: commonFiles }
+			]
+		}
 	},
-	libFiles = ['lib/**/*.js', 'lib/**/*.json', 'lib/**/*.css', 'lib/**/*.html'],
-	// dest is relative to the browser's buildDir [i.e. getBuildDir(browser)], src is relative to the root of the project
-	buildFiles = {
-		chrome: [
-			{ dest: 'images', src: ['Chrome/images/*.png'] },
-			{ dest: '/',      src: ['Chrome/*.js', 'Chrome/*.png', 'Chrome/*.html', 'package.json', 'Chrome/manifest.json'] },
-			{ dest: '/',      src: libFiles }
-		],
-		safari: [
-			{ dest: '/', src: ['RES.safariextension/*.js', 'RES.safariextension/*.png', 'RES.safariextension/*.html', 'package.json', 'RES.safariextension/info.plist'] },
-			{ dest: '/', src: libFiles }
-		],
-		firefox: [
-			{ dest: 'data', src: ['XPI/data/**/*'] },
-			{ dest: 'data', src: libFiles },
-			{ dest: 'lib',  src: ['XPI/lib/**/*'] },
-			{ dest: '/',    src: ['*.png', 'XPI/package.json'] }
-		],
-		oblink: [
-			{ dest: 'images', src: ['OperaBlink/images/*.png'] },
-			{ dest: '/',      src: ['OperaBlink/*.js', 'Chrome/browsersupport-chrome.js', 'OperaBlink/*.png', 'OperaBlink/*.json', 'package.json'] },
-			{ dest: '/',      src: libFiles }
-		],
-		opera: [
-			{ dest: 'includes', src: ['Opera/includes/*.js'] },
-			{ dest: '/',        src: ['Opera/*.js', 'OperaBlink/*.gif', 'Opera/*.html', 'Opera/*.xml', 'package.json'] },
-			{ dest: '/',        src: libFiles }
-		]
-	},
-	manifests = {
-		chrome:  'Chrome/manifest.json',
-		safari:  'RES.safariextension/Info.plist',
-		firefox: 'XPI/lib/main.js',
-		oblink:  'OperaBlink/manifest.json',
-		opera:   'Opera/includes/loader.js'
-	},
-	// the specified `-b browser` or all browsers, if unspecified
-	selectedBrowsers = options.b ? [].concat(options.b) : Object.keys(buildFiles);
+// the `-b browser` argument(s) or all browsers, if unspecified
+	selectedBrowsers = options.b ? [].concat(options.b) : Object.keys(config);
 
 function getBuildDir(browser) {
-	return path.join(rootBuildDir, buildFolder[browser]);
+	return path.join(rootBuildDir, config[browser].buildFolder);
 }
 
 gulp.task('build', function(cb) {
 	selectedBrowsers.forEach(function(browser) {
-		buildFiles[browser].forEach(function(paths) {
+		config[browser].buildFiles.forEach(function(paths) {
 			gulp.src(paths.src)
 				.pipe(gulp.dest(path.join(getBuildDir(browser), paths.dest)));
 		});
@@ -77,10 +83,11 @@ gulp.task('build', function(cb) {
 });
 
 gulp.task('zip', function(cb) {
+	// --zipdir argument or <rootBuildDir>/zip/
 	var zipDir = options.zipdir || path.join(rootBuildDir, 'zip');
 	selectedBrowsers.forEach(function(browser) {
 		gulp.src(path.join(getBuildDir(browser), '**/*'))
-			.pipe(zip(buildFolder[browser] + '.zip'))
+			.pipe(zip(config[browser].buildFolder + '.zip'))
 			.pipe(gulp.dest(zipDir));
 	});
 	cb();
@@ -89,9 +96,9 @@ gulp.task('zip', function(cb) {
 gulp.task('watch', function() {
 	var sources = selectedBrowsers.reduce(function(previous, browser) { // combine the sources of each browser
 		return previous.concat(
-			buildFiles[browser].reduce(function(pre, cur) { // combine the sources within each browser
+			config[browser].buildFiles.reduce(function(pre, cur) { // combine the sources within each browser
 				return pre.concat(
-					cur.src.filter(function(src) { // filter out repeated directories (i.e. libFiles, chrome/oblink common files)
+					cur.src.filter(function(src) { // filter out repeated directories (i.e. commonFiles, chrome/oblink common files)
 						return previous.indexOf(src) == -1;
 					})
 				);
@@ -104,13 +111,13 @@ gulp.task('watch', function() {
 // Add new modules to browser manifests
 gulp.task('add-module', function(cb) {
 	selectedBrowsers.forEach(function(browser) {
-		addModuleToManifest(manifests[browser]);
+		addModuleToManifest(config[browser].manifest);
 	});
 	cb();
 });
 gulp.task('add-host', function(cb) {
 	selectedBrowsers.forEach(function(browser) {
-		addHostToManifest(manifests[browser]);
+		addHostToManifest(config[browser].manifest);
 	});
 	cb();
 });


### PR DESCRIPTION
Fixes #2141 

This produces exactly the same output as before (unless there are unexpected files in lib/, in which case it will perform identically to Grunt and makelinks.sh).

Gulp now works as follows:

There are 6 tasks: `build, zip, watch, add-module, add-host, clean`.
Browsers (`chrome, firefox, safari, opera, oblink`) can be specified with `-b browser1 -b browser2`. If none are specified, gulp will use all of them.
Files for add-module and add-host are still specified with `--file filename.js`.
The zip output directory now defaults to `<rootBuildDir>/zip`, and can be specified with `--zipdir /path/to/dir`.

If you run multiple tasks the specified browser will apply to all of them, i.e. `gulp build watch -b chrome` will build only chrome and watch only chrome.