### PR TITLE
usernameHider: Add null check for accountSwitcher accounts

### DIFF
--- a/lib/modules/usernameHider.js
+++ b/lib/modules/usernameHider.js
@@ -113,9 +113,12 @@ modules['usernameHider'] = {
 		});
 	},
 	hideAccountSwitcherUsernames: function() {
-		modules['accountSwitcher'].options.accounts.value.forEach(function(account) {
-			modules['usernameHider'].hideUsername(account[0]);
-		});
+		var accounts = modules['accountSwitcher'].options.accounts.value;
+		if (accounts !== null) {
+			accounts.forEach(function(account) {
+				modules['usernameHider'].hideUsername(account[0]);
+			});
+		}
 	},
 	_hiddenUsername: {},
 	hideUsername: function(user) {


### PR DESCRIPTION
Fixes #1881. Could we potentially do a migration so that all users have the accounts value at least set to an empty array, so we don't require this null check anywhere?