### PR TITLE
Fade in the image loading spinner

### DIFF
--- a/lib/core/res.css
+++ b/lib/core/res.css
@@ -1655,8 +1655,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
   transition: all .75s ease 0s;
   border-radius: 100%;
   border-top: 4px solid #555555;
-  -webkit-animation: standard .75s infinite linear;
-  animation: standard .75s infinite linear;
+  -webkit-animation: fadeIn 2s 1 ease-in, standard .75s infinite linear;
+  animation: fadeIn 2s 1 ease-in, standard .75s infinite linear;
   -webkit-transform-origin: center;
   -ms-transform-origin: center;
   transform-origin: center;
@@ -1688,6 +1688,14 @@ a spinner with a static ring and no overlay.*/
     -webkit-transform: rotate(360deg);
     transform: rotate(360deg);
   }
+}
+@-webkit-keyframes fadeIn {
+	from { opacity: 0; }
+	to { opacity: 1; }
+}
+@keyframes fadeIn {
+	from { opacity: 0; }
+	to { opacity: 1; }
 }
 #url-field .progress-wrapper {
 	width: 500px;


### PR DESCRIPTION
So it doesn't flicker when you move to the next gallery image.

Alternatively, it could pop into existence after a little while, or maybe something else. (any suggestions?)

![](https://cloud.githubusercontent.com/assets/7673145/6899813/b8484428-d6d0-11e4-8d9e-99e38ec79514.gif)
