### PR TITLE
Increase max # of rows per dashboard widget

### DIFF
--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -83,6 +83,7 @@ modules['dashboard'] = {
 			}
 		}
 	},
+	MAX_ROWS: 100,
 	getLatestWidgets: function() {
 		try {
 			this.widgets = JSON.parse(RESStorage.getItem('RESmodules.dashboard.' + RESUtils.loggedInUser())) || [];
@@ -722,9 +723,9 @@ modules['dashboard'] = {
 					$('li[action="refresh"]').click();
 					break;
 				case 'addRow':
-					if (thisWidget.numPosts === 10) break;
+					if (thisWidget.numPosts === modules.dashboard.MAX_ROWS) break;
 					thisWidget.numPosts++;
-					if (thisWidget.numPosts === 10) $(thisWidget.stateControls).find('li[action=addRow]').addClass('disabled');
+					if (thisWidget.numPosts === modules.dashboard.MAX_ROWS) $(thisWidget.stateControls).find('li[action=addRow]').addClass('disabled');
 					$(thisWidget.stateControls).find('li[action=subRow]').removeClass('disabled');
 					modules['dashboard'].saveWidget(thisWidget.optionsObject());
 					thisWidget.update();


### PR DESCRIPTION
Reddit can serve up to 100 entries per request, so why not?

It won't be fun to manually increment it, but I guess you can always set the default to what you want and then add widgets.

[via reddit](https://www.reddit.com/r/Enhancement/comments/3cstep/feature_request_change_the_widget_cap_to_a_higher/)