### PR TITLE
Big Nightmode Update

### DIFF
--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -136,9 +136,6 @@ addModule('nightMode', function(module, moduleID) {
 
 		// If night mode is on and the sub isn't compatible, disable its stylesheet.
 		if (module.isNightModeOn() && !module.isNightmodeCompatible) {
-			// Hide header images since sub isn't night mode compatible and therefore they
-			// may be bright images, etc.
-			RESUtils.addCSS('.res-nightmode #header, .res-nightmode #header-bottom-left { background: #666660 !important; }');
 			modules['styleTweaks'].disableSubredditStyle();
 		}
 	},

--- a/lib/modules/nightmode.css
+++ b/lib/modules/nightmode.css
@@ -56,7 +56,8 @@
 .res-nightmode #RESHoverContainer:after {
 	border-color: transparent #222;
 }
-.res-nightmode .sr-interest-bar {
+.res-nightmode .sr-interest-bar,
+.res-nightmode.liveupdate-app .content {
 	background-color: rgb(22,22,22);
 }
 .res-nightmode .entry .buttons li a,
@@ -95,7 +96,8 @@
 	background-color: #888;
 	color: #eee;
 }
-.res-nightmode #header {
+.res-nightmode #header,
+.res-nightmode .liveupdate-home .content {
 	background-color: rgb(105,105,105);
 }
 .res-nightmode #jumpToContent {
@@ -296,6 +298,9 @@
 .res-nightmode .reported {
 	background: none;
 	border: 1px dotted;
+}
+.res-nightmode #report form {
+	background-color: rgb(76,61,61);
 }
 .res-nightmode .reason-prompt,
 .res-nightmode .report-action-form li,
@@ -633,10 +638,17 @@
 .res-nightmode .RESNotification,
 .res-nightmode .c-close,
 .res-nightmode #REScommentNavBox,
-.res-nightmode #BigEditor #BigText {
+.res-nightmode #BigEditor #BigText,
+.res-nightmode #liveupdate-statusbar,
+.res-nightmode #liveupdate-statusbar.complete {
 	border-color: rgb(76,76,76);
 	background-color: rgb(46, 46, 46);
 	color: #ccc;
