### PR TITLE
Fixes #2230 - Support horizontal scrolling on subreddit manager bar

### DIFF
--- a/lib/core/res.css
+++ b/lib/core/res.css
@@ -46,6 +46,10 @@ body.res-console-open {
 #RESConsoleContent #contributeContents h1 {
 	margin-top: 40px;
 }
+#RESShortcuts.scrollable {
+	overflow-x: scroll;
+	max-width: 100%;
+}
 .RESDonateButton {
 	display: inline-block;
 	background-color: white;
@@ -1492,7 +1496,6 @@ a.bylink.parentlink {
 .edgescroll-bottom {
 	bottom: 0;
 }
-
 
 /*
 tr looks funny with ::after

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -350,6 +350,8 @@ modules['subredditManager'] = {
 	},
 	redrawShortcuts: function() {
 		this.shortCutsContainer.textContent = '';
+		this.shortCutsContainer.classList.add('scrollable');
+
 		// Try Refresh subreddit shortcuts
 		if (this.mySubredditShortcuts.length === 0) {
 			this.getLatestShortcuts();


### PR DESCRIPTION
Fixes #2230. This makes the subreddit manager bar scroll horizontally if it overflows. If this should be feature flagged, util addCss'ed, etc. please let me know. First-time contributor so apologies in advance.