### PR TITLE
Remove duplicate buttons on new search page

### DIFF
--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -867,7 +867,7 @@ modules['dashboard'] = {
 		};
 	},
 	addDashboardShortcuts: function() {
-		var subButtons = document.querySelectorAll('.fancy-toggle-button');
+		var subButtons = document.querySelectorAll('.side .fancy-toggle-button');
 		for (var h = 0, len = subButtons.length; h < len; h++) {
 			var subButton = subButtons[h],
 				isMulti, thisSubredditFragment;

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -240,7 +240,7 @@ modules['subredditManager'] = {
 		// Listen for subscriptions / unsubscriptions from reddits so we know to reload the JSON string...
 		// also, add a +/- shortcut button...
 		if (RESUtils.currentSubreddit() && this.options.subredditShortcut.value) {
-			var subButtons = document.querySelectorAll('.fancy-toggle-button');
+			var subButtons = document.querySelectorAll('.side .fancy-toggle-button');
 			Array.prototype.slice.call(subButtons).forEach(function(subButton) {
 				var thisSubredditFragment, isMulti;
 				if ((RESUtils.currentSubreddit().indexOf('+') === -1) && (RESUtils.currentSubreddit() !== 'mod')) {


### PR DESCRIPTION
Prevents this from happening: 
![reddit-search-dupe-btns](https://cloud.githubusercontent.com/assets/7245595/8519316/3345d514-2415-11e5-95b4-389e9ef074d7.png)

[Check for yourself.](https://www.reddit.com/r/funny/search?q=search&sort=relevance&t=all)

It's odd that `.side` wasn't specified in the first place, is there a reason for that?