### PR TITLE
Donate button has lost its buttony look

### DIFF
--- a/lib/core/res.css
+++ b/lib/core/res.css
@@ -43,6 +43,7 @@ body.res-console-open {
 	color: orangered;
 	border-radius: 10px;
 	padding: 10px 20px;
+	border: 1px solid rgb(255,69,0);
 }
 .donateOption {
 	margin-top: 25px;


### PR DESCRIPTION
Adds a border around the donate button, same color as the orange text. It stopped looking like a button when the background color of the console went from light blue to white.