### PR TITLE
More expando improvements

### DIFF
--- a/lib/modules/hosts/deviantart.js
+++ b/lib/modules/hosts/deviantart.js
@@ -1,7 +1,6 @@
 modules['showImages'].siteModules['deviantart'] = {
 	name: 'deviantART',
 	domains: ['deviantart.com', 'fav.me'],
-	calls: {},
 	matchRe: /^http:\/\/(?:fav\.me\/.*|(?:.+\.)?deviantart\.com\/(?:art\/.*|[^#]*#\/d.*))$/i,
 	detect: function(href, elem) {
 		return modules['showImages'].siteModules['deviantart'].matchRe.test(elem.href);
@@ -10,32 +9,22 @@ modules['showImages'].siteModules['deviantart'] = {
 		var def = $.Deferred();
 		var siteMod = modules['showImages'].siteModules['deviantart'];
 		var apiURL = 'http://backend.deviantart.com/oembed?url=' + encodeURIComponent(elem.href);
-		if (apiURL in siteMod.calls) {
-			if (siteMod.calls[apiURL] != null) {
-				def.resolve(elem, siteMod.calls[apiURL]);
-			} else {
-				def.reject();
-			}
-		} else {
-			RESUtils.runtime.ajax({
-				method: 'GET',
-				url: apiURL,
-				// aggressiveCache: true,
-				onload: function(response) {
-					try {
-						var json = JSON.parse(response.responseText);
-						siteMod.calls[apiURL] = json;
-						def.resolve(elem, json);
-					} catch (error) {
-						siteMod.calls[apiURL] = null;
-						def.reject();
-					}
-				},
-				onerror: function(response) {
+		RESUtils.runtime.ajax({
+			method: 'GET',
+			url: apiURL,
+			// aggressiveCache: true,
+			onload: function(response) {
+				try {
+					var json = JSON.parse(response.responseText);
+					def.resolve(elem, json);
+				} catch (error) {
 					def.reject();
 				}
-			});
-		}
+			},
+			onerror: function(response) {
+				def.reject();
+			}
+		});
 		return def.promise();
 	},
 	handleInfo: function(elem, info) {

--- a/lib/modules/hosts/deviantart.js
+++ b/lib/modules/hosts/deviantart.js
@@ -44,7 +44,6 @@ modules['showImages'].siteModules['deviantart'] = {
 		switch(info.type) {
 			case 'photo':
 				elem.imageTitle = info.title;
-				var original_url = elem.href;
 				if (imgRe.test(info.url)) {
 					elem.src = info.url;
 				} else {

--- a/lib/modules/hosts/fitbamob.js
+++ b/lib/modules/hosts/fitbamob.js
@@ -10,7 +10,6 @@ modules['showImages'].siteModules['fitbamob'] = {
 		var groups = hashRe.exec(elem.href);
 
 		if (!groups) return def.reject();
-		var href = elem.href.toLowerCase();
 
 		var siteMod = modules['showImages'].siteModules['fitbamob'];
 		var link_id;

--- a/lib/modules/hosts/fitbamob.js
+++ b/lib/modules/hosts/fitbamob.js
@@ -1,6 +1,5 @@
 modules['showImages'].siteModules['fitbamob'] = {
 	domains: ['fitbamob.com','offsided.com'],
-	calls: {},
 	detect: function(href, elem) {
 		return href.indexOf('fitbamob.com') !== -1 || href.indexOf('offsided.com') !== -1 ;
 	},
@@ -22,33 +21,22 @@ modules['showImages'].siteModules['fitbamob'] = {
 		}
 		var apiURL = location.protocol + '//fitbamob.com/link/' + link_id + '/?format=json';
 
-		if (apiURL in siteMod.calls) {
-			if (siteMod.calls[apiURL] != null) {
-				def.resolve(elem, siteMod.calls[apiURL]);
-			} else {
-				siteMod.calls[apiURL] = null;
-				def.reject();
-			}
-		} else {
-			RESUtils.runtime.ajax({
-				method: 'GET',
-				url: apiURL,
-				aggressiveCache: true,
-				onload: function(response) {
-					try {
-						var json = JSON.parse(response.responseText);
-						siteMod.calls[apiURL] = json;
-						def.resolve(elem, json);
-					} catch (error) {
-						siteMod.calls[apiURL] = null;
-						def.reject();
-					}
-				},
-				onerror: function(response) {
+		RESUtils.runtime.ajax({
+			method: 'GET',
+			url: apiURL,
+			aggressiveCache: true,
+			onload: function(response) {
+				try {
+					var json = JSON.parse(response.responseText);
+					def.resolve(elem, json);
+				} catch (error) {
 					def.reject();
 				}
-			});
-		}
+			},
+			onerror: function(response) {
+				def.reject();
+			}
+		});
 		return def.promise();
 	},
 	handleInfo: function(elem, info) {

--- a/lib/modules/hosts/gfycat.js
+++ b/lib/modules/hosts/gfycat.js
@@ -7,7 +7,6 @@ modules['showImages'].siteModules['gfycat'] = {
 			type: 'boolean'
 		}
 	},
-	calls: {},
 	detect: function(href, elem) {
 		return href.indexOf('gfycat.com') !== -1 && href.substring(-1) !== '+';
 	},
@@ -21,34 +20,23 @@ modules['showImages'].siteModules['gfycat'] = {
 		if (groups && (siteMod.options['prefer RES support'].value || existingExpando.length === 0)) {
 			existingExpando.remove();
 			var apiURL = location.protocol + '//gfycat.com/cajax/get/' + encodeURIComponent(groups[1]);
-			if (apiURL in siteMod.calls) {
-				if (siteMod.calls[apiURL] != null) {
-					def.resolve(elem, siteMod.calls[apiURL]);
-				} else {
-					siteMod.calls[apiURL] = null;
-					def.reject();
-				}
-			} else {
-				RESUtils.runtime.ajax({
-					method: 'GET',
-					url: apiURL,
-					aggressiveCache: true,
-					onload: function(response) {
-						try {
-							var json = JSON.parse(response.responseText);
-							json.gfyItem.src = elem.href;
-							siteMod.calls[apiURL] = json;
-							def.resolve(elem, json.gfyItem);
-						} catch (error) {
-							siteMod.calls[apiURL] = null;
-							def.reject();
-						}
-					},
-					onerror: function(response) {
+			RESUtils.runtime.ajax({
+				method: 'GET',
+				url: apiURL,
+				aggressiveCache: true,
+				onload: function(response) {
+					try {
+						var json = JSON.parse(response.responseText);
+						json.gfyItem.src = elem.href;
+						def.resolve(elem, json.gfyItem);
+					} catch (error) {
 						def.reject();
 					}
-				});
-			}
+				},
+				onerror: function(response) {
+					def.reject();
+				}
+			});
 		} else {
 			def.reject();
 		}

--- a/lib/modules/hosts/gifyoutube.js
+++ b/lib/modules/hosts/gifyoutube.js
@@ -1,6 +1,5 @@
 modules['showImages'].siteModules['gifyoutube'] = {
 	domains: ['gifyoutube.com', 'gifyt.com'],
-	calls: {},
 	detect: function(href, elem) {
 		return (href.indexOf('gifyoutube.com') !== -1 || href.indexOf('gifyt.com') !== -1);
 	},
@@ -35,22 +34,14 @@ modules['showImages'].siteModules['gifyoutube'] = {
 			apiURL: apiURL
 		};
 
-		if (apiURL in siteMod.calls) {
-			if (siteMod.calls[apiURL] != null) {
-				def.resolve(elem, siteMod.calls[apiURL]);
-			} else {
-				siteMod.calls[apiURL] = null;
-				def.reject();
-			}
-		} else {
-			var info = {
-				gifUrl: 'http://share.gifyoutube.com/' + groups[1] + '.gif',
-				webmUrl: 'http://share.gifyoutube.com/' + groups[1] + '.webm',
-				mp4Url: 'http://share.gifyoutube.com/' + groups[1] + '.mp4',
-				original: elem.href
-			};
-			def.resolve(elem, info);
-		}
+
+		var info = {
+			gifUrl: 'http://share.gifyoutube.com/' + groups[1] + '.gif',
+			webmUrl: 'http://share.gifyoutube.com/' + groups[1] + '.webm',
+			mp4Url: 'http://share.gifyoutube.com/' + groups[1] + '.mp4',
+			original: elem.href
+		};
+		def.resolve(elem, info);
 		return def.promise();
 	},
 	handleInfo: function(elem, info) {
@@ -104,26 +95,14 @@ modules['showImages'].siteModules['gifyoutube'] = {
 		if (!data.apiURL) {
 			return;
 		}
-		var apiURL = data.apiURL,
-			siteMod = data.siteMod;
 
 		RESUtils.runtime.ajax({
 			method: 'GET',
 			url: data.apiURL,
 			aggressiveCache: true,
 			onload: function(response) {
-				try {
-					var json = JSON.parse(response.responseText);
-
-					siteMod.calls[apiURL] = json;
-					mediaLink.wrapperDiv.querySelector('.gifyoutube-source-button').href = json.sauce;
-
-				} catch (error) {
-					siteMod.calls[apiURL] = null;
-				}
-			},
-			onerror: function(response) {
-				siteMod.calls[apiURL] = null;
+				var json = safeJSON.parse(response.responseText);
+				mediaLink.wrapperDiv.querySelector('.gifyoutube-source-button').href = json.sauce;
 			}
 		});
 	}

--- a/lib/modules/hosts/giphy.js
+++ b/lib/modules/hosts/giphy.js
@@ -1,6 +1,5 @@
 modules['showImages'].siteModules['giphy'] = {
 	domains: ['giphy.com'],
-	calls: {},
 	detect: function(href, elem) {
 		return href.indexOf('giphy.com') !== -1;
 	},

--- a/lib/modules/hosts/imgrush.js
+++ b/lib/modules/hosts/imgrush.js
@@ -51,7 +51,6 @@ modules['uploader'].hosts['imgrush'] = {
 modules['showImages'].siteModules['imgrush'] = {
 	name: 'imgrush',
 	domains: ['imgrush.com'],
-	calls: {},
 	detect: function(href, elem) {
 		return (/^https?:\/\/(?:www\.|cdn\.)?imgrush\.com\/([a-zA-Z0-9_\-]{12})(?:\.(?:jpe|jpeg|jpg|png|mp3|flac|ogg|oga|ogv|mp4|webm|pdf|svg))?(?:\/?|\/(direct|grid|list|focus)\/?)(#.*)?$/).test(elem.href);
 	},
@@ -63,15 +62,13 @@ modules['showImages'].siteModules['imgrush'] = {
 		if (!groups) {
 			return def.reject();
 		}
-		var siteMod = modules['showImages'].siteModules['imgrush'],
-			mediaId = groups[1],
+		var mediaId = groups[1],
 			mediaSettings = groups[2];
 
 		if (!mediaSettings) {
 			mediaSettings = '';
 		}
 		window.Imgrush.get(mediaId, function(media) {
-			siteMod.calls['imgrush-' + mediaId] = media;
 			media.settings = mediaSettings;
 			def.resolve(elem, media);
 		});

--- a/lib/modules/hosts/imgrush.js
+++ b/lib/modules/hosts/imgrush.js
@@ -99,7 +99,6 @@ modules['showImages'].siteModules['imgrush'] = {
 			window.Imgrush.render(div);
 			return div;
 		};
-		var def = $.Deferred();
 		if (info.type === 'application/album') {
 			elem.type = 'GENERIC_EXPANDO';
 			elem.expandoClass = ' image gallery';

--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -17,7 +17,6 @@ modules['showImages'].siteModules['imgur'] = {
 	hashRe: /^https?:\/\/(?:i\.|m\.|edge\.|www\.)*imgur\.com\/(?:r\/[\w]+\/)*(?!gallery)(?!removalrequest)(?!random)(?!memegen)([\w]{5,7}(?:[&,][\w]{5,7})*)(?:#\d+)?[sbtmlh]?(\.(?:jpe?g|gif|png|gifv))?(\?.*)?$/i,
 	albumHashRe: /^https?:\/\/(?:i\.|m\.)?imgur\.com\/(?:a|gallery)\/([\w]+)(\..+)?(?:\/)?(?:#?\w*)?$/i,
 	apiPrefix: 'https://api.imgur.com/2/',
-	calls: {},
 	detect: function(href, elem) {
 		return href.indexOf('imgur.com/') !== -1;
 	},
@@ -91,35 +90,25 @@ modules['showImages'].siteModules['imgur'] = {
 				$(elem).closest('.entry').find('.expando-button.video:not(.commentImg)').remove();
 				var apiURL = siteMod.apiPrefix + 'album/' + encodeURIComponent(albumGroups[1]) + '.json';
 				elem.imgHash = albumGroups[1];
-				if (apiURL in siteMod.calls) {
-					if (siteMod.calls[apiURL] != null) {
-						def.resolve(elem, siteMod.calls[apiURL]);
-					} else {
-						def.reject();
-					}
-				} else {
-					RESUtils.runtime.ajax({
-						method: 'GET',
-						url: apiURL,
-						// aggressiveCache: true,
-						onload: function(response) {
-							if (response.status === 404) {
-								return def.reject();
-							}
-							try {
-								var json = JSON.parse(response.responseText);
-								siteMod.calls[apiURL] = json;
-								def.resolve(elem, json);
-							} catch (error) {
-								siteMod.calls[apiURL] = null;
-								def.reject();
-							}
-						},
-						onerror: function(response) {
+				RESUtils.runtime.ajax({
+					method: 'GET',
+					url: apiURL,
+					// aggressiveCache: true,
+					onload: function(response) {
+						if (response.status === 404) {
+							return def.reject();
+						}
+						try {
+							var json = JSON.parse(response.responseText);
+							def.resolve(elem, json);
+						} catch (error) {
 							def.reject();
 						}
-					});
-				}
+					},
+					onerror: function(response) {
+						def.reject();
+					}
+				});
 			} else {
 				// do not use RES's album support...
 				return def.reject();

--- a/lib/modules/hosts/minus.js
+++ b/lib/modules/hosts/minus.js
@@ -1,7 +1,6 @@
 modules['showImages'].siteModules['minus'] = {
 	name: 'min.us',
 	domains: ['min.us'],
-	calls: {},
 	detect: function(href, elem) {
 		return href.indexOf('min.us') !== -1 && href.indexOf('blog.') === -1;
 	},
@@ -19,32 +18,21 @@ modules['showImages'].siteModules['minus'] = {
 				var hash = groups[1];
 				if (hash.substr(0, 1) === 'm') {
 					var apiURL = 'http://min.us/api/GetItems/' + encodeURIComponent(hash);
-					var calls = modules['showImages'].siteModules['minus'].calls;
-					if (apiURL in calls) {
-						if (calls[apiURL] != null) {
-							def.resolve(elem, calls[apiURL]);
-						} else {
-							def.reject();
-						}
-					} else {
-						RESUtils.runtime.ajax({
-							method: 'GET',
-							url: apiURL,
-							onload: function(response) {
-								try {
-									var json = JSON.parse(response.responseText);
-									modules['showImages'].siteModules['minus'].calls[apiURL] = json;
-									def.resolve(elem, json);
-								} catch (e) {
-									modules['showImages'].siteModules['minus'].calls[apiURL] = null;
-									def.reject();
-								}
-							},
-							onerror: function(response) {
+					RESUtils.runtime.ajax({
+						method: 'GET',
+						url: apiURL,
+						onload: function(response) {
+							try {
+								var json = JSON.parse(response.responseText);
+								def.resolve(elem, json);
+							} catch (e) {
 								def.reject();
 							}
-						});
-					}
+						},
+						onerror: function(response) {
+							def.reject();
+						}
+					});
 				} else { // if not 'm', not a gallery, we can't do anything with the API.
 					def.reject();
 				}

--- a/lib/modules/hosts/onedrive.js
+++ b/lib/modules/hosts/onedrive.js
@@ -1,7 +1,6 @@
 modules['showImages'].siteModules['onedrive'] = {
 	domains: [ 'onedrive.live.com', '1drv.ms' ],
 	name: 'Microsoft OneDrive',
-	calls: {},
 	videoDetect: document.createElement("VIDEO"),
 	audioDetect: document.createElement("AUDIO"),
 	// Returns true/false to indicate whether the siteModule will attempt to handle the link.
@@ -19,28 +18,17 @@ modules['showImages'].siteModules['onedrive'] = {
 		if (elem.href.indexOf('1drv.ms/') !== -1) {
 			// Remove the protocol.
 			var href = elem.href.replace(/https?:\/\//, '');
-
-			if (href in siteMod.calls) {
-				if (siteMod.calls[href] != null)
-					siteMod.fetchJson(elem, siteMod.calls[href], def);
-				else {
-					siteMod.calls[href] = null;
+			RESUtils.runtime.ajax({
+				method: 'GET',
+				url: 'https://1.utilities.space/api/longurl/' + href,
+				aggressiveCache: true,
+				onload: function(response) {
+					siteMod.fetchJson(elem, response.responseText, def);
+				},
+				onerror: function(response) {
 					def.reject();
 				}
-			} else {
-				RESUtils.runtime.ajax({
-					method: 'GET',
-					url: 'https://1.utilities.space/api/longurl/' + href,
-					aggressiveCache: true,
-					onload: function (response) {
-						siteMod.calls[href] = response.responseText;
-						siteMod.fetchJson(elem, response.responseText, def);
-					},
-					onerror: function(response) {
-						def.reject();
-					}
-				});
-			}
+			});
 		} else {
 			siteMod.fetchJson(elem, elem.href, def);
 		}
@@ -61,74 +49,61 @@ modules['showImages'].siteModules['onedrive'] = {
 
 		var apiURL = 'https://api.onedrive.com/v1.0/drive/items/' + resId + (authKey != null ? '?authKey=' + authKey : '');
 
+		RESUtils.runtime.ajax({
+			method: 'GET',
+			url: apiURL,
+			aggressiveCache: true,
+			onload: function(response) {
+				try {
+					var json = JSON.parse(response.responseText);
+					// An error happened, reject.
+					if (json.error !== undefined) return def.reject();
 
-		if (apiURL in siteMod.calls) {
-			if (siteMod.calls[apiURL] != null) {
-				def.resolve(elem, siteMod.calls[apiURL]);
-			} else {
-				siteMod.calls[apiURL] = null;
-				def.reject();
-			}
-		} else {
-			RESUtils.runtime.ajax({
-				method: 'GET',
-				url: apiURL,
-				aggressiveCache: true,
-				onload: function (response) {
-					try {
-						var json = JSON.parse(response.responseText);
-						// An error happened, reject.
-						if (json.error !== undefined) return def.reject();
-
-						// The link is a folder, get its content instead.
-						if (json.folder !== undefined) {
-							var folderUrl = 'https://api.onedrive.com/v1.0/drive/items/' + resId + '/children' + (authKey != null ? '?authKey=' + authKey : '');
+					// The link is a folder, get its content instead.
+					if (json.folder !== undefined) {
+						var folderUrl = 'https://api.onedrive.com/v1.0/drive/items/' + resId + '/children' + (authKey != null ? '?authKey=' + authKey : '');
 
 
-							RESUtils.runtime.ajax({
-								method: 'GET',
-								url: folderUrl,
-								aggressiveCache: true,
-								onload: function (folderResponse) {
-									var folderJson = JSON.parse(folderResponse.responseText);
-									// An error happend this time, reject.
-									if (json.error !== undefined) return def.reject();
+						RESUtils.runtime.ajax({
+							method: 'GET',
+							url: folderUrl,
+							aggressiveCache: true,
+							onload: function(folderResponse) {
+								var folderJson = JSON.parse(folderResponse.responseText);
+								// An error happend this time, reject.
+								if (json.error !== undefined) return def.reject();
 
-									json.files = folderJson.value;
-									def.resolve(elem, json);
-								},
-								onerror: function (folderResponse) {
-									siteMod.calls[folderUrl] = null;
-									def.reject();
-								}
-							});
-
-
-						} else {
-							// Check if the file is a video, if that's the case, check if we can play it.
-							if (json.video !== undefined) {
-								if (siteMod.videoDetect.canPlayType(json.file.mimeType) == '') {
-									def.reject();
-								}
-							} else if (json.audio !== undefined) {							
-								if(siteMod.audioDetect.canPlayType(json.file.mimeType) == '') {
-									def.reject();
-								}
+								json.files = folderJson.value;
+								def.resolve(elem, json);
+							},
+							onerror: function(folderResponse) {
+								def.reject();
 							}
+						});
 
-							siteMod.calls[apiURL] = json;
-							def.resolve(elem, json);
+
+					} else {
+						// Check if the file is a video, if that's the case, check if we can play it.
+						if (json.video !== undefined) {
+							if (siteMod.videoDetect.canPlayType(json.file.mimeType) == '') {
+								def.reject();
+							}
+						} else if (json.audio !== undefined) {
+							if (siteMod.audioDetect.canPlayType(json.file.mimeType) == '') {
+								def.reject();
+							}
 						}
-					} catch (error) {
-						siteMod.calls[apiURL] = null;
-						def.reject();
+
+						def.resolve(elem, json);
 					}
-				},
-				onerror: function (response) {
+				} catch (error) {
 					def.reject();
 				}
-			});
-		}
+			},
+			onerror: function(response) {
+				def.reject();
+			}
+		});
 
 		return def.promise();
 	},

--- a/lib/modules/hosts/onedrive.js
+++ b/lib/modules/hosts/onedrive.js
@@ -1,8 +1,8 @@
 modules['showImages'].siteModules['onedrive'] = {
 	domains: [ 'onedrive.live.com', '1drv.ms' ],
 	name: 'Microsoft OneDrive',
-	videoDetect: document.createElement("VIDEO"),
-	audioDetect: document.createElement("AUDIO"),
+	videoDetect: document.createElement('VIDEO'),
+	audioDetect: document.createElement('AUDIO'),
 	// Returns true/false to indicate whether the siteModule will attempt to handle the link.
 	// The only parameters are the actual URL and the anchor element.
 	detect: function(href, elem) {
@@ -128,15 +128,15 @@ modules['showImages'].siteModules['onedrive'] = {
 					autoplay: false,
 					loop: false
 				};
-				
+
 				var sources = [{
 					'file': info['@content.downloadUrl'],
 					'type': info.file.mimeType
 				}];
-				
+
 				elem.type = 'VIDEO';
 				$(elem).data('sources', sources);
-				
+
 				if (RESUtils.pageType() === 'linklist') {
 					$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
 				}
@@ -182,19 +182,19 @@ modules['showImages'].siteModules['onedrive'] = {
 			});
 
 			if (gallery == null || gallery.length == 0) return def.reject();
-			
+
 			if (gallery.length > 1) {
 				elem.type = 'GALLERY';
 				elem.src = gallery.map(function(e, i, a) {
 
 					return {
-						src: e["@content.downloadUrl"],
-						href: e.webUrl,
-					}
+						src: e['@content.downloadUrl'],
+						href: e.webUrl
+					};
 				});
 			} else {
 				elem.type = 'IMAGE';
-				elem.src = gallery[0]["@content.downloadUrl"];
+				elem.src = gallery[0]['@content.downloadUrl'];
 
 				if (RESUtils.pageType() === 'linklist') {
 					$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);

--- a/lib/modules/hosts/redditbooru.js
+++ b/lib/modules/hosts/redditbooru.js
@@ -1,6 +1,5 @@
 modules['showImages'].siteModules['redditbooru'] = {
 	domains: ['redditbooru.com'],
-	calls: {},
 	detect: function(href, elem) {
 		return href.indexOf('redditbooru.com/gallery/') >= 0;
 	},
@@ -9,7 +8,6 @@ modules['showImages'].siteModules['redditbooru'] = {
 			href = elem.href.split('?')[0],
 			groups = urlRegEx.exec(href),
 			def = $.Deferred(),
-			self = modules['showImages'].siteModules['redditbooru'],
 			apiUrl = 'http://redditbooru.com/images/?postId=',
 			id;
 
@@ -23,24 +21,19 @@ modules['showImages'].siteModules['redditbooru'] = {
 			}
 
 			apiUrl += encodeURIComponent(id);
-			if (apiUrl in self.calls) {
-				def.resolve(elem, self.calls[apiUrl]);
-			} else {
-				RESUtils.runtime.ajax({
-					method: 'GET',
-					url: apiUrl,
-					onload: function(response) {
-						var json = {};
-						try {
-							json = JSON.parse(response.responseText);
-							def.resolve(elem, json);
-						} catch (error) {
-							def.reject(elem);
-						}
-						self.calls[apiUrl] = json;
+			RESUtils.runtime.ajax({
+				method: 'GET',
+				url: apiUrl,
+				onload: function(response) {
+					var json = {};
+					try {
+						json = JSON.parse(response.responseText);
+						def.resolve(elem, json);
+					} catch (error) {
+						def.reject(elem);
 					}
-				});
-			}
+				}
+			});
 		}
 		return def.promise();
 	},

--- a/lib/modules/hosts/redditbooru.js
+++ b/lib/modules/hosts/redditbooru.js
@@ -45,7 +45,6 @@ modules['showImages'].siteModules['redditbooru'] = {
 		return def.promise();
 	},
 	handleInfo: function(elem, info) {
-		var def = $.Deferred();
 		if (typeof info === 'object' && info.length > 0) {
 			elem.src = info.map(function(e, i, a) {
 				return {

--- a/lib/modules/hosts/tumblr.js
+++ b/lib/modules/hosts/tumblr.js
@@ -50,7 +50,6 @@ modules['showImages'].siteModules['tumblr'] = {
 	},
 	handleInfo: function(elem, info) {
 		var def = $.Deferred();
-		var original_url = elem.href;
 		var post = info.response.posts[0];
 		switch (post.type) {
 			case 'photo':

--- a/lib/modules/hosts/tumblr.js
+++ b/lib/modules/hosts/tumblr.js
@@ -1,7 +1,7 @@
 modules['showImages'].siteModules['tumblr'] = {
 	domains: ['tumblr.com'],
 	APIKey: 'WeJQquHCAasi5EzaN9jMtIZkYzGfESUtEvcYDeSMLICveo3XDq',
-	matchRE: /^https?:\/\/([a-z0-9\-]+\.tumblr\.com)\/post\/(\d+)(?:\/.*)?$/i,
+	matchRE: /^https?:\/\/([a-z0-9\-]+\.tumblr\.com)\/(?:post|image)\/(\d+)(?:\/|$)/i,
 	detect: function(href, elem) {
 		return modules['showImages'].siteModules['tumblr'].matchRE.test(elem.href);
 	},

--- a/lib/modules/hosts/tumblr.js
+++ b/lib/modules/hosts/tumblr.js
@@ -39,42 +39,65 @@ modules['showImages'].siteModules['tumblr'] = {
 	handleInfo: function(elem, info) {
 		var def = $.Deferred();
 		var post = info.response.posts[0];
+
+		function render(string) {
+			return post.format === 'markdown' ?
+				modules['commentPreview'].converter.render(string) :
+				string;
+		}
+
+		// Overwritten in quote posts
+		elem.credits = 'Posted by: <a href="' + info.response.blog.url + '">' + info.response.blog.name + '</a> @ Tumblr';
+
 		switch (post.type) {
 			case 'photo':
-				if (post.photos.length > 1) {
-					elem.type = 'GALLERY';
-					elem.src = post.photos.map(function(e) {
-						return {
-							src: e.original_size.url,
-							caption: e.caption
-						};
-					});
-				} else {
-					elem.type = 'IMAGE';
-					elem.src = [ {
-						src: post.photos[0].original_size.url,
-						caption: post.caption || ''
-					} ]
-				}
+				elem.type = post.photos.length > 1 ? 'GALLERY' : 'IMAGE';
+				elem.src = post.photos.map(function(photo) {
+					return {
+						src: photo.original_size.url,
+						caption: photo.caption || post.caption
+					};
+				});
 				break;
 			case 'text':
 				elem.type = 'TEXT';
 				elem.imageTitle = post.title;
-				if (post.format === 'markdown') {
-					elem.src = modules['commentPreview'].converter.render(post.body);
-				} else if (post.format === 'html') {
-					elem.src = post.body;
+				elem.src = render(post.body);
+				break;
+			case 'quote':
+				elem.type = 'TEXT';
+				elem.credits = post.source;
+				elem.src = '<blockquote><p>' + render(post.text) + '</p></blockquote>';
+				break;
+			case 'link':
+				elem.type = 'TEXT';
+				elem.imageTitle = '<a href="' + post.url + '">' + post.title + '</a>';
+				elem.src = render(post.description);
+				break;
+			case 'chat':
+				elem.type = 'TEXT';
+				elem.imageTitle = post.title;
+				elem.src = post.dialogue.reduce(function(pre, cur) {
+					return pre + '<blockquote><p><b>' + cur.label + '</b> ' + cur.phrase + '</p></blockquote>';
+				}, '');
+				break;
+			case 'answer':
+				elem.type = 'TEXT';
+				var asking;
+				if (post.asking_url) {
+					asking = '<a href="' + post.asking_url + '">' + post.asking_name + '</a>';
+				} else {
+					asking = post.asking_name;
 				}
+				elem.src = '<blockquote><p>' + asking + ' sent: ' + post.question + '</p></blockquote>' + render(post.answer);
 				break;
 			default:
 				return def.reject().promise();
 		}
-		elem.caption = post.caption;
 		if (RESUtils.pageType() === 'linklist') {
 			$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
 		}
-		elem.credits = 'Posted by: <a href="' + info.response.blog.url + '">' + info.response.blog.name + '</a> @ Tumblr';
-		def.resolve(elem);
-		return def.promise();
+
+		return def.resolve(elem).promise();
 	}
 };

--- a/lib/modules/hosts/tumblr.js
+++ b/lib/modules/hosts/tumblr.js
@@ -94,9 +94,6 @@ modules['showImages'].siteModules['tumblr'] = {
 			default:
 				return def.reject().promise();
 		}
-		if (RESUtils.pageType() === 'linklist') {
-			$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
-		}
 
 		return def.resolve(elem).promise();
 	}

--- a/lib/modules/hosts/tumblr.js
+++ b/lib/modules/hosts/tumblr.js
@@ -1,6 +1,5 @@
 modules['showImages'].siteModules['tumblr'] = {
 	domains: ['tumblr.com'],
-	calls: {},
 	APIKey: 'WeJQquHCAasi5EzaN9jMtIZkYzGfESUtEvcYDeSMLICveo3XDq',
 	matchRE: /^https?:\/\/([a-z0-9\-]+\.tumblr\.com)\/post\/(\d+)(?:\/.*)?$/i,
 	detect: function(href, elem) {
@@ -12,37 +11,26 @@ modules['showImages'].siteModules['tumblr'] = {
 		var groups = siteMod.matchRE.exec(elem.href);
 		if (groups) {
 			var apiURL = 'http://api.tumblr.com/v2/blog/' + encodeURIComponent(groups[1]) + '/posts?api_key=' + encodeURIComponent(siteMod.APIKey) + '&id=' + encodeURIComponent(groups[2]) + '&filter=raw';
-			if (apiURL in siteMod.calls) {
-				if (siteMod.calls[apiURL] != null) {
-					def.resolve(elem, siteMod.calls[apiURL]);
-				} else {
-					def.reject();
-				}
-			} else {
-				RESUtils.runtime.ajax({
-					method: 'GET',
-					url: apiURL,
-					// aggressiveCache: true,
-					onload: function(response) {
-						try {
-							var json = JSON.parse(response.responseText);
-							if ('meta' in json && json.meta.status === 200) {
-								siteMod.calls[apiURL] = json;
-								def.resolve(elem, json);
-							} else {
-								siteMod.calls[apiURL] = null;
-								def.reject();
-							}
-						} catch (error) {
-							siteMod.calls[apiURL] = null;
+			RESUtils.runtime.ajax({
+				method: 'GET',
+				url: apiURL,
+				// aggressiveCache: true,
+				onload: function(response) {
+					try {
+						var json = JSON.parse(response.responseText);
+						if ('meta' in json && json.meta.status === 200) {
+							def.resolve(elem, json);
+						} else {
 							def.reject();
 						}
-					},
-					onerror: function(response) {
+					} catch (error) {
 						def.reject();
 					}
-				});
-			}
+				},
+				onerror: function(response) {
+					def.reject();
+				}
+			});
 		} else {
 			def.reject();
 		}

--- a/lib/modules/hosts/vidble.js
+++ b/lib/modules/hosts/vidble.js
@@ -1,6 +1,5 @@
 modules['showImages'].siteModules['vidble'] = {
 	domains: ['vidble.com'],
-	calls: {},
 	detect: function(href, elem) {
 		return href.indexOf('vidble.com') > 0;
 	},
@@ -9,7 +8,6 @@ modules['showImages'].siteModules['vidble'] = {
 			hashRe = /^https?:\/\/(?:www\.)?vidble.com\/show\/([a-z0-9]+)/i,
 			albumHashRe = /^https?:\/\/(?:www\.)?vidble.com\/album\/([a-z0-9]+)/i,
 			apiPrefix = location.protocol + '//vidble.com/album/',
-			siteMod = modules['showImages'].siteModules['vidble'],
 			groups = hashRe.exec(elem.href);
 
 		if (groups) {
@@ -20,35 +18,25 @@ modules['showImages'].siteModules['vidble'] = {
 				var apiURL = apiPrefix + 'album/' + encodeURIComponent(albumGroups[1]) + '?json=1';
 				elem.imgHash = albumGroups[1];
 
-				if (apiURL in siteMod.calls) {
-					if (siteMod.calls[apiURL] != null) {
-						def.resolve(elem, siteMod.calls[apiURL]);
-					} else {
-						def.reject();
-					}
-				} else {
-					RESUtils.runtime.ajax({
-						method: 'GET',
-						url: apiURL,
-						// aggressiveCache: true,
-						onload: function(response) {
-							if (response.status === 404) {
-								return def.reject();
-							}
-							try {
-								var json = JSON.parse(response.responseText);
-								siteMod.calls[apiURL] = json;
-								def.resolve(elem, json);
-							} catch (error) {
-								siteMod.calls[apiURL] = null;
-								def.reject();
-							}
-						},
-						onerror: function(response) {
+				RESUtils.runtime.ajax({
+					method: 'GET',
+					url: apiURL,
+					// aggressiveCache: true,
+					onload: function(response) {
+						if (response.status === 404) {
+							return def.reject();
+						}
+						try {
+							var json = JSON.parse(response.responseText);
+							def.resolve(elem, json);
+						} catch (error) {
 							def.reject();
 						}
-					});
-				}
+					},
+					onerror: function(response) {
+						def.reject();
+					}
+				});
 			}
 		}
 		return def.promise();

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1500,11 +1500,9 @@ modules['showImages'] = {
 			onload: function(response) {
 				try {
 					var json = JSON.parse(response.responseText);
-					siteMod.calls[apiURL] = json;
 					modules['showImages'].handleNoEmbedQuery(expandoButton, json);
 					def.resolve(expandoButton, json);
 				} catch (error) {
-					siteMod.calls[apiURL] = null;
 					def.reject();
 				}
 			},


### PR DESCRIPTION
Mainly this PR removes the caching (anti)pattern that appears in a lot of siteModules, where responses are cached in an object (i.e. only for one pageload) - so it only makes a difference when a link appears on the same page twice, which is uncommon (especially since RES ignores repeated links by default).
Technically it doesn't *hurt* anything, but I know that many people have blindly copied it when creating new siteModules (I probably have, at some point), so I think it's best to get rid of it.

And if we absolutely need to avoid sending the same request twice, we can use `aggressiveCache: true`, which does the exact same thing.

Also includes support for `tumblr.com/image/` URLs, a few other kinds of tumblr text posts - specifically `quote, link, chat, answer` - and better handling of tumblr image captions (the album caption is used if an image doesn't have a caption).