### PR TITLE
Clicking a focused "load more comments" will focus the last new comment

### DIFF
--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -145,14 +145,23 @@ addModule('selectedEntry', function(module, moduleID) {
 		selectedContainer = newSelected && $(newSelected.thing).parent().closest('.thing');
 	}
 
-	function onNewComments(entries) {
+	var onNewCommentsCooldown;
+	function onNewComments(entry) {
+		if (onNewCommentsCooldown) {
+			// Recently selected something, ignore remainder of batch
+			return;
+		}
 		if (selectedThing && !selectedThing.parentNode) {
 			// Selected thing was replaced, so select the replacement
-			var newContainer = $(entries).closest('.thing').parent().closest('.thing');
+			var newContainer = $(entry).closest('.thing').parent().closest('.thing');
 			if (newContainer.filter(selectedContainer).length) {
-				select(entries, {
+				select(entry, {
 					replacement: true
 				});
+				// only select the first applicable thing in a batch
+				onNewCommentsCooldown = setTimeout(function() {
+					onNewCommentsCooldown = undefined;
+				}, 100);
 			}
 		}
 	}


### PR DESCRIPTION
e.g. in [this thread](https://www.reddit.com/r/AskReddit/comments/3cfifw/what_was_the_worst_pr_move_in_history/)

Focus a "load more comments" entry with keyNav, then click it or press enter.

In 4.5.4 you will focus the top loaded comment (correctly), but in dev you'll focus the last comment in the chain of loaded comments.