+}
+.res-nightmode #liveupdate-statusbar.live.connected {
+  background-color: rgb(52, 75, 78);
+  border: 1px solid rgb(56, 88, 95);
+  color: inherit;
 }
 .res-nightmode .RESHoverInfoCard:before {
   border-right-color: rgb(76,76,76);
@@ -745,7 +757,9 @@
 .res-nightmode .combined-search-page .search-result .search-result-body,
 .res-nightmode .generic-table,
 .res-nightmode .message.message-reply.recipient>.entry .head,
-.res-nightmode .message.message-parent.recipient> .entry .head {
+.res-nightmode .message.message-parent.recipient> .entry .head,
+.res-nightmode .linefield .title,
+.res-nightmode .liveupdate-listing li.liveupdate:hover time {
 	color: inherit;
 }
 .res-nightmode .nextprev a:hover,
@@ -849,7 +863,6 @@ html.res-nightmode .multi-details .subreddits .remove-sr {
 	background-color: rgb(218, 208, 179);
 	color: #000;
 }
-.res-nightmode .liveupdate-listing table tr:hover th time,
 .res-nightmode .policy-page .md p  {
 	color: #eee;
 }
@@ -867,10 +880,6 @@ body.res-nightmode,
 .res-nightmode #BigEditor .markdownEditor a,
 .res-nightmode #BigEditor .markdownEditor .RESMacroDropdownTitle {
 	color: #ccc;
-}
-.res-nightmode .liveupdate-listing table tr.separator time {
-	background: #666;
-	color: #fff;
 }
 .res-nightmode .server-seconds {
 	background: #333;
@@ -952,7 +961,8 @@ body.res-nightmode,
 .res-nightmode .RESDashboardComponent .RESDashboardComponentHeader ul .updateTime,
 .res-nightmode .remove-self .option,
 .res-nightmode .moderator.remove-self .option,
-.res-nightmode .message-count {
+.res-nightmode .message-count,
+.res-nightmode .usertable > .toggle {
 	color: #222;
 }
 .res-nightmode .gold-accent {
@@ -975,7 +985,6 @@ body.res-nightmode,
 }
 .res-nightmode .white-field,
 .res-nightmode .delete-field,
-.res-nightmode .liveupdate-listing table tr.separator td,
 .res-nightmode .RESDialogSmall.livePreview .md.RESDialogContents,
 .res-nightmode .moderator .traffic-table tbody tr:nth-child(even),
 .res-nightmode .thing .expando-button,
@@ -990,11 +999,11 @@ body.res-nightmode,
 .res-nightmode .flairselector.drop-choices.active,
 .res-nightmode .message.threaded .child,
 .res-nightmode .comment .child,
-.res-nightmode .comment .showreplies {
-	border-color: rgb(76,76,76);
-}
+.res-nightmode .comment .showreplies,
 .res-nightmode .message.message-reply:not(.threaded) .entry,
-.res-nightmode .message.message-parent:not(.threaded) .entry {
+.res-nightmode .message.message-parent:not(.threaded) .entry,
+.res-nightmode.liveupdate-app .content,
+.res-nightmode .liveupdate-listing li.separator:before {
 	border-color: rgb(76,76,76);
 }
 .res-nightmode .comment .md p a[href="/spoiler"]:hover,
@@ -1021,7 +1030,8 @@ body.res-nightmode,
 .res-nightmode .markhelp table tr:first-child {
 	background-color: rgb(76,76,76) !important;
 }
-.res-nightmode .usertext .markhelp .spaces {
+.res-nightmode .usertext .markhelp .spaces,
+.res-nightmode .liveupdate-listing li.separator time {
 	background-color: rgb(76,76,76);
 }
 .res-nightmode .flair,

--- a/lib/modules/nightmode.css
+++ b/lib/modules/nightmode.css
@@ -251,9 +251,6 @@
 	border-color: #151515;
 	color: #aaa;
 }
-.res-nightmode .login-form-side .btn {
-	color: #111;
-}
 .res-nightmode .login-form-side .error {
 	color: rgb(205,90,90);
 }
@@ -575,16 +572,16 @@
 .res-nightmode .combined-search-page .search-result a,
 .res-nightmode .combined-search-page .search-result a>mark,
 .res-nightmode .hoverHelp {
-	color: rgb(20,150,220);
+	color: hsl(202,40%,61%);
 }
 .res-nightmode .flairselector li a {
-	color: rgb(20,150,220) !important;
+	color: hsl(202,40%,61%) !important;
 }
 .res-nightmode .thing .title:visited,
 .res-nightmode .thing.visited .title,
 .res-nightmode .combined-search-page .search-result a:visited,
 .res-nightmode .combined-search-page .search-result a:visited>mark {
-	color: rgb(129, 124, 187);
+	color: hsl(245,32%,61%);
 }
 .res-nightmode .flair-settings ~ .tabpane-content {
 	border-color: #111;
@@ -905,7 +902,7 @@ body.res-nightmode,
 }
 .res-nightmode .tagline .submitter,
 .res-nightmode .tagline .submitter:visited {
-	color: rgb(44,196,224);
+	color: rgb(20,150,220);
 }
 .res-nightmode .tagline .moderator,
 .res-nightmode .tagline .moderator:visited {
@@ -990,7 +987,14 @@ body.res-nightmode,
 }
 .res-nightmode .message.message-reply .entry,
 .res-nightmode .message.message-parent .entry,
-.res-nightmode .flairselector.drop-choices.active {
+.res-nightmode .flairselector.drop-choices.active,
+.res-nightmode .message.threaded .child,
+.res-nightmode .comment .child,
+.res-nightmode .comment .showreplies {
+	border-color: rgb(76,76,76);
+}
+.res-nightmode .message.message-reply:not(.threaded) .entry,
+.res-nightmode .message.message-parent:not(.threaded) .entry {
 	border-color: rgb(76,76,76);
 }
 .res-nightmode .comment .md p a[href="/spoiler"]:hover,

--- a/lib/modules/nightmode.css
+++ b/lib/modules/nightmode.css
@@ -51,10 +51,12 @@
 	background: #c7c7c7;
 }
 .res-nightmode .RESCloseButton {
-	background: #ddd;
+  border-color: rgb(76,76,76);
+	background-color: rgb(46,46,46);
 }
-.res-nightmode .tabmenu .selected a,
-.res-nightmode #header .tabmenu .selected a,
+.res-nightmode .RESCloseButton:hover {
+	background-color: rgb(46,46,46);
+}
 .res-nightmode .RESNotificationContent,
 .res-nightmode #commentNavCloseButton:hover {
 	background: #eee;
@@ -84,16 +86,12 @@
 .res-nightmode #BigEditor .markdownEditor .RESMacroDropdownList li:hover a {
 	color: rgb(187,187,187);
 }
+.res-nightmode .comment a:visited,
 .res-nightmode .comment .md p a:visited,
 .res-nightmode .new-comment .usertext-body .md p a:visited {
-	color: #369;
 }
 .res-nightmode .trophy-info .trophy-name {
 	color: #eee!important;
-}
-.res-nightmode .comment .md > p a:not(.madeVisible):hover {
-	opacity: .9;
-	text-decoration: underline;
 }
 .res-nightmode .submit-page .submit .formtab .selected a {
 	background: gray;
@@ -126,9 +124,8 @@
 	background-color: #888;
 	color: #eee;
 }
-.res-nightmode #header,
-.res-nightmode #REScommentNavBox {
-	background-color: #999;
+.res-nightmode #header {
+	background-color: rgb(105, 105, 105);
 }
 .res-nightmode #jumpToContent {
 	color: #ddd;
@@ -183,12 +180,6 @@
 }
 .res-nightmode .new-comment .usertext-body .md {
 	border: 1px #aaa dashed;
-}
-.res-nightmode .sitetable .moderator {
-	background-color: #282;
-}
-.res-nightmode .sitetable .admin {
-	background-color: #F01;
 }
 .res-nightmode .message ul {
 	color: #abc;
@@ -273,7 +264,9 @@
 .res-nightmode .moderator .footer-parent .footer {
 	background: #191919;
 }
-.res-nightmode .wiki-page .wiki-page-content .md.wiki>.toc ul {
+.res-nightmode .wiki-page .wiki-page-content .md.wiki>.toc ul,
+.res-nightmode .tabmenu .selected a,
+.res-nightmode #header .tabmenu .selected a {
 	background-color: #222;
 }
 .res-nightmode #RESDashboardAddComponent,
@@ -294,9 +287,6 @@
 .res-nightmode .RESDashboardComponent .RESDashboardComponentHeader ul li.active,
 .res-nightmode .RESDashboardComponent .RESDashboardComponentHeader ul li:hover {
 	background-color: #ccc;
-}
-.res-nightmode .entry .score {
-	color: #dde;
 }
 .res-nightmode .permission-summary {
 	border-color: transparent;
@@ -457,8 +447,8 @@ body.res-nightmode,
 .res-nightmode .nextprev img:hover {
 	opacity: .85;
 }
-.res-nightmode #header-bottom-left .tabmenu .selected a {
-	border-color: transparent;
+.res-nightmode .tabmenu .selected a {
+	border-bottom-color: #222;
 }
 .res-nightmode #ad-frame {
 	opacity: .8;
@@ -577,10 +567,6 @@ body.res-nightmode,
 	color: #eee;
 	font-size: 10px;
 }
-.res-nightmode .RES-keyNav-activeElement .title.loggedin:visited,
-.res-nightmode .RES-keyNav-activeElement .title:visited {
-	color: #dfdfdf;
-}
 .res-nightmode .link-button,
 .res-nightmode .text-button {
 	color: #444;
@@ -642,8 +628,7 @@ body.res-nightmode,
 .res-nightmode .traffic-table tr:nth-of-type(even) {
 	background-color: #181818;
 }
-.res-nightmode .report-form,
-.res-nightmode #authorInfoToolTip {
+.res-nightmode .report-form {
 	background-color: #666;
 	color: #ccc;
 	border-color: #888;
@@ -694,7 +679,8 @@ body.res-nightmode,
 }
 .res-nightmode .usertable tr:hover,
 .res-nightmode .moderator-table tr:hover,
-.res-nightmode .usertext.border .usertext-body {
+.res-nightmode .usertext.border .usertext-body,
+.res-nightmode .usertext.grayed .usertext-body {
 	background-color: #444;
 }
 .res-nightmode .tabmenu li a,
@@ -745,7 +731,6 @@ body.res-nightmode,
 .res-nightmode a[rel=tag],
 .res-nightmode .dsq-help,
 .res-nightmode #authorInfoToolTip h3 a,
-.res-nightmode .RES-keyNav-activeElement .md,
 .res-nightmode .help-toggle .option,
 .res-nightmode .morecomments a,
 .res-nightmode .reddiquette,
@@ -754,22 +739,11 @@ body.res-nightmode,
 .res-nightmode .combined-search-page .search-result a,
 .res-nightmode .combined-search-page .search-result a>mark,
 .res-nightmode .hoverHelp {
-	color: rgb(20,150,220);
+	color: rgb(100,140,160);
 }
 .res-nightmode .combined-search-page .search-result a:visited,
 .res-nightmode .combined-search-page .search-result a:visited>mark {
 	color: rgb(132,124,184);
-}
-.res-nightmode .RES-keyNav-activeElement .usertext .md a,
-.res-nightmode .RES-keyNav-activeElement .tagline a,
-.res-nightmode .RES-keyNav-activeElement .parent-link {
-	color: #8ad;
-}
-.res-nightmode .RES-keyNav-activeElement .tagline {
-	color: #bbb;
-}
-.res-nightmode .RES-keyNav-activeElement .usertext .md a:visited {
-	color: rgb(51,137,208);
 }
 .res-nightmode>.content>.spacer>.sitetable:before,
 .res-nightmode>.content>.sharelink~.sitetable:before,
@@ -802,15 +776,11 @@ body.res-nightmode,
 .res-nightmode .content .tabmenu li a {
 	color: #ccc;
 }
-.res-nightmode .RES-keyNav-activeElement .usertext-body .md blockquote p {
-	background: rgb(40,40,40)!important;
-}
 .res-nightmode .content .md blockquote {
-	border-left-color: #ccc;
-	color: #bbb;
+	color: rgb(160,160,160);
+	border-left-color: rgb(100,100,100);
 }
-.res-nightmode .subreddit .usertext .md,
-.res-nightmode .RESDialogSmall h3 {
+.res-nightmode .subreddit .usertext .md {
 	background-color: #222;
 	color: #ccc;
 }
@@ -848,10 +818,6 @@ body.res-nightmode,
 	color: #aaa;
 }
 .res-nightmode form .usertext-body,
-.res-nightmode .sitetable .moderator,
-.res-nightmode .sitetable .admin,
-.res-nightmode .sitetable .submitter,
-.res-nightmode .sitetable .friend,
 .res-nightmode .moderator .traffic-table tbody tr:nth-child(even),
 .res-nightmode .thing .expando-button,
 .res-nightmode .instructions,
@@ -866,9 +832,28 @@ body.res-nightmode,
 .res-nightmode .usertext-edit textarea,
 .res-nightmode .usertext-edit .RESDialogSmall .md,
 .res-nightmode .RESDialogSmall,
-.res-nightmode .c-close {
-	background-color: #666;
+.res-nightmode .c-close,
+.res-nightmode #REScommentNavBox {
+	border-color: rgb(76,76,76);
+	background-color: rgb(46, 46, 46);
 	color: #ccc;
+}
+.res-nightmode .RESHoverInfoCard:before {
+  border-right-color: rgb(76,76,76);
+}
+.res-nightmode .RESHoverInfoCard:after {
+  border-right-color: rgb(46,46,46);
+}
+.res-nightmode .RESHoverInfoCard.right:before {
+  border-left-color: rgb(76,76,76);
+}
+.res-nightmode .RESHoverInfoCard.right:after {
+  border-left-color: rgb(46,46,46);
+}
+.res-nightmode .RESDialogSmall > h3 {
+	color: inherit;
+	border-color: rgb(76,76,76);
+	background-color: transparent;
 }
 .res-nightmode .RESDialogSmall.livePreview .md.RESDialogContents {
 	background-color: transparent!important;
@@ -1097,4 +1082,20 @@ html.res-nightmode .multi-details .subreddits .remove-sr {
 .res-nightmode #userbarToggle {
 	background-color: rgb(93, 104, 115);
 	border-right-color: rgb(118, 133, 148);
+}
+.res-nightmode .tagline .submitter,
+.res-nightmode .tagline .submitter:visited {
+	color: rgb(20,150,220);
+}
+.res-nightmode .tagline .moderator,
+.res-nightmode .tagline .moderator:visited {
+	color: rgb(34,136,34)
+}
+.res-nightmode .tagline .admin,
+.res-nightmode .tagline .admin:visited {
+	color: rgb(218,73,83);
+}
+.res-nightmode .tagline .friend,
+.res-nightmode .tagline .friend:visited {
+  color: rgb(255,69,0);
 }

--- a/lib/modules/nightmode.css
+++ b/lib/modules/nightmode.css
@@ -2,7 +2,6 @@
 .res-nightmode body .content,
 .res-nightmode .modal-body,
 .res-nightmode .side,
-.res-nightmode .flairselector,
 .res-nightmode .linefield,
 .res-nightmode .icon-menu a,
 .res-nightmode .side .leavemoderator,
@@ -30,13 +29,22 @@
 }
 .res-nightmode .RESCloseButton,
 .res-nightmode .message.new > .entry,
-.res-nightmode .read-next {
+.res-nightmode .read-next,
+.res-nightmode .drop-choices {
   border-color: rgb(76,76,76);
 	background-color: rgb(46,46,46);
 }
-.res-nightmode .read-next .read-next-header {
+.res-nightmode .drop-choices {
+	box-shadow: 4px 4px 4px rgba(0,0,0,.3);
+}
+.res-nightmode .read-next .read-next-header,
+.res-nightmode .flairselector h2,
+.res-nightmode .flairselector li:hover {
 	border-color: transparent;
 	background-color: rgb(62,62,62);
+}
+.res-nightmode .flairselector li.selected {
+	border-color: rgb(120,120,120);
 }
 .res-nightmode .RESCloseButton:hover {
 	background-color: rgb(46,46,46);
@@ -126,14 +134,6 @@
 	border: solid 1px rgb(84,106,128);
 	background-color: rgb(51, 68, 85);
 }
-.res-nightmode .message ul {
-	color: #abc;
-}
-.res-nightmode #tab-templates a,
-.res-nightmode #tab-link_templates a {
-	background-color: #666660;
-	color: #ddd;
-}
 .res-nightmode .markdownEditor .btn:not(.btn-macro) {
 	border-color: #333;
 	background-color: #777;
@@ -207,7 +207,10 @@
 	background-color: #222;
 	color: #ddd;
 }
-.res-nightmode .organic-listing,
+.res-nightmode .organic-listing {
+	border-color: rgb(80,80,80);
+	background-color: transparent !important;
+}
 .res-nightmode .organic-listing .link,
 .res-nightmode .link.promotedlink {
 	background-color: transparent;
@@ -444,14 +447,10 @@
 	color: #eee;
 	font-size: 10px;
 }
-.res-nightmode .flairselector h2 {
-	color: #999;
-	background-color: #444;
-}
 .res-nightmode #sr-autocomplete-area {
 	z-index: 1;
 }
-.res-nightmode .content button,
+.res-nightmode button,
 .res-nightmode #REScommentSubToggle {
 	background: #111;
 	border: 2px solid #666;
@@ -561,7 +560,6 @@
 .res-nightmode #subscribe a,
 .res-nightmode .share .option,
 .res-nightmode .tagline a,
-.res-nightmode .tagline .head .author,
 .res-nightmode .wired a,
 .res-nightmode .side a,
 .res-nightmode .subredditbox li a,
@@ -578,6 +576,9 @@
 .res-nightmode .combined-search-page .search-result a>mark,
 .res-nightmode .hoverHelp {
 	color: rgb(20,150,220);
+}
+.res-nightmode .flairselector li a {
+	color: rgb(20,150,220) !important;
 }
 .res-nightmode .thing .title:visited,
 .res-nightmode .thing.visited .title,
@@ -731,7 +732,9 @@
 .res-nightmode .sidebar h3,
 .res-nightmode .sidebar h4,
 .res-nightmode .sidebar h5,
-.res-nightmode .sidebar h6 {
+.res-nightmode .sidebar h6,
+.res-nightmode span.score,
+.res-nightmode .flairselector h2 {
 	color: #ddd;
 }
 .res-nightmode .voteWeight,
@@ -822,7 +825,8 @@ html.res-nightmode .multi-details .subreddits .remove-sr {
 }
 .res-nightmode .about-page .abouttitle h1,
 .res-nightmode .create .morelink,
-.res-nightmode .permission-summary {
+.res-nightmode .permission-summary,
+.res-nightmode .flairselector li {
 	border-color: transparent;
 }
 .res-nightmode .about-page .about-menu {
@@ -894,6 +898,11 @@ body.res-nightmode,
 	background-color: rgb(73,80,93);
 	border-right-color: rgb(118,133,148);
 }
+/* moderator style takes higher priority than friend */
+.res-nightmode .tagline .friend,
+.res-nightmode .tagline .friend:visited {
+  color: rgb(255,69,0);
+}
 .res-nightmode .tagline .submitter,
 .res-nightmode .tagline .submitter:visited {
 	color: rgb(44,196,224);
@@ -907,10 +916,6 @@ body.res-nightmode,
 .res-nightmode .user-distinction .admin,
 .res-nightmode .user-distinction .admin:visited {
 	color: rgb(218,73,83);
-}
-.res-nightmode .tagline .friend,
-.res-nightmode .tagline .friend:visited {
-  color: rgb(255,69,0);
 }
 .res-nightmode hr,
 .res-nightmode .md hr,
@@ -984,7 +989,8 @@ body.res-nightmode,
 	background-color: transparent;
 }
 .res-nightmode .message.message-reply .entry,
-.res-nightmode .message.message-parent .entry {
+.res-nightmode .message.message-parent .entry,
+.res-nightmode .flairselector.drop-choices.active {
 	border-color: rgb(76,76,76);
 }
 .res-nightmode .comment .md p a[href="/spoiler"]:hover,

--- a/lib/modules/nightmode.css
+++ b/lib/modules/nightmode.css
@@ -18,20 +18,6 @@
 	background-color: #222;
 	border-color: #777;
 }
-.res-nightmode .listing-page .sitetable > div {
-	background: rgb(18,18,18);
-}
-.res-nightmode .linklisting .link {
-	margin-bottom: 0;
-	padding: 8px 0 8px 3px;
-}
-.res-nightmode .listing-page .thing.comment {
-	margin: 0;
-	padding: 8px 0 8px 3px;
-}
-.res-nightmode body {
-	background-image: none;
-}
 .res-nightmode .popup,
 .res-nightmode .guider,
 .res-nightmode .guider p {
@@ -42,14 +28,6 @@
 	background-color: #333;
 	color: #bbb;
 }
-.res-nightmode .RESNotification {
-	border-color: #ccc;
-	color: #fefefe;
-	background-color: gray;
-}
-.res-nightmode .RESNotificationHeader {
-	background: #c7c7c7;
-}
 .res-nightmode .RESCloseButton {
   border-color: rgb(76,76,76);
 	background-color: rgb(46,46,46);
@@ -57,31 +35,20 @@
 .res-nightmode .RESCloseButton:hover {
 	background-color: rgb(46,46,46);
 }
-.res-nightmode .RESNotificationContent,
-.res-nightmode #commentNavCloseButton:hover {
-	background: #eee;
+.res-nightmode #RESConsoleContainer .RESCloseButton {
+  border-color: rgb(167, 167, 167);
+	background-color: rgb(238, 238, 238);
 }
 .res-nightmode #RESHoverContainer:after {
 	border-color: transparent #222;
 }
-.res-nightmode .listing-page .sitetable>div:nth-of-type(4n+1),
-.res-nightmode .messages-page .sitetable>div:nth-of-type(4n+1),
 .res-nightmode .sr-interest-bar {
 	background-color: rgb(22,22,22);
-	padding-top: .5em;
 }
-.res-nightmode .organic-listing[style],
-.res-nightmode .organic-listing .thing {
-	background-color: rgb(22,22,22) !important;
-}
-
 .res-nightmode .entry .buttons li a,
 .res-nightmode .entry .morecomments .gray,
 .res-nightmode .markdownEditor .RESCharCounter {
 	color: rgba(221,221,221,.8);
-}
-.res-nightmode #BigEditor .markdownEditor .RESMacroDropdownList a {
-	color: gray;
 }
 .res-nightmode #BigEditor .markdownEditor .RESMacroDropdownList li:hover a {
 	color: rgb(187,187,187);
@@ -93,18 +60,11 @@
 .res-nightmode .trophy-info .trophy-name {
 	color: #eee!important;
 }
-.res-nightmode .submit-page .submit .formtab .selected a {
-	background: gray;
-}
 .res-nightmode .sidecontentbox .content {
 	border-color: rgba(234,234,234,.1);
 }
 .res-nightmode .RESUserTagImage::after {
 	color: rgb(117,142,168);
-}
-.res-nightmode button.arrow.prev,
-.res-nightmode button.arrow.next {
-	opacity: .5;
 }
 .res-nightmode #RESMenu li.active {
 	background-color: #7f7f7f;
@@ -116,7 +76,6 @@
 .res-nightmode #DonateRES {
 	background: rgb(204,204,204);
 }
-.res-nightmode #RESConsoleTopBar #RESLogo,
 .res-nightmode #progressIndicator {
 	opacity: .4;
 }
@@ -125,7 +84,7 @@
 	color: #eee;
 }
 .res-nightmode #header {
-	background-color: rgb(105, 105, 105);
+	background-color: rgb(105,105,105);
 }
 .res-nightmode #jumpToContent {
 	color: #ddd;
