### PR TITLE
Image albums style cleanup

### DIFF
--- a/lib/core/res.css
+++ b/lib/core/res.css
@@ -1217,14 +1217,14 @@ img {
 .expando-button.video-muted.expanded:hover {background-position: 0 -536px; }
 
 .madeVisible { clear: left; display: block; overflow: hidden; }
-.madeVisible a { display: inline-block; overflow: hidden; }
+.madeVisible a.madeVisible { display: inline-block; overflow: hidden; }
 .RESImage { display: block !important;  }
 .RESImage.loaded { position: absolute;  }
 .RESImagePlaceholder { float: left; display: block !important; }
 .RESdupeimg { color: #000; font-size: 10px;  }
 .RESClear { clear: both; margin-bottom: 10px;  }
 
-.RESGalleryControls span { position: relative; top: -9px; }
+.RESGalleryControls span { line-height: 16px; vertical-align: bottom; padding: 0 5px; font-size: 11px; }
 .RESGalleryControls .next::after, .RESGalleryControls .previous::after {
 	font-family: Batch;
 	content: '\F158';
@@ -1235,7 +1235,6 @@ img {
 	font-size: 18px;
 	line-height: 16px;
 	width: 16px;
-	margin: 5px;
 }
 .RESGalleryControls .next:hover::after, .RESGalleryControls .previous:hover::after {
 	color: #6286f4;
@@ -1248,9 +1247,18 @@ img {
 	-moz-transform: scaleX(-1);
 }
 
-.imgTitle {
+.imgTitle, .md h3.imgTitle {
 	font-size: 13px;
 	padding: 2px;
+	margin: 0;
+}
+h4.imgCaptions, .md h4.imgCaptions {
+	font-size: 11px;
+	font-weight: bold;
+	margin: 0;
+}
+div.imgCaptions, .md div.imgCaptions {
+	font-size: 11px;
 }
 .imgCredits {
 	font-size: 11px;

--- a/lib/core/res.css
+++ b/lib/core/res.css
@@ -1224,6 +1224,7 @@ img {
 .RESdupeimg { color: #000; font-size: 10px;  }
 .RESClear { clear: both; margin-bottom: 10px;  }
 
+.RESGalleryControls { margin-bottom: 10px; }
 .RESGalleryControls span { line-height: 16px; vertical-align: bottom; padding: 0 5px; font-size: 11px; }
 .RESGalleryControls .next::after, .RESGalleryControls .previous::after {
 	font-family: Batch;
@@ -1249,7 +1250,6 @@ img {
 
 .imgTitle, .md h3.imgTitle {
 	font-size: 13px;
-	padding: 2px;
 	margin: 0;
 }
 h4.imgCaptions, .md h4.imgCaptions {


### PR DESCRIPTION
Restores consistency in albums between self and link submissions. This fixes a styling problem introduced when reddit changed their font sizes and line spacing within `.md` divs.

Screenshots showing exactly what this PR does: 
![image-albums-styling-02](https://cloud.githubusercontent.com/assets/7245595/8543245/cbdf9c5a-24de-11e5-8d4a-ab58f57d8bd1.png)

On the left is a self post and the right is a link submission (before & after).

I also modified the css on the controls because the current css is likely to cause headaches (e.g `top: -9px`).