### PR TITLE
Shortcuts Easy Delete

### DIFF
--- a/lib/core/res.css
+++ b/lib/core/res.css
@@ -23,7 +23,8 @@ body.res-console-open {
 	-o-transition: bottom 0.4s;
 	transition: bottom 0.4s;
 }
-#RESConsoleContainer em { font-style: italic; }
+body.res em { font-style: italic; }
+body.res strong { font-style: bold; }
 #RESConsoleContainer.slideIn {
 	visibility: visible;
 	bottom: 1.5%;

--- a/lib/core/res.css
+++ b/lib/core/res.css
@@ -24,7 +24,7 @@ body.res-console-open {
 	transition: bottom 0.4s;
 }
 body.res em { font-style: italic; }
-body.res strong { font-style: bold; }
+body.res strong { font-weight: bold; }
 #RESConsoleContainer.slideIn {
 	visibility: visible;
 	bottom: 1.5%;

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -897,7 +897,10 @@ RESUtils.createMultiLock = function() {
 			if (typeof lockname === 'undefined') return;
 			if (locks[lockname]) return;
 
-			locks[lockname] = value || true;
+			locks[lockname] = typeof value !== 'undefined' ? value : 0;
+			if (typeof locks[lockname] === 'number') {
+				locks[lockname] += 1;
+			}
 			count++;
 			return true;
 		},
