### PR TITLE
Minor siteModule cleanup

### DIFF
--- a/lib/modules/hosts/gfycat.js
+++ b/lib/modules/hosts/gfycat.js
@@ -1,24 +1,14 @@
 modules['showImages'].siteModules['gfycat'] = {
 	domains: ['gfycat.com'],
-	options: {
-		'prefer RES support': {
-			description: 'Prefer RES support for gfycat rather than reddit\'s built in support',
-			value: true,
-			type: 'boolean'
-		}
-	},
 	detect: function(href, elem) {
-		return href.indexOf('gfycat.com') !== -1 && href.substring(-1) !== '+';
+		return href.substring(-1) !== '+';
 	},
 	handleLink: function(elem) {
 		var hashRe = /^https?:\/\/(?:[\w]+.)?gfycat\.com\/(\w+)(?:\.gif)?/i,
 			def = $.Deferred(),
-			siteMod = modules['showImages'].siteModules['gfycat'],
-			groups = hashRe.exec(elem.href),
-			existingExpando = $(elem).closest('.entry').find('.expando-button.video:not(.commentImg)');
+			groups = hashRe.exec(elem.href);
 
-		if (groups && (siteMod.options['prefer RES support'].value || existingExpando.length === 0)) {
-			existingExpando.remove();
+		if (groups) {
 			var apiURL = location.protocol + '//gfycat.com/cajax/get/' + encodeURIComponent(groups[1]);
 			RESUtils.runtime.ajax({
 				method: 'GET',

--- a/lib/modules/hosts/giphy.js
+++ b/lib/modules/hosts/giphy.js
@@ -11,9 +11,6 @@ modules['showImages'].siteModules['giphy'] = {
 
 		if (!groups) return def.reject();
 
-		// remove the default reddit expando button
-		$(elem).closest('.entry').find('.expando-button.video:not(.commentImg)').remove();
-
 		var isHtml5 = (groups[2]) ? true : false;
 		var giphyUrl = location.protocol + '//giphy.com/gifs/' + groups[1];
 		var mp4Url = location.protocol + '//media.giphy.com/media/' + groups[1] + '/giphy.mp4';

--- a/lib/modules/hosts/raddit.js
+++ b/lib/modules/hosts/raddit.js
@@ -26,9 +26,6 @@ modules['showImages'].siteModules['raddit'] = {
 			groups = hashRe.exec(elem.href);
 
 		if (groups) {
-			// remove embedly's expando if present
-			$(elem).closest('.entry').find('.expando-button.video:not(.commentImg)').remove();
-
 			def.resolve(elem, '//embed.radd.it' + groups[1]);
 		} else {
 			def.reject();


### PR DESCRIPTION
98d9c22e7b3bb3629432fbf04a5dd3aa535c70fe removes existing expandos for any RES-handled post, so we don't need to do so in the siteModules.