### PR TITLE
quickMessage: refine .content selector

### DIFF
--- a/lib/modules/quickMessage.js
+++ b/lib/modules/quickMessage.js
@@ -172,7 +172,7 @@ addModule('quickMessage', function(module, moduleID) {
 			}
 		}
 		if (module.options.handleContentLinks.value) {
-			$('div.content').on('click', 'a[href*="/message/compose"]', messageLinkEventHandler);
+			$('div.content[role="main"]').on('click', 'a[href*="/message/compose"]', messageLinkEventHandler);
 		}
 		if (module.options.handleSideLinks.value) {
 			$('div.side').on('click', 'a[href*="/message/compose"]', messageLinkEventHandler);


### PR DESCRIPTION
Otherwise we end up with two overlapping listeners on "error" pages (i.e. "this sub is private" pages).