@@ -134,7 +93,6 @@
 }
 .res-nightmode #sr-header-area,
 .res-nightmode #sr-more-link,
-.res-nightmode #RESConsoleTopBar,
 .res-nightmode .moduleHeader,
 .res-nightmode .allOptionsContainer,
 .res-nightmode .optionContainer {
@@ -150,21 +108,6 @@
 }
 .res-nightmode .thing.spam {
 	background-color: rgba(250,128,114,.3);
-}
-.res-nightmode #userTaggerTable th,
-.res-nightmode #newCommentsTable th,
-.res-nightmode .buttons .stamp,
-.res-nightmode .RESNotification a,
-.res-nightmode .RESDashboardComponent .RESDashboardComponentHeader ul .updateTime:hover,
-.res-nightmode .big-mod-buttons .pretty-button,
-.res-nightmode .instructions .preftable th,
-.res-nightmode .instructions .pretty-form,
-.res-nightmode .drop-choices a,
-.res-nightmode .remove-self .option,
-.res-nightmode .unfriend-button .option,
-.res-nightmode #progressIndicator p,
-.res-nightmode .RESDashboardComponent .widgetPath {
-	color: #000;
 }
 .res-nightmode .nsfw-stamp.stamp{
 	color: rgb(209, 0, 35);
@@ -201,32 +144,8 @@
 	background-color: #777;
 	color: #aaa;
 }
-.res-nightmode .goldvertisement {
-	background-color: #dad0b3;
-	opacity: .8;
-}
-.res-nightmode .goldvertisement .inner h2 {
-	color: #fff;
-	font-weight: bold;
-}
-.res-nightmode .goldvertisement .progress .bar {
-	border-color: #fff;
-}
-.res-nightmode .gold-bubble,
-.res-nightmode .gold-accent {
-	background-color: #dad0b3;
-}
-.res-nightmode .gold-accent .gold-remaining {
-	color: #222;
-}
-.res-nightmode .hover-bubble.anchor-top-centered:after {
-	border-bottom-color: #aaa;
-}
 .res-nightmode .wiki-page .pageactions .wikiaction-current {
 	background-color: #777;
-}
-.res-nightmode .rulespage .example {
-	color: #000;
 }
 .res-nightmode .contact-us-page .button {
 	background: #777;
@@ -241,11 +160,9 @@
 .res-nightmode .content .wiki-page-content .md.wiki h4,
 .res-nightmode .content .wiki-page-content .md.wiki h5,
 .res-nightmode .content .wiki-page-content .md.wiki h6,
-.res-nightmode .content .wiki-page-content .md.wiki p {
+.res-nightmode .content .wiki-page-content .md.wiki p,
+.res-nightmode .wiki-page .wiki-page-content .pagelisting {
 	color: #ddd;
-}
-.res-nightmode .moderator.remove-self .option {
-	color: #222;
 }
 .res-nightmode .spam.thing .author,
 .res-nightmode .spam.thing .subreddit,
@@ -257,7 +174,7 @@
 	color: rgb(20, 150, 220);
 }
 .res-nightmode .message .subject .correspondent {
-	background: #ccc;
+	background: rgb(33, 47, 70);
 	color: rgb(20, 150, 220);
 }
 .res-nightmode .moderator .linefield,
@@ -265,9 +182,19 @@
 	background: #191919;
 }
 .res-nightmode .wiki-page .wiki-page-content .md.wiki>.toc ul,
-.res-nightmode .tabmenu .selected a,
-.res-nightmode #header .tabmenu .selected a {
+.res-nightmode .tabmenu li a,
+.res-nightmode .tabmenu li.selected a {
 	background-color: #222;
+}
+.res-nightmode .tabmenu li.selected a {
+	border-bottom-color: #222;
+}
+.res-nightmode .tabmenu.formtab a {
+	color: rgb(255,255,255);
+	border-color: transparent;
+}
+.res-nightmode .tabmenu.formtab li.selected a {
+	background-color: rgb(95,153,207);
 }
 .res-nightmode #RESDashboardAddComponent,
 .res-nightmode .dashboardPane>.RESDashboardComponent {
@@ -279,17 +206,9 @@
 .res-nightmode #RESDashboard .RESDashboardComponentHeader {
 	background-color: rgb(132,132,132);
 }
-.res-nightmode .RESDashboardComponentScrim span,
-.res-nightmode .RESDashboardComponent .RESDashboardComponentHeader ul .updateTime,
-.res-nightmode .remove-self .option {
-	color: #222;
-}
 .res-nightmode .RESDashboardComponent .RESDashboardComponentHeader ul li.active,
 .res-nightmode .RESDashboardComponent .RESDashboardComponentHeader ul li:hover {
 	background-color: #ccc;
-}
-.res-nightmode .permission-summary {
-	border-color: transparent;
 }
 .res-nightmode .side .titlebox form.flairtoggle,
 .res-nightmode .trophy-area .content,
@@ -298,11 +217,6 @@
 .res-nightmode .side .md ul {
 	background-color: #222;
 	color: #ddd;
-}
-body.res-nightmode,
-.res-nightmode .side,
-.res-nightmode .side * {
-	color: #ccc;
 }
 
 .res-nightmode .flair,
@@ -314,19 +228,28 @@ body.res-nightmode,
 .res-nightmode .message.message-parent.recipient> .entry .head {
 	color: inherit;
 }
