### PR TITLE
Compatibility changes

### DIFF
--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -52,14 +52,14 @@ var escapeLookups = {
 };
 
 function escapeHTML(str) {
-	return (typeof str === 'undefined' || str === null) ?
+	return (str === undefined || str === null) ?
 		null :
 		str.toString().replace(/[&"<>]/g, function(m) {
 			return escapeLookups[m];
 		});
 }
 
-// this alias is to account for opera having different behavior...
+// This alias is to account for Opera having different behavior...
 if (typeof navigator === 'undefined') {
 	/* jshint -W020 */
 	navigator = window.navigator;
@@ -67,9 +67,9 @@ if (typeof navigator === 'undefined') {
 }
 
 var safeJSON = {
-	// safely parses JSON and won't kill the whole script if JSON.parse fails
-	// if localStorageSource is specified, will offer the user the ability to delete that localStorageSource to stop further errors.
-	// if silent is specified, it will fail silently...
+	// Safely parses JSON and won't kill the whole script if JSON.parse fails
+	// If localStorageSource is specified, will offer the user the ability to delete that localStorageSource to stop further errors.
+	// If silent is specified, it will fail silently...
 	parse: function(data, localStorageSource, silent) {
 		try {
 			data = RESUtils.runtime.sanitizeJSON(data);
@@ -81,9 +81,9 @@ var safeJSON = {
 			if (localStorageSource) {
 				var msg = 'Error caught: JSON parse failure on the following data from "' + localStorageSource + '": <textarea rows="5" cols="50">' + data + '</textarea><br>RES can delete this data to stop errors from happening, but you might want to copy/paste it to a text file so you can more easily re-enter any lost information.';
 				alert(msg, function() {
-					// back up a copy of the corrupt data
+					// Back up a copy of the corrupt data
 					localStorage.setItem(localStorageSource + '.error', data);
-					// delete the corrupt data
+					// Delete the corrupt data
 					RESStorage.removeItem(localStorageSource);
 				});
 			} else {

--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -66,16 +66,6 @@ if (typeof navigator === 'undefined') {
 	/* jshint +W020 */
 }
 
-//Because Safari 5.1 doesn't have Function.bind
-if (typeof Function.prototype.bind !== 'function') {
-	Function.prototype.bind = function(context) {
-		var oldRef = this;
-		return function() {
-			return oldRef.apply(context || null, Array.prototype.slice.call(arguments));
-		};
-	};
-}
-
 var safeJSON = {
 	// safely parses JSON and won't kill the whole script if JSON.parse fails
 	// if localStorageSource is specified, will offer the user the ability to delete that localStorageSource to stop further errors.


### PR DESCRIPTION
In particular, this removes the `Function.prototype.bind` polyfill that we should no longer need, given that Safari 5.1 is far, far away.