### PR TITLE
Fixes #2367. Resume pause in Never Ending Reddit when clicking "Open Next Page"

### DIFF
--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -138,8 +138,10 @@ modules['neverEndingReddit'] = {
 			this.NREPause = RESUtils.createElement('div', 'NREPause');
 			this.NREPause.setAttribute('title', 'Pause / Restart Never Ending Reddit');
 			if (this.options.reversePauseIcon.value) this.NREPause.classList.add('reversePause');
-			this.isPaused = !!RESStorage.getItem('RESmodules.neverEndingReddit.isPaused');
-			if (this.isPaused) this.NREPause.classList.add('paused');
+
+			var isPaused = !!RESStorage.getItem('RESmodules.neverEndingReddit.isPaused');
+			this.togglePause(isPaused);
+
 			this.NREPause.addEventListener('click', modules['neverEndingReddit'].togglePause, false);
 			modules['floater'].addElement(this.NREPause);
 
@@ -156,8 +158,11 @@ modules['neverEndingReddit'] = {
 	},
 	pageMarkers: [],
 	pageURLs: [],
-	togglePause: function() {
-		modules['neverEndingReddit'].isPaused = !modules['neverEndingReddit'].isPaused;
+	togglePause: function(pause) {
+		if (typeof pause === 'undefined') {
+			pause = !modules['neverEndingReddit'].isPaused;
+		}
+		modules['neverEndingReddit'].isPaused = pause;
 		if (modules['neverEndingReddit'].isPaused) {
 			RESStorage.setItem('RESmodules.neverEndingReddit.isPaused', modules['neverEndingReddit'].isPaused);
 		} else {
@@ -360,7 +365,9 @@ modules['neverEndingReddit'] = {
 			.appendTo(this.progressIndicator);
 
 		var nextpage = $('<a id="NERStaticLink">or open next page</a>')
-			.attr('href', this.nextPageURL);
+			.attr('href', this.nextPageURL)
+			.on('click', modules['neverEndingReddit'].togglePause.bind(this, false)); // resume pause on a new page by default
+
 		$('<p class="NERWidgetText" />').append(nextpage)
 			.append('&nbsp;(and clear Never-Ending stream)')
 			.appendTo(this.progressIndicator);


### PR DESCRIPTION
After this PR, clicking "Open Next Page" button manually will always resume pause. Is that alright? I can add an option if you think it should be possible to disable such behavior, but to me it seems that there is no reason to have Never Ending Reddit be paused on a new page.