### PR TITLE
Add support for image caption linebreaks

### DIFF
--- a/lib/core/res.css
+++ b/lib/core/res.css
@@ -1261,6 +1261,7 @@ h4.imgCaptions, .md h4.imgCaptions {
 }
 div.imgCaptions, .md div.imgCaptions {
 	font-size: 11px;
+	white-space: pre-wrap;
 }
 .imgCredits {
 	font-size: 11px;


### PR DESCRIPTION
In the showImage module image caption linebreaks are currently not supported, making lists difficult to read. This PR adds a new util function, $.safeHtmlLinebreaks, which first sanitizes the input string then replaces linebreaks with a `<br>` tag.

I only tested this with an imgur album ([this post in particular](https://www.reddit.com/r/interestingasfuck/comments/3fqlf1/famous_last_words/)) so if need be I can try to test other services as well.