### PR TITLE
utils: fix minor getUrlParams issue

### DIFF
--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -129,14 +129,15 @@ RESUtils.getUrlParams = function(url) {
 		re = /([^&=]+)=([^&]*)/g,
 		m, queryString;
 	if (url) {
-		var beginning = url.lastIndexOf('?');
-		if (beginning !== -1) {
-			queryString = url.substr(beginning + 1);
+		var fullUrlRe = /\?((?:[^&=]+=[^&]*?&?)+)(?:#[^&]*)?$/;
+		var groups = fullUrlRe.exec(url);
+		if (groups) {
+			queryString = groups[1];
 		} else {
 			return {};
 		}
 	} else {
-		queryString = location.search.substring(1);
+		queryString = location.search.substr(1);
 	}
 	while ((m = re.exec(queryString))) {
 		result[decodeURIComponent(m[1])] = decodeURIComponent(m[2]);


### PR DESCRIPTION
This would cause issues when clicking message links like `/message/compose?to=/r/enhancement#header`.