### PR TITLE
L=C doesn't get set properly on search pages

### DIFF
--- a/lib/modules/singleClick.js
+++ b/lib/modules/singleClick.js
@@ -72,7 +72,7 @@ modules['singleClick'] = {
 					singleClickLink.setAttribute('class', 'redditSingleClick');
 					singleClickLink.setAttribute('thisLink', thisLink);
 					singleClickLink.setAttribute('thisComments', thisComments);
-					if (thisLink != thisComments) {
+					if (!$(entries[i]).closest('.thing').hasClass('self')) {
 						singleClickLink.textContent = '[l+c]';
 					} else if (!(modules['singleClick'].options.hideLEC.value)) {
 						singleClickLink.textContent = '[l=c]';


### PR DESCRIPTION
Fixes an issue [from reddit.](https://www.reddit.com/r/RESissues/comments/39zqd3/bug_single_click_opener_treats_self_posts/)

This'll be fine as long as nobody manages to guess their post's ID (good luck).