### PR TITLE
visitedStyle changes

### DIFF
--- a/lib/modules/nightmode.css
+++ b/lib/modules/nightmode.css
@@ -822,22 +822,17 @@ body.res-nightmode,
 	border-right-color: rgb(118,133,148);
 }
 /* moderator style takes higher priority than friend */
-.res-nightmode .tagline .friend,
-.res-nightmode .tagline .friend:visited {
+.res-nightmode .tagline .friend {
   color: rgb(255,69,0);
 }
-.res-nightmode .tagline .submitter,
-.res-nightmode .tagline .submitter:visited {
+.res-nightmode .tagline .submitter {
 	color: rgb(20,150,220);
 }
-.res-nightmode .tagline .moderator,
-.res-nightmode .tagline .moderator:visited {
+.res-nightmode .tagline .moderator {
 	color: rgb(34,136,34)
 }
 .res-nightmode .tagline .admin,
-.res-nightmode .tagline .admin:visited,
-.res-nightmode .user-distinction .admin,
-.res-nightmode .user-distinction .admin:visited {
+.res-nightmode .user-distinction .admin {
 	color: rgb(218,73,83);
 }
 .res-nightmode hr,

--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -57,8 +57,7 @@ modules['styleTweaks'] = {
 		visitedStyle: {
 			type: 'boolean',
 			value: false,
-			description: 'Reddit makes it so no links on comment pages appear as "visited" - including user profiles. This option undoes that.',
-			advanced: true
+			description: 'Change the color of links you\'ve visited to purple. (By default Reddit only does this for submission titles.)'
 		},
 		showExpandos: {
 			type: 'boolean',
@@ -206,15 +205,15 @@ modules['styleTweaks'] = {
 				this.disableAnimations();
 			}
 
-			// wow, Reddit doesn't define a visited class for any links on comments pages...
-			// let's put that back if users want it back.
-			// If not, we still need a visited class for links in comments, like imgur photos for example, or inline image viewer can't make them look different when expanded!
+			// wow, Reddit only adds a visited style for submission titles!
+			// let's add visited styles to user-editable content (.md) if the user wants to.
+			// else we still want visited styles on inline images.
 			if (this.options.visitedStyle.value) {
-				RESUtils.addCSS('.comment a:visited { color:#551a8b }');
-				RESUtils.addCSS('.res-nightmode .comment a:visited { color: hsl(245,35%,55%); }');
+				RESUtils.addCSS('.md a:visited { color: #551a8b; }'); // same color as submission titles.
+				RESUtils.addCSS('.res-nightmode .md a:visited { color: hsl(245,35%,55%); }');
 			} else {
-				RESUtils.addCSS('.comment .md p > a:visited { color:#551a8b }');
-				RESUtils.addCSS('.res-nightmode .comment .md p > a:visited { color: hsl(245,35%,55%); }');
+				RESUtils.addCSS('.md a[name^="img"]:visited { color: #551a8b; }');
+				RESUtils.addCSS('.res-nightmode .md a[name^="img"]:visited { color: hsl(245,35%,55%); }');
 			}
 			if (this.options.showExpandos.value) {
 				RESUtils.addCSS('.res .compressed .expando-button { display: block; }');


### PR DESCRIPTION
Currently visitedStyle acts a little strangely; it doesn't affect links in self text or the side bar, it overrides links in .tagline, and even when disabled styleTweaks.js applies a blanket visited style to all comments anyway (to help with expandable images).

I found that showImages.js adds a name prefixed with `img` to all expandable image links, so we can target them with the selector `a[name^="img"]`, no need to style every normal link. The only shortfall is that when visitedStyle is disabled, duplicate images don't have a name so they don't change color.

I'm not sure if it's a good idea to apply this to the side bar because I found a number of themes that aren't very strict with their side bar link colors. Fortunately I haven't seen any serious issues, and themers don't have to do much to avoid it.

Here's a screenshot of my proposal:
![visited-style-01-proposal](https://cloud.githubusercontent.com/assets/7245595/9323347/16499728-45c3-11e5-873c-a97612116313.png)

Screenshot from master for comparison:
![visited-style-01-master](https://cloud.githubusercontent.com/assets/7245595/9323351/2e20a08a-45c3-11e5-93fe-311d190b5803.png)