### PR TITLE
Fixed #2139 -- new comment count now shows in Japanese language interface

### DIFF
--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -265,7 +265,7 @@ modules['newCommentCount'] = {
 			var href = commentsLinks[i].getAttribute('href');
 			var thisCount = commentsLinks[i].textContent;
 			// split number from the word comments 
- 			var thisCount = thisCount.replace(/\D/g,'');
+ 			thisCount = thisCount.replace(/\D/g,'');
 			var matches = IDre.exec(href);
 			if (matches) {
 				var thisID = matches[1];

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -264,8 +264,8 @@ modules['newCommentCount'] = {
 		for (var i = 0, len = commentsLinks.length; i < len; i++) {
 			var href = commentsLinks[i].getAttribute('href');
 			var thisCount = commentsLinks[i].textContent;
-			var split = thisCount.split(' ');
-			thisCount = split[0];
+			// split number from the word comments 
+ 			var thisCount = thisCount.replace(/\D/g,'');
 			var matches = IDre.exec(href);
 			if (matches) {
 				var thisID = matches[1];


### PR DESCRIPTION
Fixes #2139. There was a split of the number of the comments and the word "comments" predicated on a space. Japanese doesn't use a space after numbers from what I can tell. Changed it to strip all non-numeric characters.

I noticed it always uses the word "new" no matter the interface language. Does RES have multiple interface languages? Is it an issue that "new" is always in English?