### PR TITLE
utils: Use event.target instead of eventTarget

### DIFF
--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -1559,7 +1559,7 @@ RESUtils.initObservers = function() {
 			// Opera doesn't support MutationObserver - so we need this for Opera support.
 			if (siteTable) {
 				siteTable.addEventListener('DOMNodeInserted', function(event) {
-					if ($(eventTarget).is(RESUtils.thing.prototype.containerSelector)) {
+					if ($(event.target).is(RESUtils.thing.prototype.containerSelector)) {
 						RESUtils.watchers.siteTable.forEach(function(callback) {
 							if (callback) callback(event.target);
 						});


### PR DESCRIPTION
`eventTarget` doesn't exist, and `event.target` seems like the best replacement.