### PR TITLE
Userbar: only indent username if toggle button exists

### DIFF
--- a/lib/modules/userbarHider.js
+++ b/lib/modules/userbarHider.js
@@ -85,7 +85,7 @@ addModule('userbarHider', function(module, moduleID) {
 	function addToggleButtonCSS() {
 		RESUtils.addCSS('#userbarToggle { min-height: 22px; position: absolute; top: auto; bottom: 0; left: -5px; width: 16px; padding-right: 3px; height: 100%; font-size: 15px; border-radius: 4px 0; color: #a1bcd6; display: inline-block; background-color: #dfecf9; border-right: 1px solid #cee3f8; cursor: pointer; text-align: right; line-height: 24px; }');
 		RESUtils.addCSS('#userbarToggle.userbarShow { min-height: 26px; }');
-		RESUtils.addCSS('#header-bottom-right #userbarToggle + * { margin-left: 16px; }');
+		RESUtils.addCSS('#header-bottom-right.res-userbar-toggle > .user { margin-left: 16px; }');
 		// RESUtils.addCSS('.userbarHide { background-position: 0 -137px; }');
 		RESUtils.addCSS('#userbarToggle.userbarShow { left: -12px; }');
 		RESUtils.addCSS('.res-navTop #userbarToggle.userbarShow { top: 0; bottom: auto; }');
@@ -97,6 +97,7 @@ addModule('userbarHider', function(module, moduleID) {
 	function addToggleButton() {
 		userbarToggle = RESUtils.createElement('div', 'userbarToggle');
 		userbarToggle.setAttribute('title', 'Toggle Userbar');
+		document.querySelector('#header-bottom-right').classList.add('res-userbar-toggle');
 		userbarToggle.addEventListener('click', function(e) {
 			toggleUserBar();
 		}, false);


### PR DESCRIPTION
Fixes #2368 

I tested it with usernameHider, but as far as I can tell there's no instance where `span.user` won't exist.