### PR TITLE
Removed OneDrive site dependency

### DIFF
--- a/Chrome/background.js
+++ b/Chrome/background.js
@@ -131,8 +131,8 @@ chrome.runtime.onMessage.addListener(
 				}
 				xhr.onreadystatechange = function() {
 					if (xhr.readyState === 4) {
-						// Only store `status` and `responseText` fields
-						var response = {status: xhr.status, responseText: xhr.responseText};
+						// Only store `status` and `responseText` and `responseURL` fields
+						var response = {status: xhr.status, responseText: xhr.responseText, responseURL: xhr.responseURL };
 						sendResponse(response);
 						// Only cache on HTTP OK and non empty body
 						if ((request.aggressiveCache || XHRCache.forceCache) && (xhr.status === 200 && xhr.responseText)) {

--- a/Chrome/background.js
+++ b/Chrome/background.js
@@ -131,7 +131,7 @@ chrome.runtime.onMessage.addListener(
 				}
 				xhr.onreadystatechange = function() {
 					if (xhr.readyState === 4) {
-						// Only store `status` and `responseText` and `responseURL` fields
+						// Only store `status`, `responseText` and `responseURL` fields
 						var response = {status: xhr.status, responseText: xhr.responseText, responseURL: xhr.responseURL };
 						sendResponse(response);
 						// Only cache on HTTP OK and non empty body

--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -190,6 +190,8 @@
 		"http://noembed.com/embed?url=*"
 	],
 	"optional_permissions": [
-		"https://api.twitter.com/*"
+		"https://api.twitter.com/*",
+		"https://onedrive.live.com/*",
+		"http://1drv.ms/*"
 	]
 }

--- a/lib/modules/hosts/onedrive.js
+++ b/lib/modules/hosts/onedrive.js
@@ -6,11 +6,11 @@ modules['showImages'].siteModules['onedrive'] = {
 	noChromePermission: false,
 	// Returns true/false to indicate whether the siteModule will attempt to handle the link.
 	// The only parameters are the actual URL and the anchor element.
-	detect: function (href, elem) {
+	detect: function(href, elem) {
 		return href.indexOf('onedrive.live.com/') !== -1 || href.indexOf('1drv.ms/') !== -1;
 	},
 
-	handleLink: function (elem) {
+	handleLink: function(elem) {
 		var def = $.Deferred();
 
 		var siteMod = modules['showImages'].siteModules['onedrive'];
@@ -22,9 +22,8 @@ modules['showImages'].siteModules['onedrive'] = {
 					method: 'GET',
 					url: elem.href,
 					aggressiveCache: true,
-					onload: function (response) {
-						if (response.responseText == "")
-						{
+					onload: function(response) {
+						if (response.responseText === '') {
 							siteMod.noChromePermission = true;
 							def.resolve(elem, { isShort: true });
 						} else {
@@ -40,7 +39,7 @@ modules['showImages'].siteModules['onedrive'] = {
 		return def.promise();
 	},
 
-	fetchJson: function (elem, href, def) {
+	fetchJson: function(elem, href, def) {
 		var hashRe = /(?:resid=|&id=)([a-z0-9!%]+)(?:.*&authkey=([a-z0-9%!_-]+)|)/i;
 		var groups = hashRe.exec(href);
 
@@ -51,13 +50,13 @@ modules['showImages'].siteModules['onedrive'] = {
 
 		var siteMod = modules['showImages'].siteModules['onedrive'];
 
-		var apiURL = 'https://api.onedrive.com/v1.0/drive/items/' + resId + (authKey != null ? '?authKey=' + authKey : '');
+		var apiURL = 'https://api.onedrive.com/v1.0/drive/items/' + resId + (authKey !== null ? '?authKey=' + authKey : '');
 
 		RESUtils.runtime.ajax({
 			method: 'GET',
 			url: apiURL,
 			aggressiveCache: true,
-			onload: function (response) {
+			onload: function(response) {
 				try {
 					var json = JSON.parse(response.responseText);
 					// An error happened, reject.
@@ -65,14 +64,14 @@ modules['showImages'].siteModules['onedrive'] = {
 
 					// The link is a folder, get its content instead.
 					if (json.folder !== undefined) {
-						var folderUrl = 'https://api.onedrive.com/v1.0/drive/items/' + resId + '/children' + (authKey != null ? '?authKey=' + authKey : '');
+						var folderUrl = 'https://api.onedrive.com/v1.0/drive/items/' + resId + '/children' + (authKey !== null ? '?authKey=' + authKey : '');
 
 
 						RESUtils.runtime.ajax({
 							method: 'GET',
 							url: folderUrl,
 							aggressiveCache: true,
-							onload: function (folderResponse) {
+							onload: function(folderResponse) {
 								var folderJson = JSON.parse(folderResponse.responseText);
 								// An error happend this time, reject.
 								if (json.error !== undefined) return def.reject();
@@ -80,7 +79,7 @@ modules['showImages'].siteModules['onedrive'] = {
 								json.files = folderJson.value;
 								def.resolve(elem, json);
 							},
-							onerror: function (folderResponse) {
+							onerror: function(folderResponse) {
 								def.reject();
 							}
 						});
@@ -104,7 +103,7 @@ modules['showImages'].siteModules['onedrive'] = {
 					def.reject();
 				}
 			},
-			onerror: function (response) {
+			onerror: function(response) {
 
 				def.reject();
 			}
@@ -113,25 +112,22 @@ modules['showImages'].siteModules['onedrive'] = {
 		return def.promise();
 	},
 
-	resolveElement: function (elem, info) {
+	resolveElement: function(elem, info) {
 		if (info.files === undefined) {
 
 			var type = info.file.mimeType.substring(0, info.file.mimeType.indexOf('/'));
 
 			switch (type) {
 				case 'video':
+					elem.type = 'VIDEO';
 					elem.expandoOptions = {
 						autoplay: false,
 						loop: false
 					};
-
-					var sources = [{
+					$(elem).data('sources', [{
 						'file': info['@content.downloadUrl'],
 						'type': info.file.mimeType
-					}];
-
-					elem.type = 'VIDEO';
-					$(elem).data('sources', sources);
+					}]);
 
 					if (RESUtils.pageType() === 'linklist') {
 						$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
@@ -148,17 +144,16 @@ modules['showImages'].siteModules['onedrive'] = {
 
 					break;
 				case 'audio':
+					elem.type = 'AUDIO';
 					elem.expandoOptions = {
 						autoplay: true,
 						loop: false
 					};
-					var sources = [{
+					$(elem).data('sources', [{
 						'file': info['@content.downloadUrl'],
 						'type': info.file.mimeType
-					}];
+					}]);
 
-					elem.type = 'AUDIO';
-					$(elem).data('sources', sources);
 					if (RESUtils.pageType() === 'linklist') {
 						$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
 					}
@@ -169,7 +164,7 @@ modules['showImages'].siteModules['onedrive'] = {
 		} else {
 			// Gallery
 
-			var gallery = info.files.filter(function (item) {
+			var gallery = info.files.filter(function(item) {
 				return item.file.mimeType.indexOf('image') !== -1;
 			});
 
@@ -177,7 +172,7 @@ modules['showImages'].siteModules['onedrive'] = {
 
 			if (gallery.length > 1) {
 				elem.type = 'GALLERY';
-				elem.src = gallery.map(function (e, i, a) {
+				elem.src = gallery.map(function(e, i, a) {
 
 					return {
 						src: e['@content.downloadUrl'],
@@ -203,7 +198,7 @@ modules['showImages'].siteModules['onedrive'] = {
 	// The second parameter should be module-specific data.
 	// A new $.Deferred object should be created and resolved/rejected as necessary and then returned.
 	// If resolving, the element should be passed.
-	handleInfo: function (elem, info) {
+	handleInfo: function(elem, info) {
 		var def = $.Deferred();
 
 		var siteMod = modules['showImages'].siteModules['onedrive'];
@@ -212,27 +207,27 @@ modules['showImages'].siteModules['onedrive'] = {
 			elem.expandoClass = ' selftext';
 			elem.doNotExpandInSelfText = BrowserDetect.isChrome();
 			elem.expandoOptions = {
-				generate: function () {
-					var genDef = $.Deferred().done(function (genElem, genInfo) {
+				generate: function() {
+					var genDef = $.Deferred().done(function(genElem, genInfo) {
 						genElem = siteMod.resolveElement(genElem, genInfo);
-						if (genElem == null) {
+						if (genElem === null) {
 							fail();
 						} else {
 							elem = genElem;
 						}
 
-						var target = $(genElem).closest('.entry').find(".expando-button")[0];
-						target.classList.remove("selftext");
+						var target = $(genElem).closest('.entry').find('.expando-button')[0];
+						target.classList.remove('selftext');
 						switch (elem.type) {
 							case 'IMAGE':
-								target.classList.add("image");
+								target.classList.add('image');
 								break;
 							case 'GALLERY':
-								target.classList.add("image gallery");
+								target.classList.add('image gallery');
 								break;
 							case 'AUDIO':
 							case 'VIDEO':
-								target.classList.add("video");
+								target.classList.add('video');
 								break;
 							default:
 								target.classList.add('selftext');
@@ -245,14 +240,13 @@ modules['showImages'].siteModules['onedrive'] = {
 
 					var expando = RESUtils.createElement('div', '', 'expando');
 
-					function run()
-					{
+					function run() {
 						RESUtils.runtime.ajax({
 							method: 'GET',
 							url: elem.href,
 							aggressiveCache: false,
-							onload: function (response) {
-								if (response.responseText == "") {
+							onload: function(response) {
+								if (response.responseText === '') {
 									genDef.reject();
 								} else {
 									siteMod.fetchJson(elem, response.responseURL, genDef);
@@ -275,7 +269,7 @@ modules['showImages'].siteModules['onedrive'] = {
 						};
 						// save a function call that'll run the expando if our permissions request
 						// comes back with a result of true
-						permissionQueue.onloads[permissionQueue.count] = function (hasPermission) {
+						permissionQueue.onloads[permissionQueue.count] = function(hasPermission) {
 							if (hasPermission) {
 								run();
 							} else {
@@ -286,7 +280,7 @@ modules['showImages'].siteModules['onedrive'] = {
 
 						// we do a noop in the callback here because we can't actually get a
 						// response - there's multiple async calls going on...
-						chrome.runtime.sendMessage(permissionsJSON, function (response) { });
+						chrome.runtime.sendMessage(permissionsJSON, function(response) { });
 					} else {
 						run();
 					}
@@ -297,7 +291,7 @@ modules['showImages'].siteModules['onedrive'] = {
 			def.resolve(elem);
 		} else {
 			elem = siteMod.resolveElement(elem, info);
-			if (elem == null)
+			if (elem === null)
 				def.reject();
 			else
 				def.resolve(elem);

--- a/lib/modules/hosts/onedrive.js
+++ b/lib/modules/hosts/onedrive.js
@@ -1,32 +1,38 @@
 modules['showImages'].siteModules['onedrive'] = {
-	domains: [ 'onedrive.live.com', '1drv.ms' ],
+	domains: ['onedrive.live.com', '1drv.ms'],
 	name: 'Microsoft OneDrive',
 	videoDetect: document.createElement('VIDEO'),
 	audioDetect: document.createElement('AUDIO'),
+	noChromePermission: false,
 	// Returns true/false to indicate whether the siteModule will attempt to handle the link.
 	// The only parameters are the actual URL and the anchor element.
-	detect: function(href, elem) {
+	detect: function (href, elem) {
 		return href.indexOf('onedrive.live.com/') !== -1 || href.indexOf('1drv.ms/') !== -1;
 	},
 
-	handleLink: function(elem) {
+	handleLink: function (elem) {
 		var def = $.Deferred();
-		var siteMod = modules['showImages'].siteModules['onedrive'];
 
+		var siteMod = modules['showImages'].siteModules['onedrive'];
 		if (elem.href.indexOf('1drv.ms/') !== -1) {
-			// Remove the protocol.
-			var href = elem.href.replace(/https?:\/\//, '');
-			RESUtils.runtime.ajax({
-				method: 'GET',
-				url: 'https://1.utilities.space/api/longurl/' + href,
-				aggressiveCache: true,
-				onload: function(response) {
-					siteMod.fetchJson(elem, response.responseText, def);
-				},
-				onerror: function(response) {
-					def.reject();
-				}
-			});
+			if (siteMod.noChromePermission) {
+				def.resolve(elem, { isShort: true });
+			} else {
+				RESUtils.runtime.ajax({
+					method: 'GET',
+					url: elem.href,
+					aggressiveCache: true,
+					onload: function (response) {
+						if (response.responseText == "")
+						{
+							siteMod.noChromePermission = true;
+							def.resolve(elem, { isShort: true });
+						} else {
+							siteMod.fetchJson(elem, response.responseURL, def);
+						}
+					}
+				});
+			}
 		} else {
 			siteMod.fetchJson(elem, elem.href, def);
 		}
@@ -34,7 +40,7 @@ modules['showImages'].siteModules['onedrive'] = {
 		return def.promise();
 	},
 
-	fetchJson: function(elem, href, def) {
+	fetchJson: function (elem, href, def) {
 		var hashRe = /(?:resid=|&id=)([a-z0-9!%]+)(?:.*&authkey=([a-z0-9%!_-]+)|)/i;
 		var groups = hashRe.exec(href);
 
@@ -45,13 +51,13 @@ modules['showImages'].siteModules['onedrive'] = {
 
 		var siteMod = modules['showImages'].siteModules['onedrive'];
 
-		var apiURL = 'https://api.onedrive.com/v1.0/drive/items/' + resId + '?authKey=' + authKey;
+		var apiURL = 'https://api.onedrive.com/v1.0/drive/items/' + resId + (authKey != null ? '?authKey=' + authKey : '');
 
 		RESUtils.runtime.ajax({
 			method: 'GET',
 			url: apiURL,
 			aggressiveCache: true,
-			onload: function(response) {
+			onload: function (response) {
 				try {
 					var json = JSON.parse(response.responseText);
 					// An error happened, reject.
@@ -59,13 +65,14 @@ modules['showImages'].siteModules['onedrive'] = {
 
 					// The link is a folder, get its content instead.
 					if (json.folder !== undefined) {
-						var folderUrl = 'https://api.onedrive.com/v1.0/drive/items/' + resId + '/children' + '?authKey=' + authKey;
+						var folderUrl = 'https://api.onedrive.com/v1.0/drive/items/' + resId + '/children' + (authKey != null ? '?authKey=' + authKey : '');
+
 
 						RESUtils.runtime.ajax({
 							method: 'GET',
 							url: folderUrl,
 							aggressiveCache: true,
-							onload: function(folderResponse) {
+							onload: function (folderResponse) {
 								var folderJson = JSON.parse(folderResponse.responseText);
 								// An error happend this time, reject.
 								if (json.error !== undefined) return def.reject();
@@ -73,7 +80,7 @@ modules['showImages'].siteModules['onedrive'] = {
 								json.files = folderJson.value;
 								def.resolve(elem, json);
 							},
-							onerror: function(folderResponse) {
+							onerror: function (folderResponse) {
 								def.reject();
 							}
 						});
@@ -97,7 +104,8 @@ modules['showImages'].siteModules['onedrive'] = {
 					def.reject();
 				}
 			},
-			onerror: function(response) {
+			onerror: function (response) {
+
 				def.reject();
 			}
 		});
@@ -105,85 +113,71 @@ modules['showImages'].siteModules['onedrive'] = {
 		return def.promise();
 	},
 
-	// This is where the embedding information is added to the link.
-	// handleInfo sits in the Deferred chain after handleLink
-	// and should receive both the element and a data object from handleLink.
-	// The first parameter should the same anchor element passed to handleLink.
-	// The second parameter should be module-specific data.
-	// A new $.Deferred object should be created and resolved/rejected as necessary and then returned.
-	// If resolving, the element should be passed.
-	handleInfo: function(elem, info) {
-		var def = $.Deferred();
-
+	resolveElement: function (elem, info) {
 		if (info.files === undefined) {
 
 			var type = info.file.mimeType.substring(0, info.file.mimeType.indexOf('/'));
-			var sources;
 
 			switch (type) {
-			case 'video':
-				elem.expandoOptions = {
-					autoplay: false,
-					loop: false
-				};
+				case 'video':
+					elem.expandoOptions = {
+						autoplay: false,
+						loop: false
+					};
 
-				sources = [{
-					'file': info['@content.downloadUrl'],
-					'type': info.file.mimeType
-				}];
+					var sources = [{
+						'file': info['@content.downloadUrl'],
+						'type': info.file.mimeType
+					}];
 
-				elem.type = 'VIDEO';
-				$(elem).data('sources', sources);
+					elem.type = 'VIDEO';
+					$(elem).data('sources', sources);
 
-				if (RESUtils.pageType() === 'linklist') {
-					$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
-				}
+					if (RESUtils.pageType() === 'linklist') {
+						$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
+					}
 
-				def.resolve(elem);
-				break;
-			case 'image':
-				elem.type = 'IMAGE';
-				elem.src = info['@content.downloadUrl'];
+					break;
+				case 'image':
+					elem.type = 'IMAGE';
+					elem.src = info['@content.downloadUrl'];
 
-				if (RESUtils.pageType() === 'linklist') {
-					$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
-				}
+					if (RESUtils.pageType() === 'linklist') {
+						$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
+					}
 
-				def.resolve(elem);
-				break;
-			case 'audio':
-				elem.expandoOptions = {
-					autoplay: true,
-					loop: false
-				};
-				sources = [{
-					'file': info['@content.downloadUrl'],
-					'type': info.file.mimeType
-				}];
+					break;
+				case 'audio':
+					elem.expandoOptions = {
+						autoplay: true,
+						loop: false
+					};
+					var sources = [{
+						'file': info['@content.downloadUrl'],
+						'type': info.file.mimeType
+					}];
 
-				elem.type = 'AUDIO';
-				$(elem).data('sources', sources);
-				if (RESUtils.pageType() === 'linklist') {
-					$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
-				}
-				def.resolve(elem);
-				break;
-			default:
-				def.reject();
-				break;
+					elem.type = 'AUDIO';
+					$(elem).data('sources', sources);
+					if (RESUtils.pageType() === 'linklist') {
+						$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
+					}
+					break;
+				default:
+					return null;
 			}
 		} else {
 			// Gallery
 
-			var gallery = info.files.filter(function(item) {
+			var gallery = info.files.filter(function (item) {
 				return item.file.mimeType.indexOf('image') !== -1;
 			});
 
-			if (gallery === null || gallery.length === 0) return def.reject();
+			if (gallery === null || gallery.length === 0) return null;
 
 			if (gallery.length > 1) {
 				elem.type = 'GALLERY';
-				elem.src = gallery.map(function(e, i, a) {
+				elem.src = gallery.map(function (e, i, a) {
 
 					return {
 						src: e['@content.downloadUrl'],
@@ -198,9 +192,116 @@ modules['showImages'].siteModules['onedrive'] = {
 					$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
 				}
 			}
-			def.resolve(elem);
 		}
+		return elem;
+	},
 
+	// This is where the embedding information is added to the link.
+	// handleInfo sits in the Deferred chain after handleLink
+	// and should receive both the element and a data object from handleLink.
+	// The first parameter should the same anchor element passed to handleLink.
+	// The second parameter should be module-specific data.
+	// A new $.Deferred object should be created and resolved/rejected as necessary and then returned.
+	// If resolving, the element should be passed.
+	handleInfo: function (elem, info) {
+		var def = $.Deferred();
+
+		var siteMod = modules['showImages'].siteModules['onedrive'];
+		if (info.isShort) {
+			elem.type = 'GENERIC_EXPANDO';
+			elem.expandoClass = ' selftext';
+			elem.doNotExpandInSelfText = BrowserDetect.isChrome();
+			elem.expandoOptions = {
+				generate: function () {
+					var genDef = $.Deferred().done(function (genElem, genInfo) {
+						genElem = siteMod.resolveElement(genElem, genInfo);
+						if (genElem == null) {
+							fail();
+						} else {
+							elem = genElem;
+						}
+
+						var target = $(genElem).closest('.entry').find(".expando-button")[0];
+						target.classList.remove("selftext");
+						switch (elem.type) {
+							case 'IMAGE':
+								target.classList.add("image");
+								break;
+							case 'GALLERY':
+								target.classList.add("image gallery");
+								break;
+							case 'AUDIO':
+							case 'VIDEO':
+								target.classList.add("video");
+								break;
+							default:
+								target.classList.add('selftext');
+								break;
+						}
+						modules['showImages'].revealImage(target, target.classList.contains('collapsedExpando'));
+					}).fail(function() {
+						fail();
+					});
+
+					var expando = RESUtils.createElement('div', '', 'expando');
+
+					function run()
+					{
+						RESUtils.runtime.ajax({
+							method: 'GET',
+							url: elem.href,
+							aggressiveCache: false,
+							onload: function (response) {
+								if (response.responseText == "") {
+									genDef.reject();
+								} else {
+									siteMod.fetchJson(elem, response.responseURL, genDef);
+								}
+							}
+						});
+					}
+
+					function fail() {
+						$(expando).html('<span class="error">Error loading OneDrive file.</span>');
+					}
+
+					if (BrowserDetect.isChrome()) {
+						var permissionsJSON = {
+							requestType: 'permissions',
+							callbackID: permissionQueue.count,
+							data: {
+								origins: ['http://1drv.ms/*', 'https://onedrive.live.com/*']
+							}
+						};
+						// save a function call that'll run the expando if our permissions request
+						// comes back with a result of true
+						permissionQueue.onloads[permissionQueue.count] = function (hasPermission) {
+							if (hasPermission) {
+								run();
+							} else {
+								fail();
+							}
+						};
+						permissionQueue.count++;
+
+						// we do a noop in the callback here because we can't actually get a
+						// response - there's multiple async calls going on...
+						chrome.runtime.sendMessage(permissionsJSON, function (response) { });
+					} else {
+						run();
+					}
+
+					return expando;
+				}
+			};
+			def.resolve(elem);
+		} else {
+			elem = siteMod.resolveElement(elem, info);
+			if (elem == null)
+				def.reject();
+			else
+				def.resolve(elem);
+		}
 		return def.promise();
 	}
 };


### PR DESCRIPTION
The old implementation of the OneDrive host used an external URL extender for 1drv.ms links because Chrome doesn't allow CORS requests without permissions.

I've re-implemented it so it is no longer depended on the site and now it will ask for optional permissions. The only problem atm is that it will show a message about Twitter if they disallowed it.

If the user already gave permission it will load regularly, if they haven't given permission the expando will show up as a selftext and on open it will transform to the proper expando (if they've given access).

It required changes to the `background.js` from Chrome because I needed the responseURL field of the xhr requests. I'm not entirely sure if this is the best way because it caches extra info for all requests?

I've tested it a lot on Google Chrome, might need some extra testing on other browsers.