### PR TITLE
settingsConsole: Replace RuntimeError with Exception

### DIFF
--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -1354,7 +1354,7 @@ addModule('settingsConsole', function(module, moduleID) {
 			case '<':	return a < b;
 			case '>=':	return a >= b;
 			case '<=':	return a <= b;
-			default: throw new RuntimeError('Unhandled operator ' + op);
+			default: throw new Exception('Unhandled operator ' + op);
 			}
 		},
 		builderFields: {


### PR DESCRIPTION
`RuntimeError` does not exist as an error for JavaScript.