### PR TITLE
Use commas by default to match reddit's style

### DIFF
--- a/lib/modules/showKarma.js
+++ b/lib/modules/showKarma.js
@@ -11,7 +11,7 @@ modules['showKarma'] = {
 		},
 		useCommas: {
 			type: 'boolean',
-			value: false,
+			value: true,
 			description: 'Use commas for large karma numbers'
 		}
 	},


### PR DESCRIPTION
Reddit now shows commas in your link karma total by default, so for consistency we should show commas when displaying comment karma. Screenshot without RES active:

![screenshot of Reddit showing commas in karma counts](https://cloud.githubusercontent.com/assets/57813/7169681/c3eee742-e395-11e4-94f6-8fc47b0cf6f4.png)
