### PR TITLE
Fix pre tags, and wiki UL tags in nightmode

### DIFF
--- a/lib/modules/nightmode.css
+++ b/lib/modules/nightmode.css
@@ -1107,3 +1107,7 @@ html.res-nightmode .multi-details .subreddits .remove-sr {
 	background-color: rgb(93, 104, 115);
 	border-right-color: rgb(118, 133, 148);
 }
+
+.res-nightmode .md.wiki {
+	color: rgb(204, 204, 204);
+}

--- a/lib/modules/nightmode.css
+++ b/lib/modules/nightmode.css
@@ -1111,3 +1111,7 @@ html.res-nightmode .multi-details .subreddits .remove-sr {
 .res-nightmode .md.wiki {
 	color: rgb(204, 204, 204);
 }
+
+.res-nightmode .md pre {
+	background-color: transparent;
+}


### PR DESCRIPTION
This makes pre tags, and Wiki UL tags readable

Before, the UL tags had the same color as the background, and the pre tags had a white background with blue text on top, both of which made it hard to read them.