@@ -905,7 +908,11 @@ RESUtils.createMultiLock = function() {
 			if (typeof lockname === 'undefined') return;
 			if (!locks[lockname]) return;
 
-			locks[lockname] = false;
+			if (typeof locks[lockname] === 'number') {
+				locks[lockname] = Math.max(locks[lockname], 0);
+			} else {
+				locks[lockname] = false;
+			}
 			count--;
 			return true;
 		},

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -1050,7 +1050,7 @@ modules['subredditManager'] = {
 		this.shortCutsTrashWrap = RESUtils.createElement('div', 'res-shortcut-trash');
 		this.shortCutsTrashTitle = RESUtils.createElement('div', '', 'res-shortcut-trash-title');
 		this.dragDropTip = RESUtils.createElement('div', 'res-dragDrop-tip');
-		this.dragDropTip.innerHTML = 'Did you know? You can arrange shortcuts by dragging them left & right along the top bar.'
+		this.dragDropTip.innerHTML = 'Did you know? You can arrange shortcuts by dragging them left & right along the top bar.';
 		this.shortCutsTrash = RESUtils.createElement('div', 'res-shortcut-trash-zone', 'res-icon');
 		this.shortCutsTrash.addEventListener('dragenter', modules['subredditManager'].subredditDragEnter, false);
 		this.shortCutsTrash.addEventListener('dragleave', modules['subredditManager'].subredditDragLeave, false);

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -177,6 +177,7 @@ modules['subredditManager'] = {
 			RESUtils.addCSS('#res-shortcut-trash { opacity: 0; transition: opacity .2s; overflow: hidden; z-index: 1000; width: 400px; padding: 20px; position: fixed; top: 20%; left: 50%; margin-right: -50%; transform: translate(-50%, 0); background-color: rgb(255,255,255); border: 5px solid rgb(156,193,228); border-radius: 5px; box-shadow: 2px 2px 1px 0 rgba(0,50,100,.1); font: 14px/1.5 verdana, sans-serif; color: rgb(30,30,30); box-sizing: content-box; }');
 			RESUtils.addCSS('#res-shortcut-trash strong {  }');
 			RESUtils.addCSS('#res-shortcut-trash-zone { display: block; padding: 10px; margin: 10px 0; border: 2px dashed rgb(200,200,200); font-size: 32px; text-align: center; color: rgb(200,200,200); }');
+			RESUtils.addCSS('#res-shortcut-trash-zone:before { content: "\\F155"; font-family: "Batch"; }');
 			RESUtils.addCSS('#res-shortcut-trash-zone.srOver { outline: none; border-color: rgb(200,50,50); }');
 			RESUtils.addCSS('#res-dragDrop-tip { font-size: 12px; line-height: 1.5 }');
 			RESUtils.addCSS('#res-page-overlay.fadeIn, #res-shortcut-trash.fadeIn { animation: fade .2s; opacity: 1; }');
@@ -487,7 +488,7 @@ modules['subredditManager'] = {
 			if (modules['subredditManager'].options.dropdownEditButton.value) {
 				$('	\
 					<div class="RESShortcutsEditButtons">	\
-						<a href="#"  class="delete res-icon" title="delete">&#xF056;</a>	\
+						<a href="#"  class="delete res-icon" title="delete">&#xF155;</a>	\
 						<a href="#" class="edit res-icon" title="edit">&#xF139;</a>	\
 					</div>	\
 					').appendTo(this.subredditGroupDropdown);
@@ -961,7 +962,7 @@ modules['subredditManager'] = {
 					<label for="newShortcut">Subreddit:</label> <input type="text" id="newShortcut"><br> \
 					<label for="displayName">Display Name:</label> <input type="text" id="displayName"><br> \
 					<input type="submit" name="submit" value="add" id="addSubreddit"> \
-					<div style="clear: both; float: right; margin-top: 5px;"><a class="res-trash-open" href="#" title="Choose which shortcuts to remove"><span class="res-icon">&#xF056;</span> remove shortcuts...</a> | <a style="font-size: 9px;" href="/subreddits/">manage subscribed</a></div> \
+					<div style="clear: both; float: right; margin-top: 5px;"><a class="res-trash-open" href="#" title="Choose which shortcuts to remove"><span class="res-icon">&#xF155;</span> remove shortcuts...</a> | <a style="font-size: 9px;" href="/subreddits/">manage subscribed</a></div> \
 				</form> \
 			';
 			$(this.shortCutsAddFormContainer).html(thisForm);
@@ -1051,7 +1052,6 @@ modules['subredditManager'] = {
 		this.dragDropTip = RESUtils.createElement('div', 'res-dragDrop-tip');
 		this.dragDropTip.innerHTML = 'Did you know? You can arrange shortcuts by dragging them left & right along the top bar.'
 		this.shortCutsTrash = RESUtils.createElement('div', 'res-shortcut-trash-zone', 'res-icon');
-		this.shortCutsTrash.innerHTML = '&#xF056;';
 		this.shortCutsTrash.addEventListener('dragenter', modules['subredditManager'].subredditDragEnter, false);
 		this.shortCutsTrash.addEventListener('dragleave', modules['subredditManager'].subredditDragLeave, false);
 		this.shortCutsTrash.addEventListener('dragover', modules['subredditManager'].subredditDragOver, false);

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -548,14 +548,13 @@ modules['subredditManager'] = {
 		// this.subredditGroupDropdown.style.top = '20px';
 		this.subredditGroupDropdown.style.left = thisXY.x + 'px';
 		this.subredditGroupDropdown.style.display = 'block';
-		// Intentionally exclude second param for finer control of behavior.
-		modules['styleTweaks'].setSRStyleToggleVisibility(false);
+		modules['styleTweaks'].setSRStyleToggleVisibility(false, 'subredditGroupDropdown');
 	},
 	hideSubredditGroupDropdown: function() {
 		delete modules['subredditManager'].hideSubredditGroupDropdownTimer;
 		if (this.subredditGroupDropdown) {
 			this.subredditGroupDropdown.style.display = 'none';
-			modules['styleTweaks'].setSRStyleToggleVisibility(true);
+			modules['styleTweaks'].setSRStyleToggleVisibility(true, 'subredditGroupDropdown');
 		}
 	},
 	editSubredditShortcut: function(ele) {
@@ -1096,7 +1095,7 @@ modules['subredditManager'] = {
 			document.body.appendChild(pageOverlay).classList.add('fadeIn');
 			pageOverlay.style.top = srHeaderArea.offsetHeight + 'px';
 			pageOverlay.addEventListener('click', modules['subredditManager'].removeTrashBin, false);
-			modules['styleTweaks'].setSRStyleToggleVisibility(false);
+			modules['styleTweaks'].setSRStyleToggleVisibility(false, 'subredditManager-trashbin');
 		}
 	},
 	removeTrashBin: function() {
@@ -1109,7 +1108,7 @@ modules['subredditManager'] = {
 			trashWrap.remove();
 		}, 200); // same as CSS transition/animation.
 		modules['subredditManager'].shortCutsTrash.classList.remove('srOver');
-		modules['styleTweaks'].setSRStyleToggleVisibility(true);
+		modules['styleTweaks'].setSRStyleToggleVisibility(true, 'subredditManager-trashbin');
 	},
 	showSortMenu: function() {
 		// Add shortcut sorting menu if it doesn't exist in the DOM yet...

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -93,6 +93,12 @@ modules['subredditManager'] = {
 			type: 'boolean',
 			value: true,
 			description: 'Show last update information on the front page (work only if you have at least 50/100 subscription, see <a href="/r/help/wiki/faq#wiki_some_of_my_subreddits_keep_disappearing.__why.3F">here</a> for more info).'
+		},
+		dragDropDelete: {
+			type: 'boolean',
+			value: true,
+			description: 'Show a trash bin while dragging subreddit shortcuts.',
+			advanced: true
 		}
 		/*		sortingField: {
 			type: 'enum',
@@ -151,7 +157,7 @@ modules['subredditManager'] = {
 			RESUtils.addCSS('#editShortcutDialog .RESDescription { font-size: smaller; color: #666; width: 270px; }');
 			// Fix a Firefox alignment quirk with -moz-focus-inner
 			RESUtils.addCSS('#editShortcutDialog #sortButton::-moz-focus-inner, #editShortcutDialog input#shortcut-subreddit::-moz-focus-inner { border: 0; padding: 0; }');
-			RESUtils.addCSS('#editShortcutDialog [name=shortcut-save] { float: right; padding: 1px 6px; }');
+			RESUtils.addCSS('#editShortcutDialog [name=shortcut-save] { float: right; }');
 
 			RESUtils.addCSS('#srLeftContainer { z-index: 4; padding-left: 4px; margin-right: 6px; }');
 			// RESUtils.addCSS('#RESShortcuts { position: absolute; left: '+ this.srLeftContainerWidth+'px;  z-index: 6; white-space: nowrap; overflow-x: hidden; padding-left: 2px; margin-top: -2px; padding-top: 2px; }');
@@ -173,14 +179,14 @@ modules['subredditManager'] = {
 			RESUtils.addCSS('#RESShortcutsSort { font-size: 14px; }');
 			// Deleting shortcuts
 			RESUtils.addCSS('@keyframes fade { from {opacity: 0} to {opacity: 1}}');
-			RESUtils.addCSS('#res-page-overlay { opacity: 0; transition: opacity .2s; position: fixed; top: 20px; right: 0; bottom: 0; left: 0; background-color: rgba(255,255,255,.7); z-index: 999; }');
+			RESUtils.addCSS('#res-trash-overlay { opacity: 0; transition: opacity .2s; position: fixed; top: 20px; right: 0; bottom: 0; left: 0; background-color: rgba(255,255,255,.7); z-index: 999; }');
 			RESUtils.addCSS('#res-shortcut-trash { opacity: 0; transition: opacity .2s; overflow: hidden; z-index: 1000; width: 400px; padding: 20px; position: fixed; top: 20%; left: 50%; margin-right: -50%; transform: translate(-50%, 0); background-color: rgb(255,255,255); border: 5px solid rgb(156,193,228); border-radius: 5px; box-shadow: 2px 2px 1px 0 rgba(0,50,100,.1); font: 14px/1.5 verdana, sans-serif; color: rgb(30,30,30); box-sizing: content-box; }');
 			RESUtils.addCSS('#res-shortcut-trash strong {  }');
 			RESUtils.addCSS('#res-shortcut-trash-zone { display: block; padding: 10px; margin: 10px 0; border: 2px dashed rgb(200,200,200); font-size: 32px; text-align: center; color: rgb(200,200,200); }');
 			RESUtils.addCSS('#res-shortcut-trash-zone:before { content: "\\F155"; font-family: "Batch"; }');
 			RESUtils.addCSS('#res-shortcut-trash-zone.srOver { outline: none; border-color: rgb(200,50,50); }');
 			RESUtils.addCSS('#res-dragDrop-tip { font-size: 12px; line-height: 1.5 }');
-			RESUtils.addCSS('#res-page-overlay.fadeIn, #res-shortcut-trash.fadeIn { animation: fade .2s; opacity: 1; }');
+			RESUtils.addCSS('#res-trash-overlay.fadeIn, #res-shortcut-trash.fadeIn { animation: fade .2s; opacity: 1; }');
 
 			RESUtils.addCSS('.srSep { margin-left: 6px; }');
 			// RESUtils.addCSS('h1.redditname > a { float: left; }');
@@ -189,15 +195,13 @@ modules['subredditManager'] = {
 			RESUtils.addCSS('.sortAsc::after, .sortDesc::after { width: 12px; line-height: 12px; font-size: 12px; color: #82a3c0 }');
 			RESUtils.addCSS('.sortAsc::after { content: "\\25B2" }');
 			RESUtils.addCSS('.sortDesc::after { content: "\\25BC" }');
-			RESUtils.addCSS('#RESShortcutsAddFormContainer { display: none; position: absolute; width: 290px; padding: 2px; right: 0; top: 21px; z-index: 10000; background-color: #f0f3fc; border: 1px solid #c7c7c7; border-radius: 3px; font-size: 12px; color: #000; }');
-			RESUtils.addCSS('#RESShortcutsAddFormContainer  a { font-weight: bold; }');
-			RESUtils.addCSS('#newShortcut { width: 130px; }');
-			RESUtils.addCSS('#displayName { width: 130px; }');
-			RESUtils.addCSS('#shortCutsAddForm { padding: 5px; }');
-			RESUtils.addCSS('#shortCutsAddForm div { font-size: 10px; margin-bottom: 10px; }');
+			RESUtils.addCSS('#RESShortcutsAddFormContainer { display: none; position: absolute; width: 300px; padding: 5px 10px; right: 2px; top: 21px; z-index: 10000; background-color: #f0f3fc; border: 1px solid #c7c7c7; border-radius: 3px; font-size: 12px; color: #000; box-sizing: content-box; box-shadow: 2px 0px 7px rgba(0,0,0,.1); }');
 			RESUtils.addCSS('#shortCutsAddForm label { display: inline-block; width: 100px; }');
-			RESUtils.addCSS('#shortCutsAddForm input[type=text] { width: 170px; margin-bottom: 6px; }');
-			RESUtils.addCSS('#addSubreddit { float: right; cursor: pointer; padding: 3px 5px; font-size: 12px; color: #fff; border: 1px solid #636363; border-radius: 3px; background-color: #5cc410; }');
+			RESUtils.addCSS('#shortCutsAddForm div { margin: 5px 0; clear: both; }');
+			RESUtils.addCSS('#shortCutsAddForm .res-shortcuts-add-tip { font-size: smaller; color: #666; }');
+			RESUtils.addCSS('#shortCutsAddForm input[type=text] { width: 200px; box-sizing: border-box; }');
+			RESUtils.addCSS('#shortCutsAddForm input[type=submit] { float: right; }');
+			RESUtils.addCSS('#shortCutsAddForm .res-shortcuts-add-footer { text-align: right; padding-top: 5px; }');
 			RESUtils.addCSS('#sr-header-area a.RESShortcutsCurrentSub, #RESSubredditGroupDropdown .RESShortcutsCurrentSub a { color: orangered !important; font-weight: bold; }');
 			RESUtils.addCSS('#srLeftContainer, #RESShortcutsViewport, #RESShortcutsEditContainer{max-height:18px;}');
 			RESUtils.addCSS('#RESSubredditGroupDropdown { margin-left: -5px; }');
@@ -757,7 +761,9 @@ modules['subredditManager'] = {
 		// Target (this) element is the source node.
 		this.style.opacity = '0.4';
 		modules['subredditManager'].dragSrcEl = this;
-		modules['subredditManager'].addTrashBin(modules['subredditManager'].dragSrcEl);
+		if (modules['subredditManager'].options.dragDropDelete.value) {
+			modules['subredditManager'].addTrashBin(modules['subredditManager'].dragSrcEl);
+		}
 
 		e.dataTransfer.effectAllowed = 'move';
 		// because Safari is stupid, we have to do this.
@@ -843,7 +849,9 @@ modules['subredditManager'] = {
 	subredditDragEnd: function(e) {
 		this.style.opacity = '1';
 		this.classList.remove('srOver');
-		modules['subredditManager'].removeTrashBin();
+		if (modules['subredditManager'].options.dragDropDelete.value) {
+			modules['subredditManager'].removeTrashBin();
+		}
 		return false;
 	},
 	redrawSubredditBar: function() {
@@ -958,11 +966,12 @@ modules['subredditManager'] = {
 			this.shortCutsAddFormContainer.style.display = 'none';
 			var thisForm = ' \
 				<form id="shortCutsAddForm"> \
-					<div>Add shortcut or multi-reddit (i.e. foo+bar+baz):</div> \
-					<label for="newShortcut">Subreddit:</label> <input type="text" id="newShortcut"><br> \
-					<label for="displayName">Display Name:</label> <input type="text" id="displayName"><br> \
+					<div><strong>Add Shortcut</strong></div> \
+					<div class="res-shortcuts-add-tip">Put a &plus; between subreddits to make a multireddit.</div>\
+					<div><label for="newShortcut">Subreddit:</label><input type="text" id="newShortcut"></div> \
+					<div><label for="displayName">Display Name:</label><input type="text" id="displayName"></div> \
 					<input type="submit" name="submit" value="add" id="addSubreddit"> \
-					<div style="clear: both; float: right; margin-top: 5px;"><a class="res-trash-open" href="#" title="Choose which shortcuts to remove"><span class="res-icon">&#xF155;</span> remove shortcuts...</a> | <a style="font-size: 9px;" href="/subreddits/">manage subscribed</a></div> \
+					<div class="res-shortcuts-add-footer"><a href="/subreddits/">manage subscribed</a></div> \
 				</form> \
 			';
 			$(this.shortCutsAddFormContainer).html(thisForm);
@@ -1016,14 +1025,19 @@ modules['subredditManager'] = {
 			this.shortCutsEditContainer.appendChild(this.shortCutsAdd);
 			document.body.appendChild(this.shortCutsAddFormContainer);
 			
-			var trashOpenLink = document.querySelector('#RESShortcutsAddFormContainer a.res-trash-open');
-			trashOpenLink.addEventListener('click', function(e) {
-				e.preventDefault();
-				modules['subredditManager'].addTrashBin();
-			}, false);
-
-			// create "trash bin" popup.
-			modules['subredditManager'].createTrashBin();
+			// Add trash bin elements.
+			if (modules['subredditManager'].options.dragDropDelete.value) {
+				var trashOpenLink = RESUtils.createElement('a', null, 'res-trash-open');
+				trashOpenLink.href = '#';
+				trashOpenLink.title = 'Choose which shortcuts to remove';
+				trashOpenLink.innerHTML = '<span class="res-icon">&#xF155;</span> remove shortcuts...';
+				$('#RESShortcutsAddFormContainer .res-shortcuts-add-footer').prepend(' | ').prepend(trashOpenLink);
+				trashOpenLink.addEventListener('click', function(e) {
+					e.preventDefault();
+					modules['subredditManager'].addTrashBin();
+				}, false);
+				modules['subredditManager'].createTrashBin();
+			}
 
 			// add left scroll arrow...
 			this.shortCutsLeft = document.createElement('div');
@@ -1063,7 +1077,7 @@ modules['subredditManager'] = {
 	addTrashBin: function(e) {
 		var shortcut = e;
 		var srHeaderArea = document.querySelector('#sr-header-area');
-		var pageOverlay = document.querySelector('#res-page-overlay') || RESUtils.createElement('div', 'res-page-overlay');
+		var pageOverlay = document.querySelector('#res-trash-overlay') || RESUtils.createElement('div', 'res-trash-overlay');
 		// hide other elements.
 		if (modules['subredditManager'].subredditGroupDropdown) {
 			modules['subredditManager'].subredditGroupDropdown.style.display = 'none';
@@ -1086,7 +1100,7 @@ modules['subredditManager'] = {
 		}
 	},
 	removeTrashBin: function() {
-		var overlay = document.querySelector('#res-page-overlay');
+		var overlay = document.querySelector('#res-trash-overlay');
 		var trashWrap = modules['subredditManager'].shortCutsTrashWrap;
 		overlay.classList.remove('fadeIn');
 		trashWrap.classList.remove('fadeIn');
@@ -1570,7 +1584,7 @@ modules['subredditManager'] = {
 
 			modules['notifications'].showNotification({
 				moduleID: 'subredditManager',
-				message: 'Subreddit shortcut added. You can edit by double clicking, or trash by dragging to the trash can.'
+				message: 'Subreddit shortcut added. You can edit by double clicking the shortcut.'
 			});
 		}
 	},

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -169,10 +169,17 @@ modules['subredditManager'] = {
 			RESUtils.addCSS('#RESShortcutsAdd { right: 15px; }');
 			RESUtils.addCSS('#RESShortcutsLeft { right: 31px; }');
 			RESUtils.addCSS('#RESShortcutsSort { right: 47px; }');
-
-			RESUtils.addCSS('#RESShortcutsSort, #RESShortcutsRight, #RESShortcutsLeft, #RESShortcutsAdd, #RESShortcutsTrash { width: 16px; cursor: pointer; background: #F0F0F0; font-size: 20px; color: #369; height: 18px; line-height: 15px; position: absolute; top: 0; z-index: 999; background-color: #f0f0f0; user-select: none; -webkit-user-select: none; -moz-user-select: none; }');
+			RESUtils.addCSS('#RESShortcutsSort, #RESShortcutsRight, #RESShortcutsLeft, #RESShortcutsAdd { width: 16px; cursor: pointer; background: #F0F0F0; font-size: 20px; color: #369; height: 18px; line-height: 15px; position: absolute; top: 0; z-index: 999; background-color: #f0f0f0; user-select: none; -webkit-user-select: none; -moz-user-select: none; }');
 			RESUtils.addCSS('#RESShortcutsSort { font-size: 14px; }');
-			RESUtils.addCSS('#RESShortcutsTrash { display: none; font-size: 17px; width: 16px; cursor: pointer; right: 15px; height: 16px; position: absolute; top: 0; z-index: 1000; user-select: none; -webkit-user-select: none; -moz-user-select: none; }');
+			// Deleting shortcuts
+			RESUtils.addCSS('#res-page-overlay { opacity: 0; transition: opacity .2s; position: fixed; top: 20px; right: 0; bottom: 0; left: 0; background-color: rgba(0,0,0,.7); z-index: 999; }');
+			RESUtils.addCSS('@keyframes fade { from {opacity: 0} to {opacity: 1}}');
+			RESUtils.addCSS('#res-shortcut-trash { opacity: 0; transition: opacity .2s; overflow: hidden; z-index: 1000; width: 300px; padding: 20px; position: fixed; top: 20%; left: 50%; margin-right: -50%; transform: translate(-50%, 0); background-color: rgb(255,255,255); border-radius: 5px; box-shadow: 3px 3px 10px 0 rgba(0,0,0,.3); font: 14px/1.5 verdana, sans-serif; color: rgb(100,100,100); }');
+			RESUtils.addCSS('#res-shortcut-trash-zone { display: block; padding: 10px; margin: 10px 0; border: 2px dashed rgb(200,200,200); font-size: 32px; text-align: center; color: rgb(200,200,200); background: transparent !important; }');
+			RESUtils.addCSS('#res-shortcut-trash-zone.srOver { outline: none; border-color: rgb(200,50,50); }');
+			RESUtils.addCSS('#res-dragDrop-tip { font-size: 12px; line-height: 1.5 }');
+			RESUtils.addCSS('#res-page-overlay.fadeIn, #res-shortcut-trash.fadeIn { animation: fade .2s; opacity: 1; }');
+
 			RESUtils.addCSS('.srSep { margin-left: 6px; }');
 			// RESUtils.addCSS('h1.redditname > a { float: left; }');
 			RESUtils.addCSS('h1.redditname { overflow: auto; }');
@@ -745,20 +752,31 @@ modules['subredditManager'] = {
 	},
 	subredditDragStart: function(e) {
 		clearTimeout(modules['subredditManager'].clickTimer);
+		var srHeaderArea = document.querySelector('#sr-header-area');
+		var pageOverlay = RESUtils.createElement('div', 'res-page-overlay');
 		// Target (this) element is the source node.
 		this.style.opacity = '0.4';
-		modules['subredditManager'].shortCutsTrash.style.display = 'block';
+		document.body.appendChild(modules['subredditManager'].shortCutsTrashWrap).classList.add('fadeIn');
 		modules['subredditManager'].dragSrcEl = this;
+		modules['subredditManager'].shortCutsTrashTitle.querySelector('em').innerHTML = this.innerHTML;
 
 		e.dataTransfer.effectAllowed = 'move';
 		// because Safari is stupid, we have to do this.
 		modules['subredditManager'].srDataTransfer = this.getAttribute('orderIndex') + ',' + $(this).data('subreddit');
+
+		document.body.appendChild(pageOverlay).classList.add('fadeIn');
+		// Second param won't work because it's checking for style.display,
+		// yet the element gets removed instead of hidden.
+		modules['styleTweaks'].setSRStyleToggleVisibility(false, pageOverlay);
+		pageOverlay.style.top = srHeaderArea.offsetHeight + 'px';
+		modules['subredditManager'].hideSubredditGroupDropdown();
 	},
 	subredditDragEnter: function(e) {
 		this.classList.add('srOver');
 		return false;
 	},
 	subredditDragOver: function(e) {
+		modules['subredditManager'].hideSubredditGroupDropdown();
 		if (e.preventDefault) {
 			e.preventDefault(); // Necessary. Allows us to drop.
 		}
@@ -780,11 +798,10 @@ modules['subredditManager'] = {
 		// Stops other browsers from redirecting.
 		e.preventDefault();
 
-		modules['subredditManager'].shortCutsTrash.style.display = 'none';
 		// Don't do anything if dropping the same column we're dragging.
 		if (modules['subredditManager'].dragSrcEl !== this) {
 			var theData, srcOrderIndex, srcSubreddit;
-			if (e.target.getAttribute('id') !== 'RESShortcutsTrash') {
+			if (e.target.getAttribute('id') !== 'res-shortcut-trash') {
 				// get the order index of the src and destination to swap...
 				// var theData = e.dataTransfer.getData('text/html').split(',');
 				theData = modules['subredditManager'].srDataTransfer.split(',');
@@ -793,8 +810,7 @@ modules['subredditManager'] = {
 				var destOrderIndex = parseInt(this.getAttribute('orderIndex'), 10);
 				var destSubreddit = modules['subredditManager'].mySubredditShortcuts[destOrderIndex];
 				var rearranged = [];
-				var rearrangedI = 0;
-
+				var rearrangedI = 0;				
 				modules['subredditManager'].mySubredditShortcuts.forEach(function(shortcut, i) {
 					if ((i !== srcOrderIndex) && (i !== destOrderIndex)) {
 						rearranged[rearrangedI] = shortcut;
@@ -821,7 +837,6 @@ modules['subredditManager'] = {
 				modules['subredditManager'].saveLatestShortcuts();
 				// redraw the shortcut bar...
 				modules['subredditManager'].redrawShortcuts();
-				this.classList.remove('srOver');
 			} else {
 				theData = modules['subredditManager'].srDataTransfer.split(',');
 				srcOrderIndex = parseInt(theData[0], 10);
@@ -832,8 +847,15 @@ modules['subredditManager'] = {
 		return false;
 	},
 	subredditDragEnd: function(e) {
-		modules['subredditManager'].shortCutsTrash.style.display = 'none';
 		this.style.opacity = '1';
+		document.querySelector('#res-page-overlay').classList.remove('fadeIn');
+		modules['subredditManager'].shortCutsTrashWrap.classList.remove('fadeIn');
+		setTimeout(function() {
+			document.querySelector('#res-page-overlay').remove();
+			modules['subredditManager'].shortCutsTrashWrap.remove();
+		}, 200);
+		this.classList.remove('srOver');
+		modules['subredditManager'].shortCutsTrash.classList.remove('srOver');
 		return false;
 	},
 	redrawSubredditBar: function() {
@@ -1007,13 +1029,20 @@ modules['subredditManager'] = {
 			document.body.appendChild(this.shortCutsAddFormContainer);
 
 			// add the "trash bin"...
-			this.shortCutsTrash = RESUtils.createElement('div', 'RESShortcutsTrash', 'res-icon');
+			this.shortCutsTrashWrap = RESUtils.createElement('div', 'res-shortcut-trash');
+			this.shortCutsTrashTitle = RESUtils.createElement('div', '', 'res-shortcut-trash-title');
+			this.shortCutsTrashTitle.innerHTML = 'Drop here to delete shortcut <em></em>';
+			this.dragDropTip = RESUtils.createElement('div', 'res-dragDrop-tip');
+			this.dragDropTip.innerHTML = 'Did you know? You can move shortcuts by dragging them left & right along the top bar.'
+			this.shortCutsTrash = RESUtils.createElement('div', 'res-shortcut-trash-zone', 'res-icon');
 			this.shortCutsTrash.innerHTML = '&#xF056;';
 			this.shortCutsTrash.addEventListener('dragenter', modules['subredditManager'].subredditDragEnter, false);
 			this.shortCutsTrash.addEventListener('dragleave', modules['subredditManager'].subredditDragLeave, false);
 			this.shortCutsTrash.addEventListener('dragover', modules['subredditManager'].subredditDragOver, false);
 			this.shortCutsTrash.addEventListener('drop', modules['subredditManager'].subredditDrop, false);
-			this.shortCutsEditContainer.appendChild(this.shortCutsTrash);
+			this.shortCutsTrashWrap.appendChild(this.shortCutsTrashTitle);
+			this.shortCutsTrashWrap.appendChild(this.shortCutsTrash);
+			this.shortCutsTrashWrap.appendChild(this.dragDropTip);
 
 			// add left scroll arrow...
 			this.shortCutsLeft = document.createElement('div');

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -172,10 +172,11 @@ modules['subredditManager'] = {
 			RESUtils.addCSS('#RESShortcutsSort, #RESShortcutsRight, #RESShortcutsLeft, #RESShortcutsAdd { width: 16px; cursor: pointer; background: #F0F0F0; font-size: 20px; color: #369; height: 18px; line-height: 15px; position: absolute; top: 0; z-index: 999; background-color: #f0f0f0; user-select: none; -webkit-user-select: none; -moz-user-select: none; }');
 			RESUtils.addCSS('#RESShortcutsSort { font-size: 14px; }');
 			// Deleting shortcuts
-			RESUtils.addCSS('#res-page-overlay { opacity: 0; transition: opacity .2s; position: fixed; top: 20px; right: 0; bottom: 0; left: 0; background-color: rgba(0,0,0,.7); z-index: 999; }');
 			RESUtils.addCSS('@keyframes fade { from {opacity: 0} to {opacity: 1}}');
-			RESUtils.addCSS('#res-shortcut-trash { opacity: 0; transition: opacity .2s; overflow: hidden; z-index: 1000; width: 300px; padding: 20px; position: fixed; top: 20%; left: 50%; margin-right: -50%; transform: translate(-50%, 0); background-color: rgb(255,255,255); border-radius: 5px; box-shadow: 3px 3px 10px 0 rgba(0,0,0,.3); font: 14px/1.5 verdana, sans-serif; color: rgb(100,100,100); }');
-			RESUtils.addCSS('#res-shortcut-trash-zone { display: block; padding: 10px; margin: 10px 0; border: 2px dashed rgb(200,200,200); font-size: 32px; text-align: center; color: rgb(200,200,200); background: transparent !important; }');
+			RESUtils.addCSS('#res-page-overlay { opacity: 0; transition: opacity .2s; position: fixed; top: 20px; right: 0; bottom: 0; left: 0; background-color: rgba(255,255,255,.7); z-index: 999; }');
+			RESUtils.addCSS('#res-shortcut-trash { opacity: 0; transition: opacity .2s; overflow: hidden; z-index: 1000; width: 400px; padding: 20px; position: fixed; top: 20%; left: 50%; margin-right: -50%; transform: translate(-50%, 0); background-color: rgb(255,255,255); border: 5px solid rgb(156,193,228); border-radius: 5px; box-shadow: 2px 2px 1px 0 rgba(0,50,100,.1); font: 14px/1.5 verdana, sans-serif; color: rgb(30,30,30); box-sizing: content-box; }');
+			RESUtils.addCSS('#res-shortcut-trash strong {  }');
+			RESUtils.addCSS('#res-shortcut-trash-zone { display: block; padding: 10px; margin: 10px 0; border: 2px dashed rgb(200,200,200); font-size: 32px; text-align: center; color: rgb(200,200,200); }');
 			RESUtils.addCSS('#res-shortcut-trash-zone.srOver { outline: none; border-color: rgb(200,50,50); }');
 			RESUtils.addCSS('#res-dragDrop-tip { font-size: 12px; line-height: 1.5 }');
 			RESUtils.addCSS('#res-page-overlay.fadeIn, #res-shortcut-trash.fadeIn { animation: fade .2s; opacity: 1; }');
@@ -542,14 +543,14 @@ modules['subredditManager'] = {
 		// this.subredditGroupDropdown.style.top = '20px';
 		this.subredditGroupDropdown.style.left = thisXY.x + 'px';
 		this.subredditGroupDropdown.style.display = 'block';
-
-		modules['styleTweaks'].setSRStyleToggleVisibility(false, 'subredditGroupDropdown');
+		// Intentionally exclude second param for finer control of behavior.
+		modules['styleTweaks'].setSRStyleToggleVisibility(false);
 	},
 	hideSubredditGroupDropdown: function() {
 		delete modules['subredditManager'].hideSubredditGroupDropdownTimer;
 		if (this.subredditGroupDropdown) {
 			this.subredditGroupDropdown.style.display = 'none';
-			modules['styleTweaks'].setSRStyleToggleVisibility(true, 'subredditGroupDropdown');
+			modules['styleTweaks'].setSRStyleToggleVisibility(true);
 		}
 	},
 	editSubredditShortcut: function(ele) {
@@ -752,31 +753,23 @@ modules['subredditManager'] = {
 	},
 	subredditDragStart: function(e) {
 		clearTimeout(modules['subredditManager'].clickTimer);
-		var srHeaderArea = document.querySelector('#sr-header-area');
-		var pageOverlay = RESUtils.createElement('div', 'res-page-overlay');
 		// Target (this) element is the source node.
 		this.style.opacity = '0.4';
-		document.body.appendChild(modules['subredditManager'].shortCutsTrashWrap).classList.add('fadeIn');
 		modules['subredditManager'].dragSrcEl = this;
-		modules['subredditManager'].shortCutsTrashTitle.querySelector('em').innerHTML = this.innerHTML;
+		modules['subredditManager'].addTrashBin(modules['subredditManager'].dragSrcEl);
 
 		e.dataTransfer.effectAllowed = 'move';
 		// because Safari is stupid, we have to do this.
 		modules['subredditManager'].srDataTransfer = this.getAttribute('orderIndex') + ',' + $(this).data('subreddit');
-
-		document.body.appendChild(pageOverlay).classList.add('fadeIn');
-		// Second param won't work because it's checking for style.display,
-		// yet the element gets removed instead of hidden.
-		modules['styleTweaks'].setSRStyleToggleVisibility(false, pageOverlay);
-		pageOverlay.style.top = srHeaderArea.offsetHeight + 'px';
-		modules['subredditManager'].hideSubredditGroupDropdown();
 	},
 	subredditDragEnter: function(e) {
 		this.classList.add('srOver');
 		return false;
 	},
 	subredditDragOver: function(e) {
-		modules['subredditManager'].hideSubredditGroupDropdown();
+		if (modules['subredditManager'].subredditGroupDropdown) {
+			modules['subredditManager'].subredditGroupDropdown.style.display = 'none';
+		}
 		if (e.preventDefault) {
 			e.preventDefault(); // Necessary. Allows us to drop.
 		}
@@ -810,7 +803,7 @@ modules['subredditManager'] = {
 				var destOrderIndex = parseInt(this.getAttribute('orderIndex'), 10);
 				var destSubreddit = modules['subredditManager'].mySubredditShortcuts[destOrderIndex];
 				var rearranged = [];
-				var rearrangedI = 0;				
+				var rearrangedI = 0;
 				modules['subredditManager'].mySubredditShortcuts.forEach(function(shortcut, i) {
 					if ((i !== srcOrderIndex) && (i !== destOrderIndex)) {
 						rearranged[rearrangedI] = shortcut;
@@ -848,14 +841,8 @@ modules['subredditManager'] = {
 	},
 	subredditDragEnd: function(e) {
 		this.style.opacity = '1';
-		document.querySelector('#res-page-overlay').classList.remove('fadeIn');
-		modules['subredditManager'].shortCutsTrashWrap.classList.remove('fadeIn');
-		setTimeout(function() {
-			document.querySelector('#res-page-overlay').remove();
-			modules['subredditManager'].shortCutsTrashWrap.remove();
-		}, 200);
 		this.classList.remove('srOver');
-		modules['subredditManager'].shortCutsTrash.classList.remove('srOver');
+		modules['subredditManager'].removeTrashBin();
 		return false;
 	},
 	redrawSubredditBar: function() {
@@ -974,7 +961,7 @@ modules['subredditManager'] = {
 					<label for="newShortcut">Subreddit:</label> <input type="text" id="newShortcut"><br> \
 					<label for="displayName">Display Name:</label> <input type="text" id="displayName"><br> \
 					<input type="submit" name="submit" value="add" id="addSubreddit"> \
-					<div style="clear: both; float: right; margin-top: 5px;"><a style="font-size: 9px;" href="/subreddits/">Edit frontpage subscriptions</a></div> \
+					<div style="clear: both; float: right; margin-top: 5px;"><a class="res-trash-open" href="#" title="Choose which shortcuts to remove"><span class="res-icon">&#xF056;</span> remove shortcuts...</a> | <a style="font-size: 9px;" href="/subreddits/">manage subscribed</a></div> \
 				</form> \
 			';
 			$(this.shortCutsAddFormContainer).html(thisForm);
@@ -1027,22 +1014,15 @@ modules['subredditManager'] = {
 			}, false);
 			this.shortCutsEditContainer.appendChild(this.shortCutsAdd);
 			document.body.appendChild(this.shortCutsAddFormContainer);
+			
+			var trashOpenLink = document.querySelector('#RESShortcutsAddFormContainer a.res-trash-open');
+			trashOpenLink.addEventListener('click', function(e) {
+				e.preventDefault();
+				modules['subredditManager'].addTrashBin();
+			}, false);
 
-			// add the "trash bin"...
-			this.shortCutsTrashWrap = RESUtils.createElement('div', 'res-shortcut-trash');
-			this.shortCutsTrashTitle = RESUtils.createElement('div', '', 'res-shortcut-trash-title');
-			this.shortCutsTrashTitle.innerHTML = 'Drop here to delete shortcut <em></em>';
-			this.dragDropTip = RESUtils.createElement('div', 'res-dragDrop-tip');
-			this.dragDropTip.innerHTML = 'Did you know? You can move shortcuts by dragging them left & right along the top bar.'
-			this.shortCutsTrash = RESUtils.createElement('div', 'res-shortcut-trash-zone', 'res-icon');
-			this.shortCutsTrash.innerHTML = '&#xF056;';
-			this.shortCutsTrash.addEventListener('dragenter', modules['subredditManager'].subredditDragEnter, false);
-			this.shortCutsTrash.addEventListener('dragleave', modules['subredditManager'].subredditDragLeave, false);
-			this.shortCutsTrash.addEventListener('dragover', modules['subredditManager'].subredditDragOver, false);
-			this.shortCutsTrash.addEventListener('drop', modules['subredditManager'].subredditDrop, false);
-			this.shortCutsTrashWrap.appendChild(this.shortCutsTrashTitle);
-			this.shortCutsTrashWrap.appendChild(this.shortCutsTrash);
-			this.shortCutsTrashWrap.appendChild(this.dragDropTip);
+			// create "trash bin" popup.
+			modules['subredditManager'].createTrashBin();
 
 			// add left scroll arrow...
 			this.shortCutsLeft = document.createElement('div');
@@ -1064,6 +1044,58 @@ modules['subredditManager'] = {
 
 			this.redrawShortcuts();
 		}
+	},
+	createTrashBin: function() {
+		this.shortCutsTrashWrap = RESUtils.createElement('div', 'res-shortcut-trash');
+		this.shortCutsTrashTitle = RESUtils.createElement('div', '', 'res-shortcut-trash-title');
+		this.dragDropTip = RESUtils.createElement('div', 'res-dragDrop-tip');
+		this.dragDropTip.innerHTML = 'Did you know? You can arrange shortcuts by dragging them left & right along the top bar.'
+		this.shortCutsTrash = RESUtils.createElement('div', 'res-shortcut-trash-zone', 'res-icon');
+		this.shortCutsTrash.innerHTML = '&#xF056;';
+		this.shortCutsTrash.addEventListener('dragenter', modules['subredditManager'].subredditDragEnter, false);
+		this.shortCutsTrash.addEventListener('dragleave', modules['subredditManager'].subredditDragLeave, false);
+		this.shortCutsTrash.addEventListener('dragover', modules['subredditManager'].subredditDragOver, false);
+		this.shortCutsTrash.addEventListener('drop', modules['subredditManager'].subredditDrop, false);
+		this.shortCutsTrashWrap.appendChild(this.shortCutsTrashTitle);
+		this.shortCutsTrashWrap.appendChild(this.shortCutsTrash);
+		this.shortCutsTrashWrap.appendChild(this.dragDropTip);
+	},
+	addTrashBin: function(e) {
+		var shortcut = e;
+		var srHeaderArea = document.querySelector('#sr-header-area');
+		var pageOverlay = document.querySelector('#res-page-overlay') || RESUtils.createElement('div', 'res-page-overlay');
+		// hide other elements.
+		if (modules['subredditManager'].subredditGroupDropdown) {
+			modules['subredditManager'].subredditGroupDropdown.style.display = 'none';
+		}
+		modules['subredditManager'].shortCutsAddFormContainer.style.display = 'none';
+		// set the title.
+		if (shortcut) {
+			modules['subredditManager'].shortCutsTrashTitle.innerHTML = 'Drop here to delete shortcut <strong>' + shortcut.innerHTML + '</strong>';
+		} else {
+			modules['subredditManager'].shortCutsTrashTitle.innerHTML = 'Drag and drop shortcuts to delete them';
+		}
+		if (!pageOverlay.parentNode) {
+			// add trash bin
+			document.body.appendChild(modules['subredditManager'].shortCutsTrashWrap).classList.add('fadeIn');
+			// add overlay
+			document.body.appendChild(pageOverlay).classList.add('fadeIn');
+			pageOverlay.style.top = srHeaderArea.offsetHeight + 'px';
+			pageOverlay.addEventListener('click', modules['subredditManager'].removeTrashBin, false);
+			modules['styleTweaks'].setSRStyleToggleVisibility(false);
+		}
+	},
+	removeTrashBin: function() {
+		var overlay = document.querySelector('#res-page-overlay');
+		var trashWrap = modules['subredditManager'].shortCutsTrashWrap;
+		overlay.classList.remove('fadeIn');
+		trashWrap.classList.remove('fadeIn');
+		setTimeout(function() {
+			overlay.remove();
+			trashWrap.remove();
+		}, 200); // same as CSS transition/animation.
+		modules['subredditManager'].shortCutsTrash.classList.remove('srOver');
+		modules['styleTweaks'].setSRStyleToggleVisibility(true);
 	},
 	showSortMenu: function() {
 		// Add shortcut sorting menu if it doesn't exist in the DOM yet...


### PR DESCRIPTION
When dragging and dropping shortcuts to the trash bin you have to drop them on a tiny 16x16 icon on the far corner of the page, why not make the icon really big and in the middle of the page instead?

Demo 1 (normal use): https://imgrush.com/CrrCGY95fNUf

Demo 2 (how users can discover it): https://imgrush.com/MTPhAfcOmfWY

It includes a little tip under the 'trash zone' about how to rearrange shortcuts.
