### PR TITLE
YouTube expandos: only ignore post if it already has an expando

### DIFF
--- a/lib/modules/hosts/youtube.js
+++ b/lib/modules/hosts/youtube.js
@@ -2,11 +2,8 @@ modules['showImages'].siteModules['youtube'] = {
 	name: 'youtube',
 	domains: ['youtube.com', 'youtu.be'],
 	detect: function(href, elem) {
-		// Only find comments, not the titles.
-		if (href.indexOf('youtube.com') !== -1  || href.indexOf('youtu.be') !== -1) {
-			if (elem.className.indexOf('title') === -1) return true;
-		}
-		return false;
+		// Ignore links with expandos
+		return $(elem).closest('.entry').find('.expando-button.video:not(.commentImg)').length === 0;
 	},
 	handleLink: function(elem) {
 		var def = $.Deferred();

--- a/lib/modules/hosts/youtube.js
+++ b/lib/modules/hosts/youtube.js
@@ -25,7 +25,7 @@ modules['showImages'].siteModules['youtube'] = {
 
 			if (timecodeResult !== null) {
 				var time_blocks = {'h':3600, 'm':60, 's':1},
-					timeRE = /[0-9]+[h|m|s]/ig;
+					timeRE = /[0-9]+[hms]/ig;
 
 				// Get each segment e.g. 8m and calculate its value in seconds
 				var timeMatch = timecodeResult[0].match(timeRE);


### PR DESCRIPTION
–instead of ignoring all posts.

Fixes #2184 

Also, we already know that the domain matches, so we don't need to check it again.