### PR TITLE
Lazy RESStorage command line support

### DIFF
--- a/lib/modules/commandLine.js
+++ b/lib/modules/commandLine.js
@@ -484,7 +484,7 @@ addModule('commandLine', function(module, moduleID) {
 		}
 	);
 
-	module.registerCommand('RESStorage', 'RESStorage [get|set|update|remove] [key] [value] - For debug use only, you shouldn\'t mess with this unless you know what you\'re doing.',
+	module.registerCommand(/(?:RES)?stor(?:e|age)?/i, 'RESStorage [get|set|update|remove] [key] [value] - For debug use only, you shouldn\'t mess with this unless you know what you\'re doing.',
 		function(command, value, match) { },
 		function(command, val, match, e) {
 			// get or set RESStorage data

--- a/lib/modules/commandLine.js
+++ b/lib/modules/commandLine.js
@@ -496,8 +496,7 @@ addModule('commandLine', function(module, moduleID) {
 				var key = splitWords[1],
 					value;
 				if (splitWords.length > 2) {
-					splitWords.splice(0, 2);
-					value = splitWords.join(' ');
+					value = splitWords.slice(2).join(' ');
 				}
 				// console.log(command);
 				if (command === 'get') {

--- a/lib/modules/commandLine.js
+++ b/lib/modules/commandLine.js
@@ -498,12 +498,26 @@ addModule('commandLine', function(module, moduleID) {
 				if (splitWords.length > 2) {
 					value = splitWords.slice(2).join(' ');
 				}
+				key = storage.sanitizeStorageKey(key);
+
 				// console.log(command);
 				return storage.executeCommand(command, key, value);
 			}
 		}
 	);
 	var storage = {
+		optionsRegex: /(?:RES)?opt(?:ion)?s?[\.\s]+(.*)/i,
+		moduleDataRegex: /(?:RES)?mod(?:ule)?s?[\.\s]+(.*)/i,
+		sanitizeStorageKey: function(key) {
+			var match;
+			if (match = storage.optionsRegex.exec(key)) {
+				key = 'RESoptions.' + match[1];
+			} else if (match = storage.moduleDataRegex.exec(key)) {
+				key = 'RESmodules.' + match[1];
+			}
+
+			return key;
+		},
 		executeCommand: function(command, key, value) {
 			if (command === 'get') {
 				alert('Value of RESStorage[' + escapeHTML(key) + ']: <br><br><textarea rows="5" cols="50">' + escapeHTML(RESStorage.getItem(key)) + '</textarea>');

--- a/lib/modules/commandLine.js
+++ b/lib/modules/commandLine.js
@@ -499,29 +499,34 @@ addModule('commandLine', function(module, moduleID) {
 					value = splitWords.slice(2).join(' ');
 				}
 				// console.log(command);
-				if (command === 'get') {
-					alert('Value of RESStorage[' + escapeHTML(key) + ']: <br><br><textarea rows="5" cols="50">' + escapeHTML(RESStorage.getItem(key)) + '</textarea>');
-				} else if (command === 'update') {
-					var now = Date.now();
-					alert('Value of RESStorage[' + escapeHTML(key) + ']: <br><br><textarea id="RESStorageUpdate' + now + '" rows="5" cols="50">' + escapeHTML(RESStorage.getItem(key)) + '</textarea>', function() {
-						var textArea = document.getElementById('RESStorageUpdate' + now);
-						if (textArea) {
-							var value = textArea.value;
-							RESStorage.setItem(key, value);
-						}
-					});
-				} else if (command === 'remove') {
-					RESStorage.removeItem(key);
-					alert('RESStorage[' + escapeHTML(key) + '] deleted');
-				} else if (command === 'set') {
-					RESStorage.setItem(key, value);
-					alert('RESStorage[' + escapeHTML(key) + '] set to:<br><br><textarea rows="5" cols="50">' + escapeHTML(value) + '</textarea>');
-				} else {
-					return 'You must specify either "get [key]" or "set [key] [value]"';
-				}
+				return storage.executeCommand(command, key, value);
 			}
 		}
 	);
+	var storage = {
+		executeCommand: function(command, key, value) {
+			if (command === 'get') {
+				alert('Value of RESStorage[' + escapeHTML(key) + ']: <br><br><textarea rows="5" cols="50">' + escapeHTML(RESStorage.getItem(key)) + '</textarea>');
+			} else if (command === 'update') {
+				var now = Date.now();
+				alert('Value of RESStorage[' + escapeHTML(key) + ']: <br><br><textarea id="RESStorageUpdate' + now + '" rows="5" cols="50">' + escapeHTML(RESStorage.getItem(key)) + '</textarea>', function() {
+					var textArea = document.getElementById('RESStorageUpdate' + now);
+					if (textArea) {
+						var value = textArea.value;
+						RESStorage.setItem(key, value);
+					}
+				});
+			} else if (command === 'remove') {
+				RESStorage.removeItem(key);
+				alert('RESStorage[' + escapeHTML(key) + '] deleted');
+			} else if (command === 'set') {
+				RESStorage.setItem(key, value);
+				alert('RESStorage[' + escapeHTML(key) + '] set to:<br><br><textarea rows="5" cols="50">' + escapeHTML(value) + '</textarea>');
+			} else {
+				return 'You must specify either "get [key]" or "set [key] [value]"';
+			}
+		}
+	};
 
 	module.registerCommand(/^\/([nthcgp])?/, '/n, /t, /h, /c, /g, or /p - goes to new, top, hot, controversial, gilded, or promoted sort of current subreddit, multireddit or user page',
 		function(command, val, match) {


### PR DESCRIPTION
lets you be super lazy about capitalization and full words with `RESStorage get RESmodules.moduleName'.  basically takes anything except bad capitalization/spelling for the module name or the or storage key

![screen shot 2015-04-16 at 8 37 14 pm](https://cloud.githubusercontent.com/assets/455632/7195714/482d0758-e479-11e4-9407-5f4634685f0a.png)
![screen shot 2015-04-16 at 8 37 20 pm](https://cloud.githubusercontent.com/assets/455632/7195715/48615512-e479-11e4-82b2-1f770ac70399.png)
