### PR TITLE
Universal class for subreddit-specific toggle buttons

### DIFF
--- a/lib/core/res.css
+++ b/lib/core/res.css
@@ -795,15 +795,16 @@ p.moduleListing {
 .res-subreddit-btn {
 	font: bold 10px verdana, sans-serif; /* allow line-height to be inherited */
 	color: white;
+	display: inline-block;
 	margin: 0 5px 5px 0;
 	padding: 1px 6px;
 	border: 1px solid rgb(68,68,68);
-	background: rgb(123,184,80) url(https://redditstatic.s3.amazonaws.com/bg-button-add.png) 0 100% repeat-x;
+	background-image: linear-gradient(to bottom, rgb(123,184,80), rgb(117,168,73));
 	border-radius: 3px;
 	cursor: pointer;
 }
 .res-subreddit-btn.remove {
-	background: rgb(207,97,101) url(https://redditstatic.s3.amazonaws.com/bg-button-remove.png) 0 100% repeat-x;
+	background-image: linear-gradient(to bottom, rgb(207,97,101), rgb(190,94,96));
 }
 #SearchRES-results-container + #SearchRES-boilerplate { margin-top: 1em; border-top: 1px black solid; padding-top: 1em; }
 #SearchRES-results-container li {

--- a/lib/core/res.css
+++ b/lib/core/res.css
@@ -790,6 +790,21 @@ p.moduleListing {
 #RESConsoleContent.advanced-options-disabled .SearchRES-result-item.advanced {
 	display: none;
 }
+/* Universal subreddit toggle button (subscribe, filter, shortcut, etc) */
+/* Borrowed from fancty-toggle-button */
+.res-subreddit-btn {
+	font: bold 10px verdana, sans-serif; /* allow line-height to be inherited */
+	color: white;
+	margin: 0 5px 5px 0;
+	padding: 1px 6px;
+	border: 1px solid rgb(68,68,68);
+	background: rgb(123,184,80) url(https://redditstatic.s3.amazonaws.com/bg-button-add.png) 0 100% repeat-x;
+	border-radius: 3px;
+	cursor: pointer;
+}
+.res-subreddit-btn.remove {
+	background: rgb(207,97,101) url(https://redditstatic.s3.amazonaws.com/bg-button-remove.png) 0 100% repeat-x;
+}
 #SearchRES-results-container + #SearchRES-boilerplate { margin-top: 1em; border-top: 1px black solid; padding-top: 1em; }
 #SearchRES-results-container li {
 	list-style-type: none;

--- a/lib/core/res.css
+++ b/lib/core/res.css
@@ -792,7 +792,7 @@ p.moduleListing {
 }
 /* Universal subreddit toggle button (subscribe, filter, shortcut, etc) */
 /* Borrowed from fancty-toggle-button */
-.res-subreddit-btn {
+.res-fancy-toggle-button {
 	font: bold 10px verdana, sans-serif; /* allow line-height to be inherited */
 	color: white;
 	display: inline-block;

--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -61,8 +61,6 @@ modules['dashboard'] = {
 	go: function() {
 		if (this.isEnabled()) {
 			this.getLatestWidgets();
-			RESUtils.addCSS('.RESDashboardToggle { margin-right: 5px; color: white; background-image: url(https://redditstatic.s3.amazonaws.com/bg-button-add.png); cursor: pointer; text-align: center; width: 68px; font-weight: bold; font-size: 10px; border: 1px solid #444; padding: 1px 6px; border-radius: 3px 3px 3px 3px;  }');
-			RESUtils.addCSS('.RESDashboardToggle.remove { background-image: url(https://redditstatic.s3.amazonaws.com/bg-button-remove.png) }');
 			if (this.isMatchURL()) {
 				if (this.options.menuItem.value) {
 					modules['RESMenu'].addMenuItem('<div id="DashboardLink"><a href="/r/Dashboard">my dashboard</a></div>', null, true);
@@ -892,7 +890,7 @@ modules['dashboard'] = {
 				}
 			}
 			var dashboardToggle = document.createElement('span');
-			dashboardToggle.setAttribute('class', 'REStoggle RESDashboardToggle');
+			dashboardToggle.setAttribute('class', 'res-subreddit-btn RESDashboardToggle');
 			dashboardToggle.setAttribute('data-subreddit', thisSubredditFragment);
 			var exists = this.widgets.some(function(widget) {
 				return (widget &&

--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -890,7 +890,7 @@ modules['dashboard'] = {
 				}
 			}
 			var dashboardToggle = document.createElement('span');
-			dashboardToggle.setAttribute('class', 'res-subreddit-btn RESDashboardToggle REStoggle');
+			dashboardToggle.setAttribute('class', 'res-fancy-toggle-button RESDashboardToggle REStoggle');
 			dashboardToggle.setAttribute('data-subreddit', thisSubredditFragment);
 			var exists = this.widgets.some(function(widget) {
 				return (widget &&

--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -890,7 +890,7 @@ modules['dashboard'] = {
 				}
 			}
 			var dashboardToggle = document.createElement('span');
-			dashboardToggle.setAttribute('class', 'res-subreddit-btn RESDashboardToggle');
+			dashboardToggle.setAttribute('class', 'res-subreddit-btn RESDashboardToggle REStoggle');
 			dashboardToggle.setAttribute('data-subreddit', thisSubredditFragment);
 			var exists = this.widgets.some(function(widget) {
 				return (widget &&

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -666,8 +666,6 @@ modules['filteReddit'] = {
 	},
 	beforeLoad: function() {
 		if (this.isEnabled()) {
-			RESUtils.addCSS('.RESFilterToggle { margin-right: 5px; color: white; background-image: url(https://redditstatic.s3.amazonaws.com/bg-button-add.png); cursor: pointer; text-align: center; width: 68px; font-weight: bold; font-size: 10px; border: 1px solid #444; padding: 1px 6px; border-radius: 3px 3px 3px 3px;  }');
-			RESUtils.addCSS('.RESFilterToggle.remove { background-image: url(https://redditstatic.s3.amazonaws.com/bg-button-remove.png) }');
 			RESUtils.addCSS('.RESFiltered { display: none !important; }');
 			if (this.options.NSFWfilter.value && this.isEnabled() && this.isMatchURL()) {
 				this.addNSFWFilterStyle();

--- a/lib/modules/subredditInfo.js
+++ b/lib/modules/subredditInfo.js
@@ -83,7 +83,7 @@ modules['subredditInfo'] = {
 			var subscribeToggle = $('<span />');
 			subscribeToggle
 				.attr('id', 'RESHoverInfoSubscriptionButton')
-				.addClass('res-subreddit-btn')
+				.addClass('res-fancy-toggle-button')
 				.css('margin-left', '12px')
 				.hide()
 				.on('click', modules['subredditInfo'].toggleSubscription);
@@ -143,7 +143,7 @@ modules['subredditInfo'] = {
 		// bottom buttons will include: +filter +shortcut +dashboard (maybe sub/unsub too?)
 		if (modules['subredditManager'].isEnabled()) {
 			var theSC = document.createElement('span');
-			theSC.setAttribute('class', 'REStoggle RESshortcut res-subreddit-btn');
+			theSC.setAttribute('class', 'res-fancy-toggle-button REStoggle RESshortcut');
 			theSC.setAttribute('data-subreddit', jsonData.data.display_name.toLowerCase());
 			var idx = modules['subredditManager'].mySubredditShortcuts.findIndex(function(shortcut) {
 				return shortcut.subreddit.toLowerCase() === jsonData.data.display_name.toLowerCase();
@@ -162,7 +162,7 @@ modules['subredditInfo'] = {
 		}
 		if (modules['dashboard'].isEnabled()) {
 			var dashboardToggle = document.createElement('span');
-			dashboardToggle.setAttribute('class', 'res-subreddit-btn RESDashboardToggle');
+			dashboardToggle.setAttribute('class', 'res-fancy-toggle-button RESDashboardToggle');
 			dashboardToggle.setAttribute('data-subreddit', jsonData.data.display_name.toLowerCase());
 			exists = modules['dashboard'].widgets.some(function(widget) {
 				return widget && (widget.basePath.toLowerCase() === '/r/' + jsonData.data.display_name.toLowerCase());
@@ -180,7 +180,7 @@ modules['subredditInfo'] = {
 		}
 		if (modules['filteReddit'].isEnabled()) {
 			var filterToggle = document.createElement('span');
-			filterToggle.setAttribute('class', 'res-subreddit-btn RESFilterToggle');
+			filterToggle.setAttribute('class', 'res-fancy-toggle-button RESFilterToggle');
 			filterToggle.setAttribute('data-subreddit', jsonData.data.display_name.toLowerCase());
 			var filteredReddits = modules['filteReddit'].options.subreddits.value;
 			exists = filteredReddits.some(function(reddit) {

--- a/lib/modules/subredditInfo.js
+++ b/lib/modules/subredditInfo.js
@@ -143,7 +143,7 @@ modules['subredditInfo'] = {
 		// bottom buttons will include: +filter +shortcut +dashboard (maybe sub/unsub too?)
 		if (modules['subredditManager'].isEnabled()) {
 			var theSC = document.createElement('span');
-			theSC.setAttribute('class', 'RESshortcut res-subreddit-btn');
+			theSC.setAttribute('class', 'REStoggle RESshortcut res-subreddit-btn');
 			theSC.setAttribute('data-subreddit', jsonData.data.display_name.toLowerCase());
 			var idx = modules['subredditManager'].mySubredditShortcuts.findIndex(function(shortcut) {
 				return shortcut.subreddit.toLowerCase() === jsonData.data.display_name.toLowerCase();

--- a/lib/modules/subredditInfo.js
+++ b/lib/modules/subredditInfo.js
@@ -83,7 +83,7 @@ modules['subredditInfo'] = {
 			var subscribeToggle = $('<span />');
 			subscribeToggle
 				.attr('id', 'RESHoverInfoSubscriptionButton')
-				.addClass('RESFilterToggle')
+				.addClass('res-subreddit-btn')
 				.css('margin-left', '12px')
 				.hide()
 				.on('click', modules['subredditInfo'].toggleSubscription);
@@ -143,8 +143,7 @@ modules['subredditInfo'] = {
 		// bottom buttons will include: +filter +shortcut +dashboard (maybe sub/unsub too?)
 		if (modules['subredditManager'].isEnabled()) {
 			var theSC = document.createElement('span');
-			theSC.setAttribute('style', 'display: inline-block !important;');
-			theSC.setAttribute('class', 'REStoggle RESshortcut RESshortcutside');
+			theSC.setAttribute('class', 'RESshortcut res-subreddit-btn');
 			theSC.setAttribute('data-subreddit', jsonData.data.display_name.toLowerCase());
 			var idx = modules['subredditManager'].mySubredditShortcuts.findIndex(function(shortcut) {
 				return shortcut.subreddit.toLowerCase() === jsonData.data.display_name.toLowerCase();
@@ -163,7 +162,7 @@ modules['subredditInfo'] = {
 		}
 		if (modules['dashboard'].isEnabled()) {
 			var dashboardToggle = document.createElement('span');
-			dashboardToggle.setAttribute('class', 'RESDashboardToggle');
+			dashboardToggle.setAttribute('class', 'res-subreddit-btn RESDashboardToggle');
 			dashboardToggle.setAttribute('data-subreddit', jsonData.data.display_name.toLowerCase());
 			exists = modules['dashboard'].widgets.some(function(widget) {
 				return widget && (widget.basePath.toLowerCase() === '/r/' + jsonData.data.display_name.toLowerCase());
@@ -181,7 +180,7 @@ modules['subredditInfo'] = {
 		}
 		if (modules['filteReddit'].isEnabled()) {
 			var filterToggle = document.createElement('span');
-			filterToggle.setAttribute('class', 'RESFilterToggle');
+			filterToggle.setAttribute('class', 'res-subreddit-btn RESFilterToggle');
 			filterToggle.setAttribute('data-subreddit', jsonData.data.display_name.toLowerCase());
 			var filteredReddits = modules['filteReddit'].options.subreddits.value;
 			exists = filteredReddits.some(function(reddit) {

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -264,7 +264,7 @@ modules['subredditManager'] = {
 					RESStorage.setItem('RESmodules.subredditManager.subreddits.lastCheck.' + RESUtils.loggedInUser(), 0);
 				}, false);
 				var theSC = document.createElement('span');
-				theSC.setAttribute('class', 'RESshortcut RESshortcutside res-subreddit-btn');
+				theSC.setAttribute('class', 'res-fancy-toggle-button RESshortcut RESshortcutside');
 				theSC.setAttribute('data-subreddit', thisSubredditFragment);
 				var idx = modules['subredditManager'].mySubredditShortcuts.findIndex(function(shortcut) {
 					return shortcut.subreddit.toLowerCase() === thisSubredditFragment.toLowerCase();
@@ -307,7 +307,7 @@ modules['subredditManager'] = {
 			var subreddit = $(this).find('a.title').attr('href').match(/^https?:\/\/(?:[a-z]+).reddit.com\/r\/([\w]+).*/i)[1],
 				$theSC = $('<span>')
 					.css({'margin-right': '0'})
-					.addClass('res-subreddit-btn')
+					.addClass('res-fancy-toggle-button')
 					.data('subreddit', subreddit),
 				isShortcut = modules['subredditManager'].mySubredditShortcuts.some(function(shortcut) {
 					return shortcut.subreddit === subreddit;

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -264,7 +264,7 @@ modules['subredditManager'] = {
 					RESStorage.setItem('RESmodules.subredditManager.subreddits.lastCheck.' + RESUtils.loggedInUser(), 0);
 				}, false);
 				var theSC = document.createElement('span');
-				theSC.setAttribute('class', 'RESshortcutside res-subreddit-btn');
+				theSC.setAttribute('class', 'RESshortcut RESshortcutside res-subreddit-btn');
 				theSC.setAttribute('data-subreddit', thisSubredditFragment);
 				var idx = modules['subredditManager'].mySubredditShortcuts.findIndex(function(shortcut) {
 					return shortcut.subreddit.toLowerCase() === thisSubredditFragment.toLowerCase();
@@ -306,7 +306,7 @@ modules['subredditManager'] = {
 
 			var subreddit = $(this).find('a.title').attr('href').match(/^https?:\/\/(?:[a-z]+).reddit.com\/r\/([\w]+).*/i)[1],
 				$theSC = $('<span>')
-					.css({'margin-right': '0', 'line-height': '20px'}) // same as subscribe btn.
+					.css({'margin-right': '0'})
 					.addClass('res-subreddit-btn')
 					.data('subreddit', subreddit),
 				isShortcut = modules['subredditManager'].mySubredditShortcuts.some(function(shortcut) {

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -173,9 +173,6 @@ modules['subredditManager'] = {
 			RESUtils.addCSS('#RESShortcutsSort { font-size: 14px; }');
 			RESUtils.addCSS('#RESShortcutsTrash { display: none; font-size: 17px; width: 16px; cursor: pointer; right: 15px; height: 16px; position: absolute; top: 0; z-index: 1000; user-select: none; -webkit-user-select: none; -moz-user-select: none; }');
 			RESUtils.addCSS('.srSep { margin-left: 6px; }');
-			RESUtils.addCSS('.RESshortcutside { margin-right: 5px; margin-top: 2px; color: white; background-image: url(https://redditstatic.s3.amazonaws.com/bg-button-add.png); cursor: pointer; text-align: center; width: 68px; font-weight: bold; font-size: 10px; border: 1px solid #444; padding: 1px 6px; border-radius: 3px 3px 3px 3px; }');
-			RESUtils.addCSS('.RESshortcutside.remove { background-image: url(https://redditstatic.s3.amazonaws.com/bg-button-remove.png) }');
-			RESUtils.addCSS('.RESshortcutside:hover { background-color: #f0f0ff; }');
 			// RESUtils.addCSS('h1.redditname > a { float: left; }');
 			RESUtils.addCSS('h1.redditname { overflow: auto; }');
 			RESUtils.addCSS('.sortAsc, .sortDesc { float: right; }');
@@ -267,8 +264,7 @@ modules['subredditManager'] = {
 					RESStorage.setItem('RESmodules.subredditManager.subreddits.lastCheck.' + RESUtils.loggedInUser(), 0);
 				}, false);
 				var theSC = document.createElement('span');
-				theSC.setAttribute('style', 'display: inline-block !important;');
-				theSC.setAttribute('class', 'RESshortcut RESshortcutside');
+				theSC.setAttribute('class', 'RESshortcutside res-subreddit-btn');
 				theSC.setAttribute('data-subreddit', thisSubredditFragment);
 				var idx = modules['subredditManager'].mySubredditShortcuts.findIndex(function(shortcut) {
 					return shortcut.subreddit.toLowerCase() === thisSubredditFragment.toLowerCase();

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -306,11 +306,8 @@ modules['subredditManager'] = {
 
 			var subreddit = $(this).find('a.title').attr('href').match(/^https?:\/\/(?:[a-z]+).reddit.com\/r\/([\w]+).*/i)[1],
 				$theSC = $('<span>')
-					.css({
-						display: 'inline-block',
-						'margin-right': '0'
-					})
-					.addClass('RESshortcut RESshortcutside')
+					.css({'margin-right': '0', 'line-height': '20px'}) // same as subscribe btn.
+					.addClass('res-subreddit-btn')
 					.data('subreddit', subreddit),
 				isShortcut = modules['subredditManager'].mySubredditShortcuts.some(function(shortcut) {
 					return shortcut.subreddit === subreddit;


### PR DESCRIPTION
subredditInfo.js relied on filteReddit.js to apply the correct style to the subscribe button. This PR creates a universal class based on fancy-toggle-button which is module-independent, and removes doubled-up CSS.

I named the class res-subreddit-btn because all the relevant buttons perform subreddit actions: subscribe, shortcut, dashboard, filter. This doesn't touch the +friends button because that uses reddit's class names.