-.res-nightmode .arrow {
+.res-nightmode .organic-listing,
+.res-nightmode .organic-listing .link,
+.res-nightmode .link.promotedlink {
+	background-color: transparent;
+	border-color: rgb(80,80,80);
+}
+.res-nightmode .organic-listing .nextprev {
+	opacity: .5;
+}
+.res-nightmode .thing .arrow {
 	height: 14px!important;
 	margin-top: 0;
 	width: 15px!important;
 	background-image: url(https://b.thumbs.redditmedia.com/WZDoQsDzUySVTErcweuA3k2HH1HU5-BZNnBXOR4FDwc.png) !important;
 	background-repeat: no-repeat;
 }
-.res-nightmode .arrow.up { background-position: -15px 0!important; }
-.res-nightmode .arrow.down { background-position: -15px -14px!important; }
-.res-nightmode .arrow.up:hover { background-position: -30px 0!important; }
-.res-nightmode .arrow.down:hover { background-position: -30px -14px!important; }
-.res-nightmode .arrow.upmod { background-position: 0 0!important; }
-.res-nightmode .arrow.downmod { background-position: 0 -14px!important; }
+.res-nightmode .thing .arrow.up { background-position: -15px 0!important; }
+.res-nightmode .thing .arrow.down { background-position: -15px -14px!important; }
+.res-nightmode .thing .arrow.up:hover { background-position: -30px 0!important; }
+.res-nightmode .thing .arrow.down:hover { background-position: -30px -14px!important; }
+.res-nightmode .thing .arrow.upmod { background-position: 0 0!important; }
+.res-nightmode .thing .arrow.downmod { background-position: 0 -14px!important; }
 .res-nightmode .message.new > .entry {
 	background-color: #444;
 	border: 1px solid #E9E9E9;
@@ -380,24 +303,15 @@ body.res-nightmode,
 .res-nightmode .morelink:hover a {
 	color: rgb(20, 150, 220);
 }
-.res-nightmode .create .morelink {
-	border-color: transparent;
+.res-nightmode .morelink .nub {
+	display: none;
 }
 .res-nightmode .sidebox .spacer,
 .res-nightmode .side .linkinfo {
 	background-color: #393939;
 }
-.res-nightmode .side .nub {
-	display: none;
-}
-.res-nightmode h1 {
-	border-bottom: 1px solid #444;
-}
 .res-nightmode .commentbody.border {
 	background-color: #369;
-}
-.res-nightmode .message .entry {
-	border-left: 1px dashed #aaa;
 }
 .res-nightmode .side input[type="text"],
 .res-nightmode .side input[type="password"],
@@ -412,19 +326,26 @@ body.res-nightmode,
 	background-color: rgb(51, 51, 51);
 	color: #eee;
 }
-.res-nightmode .message .md {
-	margin-left: 0;
-}
 .res-nightmode .spam,
 .res-nightmode .reported {
 	background: none;
 	border: 1px dotted;
 }
-.res-nightmode .report-action-form {
-	background-color: #dad0b3;
-}
 .res-nightmode .reason-prompt,
-.res-nightmode .report-action-form li {
+.res-nightmode .report-action-form li,
+.res-nightmode .rulespage .example,
+.res-nightmode #userTaggerTable th,
+.res-nightmode #newCommentsTable th,
+.res-nightmode .buttons .stamp,
+.res-nightmode .RESDashboardComponent .RESDashboardComponentHeader ul .updateTime:hover,
+.res-nightmode .big-mod-buttons .pretty-button,
+.res-nightmode .instructions .preftable th,
+.res-nightmode .instructions .pretty-form,
+.res-nightmode .drop-choices a,
+.res-nightmode .remove-self .option,
+.res-nightmode .unfriend-button .option,
+.res-nightmode #progressIndicator p,
+.res-nightmode .RESDashboardComponent .widgetPath {
 	color: #000;
 }
 .res-nightmode .viewSource textarea[readonly] {
@@ -447,9 +368,6 @@ body.res-nightmode,
 .res-nightmode .nextprev img:hover {
 	opacity: .85;
 }
-.res-nightmode .tabmenu .selected a {
-	border-bottom-color: #222;
-}
 .res-nightmode #ad-frame {
 	opacity: .8;
 }
@@ -466,11 +384,8 @@ body.res-nightmode,
 .res-nightmode .instructions {
 	background: #fff;
 }
-.res-nightmode #siteTable .visited.link .title.loggedin,
-.res-nightmode #siteTable .link .title.loggedin:visited,
-.res-nightmode #siteTable .link .title:visited,
 .res-nightmode #siteTable .link .title.loggedin.click,
-.res-nightmode .organic-listing .link .title:visited {
+.res-nightmode #BigEditor .markdownEditor .RESMacroDropdownList a {
 	color: gray;
 }
 .res-nightmode .markhelp.md tr td {
@@ -483,70 +398,71 @@ body.res-nightmode,
 .res-nightmode .mail .nohavemail img {
 	visibility: hidden;
 }
-.res-nightmode .thing .expando-button {
+.res-nightmode .expando-button {
+	background-color: transparent;
 	background-image: url(https://s3.amazonaws.com/a.thumbs.redditmedia.com/PkckcN8_3ijRUVP-GUQ6E-c8Ash_jQ3kCrEAoqKjSC4.png)!important;
 	cursor: pointer;
 }
-.res-nightmode .thing .expando-button.image.collapsed,
-.res-nightmode .thing .expando-button.image.collapsedExpando {
+.res-nightmode .expando-button.image.collapsed,
+.res-nightmode .expando-button.image.collapsedExpando {
 	background-position: 0 0;
 }
-.res-nightmode .thing .expando-button.image.collapsed:hover,
-.res-nightmode .thing .expando-button.image.collapsedExpando:hover {
+.res-nightmode .expando-button.image.collapsed:hover,
+.res-nightmode .expando-button.image.collapsedExpando:hover {
 	background-position: 0 -24px;
 }
-.res-nightmode .thing .expando-button.image.expanded {
+.res-nightmode.expando-button.image.expanded {
 	margin-bottom: 5px;
 	background-position: 0 -48px;
 }
-.res-nightmode .thing .expando-button.image.expanded:hover {
+.res-nightmode .expando-button.image.expanded:hover {
 	background-position: 0 -72px;
 }
-.res-nightmode .thing .expando-button.image.gallery.collapsed,
-.res-nightmode .thing .expando-button.image.gallery.collapsedExpando {
+.res-nightmode .expando-button.image.gallery.collapsed,
+.res-nightmode .expando-button.image.gallery.collapsedExpando {
 	background-position: 0 -288px;
 }
-.res-nightmode .thing .expando-button.image.gallery.collapsed:hover,
-.res-nightmode .thing .expando-button.image.gallery.collapsedExpando:hover {
+.res-nightmode .expando-button.image.gallery.collapsed:hover,
+.res-nightmode .expando-button.image.gallery.collapsedExpando:hover {
 	background-position: 0 -312px;
 }
-.res-nightmode .thing .expando-button.image.gallery.expanded {
+.res-nightmode .expando-button.image.gallery.expanded {
 	margin-bottom: 5px;
 	background-position: 0 -336px;
 }
-.res-nightmode .thing .expando-button.image.gallery.expanded:hover {
+.res-nightmode .expando-button.image.gallery.expanded:hover {
 	background-position: 0 -360px;
 }
-.res-nightmode .thing .expando-button.selftext.collapsed,
-.res-nightmode .thing .expando-button.selftext.collapsedExpando {
+.res-nightmode .expando-button.selftext.collapsed,
+.res-nightmode .expando-button.selftext.collapsedExpando {
 	background-position: 0 -96px;
 }
-.res-nightmode .thing .expando-button.selftext.collapsed:hover,
-.res-nightmode .thing .expando-button.selftext.collapsedExpando:hover {
+.res-nightmode .expando-button.selftext.collapsed:hover,
+.res-nightmode .expando-button.selftext.collapsedExpando:hover {
 	background-position: 0 -120px;
 }
-.res-nightmode .thing .expando-button.selftext.expanded,
+.res-nightmode .expando-button.selftext.expanded,
 .res-nightmode .eb-se {
 	margin-bottom: 5px;
 	background-position: 0 -144px;
 }
-.res-nightmode .thing .expando-button.selftext.expanded:hover,
+.res-nightmode .expando-button.selftext.expanded:hover,
 .res-nightmode .eb-seh {
 	background-position: 0 -168px;
 }
-.res-nightmode .thing .expando-button.video.collapsed,
-.res-nightmode .thing .expando-button.video.collapsedExpando {
+.res-nightmode .expando-button.video.collapsed,
+.res-nightmode .expando-button.video.collapsedExpando {
 	background-position: 0 -192px;
 }
-.res-nightmode .thing .expando-button.video.collapsed:hover,
-.res-nightmode .thing .expando-button.video.collapsedExpando:hover {
+.res-nightmode .expando-button.video.collapsed:hover,
+.res-nightmode .expando-button.video.collapsedExpando:hover {
 	background-position: 0 -216px;
 }
-.res-nightmode .thing .expando-button.video.expanded {
+.res-nightmode .expando-button.video.expanded {
 	margin-bottom: 5px;
 	background-position: 0 -240px;
 }
-.res-nightmode .thing .expando-button.video.expanded:hover {
+.res-nightmode .expando-button.video.expanded:hover {
 	background-position: 0 -264px;
 }
 .res-nightmode .expando-button.video-muted.collapsed,
@@ -567,16 +483,9 @@ body.res-nightmode,
 	color: #eee;
 	font-size: 10px;
 }
-.res-nightmode .link-button,
-.res-nightmode .text-button {
-	color: #444;
-}
 .res-nightmode .flairselector h2 {
 	color: #999;
 	background-color: #444;
-}
-.res-nightmode .formtabs-content {
-	border-top-color: #222;
 }
 .res-nightmode #sr-autocomplete-area {
 	z-index: 1;
@@ -683,12 +592,17 @@ body.res-nightmode,
 .res-nightmode .usertext.grayed .usertext-body {
 	background-color: #444;
 }
-.res-nightmode .tabmenu li a,
 .res-nightmode .login-form,
 .res-nightmode .login-form-side .submit,
 .res-nightmode #header-bottom-right,
 .res-nightmode #srList {
 	background-color: #333;
+}
+.res-nightmode #srList tr {
+  border-bottom-color: rgb(100,100,100);
+}
+.res-nightmode #srList tr:hover {
+  background-color: rgb(62, 62, 62);
 }
 .res-nightmode .token-input-list-facebook,
 .res-nightmode #quickMessage textarea,
@@ -717,6 +631,7 @@ body.res-nightmode,
 	color: #fff;
 }
 .res-nightmode a,
+.res-nightmode .thing .title,
 .res-nightmode .md a,
 .res-nightmode .share-button .option,
 .res-nightmode #subscribe a,
@@ -739,11 +654,13 @@ body.res-nightmode,
 .res-nightmode .combined-search-page .search-result a,
 .res-nightmode .combined-search-page .search-result a>mark,
 .res-nightmode .hoverHelp {
-	color: rgb(100,140,160);
+	color: rgb(20,150,220);
 }
+.res-nightmode .thing .title:visited,
+.res-nightmode .thing.visited .title,
 .res-nightmode .combined-search-page .search-result a:visited,
 .res-nightmode .combined-search-page .search-result a:visited>mark {
-	color: rgb(132,124,184);
+	color: rgb(110,103,185);
 }
 .res-nightmode>.content>.spacer>.sitetable:before,
 .res-nightmode>.content>.sharelink~.sitetable:before,
@@ -751,11 +668,8 @@ body.res-nightmode,
 .res-nightmode .trophy-info *,
 .res-nightmode .golddvertisement,
 .res-nightmode .flair-jump .title,
-.res-nightmode #siteTable .thing .title.loggedin,
-.res-nightmode #siteTable .thing .title,
 .res-nightmode .NERdupe p.title:after,
-.res-nightmode .savedComment,
-.res-nightmode .organic-listing .thing .title {
+.res-nightmode .savedComment {
 	color: #ddd;
 }
 .res-nightmode .flair-settings ~ .tabpane-content {
@@ -764,19 +678,7 @@ body.res-nightmode,
 .res-nightmode .flaircell input[type="text"] {
 	border: 1px solid #555;
 }
-.res-nightmode .side .spacer,
-.res-nightmode .content,
-.res-nightmode .traffic-tables .traffic-table tr,
-.res-nightmode .parentComment .md,
-.res-nightmode .post-body.entry-content,
-.res-nightmode .dsq-auth-header,
-.res-nightmode .instructions .preftable th,
-.res-nightmode #BigEditor .markdownEditor a,
-.res-nightmode #BigEditor .markdownEditor .RESMacroDropdownTitle,
-.res-nightmode .content .tabmenu li a {
-	color: #ccc;
-}
-.res-nightmode .content .md blockquote {
+.res-nightmode .md blockquote {
 	color: rgb(160,160,160);
 	border-left-color: rgb(100,100,100);
 }
@@ -798,11 +700,9 @@ body.res-nightmode,
 .res-nightmode .linkcompressed .entry .buttons li a,
 .res-nightmode .link .usertext .md,
 .res-nightmode .thing .compressed,
-.res-nightmode .organic-listing .link,
 .res-nightmode .link.promotedlink,
 .res-nightmode .link.promotedlink.promoted,
 .res-nightmode .commentreply .help tr,
-.res-nightmode .organic-listing .linkcompressed,
 .res-nightmode .sr-interest-bar .bubble {
 	background: none;
 }
@@ -817,21 +717,13 @@ body.res-nightmode,
 .res-nightmode .modactionlisting .timestamp {
 	color: #aaa;
 }
-.res-nightmode form .usertext-body,
-.res-nightmode .moderator .traffic-table tbody tr:nth-child(even),
-.res-nightmode .thing .expando-button,
-.res-nightmode .instructions,
-.res-nightmode .linefield .delete-field,
-.res-nightmode #pref-delete .delete-field,
-.res-nightmode .usertext .usertext-body .md {
-	background-color: transparent;
-}
 .res-nightmode .submit textarea,
 .res-nightmode .submit #url,
 .res-nightmode .submit #sr-autocomplete,
 .res-nightmode .usertext-edit textarea,
 .res-nightmode .usertext-edit .RESDialogSmall .md,
 .res-nightmode .RESDialogSmall,
+.res-nightmode .RESNotification,
 .res-nightmode .c-close,
 .res-nightmode #REScommentNavBox {
 	border-color: rgb(76,76,76);
@@ -854,9 +746,6 @@ body.res-nightmode,
 	color: inherit;
 	border-color: rgb(76,76,76);
 	background-color: transparent;
-}
-.res-nightmode .RESDialogSmall.livePreview .md.RESDialogContents {
-	background-color: transparent!important;
 }
 .res-nightmode.res-commentBoxes .comments-page .comment,
 .res-nightmode.res-commentBoxes .comments-page .comment .comment .comment,
@@ -983,63 +872,57 @@ html.res-nightmode .multi-details .subreddits .remove-sr {
 .res-nightmode .with-listing-chooser:not(.multi-page) .footer-parent {
 	background: url(https://b.thumbs.redditmedia.com/oPSTBWXkQufBAIYbFWiN0eI2J06zBLDEmq1NMHQ-Ems.png) no-repeat 49% 0;
 }
-.res-nightmode #about-main #history .events.timeline .event-content {
-	background: #aaa;
-}
-.res-nightmode #about-main #history .events.timeline .event-marker.top,
-.res-nightmode #about-main #history .events.timeline .event-marker.bottom {
-	border-bottom-color: #aaa
-}
 .res-nightmode #about-main #history .events.timeline .event:hover .event-content {
-	box-shadow: 1px 0 3px 2px #aaa
+	box-shadow: 1px 0 3px 2px #aaa;
 }
 .res-nightmode #about-main .statsgrid .stat .value {
-	text-shadow: 0 3px 5px #111
+	text-shadow: 0 3px 5px #111;
 }
-.res-nightmode .about-page .abouttitle h1 {
+.res-nightmode .about-page .abouttitle h1,
+.res-nightmode .create .morelink,
+.res-nightmode .permission-summary {
 	border-color: transparent;
 }
 .res-nightmode .about-page .about-menu {
-	background: #ddd
+	background: #ddd;
 }
 .res-nightmode .about-page h2,
 .res-nightmode  .md del {
-	color: #777
+	color: #777;
 }
 .res-nightmode .about-page .about-menu li.selected a,
-.res-nightmode .about-page .about-menu li:hover a {
-	background: #aaa
+.res-nightmode .about-page .about-menu li:hover a,
+.res-nightmode #about-main #history .events.timeline .event-content {
+	background: #aaa;
 }
 .res-nightmode .about-page .abouttitle {
-	background-image: url(https://a.thumbs.redditmedia.com/xxM_X1OL6Lt4I4GC9F1SbNIcbeoZPXOmPIo6P1slaP4.png)
-}
-/* Policy pages */
-.res-nightmode .policy-page .md p {
-	color: #eee;
+	background-image: url(https://a.thumbs.redditmedia.com/xxM_X1OL6Lt4I4GC9F1SbNIcbeoZPXOmPIo6P1slaP4.png);
 }
 .res-nightmode .policy-page .md h1 a,
 .res-nightmode .policy-page .md h3 a {
-	color: #369
+	color: #369;
 }
 .res-nightmode .policy-page .md p em {
 	background-color: rgb(218, 208, 179);
 	color: #000;
 }
-/* Gold page */
-.res-nightmode .letter-body p,
-.res-nightmode #gold-letter h1,
-.res-nightmode #about-gold h1,
-.res-nightmode #about-gold footer > p {
-	color: #222;
-}
-/* Live pages */
-.res-nightmode .liveupdate-listing table tr:hover th time {
+.res-nightmode .liveupdate-listing table tr:hover th time,
+.res-nightmode .policy-page .md p  {
 	color: #eee;
 }
-.res-nightmode aside.sidebar #discussions li {
-	background: #222;
-}
-.res-nightmode .sidebar .md {
+.res-nightmode .sidebar .md,
+body.res-nightmode,
+.res-nightmode .side,
+.res-nightmode .side *,
+.res-nightmode .side .spacer,
+.res-nightmode .content,
+.res-nightmode .traffic-tables .traffic-table tr,
+.res-nightmode .parentComment .md,
+.res-nightmode .post-body.entry-content,
+.res-nightmode .dsq-auth-header,
+.res-nightmode .instructions .preftable th,
+.res-nightmode #BigEditor .markdownEditor a,
+.res-nightmode #BigEditor .markdownEditor .RESMacroDropdownTitle {
 	color: #ccc;
 }
 .res-nightmode .sidebar h1,
@@ -1050,9 +933,6 @@ html.res-nightmode .multi-details .subreddits .remove-sr {
 .res-nightmode .sidebar h6 {
 	color: #ddd;
 }
-.res-nightmode .liveupdate-listing table tr.separator td {
-	background-color: transparent;
-}
 .res-nightmode .liveupdate-listing table tr.separator time {
 	background: #666;
 	color: #fff;
@@ -1061,16 +941,13 @@ html.res-nightmode .multi-details .subreddits .remove-sr {
 	background: #333;
 	border-color: #111;
 }
-/* Mod stuff */
 .res-nightmode .stylesheet-customize-container textarea {
 	background-color: #222;
 	color: #ddd;
 }
-.res-nightmode .guider {
-	background: #222;
-}
-/* snoovatar page */
-.res-nightmode .snoovatar-page footer .inputs {
+.res-nightmode .snoovatar-page footer .inputs,
+.res-nightmode .guider,
+.res-nightmode aside.sidebar #discussions li {
 	background: #222;
 }
 .res-nightmode .snoovatar-page .checkbox-label [type=checkbox] + .proxy-checkbox {
@@ -1080,12 +957,12 @@ html.res-nightmode .multi-details .subreddits .remove-sr {
 	background: rgb(10, 128, 46);
 }
 .res-nightmode #userbarToggle {
-	background-color: rgb(93, 104, 115);
-	border-right-color: rgb(118, 133, 148);
+	background-color: rgb(73,80,93);
+	border-right-color: rgb(118,133,148);
 }
 .res-nightmode .tagline .submitter,
 .res-nightmode .tagline .submitter:visited {
-	color: rgb(20,150,220);
+	color: rgb(44,196,224);
 }
 .res-nightmode .tagline .moderator,
 .res-nightmode .tagline .moderator:visited {
@@ -1098,4 +975,71 @@ html.res-nightmode .multi-details .subreddits .remove-sr {
 .res-nightmode .tagline .friend,
 .res-nightmode .tagline .friend:visited {
   color: rgb(255,69,0);
+}
+.res-nightmode hr,
+.res-nightmode .md hr,
+.res-nightmode .message.gold-auto blockquote,
+.res-nightmode .RESNotificationHeader {
+  border-color: rgb(60,60,60);
+  background-color: rgb(60,60,60);
+}
+.res-nightmode #RESSubredditGroupDropdown {
+	background-color: rgb(204,204,204);
+}
+.res-nightmode #RESSubredditGroupDropdown a {
+	color: rgb(0,0,0);
+}
+.res-nightmode .goldvertisement,
+.res-nightmode .goldvertisement .inner {
+	border-color: rgba(196, 180, 135,.5);
+}
+.res-nightmode .goldvertisement .inner h2,
+.res-nightmode .goldvertisement .progress p {
+	color: rgb(196, 180, 135);
+}
+.res-nightmode .goldvertisement a,
+.res-nightmode .goldvertisement a:hover {
+	background-color: rgb(76, 76, 76);
+	border-color: rgb(0, 0, 0);
+	color: rgb(255, 255, 255);
+}
+.res-nightmode .gold-bubble,
+.res-nightmode .gold-accent,
+.res-nightmode .report-action-form {
+	background-color: #dad0b3;
+}
+.res-nightmode .gold-accent .gold-remaining,
+.res-nightmode .letter-body p,
+.res-nightmode #gold-letter h1,
+.res-nightmode #about-gold h1,
+.res-nightmode #about-gold footer > p,
+.res-nightmode .RESDashboardComponentScrim span,
+.res-nightmode .RESDashboardComponent .RESDashboardComponentHeader ul .updateTime,
+.res-nightmode .remove-self .option,
+.res-nightmode .moderator.remove-self .option {
+	color: #222;
+}
+.res-nightmode .hover-bubble.anchor-top-centered:after,
+.res-nightmode #about-main #history .events.timeline .event-marker.top,
+.res-nightmode #about-main #history .events.timeline .event-marker.bottom {
+	border-bottom-color: #aaa;
+}
+.res-nightmode .thumbnail.self,
+.res-nightmode .guiders_arrow {
+	-webkit-filter: invert(100%) grayscale(100%);
+	filter: invert(100%) grayscale(100%);
+}
+.res-nightmode .white-field,
+.res-nightmode .delete-field,
+.res-nightmode .liveupdate-listing table tr.separator td,
+.res-nightmode .RESDialogSmall.livePreview .md.RESDialogContents,
+.res-nightmode form .usertext-body,
+.res-nightmode .moderator .traffic-table tbody tr:nth-child(even),
+.res-nightmode .thing .expando-button,
+.res-nightmode .instructions,
+.res-nightmode .linefield .delete-field,
+.res-nightmode #pref-delete .delete-field,
+.res-nightmode .usertext .usertext-body .md,
+.res-nightmode .contact-us-page .details li  {
+	background-color: transparent;
 }

--- a/lib/modules/nightmode.css
+++ b/lib/modules/nightmode.css
@@ -28,9 +28,15 @@
 	background-color: #333;
 	color: #bbb;
 }
-.res-nightmode .RESCloseButton {
+.res-nightmode .RESCloseButton,
+.res-nightmode .message.new > .entry,
+.res-nightmode .read-next {
   border-color: rgb(76,76,76);
 	background-color: rgb(46,46,46);
+}
+.res-nightmode .read-next .read-next-header {
+	border-color: transparent;
+	background-color: rgb(62,62,62);
 }
 .res-nightmode .RESCloseButton:hover {
 	background-color: rgb(46,46,46);
@@ -53,10 +59,6 @@
 .res-nightmode #BigEditor .markdownEditor .RESMacroDropdownList li:hover a {
 	color: rgb(187,187,187);
 }
-.res-nightmode .comment a:visited,
-.res-nightmode .comment .md p a:visited,
-.res-nightmode .new-comment .usertext-body .md p a:visited {
-}
 .res-nightmode .trophy-info .trophy-name {
 	color: #eee!important;
 }
@@ -77,7 +79,9 @@
 	background: rgb(204,204,204);
 }
 .res-nightmode #progressIndicator {
-	opacity: .4;
+	color: #ddd;
+	border-color: rgb(76,76,76);
+	background-color: rgb(46,46,46);
 }
 .res-nightmode .login-form-side {
 	background-color: #888;
@@ -109,9 +113,6 @@
 .res-nightmode .thing.spam {
 	background-color: rgba(250,128,114,.3);
 }
-.res-nightmode .nsfw-stamp.stamp{
-	color: rgb(209, 0, 35);
-}
 .res-nightmode .content .pretty-form * {
 	box-shadow: none;
 }
@@ -121,8 +122,9 @@
 .res-nightmode .RESDashboardComponentContainer .linklisting {
 	padding: 5px;
 }
-.res-nightmode .new-comment .usertext-body .md {
-	border: 1px #aaa dashed;
+.res-nightmode .new-comment .usertext-body  {
+	border: solid 1px rgb(84,106,128);
+	background-color: rgb(51, 68, 85);
 }
 .res-nightmode .message ul {
 	color: #abc;
@@ -131,9 +133,6 @@
 .res-nightmode #tab-link_templates a {
 	background-color: #666660;
 	color: #ddd;
-}
-.res-nightmode .livePreview .md a {
-	color: rgb(20, 10, 200);
 }
 .res-nightmode .markdownEditor .btn:not(.btn-macro) {
 	border-color: #333;
@@ -153,16 +152,6 @@
 }
 .res-nightmode .contact-us-page .button:hover {
 	background: #666;
-}
-.res-nightmode .content .wiki-page-content .md.wiki h1,
-.res-nightmode .content .wiki-page-content .md.wiki h2,
-.res-nightmode .content .wiki-page-content .md.wiki h3,
-.res-nightmode .content .wiki-page-content .md.wiki h4,
-.res-nightmode .content .wiki-page-content .md.wiki h5,
-.res-nightmode .content .wiki-page-content .md.wiki h6,
-.res-nightmode .content .wiki-page-content .md.wiki p,
-.res-nightmode .wiki-page .wiki-page-content .pagelisting {
-	color: #ddd;
 }
 .res-nightmode .spam.thing .author,
 .res-nightmode .spam.thing .subreddit,
@@ -191,7 +180,7 @@
 }
 .res-nightmode .tabmenu.formtab a {
 	color: rgb(255,255,255);
-	border-color: transparent;
+	border-color: rgb(80,80,80);
 }
 .res-nightmode .tabmenu.formtab li.selected a {
 	background-color: rgb(95,153,207);
@@ -218,16 +207,6 @@
 	background-color: #222;
 	color: #ddd;
 }
-
-.res-nightmode .flair,
-.res-nightmode .linkflairlabel {
-	background-color: #bbb;
-	color: #000;
-}
-.res-nightmode .message.message-reply.recipient>.entry .head,
-.res-nightmode .message.message-parent.recipient> .entry .head {
-	color: inherit;
-}
 .res-nightmode .organic-listing,
 .res-nightmode .organic-listing .link,
 .res-nightmode .link.promotedlink {
@@ -250,10 +229,6 @@
 .res-nightmode .thing .arrow.down:hover { background-position: -30px -14px!important; }
 .res-nightmode .thing .arrow.upmod { background-position: 0 0!important; }
 .res-nightmode .thing .arrow.downmod { background-position: 0 -14px!important; }
-.res-nightmode .message.new > .entry {
-	background-color: #444;
-	border: 1px solid #E9E9E9;
-}
 .res-nightmode .subredditbox li a:before {
 	content: "#";
 }
@@ -261,15 +236,8 @@
 	font-weight: 700;
 	text-transform: lowercase;
 }
-.res-nightmode .dropdown.lightdrop .drop-choices {
-	background-color: #333;
-}
 .res-nightmode .dropdown.lightdrop a.choice:hover {
 	background-color: #111;
-}
-.res-nightmode .guiders_button,
-.res-nightmode .blueButton {
-	color: #fff;
 }
 .res-nightmode .sidebox,
 .res-nightmode .subredditbox,
@@ -313,10 +281,8 @@
 .res-nightmode .commentbody.border {
 	background-color: #369;
 }
-.res-nightmode .side input[type="text"],
-.res-nightmode .side input[type="password"],
-.res-nightmode .content input[type="text"],
-.res-nightmode .content input[type="password"],
+.res-nightmode input[type="text"],
+.res-nightmode input[type="password"],
 .res-nightmode .c-form-control {
 	background-color: #333;
 	border-color: #000;
@@ -336,7 +302,6 @@
 .res-nightmode .rulespage .example,
 .res-nightmode #userTaggerTable th,
 .res-nightmode #newCommentsTable th,
-.res-nightmode .buttons .stamp,
 .res-nightmode .RESDashboardComponent .RESDashboardComponentHeader ul .updateTime:hover,
 .res-nightmode .big-mod-buttons .pretty-button,
 .res-nightmode .instructions .preftable th,
@@ -344,12 +309,11 @@
 .res-nightmode .drop-choices a,
 .res-nightmode .remove-self .option,
 .res-nightmode .unfriend-button .option,
-.res-nightmode #progressIndicator p,
 .res-nightmode .RESDashboardComponent .widgetPath {
 	color: #000;
 }
 .res-nightmode .viewSource textarea[readonly] {
-	background: rgb(102, 102, 102);
+	background: rgb(102,102,102);
 }
 .res-nightmode .spam {
 	border-color: #FF4500;
@@ -361,9 +325,6 @@
 	background: #777;
 	border-color: #333;
 	color: #ddd;
-}
-.res-nightmode .nextprev img {
-	opacity: .7;
 }
 .res-nightmode .nextprev img:hover {
 	opacity: .85;
@@ -520,12 +481,6 @@
 .res-nightmode div#RESShortcutsTrash {
 	background: #ccc;
 }
-.res-nightmode #BigEditor .md :not(code),
-.res-nightmode #BigEditor #BigText {
-	background: #666;
-	color: #ccc;
-	font-weight: 400;
-}
 .res-nightmode.res-commentBoxes .comments-page .comment .comment {
 	margin-right: 0;
 }
@@ -542,49 +497,20 @@
 	color: #ccc;
 	border-color: #888;
 }
-.res-nightmode .new-comment .usertext-body {
-	background-color: #345;
-}
 .res-nightmode .md code,
 .res-nightmode .md pre,
 .res-nightmode .content .md pre,
 .res-nightmode .link .md :not(pre)>code {
 	background-color: #456;
 }
-.res-nightmode .new-comment .usertext-body .md p a,
-.res-nightmode code, .res-nightmode .md code {
+.res-nightmode code,
+.res-nightmode .md code {
 	color: #87CEEB;
 }
 .res-nightmode .comment .md p a[href="/spoiler"],
 .res-nightmode .comment .md p a[href="#spoiler"] {
 	background-color: #000;
 	color: #000;
-}
-.res-nightmode .comment .md p a[href="/spoiler"]:hover,
-.res-nightmode .comment .md p a[href="/spoiler"]:active,
-.res-nightmode .comment .md p a[href="#spoiler"]:hover,
-.res-nightmode .comment .md p a[href="#spoiler"]:active,
-.res-nightmode .addNewWidget,
-.res-nightmode .editWidget,
-.res-nightmode #authorInfoToolTip .option,
-.res-nightmode .updateTime,
-.res-nightmode .toggle .option,
-.res-nightmode .REStoggle,
-.res-nightmode .RESshortcut,
-.res-nightmode #RESSubmitOptions ~ div a {
-	color: #fff;
-}
-.res-nightmode .md,
-.res-nightmode .content .sitetable .thing .md,
-.res-nightmode .side .usertext-body ol,
-.res-nightmode .side .redditname a,
-.res-nightmode .side h1,
-.res-nightmode .side h2,
-.res-nightmode .side h3,
-.res-nightmode .side h4,
-.res-nightmode .side h5,
-.res-nightmode .side h6 {
-	color: #ddd;
 }
 .res-nightmode .usertable tr:hover,
 .res-nightmode .moderator-table tr:hover,
@@ -595,7 +521,8 @@
 .res-nightmode .login-form,
 .res-nightmode .login-form-side .submit,
 .res-nightmode #header-bottom-right,
-.res-nightmode #srList {
+.res-nightmode #srList,
+.res-nightmode .dropdown.lightdrop .drop-choices {
 	background-color: #333;
 }
 .res-nightmode #srList tr {
@@ -627,9 +554,6 @@
 .res-nightmode .combined-search-page .search-result-group .search-result-group-header {
 	border-bottom-color: rgb(128,128,128);
 }
-.res-nightmode #shortlink-text {
-	color: #fff;
-}
 .res-nightmode a,
 .res-nightmode .thing .title,
 .res-nightmode .md a,
@@ -646,7 +570,6 @@
 .res-nightmode a[rel=tag],
 .res-nightmode .dsq-help,
 .res-nightmode #authorInfoToolTip h3 a,
-.res-nightmode .help-toggle .option,
 .res-nightmode .morecomments a,
 .res-nightmode .reddiquette,
 .res-nightmode .parent .author,
@@ -660,17 +583,7 @@
 .res-nightmode .thing.visited .title,
 .res-nightmode .combined-search-page .search-result a:visited,
 .res-nightmode .combined-search-page .search-result a:visited>mark {
-	color: rgb(110,103,185);
-}
-.res-nightmode>.content>.spacer>.sitetable:before,
-.res-nightmode>.content>.sharelink~.sitetable:before,
-.res-nightmode .side .age,
-.res-nightmode .trophy-info *,
-.res-nightmode .golddvertisement,
-.res-nightmode .flair-jump .title,
-.res-nightmode .NERdupe p.title:after,
-.res-nightmode .savedComment {
-	color: #ddd;
+	color: rgb(129, 124, 187);
 }
 .res-nightmode .flair-settings ~ .tabpane-content {
 	border-color: #111;
@@ -681,10 +594,6 @@
 .res-nightmode .md blockquote {
 	color: rgb(160,160,160);
 	border-left-color: rgb(100,100,100);
-}
-.res-nightmode .subreddit .usertext .md {
-	background-color: #222;
-	color: #ccc;
 }
 .res-nightmode .infobar,
 .res-nightmode .infobar .md {
@@ -698,10 +607,11 @@
 	color: #FF4500;
 }
 .res-nightmode .linkcompressed .entry .buttons li a,
-.res-nightmode .link .usertext .md,
+.res-nightmode .link .usertext-body .md,
 .res-nightmode .thing .compressed,
 .res-nightmode .link.promotedlink,
 .res-nightmode .link.promotedlink.promoted,
+.res-nightmode .subreddit .usertext .md,
 .res-nightmode .commentreply .help tr,
 .res-nightmode .sr-interest-bar .bubble {
 	background: none;
@@ -721,11 +631,11 @@
 .res-nightmode .submit #url,
 .res-nightmode .submit #sr-autocomplete,
 .res-nightmode .usertext-edit textarea,
-.res-nightmode .usertext-edit .RESDialogSmall .md,
 .res-nightmode .RESDialogSmall,
 .res-nightmode .RESNotification,
 .res-nightmode .c-close,
-.res-nightmode #REScommentNavBox {
+.res-nightmode #REScommentNavBox,
+.res-nightmode #BigEditor #BigText {
 	border-color: rgb(76,76,76);
 	background-color: rgb(46, 46, 46);
 	color: #ccc;
@@ -788,10 +698,44 @@
 .res-nightmode #delete-img:hover {
 	background-color: rgb(102,102,102);
 }
-.res-nightmode .md h2 {
+.res-nightmode>.content>.spacer>.sitetable:before,
+.res-nightmode>.content>.sharelink~.sitetable:before,
+.res-nightmode .side .age,
+.res-nightmode .trophy-info *,
+.res-nightmode .golddvertisement,
+.res-nightmode .flair-jump .title,
+.res-nightmode .NERdupe p.title:after,
+.res-nightmode .savedComment,
+.res-nightmode .md,
+.res-nightmode .md h2,
+.res-nightmode .content .sitetable .thing .md,
+.res-nightmode .side .usertext-body ol,
+.res-nightmode .side .redditname a,
+.res-nightmode .side h1,
+.res-nightmode .side h2,
+.res-nightmode .side h3,
+.res-nightmode .side h4,
+.res-nightmode .side h5,
+.res-nightmode .side h6,
+.res-nightmode .content .wiki-page-content .md.wiki h1,
+.res-nightmode .content .wiki-page-content .md.wiki h2,
+.res-nightmode .content .wiki-page-content .md.wiki h3,
+.res-nightmode .content .wiki-page-content .md.wiki h4,
+.res-nightmode .content .wiki-page-content .md.wiki h5,
+.res-nightmode .content .wiki-page-content .md.wiki h6,
+.res-nightmode .content .wiki-page-content .md.wiki p,
+.res-nightmode .wiki-page .wiki-page-content .pagelisting,
+.res-nightmode .RESUserTag,
+.res-nightmode .sidebar h1,
+.res-nightmode .sidebar h2,
+.res-nightmode .sidebar h3,
+.res-nightmode .sidebar h4,
+.res-nightmode .sidebar h5,
+.res-nightmode .sidebar h6 {
 	color: #ddd;
 }
-.res-nightmode .voteWeight {
+.res-nightmode .voteWeight,
+.res-nightmode .nextprev img {
 	opacity: .7;
 }
 .res-nightmode .searchfacets {
@@ -799,7 +743,9 @@
 	box-shadow: none;
 }
 .res-nightmode .combined-search-page .search-result .search-result-body,
-.res-nightmode .generic-table {
+.res-nightmode .generic-table,
+.res-nightmode .message.message-reply.recipient>.entry .head,
+.res-nightmode .message.message-parent.recipient> .entry .head {
 	color: inherit;
 }
 .res-nightmode .nextprev a:hover,
@@ -864,10 +810,6 @@ html.res-nightmode .multi-details .add-sr .add {
 html.res-nightmode .multi-details .subreddits .remove-sr {
 	background-position: -3px -15px;
 }
-/* Neutral background colour for tags in nightmode */
-.res-nightmode .hasTag[style*="background-color: transparent"] {
-	background-color: #999 !important;
-}
 /* Nightmode friendly snoo/balloons image */
 .res-nightmode .with-listing-chooser:not(.multi-page) .footer-parent {
 	background: url(https://b.thumbs.redditmedia.com/oPSTBWXkQufBAIYbFWiN0eI2J06zBLDEmq1NMHQ-Ems.png) no-repeat 49% 0;
@@ -925,14 +867,6 @@ body.res-nightmode,
 .res-nightmode #BigEditor .markdownEditor .RESMacroDropdownTitle {
 	color: #ccc;
 }
-.res-nightmode .sidebar h1,
-.res-nightmode .sidebar h2,
-.res-nightmode .sidebar h3,
-.res-nightmode .sidebar h4,
-.res-nightmode .sidebar h5,
-.res-nightmode .sidebar h6 {
-	color: #ddd;
-}
 .res-nightmode .liveupdate-listing table tr.separator time {
 	background: #666;
 	color: #fff;
@@ -969,7 +903,9 @@ body.res-nightmode,
 	color: rgb(34,136,34)
 }
 .res-nightmode .tagline .admin,
-.res-nightmode .tagline .admin:visited {
+.res-nightmode .tagline .admin:visited,
+.res-nightmode .user-distinction .admin,
+.res-nightmode .user-distinction .admin:visited {
 	color: rgb(218,73,83);
 }
 .res-nightmode .tagline .friend,
@@ -991,24 +927,21 @@ body.res-nightmode,
 }
 .res-nightmode .goldvertisement,
 .res-nightmode .goldvertisement .inner {
-	border-color: rgba(196, 180, 135,.5);
+	border-color: rgba(196,180,135,.5);
 }
 .res-nightmode .goldvertisement .inner h2,
 .res-nightmode .goldvertisement .progress p {
-	color: rgb(196, 180, 135);
+	color: rgb(196,180,135);
 }
 .res-nightmode .goldvertisement a,
 .res-nightmode .goldvertisement a:hover {
-	background-color: rgb(76, 76, 76);
-	border-color: rgb(0, 0, 0);
-	color: rgb(255, 255, 255);
+	background-color: rgb(76,76,76);
+	border-color: rgb(0,0,0);
+	color: rgb(255,255,255);
 }
-.res-nightmode .gold-bubble,
-.res-nightmode .gold-accent,
 .res-nightmode .report-action-form {
 	background-color: #dad0b3;
 }
-.res-nightmode .gold-accent .gold-remaining,
 .res-nightmode .letter-body p,
 .res-nightmode #gold-letter h1,
 .res-nightmode #about-gold h1,
@@ -1016,8 +949,17 @@ body.res-nightmode,
 .res-nightmode .RESDashboardComponentScrim span,
 .res-nightmode .RESDashboardComponent .RESDashboardComponentHeader ul .updateTime,
 .res-nightmode .remove-self .option,
-.res-nightmode .moderator.remove-self .option {
+.res-nightmode .moderator.remove-self .option,
+.res-nightmode .message-count {
 	color: #222;
+}
+.res-nightmode .gold-accent {
+  color: rgb(230,218,174);
+  background-color: hsl(46,22%,42%);
+  border-color: hsl(46,29%,54%);
+}
+.res-nightmode .side .gold-accent * {
+  color: rgb(230,218,174);
 }
 .res-nightmode .hover-bubble.anchor-top-centered:after,
 .res-nightmode #about-main #history .events.timeline .event-marker.top,
@@ -1033,13 +975,50 @@ body.res-nightmode,
 .res-nightmode .delete-field,
 .res-nightmode .liveupdate-listing table tr.separator td,
 .res-nightmode .RESDialogSmall.livePreview .md.RESDialogContents,
-.res-nightmode form .usertext-body,
 .res-nightmode .moderator .traffic-table tbody tr:nth-child(even),
 .res-nightmode .thing .expando-button,
 .res-nightmode .instructions,
 .res-nightmode .linefield .delete-field,
 .res-nightmode #pref-delete .delete-field,
-.res-nightmode .usertext .usertext-body .md,
 .res-nightmode .contact-us-page .details li  {
 	background-color: transparent;
+}
+.res-nightmode .message.message-reply .entry,
+.res-nightmode .message.message-parent .entry {
+	border-color: rgb(76,76,76);
+}
+.res-nightmode .comment .md p a[href="/spoiler"]:hover,
+.res-nightmode .comment .md p a[href="/spoiler"]:active,
+.res-nightmode .comment .md p a[href="#spoiler"]:hover,
+.res-nightmode .comment .md p a[href="#spoiler"]:active,
+.res-nightmode .addNewWidget,
+.res-nightmode .editWidget,
+.res-nightmode #authorInfoToolTip .option,
+.res-nightmode .updateTime,
+.res-nightmode .REStoggle,
+.res-nightmode .RESshortcut,
+.res-nightmode #RESSubmitOptions ~ div a,
+.res-nightmode #shortlink-text,
+.res-nightmode .guiders_button,
+.res-nightmode .blueButton,
+.res-nightmode .gold-accent a,
+.res-nightmode .snoovatar-page .gold-accent a,
+.combined-search-page .search-result-subreddit .search-subscribe-button .add.active,
+.combined-search-page .search-result-subreddit .search-subscribe-button .remove.active,
+.res-nightmode .fancy-toggle-button a {
+	color: rgb(255,255,255);
+}
+.res-nightmode .markhelp table tr:first-child {
+	background-color: rgb(76,76,76) !important;
+}
+.res-nightmode .usertext .markhelp .spaces {
+	background-color: rgb(76,76,76);
+}
+.res-nightmode .flair,
+.res-nightmode .linkflairlabel {
+	background-color: #bbb;
+	color: #000;
+}
+.res-nightmode #NERContent {
+	background-color: rgb(160,160,160);
 }

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -303,7 +303,7 @@ addModule('selectedEntry', function(module, moduleID) {
 		RESUtils.addCSS('	\
 			.RES-keyNav-activeElement, .commentarea .RES-keyNav-activeElement .md, .commentarea .RES-keyNav-activeElement.entry .noncollapsed { background-color: ' + focusBGColor + ' !important; } \
 			.res-nightmode .RES-keyNav-activeElement, .res-nightmode .RES-keyNav-activeElement .usertext-body, .res-nightmode .RES-keyNav-activeElement .usertext-body .md, .res-nightmode .RES-keyNav-activeElement .usertext-body .md p, .res-nightmode .commentarea .RES-keyNav-activeElement .noncollapsed, .res-nightmode .RES-keyNav-activeElement .noncollapsed .md, .res-nightmode .RES-keyNav-activeElement .noncollapsed .md p { background-color: ' + focusBGColorNight + ' !important; color: ' + focusFGColorNight + ' !important;} \
-			.res-nightmode .RES-keyNav-activeElement a.title:first-of-type {color: ' + focusFGColorNight + ' !important; } \
+			.res-nightmode .RES-keyNav-activeElement a.title, .res-nightmode .comment.collapsed .RES-keyNav-activeElement .tagline {color: ' + focusFGColorNight + ' !important; } \
 			');
 	}
 

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -301,9 +301,15 @@ addModule('selectedEntry', function(module, moduleID) {
 		}
 
 		RESUtils.addCSS('	\
-			.RES-keyNav-activeElement, .commentarea .RES-keyNav-activeElement .md, .commentarea .RES-keyNav-activeElement.entry .noncollapsed { background-color: ' + focusBGColor + ' !important; } \
-			.res-nightmode .RES-keyNav-activeElement, .res-nightmode .RES-keyNav-activeElement .usertext-body, .res-nightmode .RES-keyNav-activeElement .usertext-body .md, .res-nightmode .RES-keyNav-activeElement .usertext-body .md p, .res-nightmode .commentarea .RES-keyNav-activeElement .noncollapsed, .res-nightmode .RES-keyNav-activeElement .noncollapsed .md, .res-nightmode .RES-keyNav-activeElement .noncollapsed .md p { background-color: ' + focusBGColorNight + ' !important; color: ' + focusFGColorNight + ' !important;} \
-			.res-nightmode .RES-keyNav-activeElement a.title, .res-nightmode .comment.collapsed .RES-keyNav-activeElement .tagline {color: ' + focusFGColorNight + ' !important; } \
+			.RES-keyNav-activeElement,\
+			.RES-keyNav-activeElement .md-container { background-color: ' + focusBGColor + ' !important; }\
+			\
+			.res-nightmode .RES-keyNav-activeElement > .tagline,\
+			.res-nightmode .RES-keyNav-activeElement .md-container > .md,\
+			.res-nightmode .RES-keyNav-activeElement .md-container > .md p { color: ' + focusFGColorNight + ' !important; }\
+			\
+			.res-nightmode .RES-keyNav-activeElement,\
+			.res-nightmode .RES-keyNav-activeElement .md-container { background-color: ' + focusBGColorNight + ' !important; }\
 			');
 	}
 

--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -211,8 +211,10 @@ modules['styleTweaks'] = {
 			// If not, we still need a visited class for links in comments, like imgur photos for example, or inline image viewer can't make them look different when expanded!
 			if (this.options.visitedStyle.value) {
 				RESUtils.addCSS('.comment a:visited { color:#551a8b }');
+				RESUtils.addCSS('.res-nightmode .comment a:visited { color: rgb(110, 103, 185); }');
 			} else {
 				RESUtils.addCSS('.comment .md p > a:visited { color:#551a8b }');
+				RESUtils.addCSS('.res-nightmode .comment .md p > a:visited { color: rgb(110, 103, 185); }');
 			}
 			if (this.options.showExpandos.value) {
 				RESUtils.addCSS('.res .compressed .expando-button { display: block; }');

--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -211,10 +211,10 @@ modules['styleTweaks'] = {
 			// If not, we still need a visited class for links in comments, like imgur photos for example, or inline image viewer can't make them look different when expanded!
 			if (this.options.visitedStyle.value) {
 				RESUtils.addCSS('.comment a:visited { color:#551a8b }');
-				RESUtils.addCSS('.res-nightmode .comment a:visited { color: rgb(129, 124, 187); }');
+				RESUtils.addCSS('.res-nightmode .comment a:visited { color: hsl(245,32%,61%); }');
 			} else {
 				RESUtils.addCSS('.comment .md p > a:visited { color:#551a8b }');
-				RESUtils.addCSS('.res-nightmode .comment .md p > a:visited { color: rgb(129, 124, 187); }');
+				RESUtils.addCSS('.res-nightmode .comment .md p > a:visited { color: hsl(245,32%,61%); }');
 			}
 			if (this.options.showExpandos.value) {
 				RESUtils.addCSS('.res .compressed .expando-button { display: block; }');

--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -211,10 +211,10 @@ modules['styleTweaks'] = {
 			// If not, we still need a visited class for links in comments, like imgur photos for example, or inline image viewer can't make them look different when expanded!
 			if (this.options.visitedStyle.value) {
 				RESUtils.addCSS('.comment a:visited { color:#551a8b }');
-				RESUtils.addCSS('.res-nightmode .comment a:visited { color: rgb(110, 103, 185); }');
+				RESUtils.addCSS('.res-nightmode .comment a:visited { color: rgb(129, 124, 187); }');
 			} else {
 				RESUtils.addCSS('.comment .md p > a:visited { color:#551a8b }');
-				RESUtils.addCSS('.res-nightmode .comment .md p > a:visited { color: rgb(110, 103, 185); }');
+				RESUtils.addCSS('.res-nightmode .comment .md p > a:visited { color: rgb(129, 124, 187); }');
 			}
 			if (this.options.showExpandos.value) {
 				RESUtils.addCSS('.res .compressed .expando-button { display: block; }');

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -75,6 +75,7 @@ modules['userTagger'] = {
 
 			css += '#benefits { width: 200px; margin-left: 0; }';
 			css += '#userTaggerToolTip #userTaggerVoteWeight { width: 30px; }';
+			css += '.RESUserTag { color: black; }';
 			css += '.userTagLink.RESUserTagImage:hover { text-decoration: none; }';
 			css += '.RESUserTagImage::after { content: "\\F0AC"; font: normal 14px/8px "Batch"; vertical-align: middle; color: #9BD }';
 			css += '.userTagLink { display: inline-block; }';
@@ -590,7 +591,7 @@ modules['userTagger'] = {
 		modules['userTagger'].setUserTag(thisName, thisTag, thisColor, thisIgnore, thisLink, thisVotes);
 	},
 	bgToTextColorMap: {
-		'none': 'black',
+		'none': 'inherit',
 		'aqua': 'black',
 		'black': 'white',
 		'blue': 'white',


### PR DESCRIPTION
* Makes nightmode compatible with different modules and reddit features
 * e.g. Visited link color, sticky color, username colors with username highlighter disabled.
* Removes duplicate and unnecessary styles
 * The color of the NSFW tag was set in two places, yet it doesn't need to be included at all
 * Alternating background colors on link listings isn't something reddit or RES does by default, why should nightmode introduce it? Should be an option in styletweaks that works with and without nightmode.
* Removes overreaching styles
 * e.g. selectedEntry should only add BG color on .md-container, not every .md inside the container.
* Groups more selectors to reduce number of lines
* Adds new styles that were missing. e.g. white drop shadows, black text on black, etc
* Doesn't break existing nightmode themes like /r/space, /r/askreddit and /r/askscience. However /r/videos looks quite different, but that's because their stylesheet is actually having an effect. :/

Give it a twirl and see what you think.