### PR TITLE
filteReddit: Avoid unnecessary [].slice wrapping

### DIFF
--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -758,7 +758,7 @@ modules['filteReddit'] = {
 			(RESUtils.currentSubreddit('all')) || (RESUtils.currentDomain()) || (RESUtils.currentMultireddit('me/f/all')),
 			onSavedPage = modules['filteReddit'].excludeSaved.test && modules['filteReddit'].excludeSaved.test(location.href);
 
-		Array.prototype.slice.call(things).forEach(function(thing) {
+		things.forEach(function(thing) {
 			var currSub, postTitle, postDomain, postSubreddit, postFlair;
 			var filtered;
 			if (!onSavedPage) {


### PR DESCRIPTION
`RESUtils.things` should already return an array, so this is unnecessary.