### PR TITLE
Improve imgur album regex

### DIFF
--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -18,10 +18,10 @@ addLibrary('mediaHosts', 'imgur', {
 	// was too greedy a search...
 	// the hashRe below was provided directly by MrGrim (well, everything after the domain was), using that now.
 	// in addition to the above, the album index was moved out of the first capture group.
-	hashRe: /^https?:\/\/(?:i\.|m\.|edge\.|www\.)*imgur\.com\/(?:r\/[\w]+\/)*(?!gallery)(?!removalrequest)(?!random)(?!memegen)([\w]{5,7}(?:[&,][\w]{5,7})*)(?:#\d+)?[sbtmlh]?(\.(?:jpe?g|gif|png|gifv))?(\?.*)?$/i,
-	hostedHashRe: /^https?:(\/\/i\.\w+\.*imgur\.com\/)([\w]{5,7}(?:[&,][\w]{5,7})*)(?:#\d+)?[sbtmlh]?(\.(?:jpe?g|gif|png))?(\?.*)?$/i,
-	galleryHashRe: /^https?:\/\/(?:m\.)?imgur\.com\/gallery\/([\w]+)(\..+)?(?:\/)?(?:#?\w*)?$/i,
-	albumHashRe: /^https?:\/\/(?:m\.)?imgur\.com\/a\/([\w]+)(\..+)?(?:\/)?(?:#?\w*)?$/i,
+	hashRe: /^https?:\/\/(?:i\.|m\.|edge\.|www\.)*imgur\.com\/(?:r\/\w+\/)*(?!gallery)(?!removalrequest)(?!random)(?!memegen)(\w{5,7}(?:[&,]\w{5,7})*)(?:#\d+)?[sbtmlh]?(\.(?:jpe?g|gif|png|gifv))?(\?.*)?$/i,
+	hostedHashRe: /^https?:(\/\/i\.\w+\.*imgur\.com\/)(\w{5,7}(?:[&,]\w{5,7})*)(?:#\d+)?[sbtmlh]?(\.(?:jpe?g|gif|png))?(\?.*)?$/i,
+	galleryHashRe: /^https?:\/\/(?:m\.|www\.)?imgur\.com\/gallery\/(\w+)(?:[/#]|$)/i,
+	albumHashRe: /^https?:\/\/(?:m\.|www\.)?imgur\.com\/a\/(\w+)(?:[/#]|$)/i,
 	detect: (href, elem) => (
 		elem.pathname !== '/rules' &&
 		elem.pathname !== '/inbox'


### PR DESCRIPTION
Fixes #2300.

I removed the file extension `(\..+)?` because there don't appear to be any valid `/a/` or `/gallery/` URLs with a file extension. (@andytuba?)