### PR TITLE
Only use legacy gearIcon in user bar

### DIFF
--- a/lib/core/res.css
+++ b/lib/core/res.css
@@ -129,13 +129,13 @@ body.res-console-open {
 	from { transform: scale(0, 0); }
 	to { transform: scale(1.5, 1.5); }
 }
-.res-gearIcon-legacy .gearIcon{
+.res-gearIcon-legacy.gearIcon{
 	display: inline-block;
 	width: 15px;
 	height: 15px;
 	background-repeat: no-repeat;
 }
-.res-gearIcon-legacy .gearIcon::after {
+.res-gearIcon-legacy.gearIcon::after {
 	content: none;
 }
 #RESMainGearOverlay .gearIcon {

--- a/lib/modules/menu.js
+++ b/lib/modules/menu.js
@@ -99,7 +99,7 @@ addModule('RESMenu', function(module, moduleID) {
 		var gearIcon = module.RESPrefsLink.querySelector('.gearIcon'),
 			backgroundImage = window.getComputedStyle(gearIcon).backgroundImage;
 		if (modules['styleTweaks'].isSubredditStyleEnabled() && backgroundImage && backgroundImage !== 'none') {
-			document.body.classList.add('res-gearIcon-legacy');
+			gearIcon.classList.add('res-gearIcon-legacy');
 		}
 	}
 });


### PR DESCRIPTION
I believe this was the intended purpose of this function, because it's only checking the background property of the icon in the user bar. The legacy class shouldn't affect every icon on the page since they could be styled differently.

See /r/naut and /r/askreddit using master and notice the broken icons in userTagger, commentPreview and NER. I'm not sure which other subreddits to check.