### PR TITLE
Update to NER notifications

### DIFF
--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -15,12 +15,6 @@ modules['neverEndingReddit'] = {
 			value: true,
 			description: 'Automatically load new page on scroll (if off, you click to load)'
 		},
-		notifyWhenPaused: {
-			type: 'boolean',
-			value: true,
-			description: 'Show a reminder to unpause Never-Ending Reddit after pausing',
-			advanced: true
-		},
 		reversePauseIcon: {
 			type: 'boolean',
 			value: false,
@@ -156,7 +150,7 @@ modules['neverEndingReddit'] = {
 	},
 	pageMarkers: [],
 	pageURLs: [],
-	togglePause: function() {
+	togglePause: function(source) {
 		modules['neverEndingReddit'].isPaused = !modules['neverEndingReddit'].isPaused;
 		if (modules['neverEndingReddit'].isPaused) {
 			RESStorage.setItem('RESmodules.neverEndingReddit.isPaused', modules['neverEndingReddit'].isPaused);
@@ -165,14 +159,11 @@ modules['neverEndingReddit'] = {
 		}
 		if (modules['neverEndingReddit'].isPaused) {
 			modules['neverEndingReddit'].NREPause.classList.add('paused');
-			if (modules['neverEndingReddit'].options.notifyWhenPaused.value) {
-				var notification = [];
-				notification.push('Never-Ending Reddit has been paused. Click the play/pause button to unpause it.');
-				notification.push('To hide this message, disable Never-Ending Reddit\'s ' + modules['settingsNavigation'].makeUrlHashLink('neverEndingReddit', 'notifyWhenPaused', 'notifyWhenPaused option <span class="gearIcon" />') + '.');
-				notification = notification.join('<br><br>');
+			if (source !== 'pauseAfterEvery') {
 				modules['notifications'].showNotification({
-					moduleID: 'neverEndingReddit',
-					message: notification
+					moduleID: modules['neverEndingReddit'].moduleID,
+					notificationID: 'paused',
+					message: 'Never-Ending Reddit has been paused. Click the play/pause button to unpause it.'
 				});
 			}
 		} else {
@@ -271,14 +262,15 @@ modules['neverEndingReddit'] = {
 		if (this.pauseAfterPages === null) {
 			this.pauseAfterPages = parseInt(modules['neverEndingReddit'].options.pauseAfterEvery.value, 10);
 		}
-
 		if ((this.pauseAfterPages > 0) && (currPageNum % this.pauseAfterPages === 0)) {
-			this.togglePause(true);
-			var notification = [];
-			notification.push('Time for a break!');
-			notification.push('Never-Ending Reddit was paused automatically. ' + modules['settingsNavigation'].makeUrlHashLink('neverEndingReddit', 'pauseAfterEvery', '', 'gearIcon'));
-			notification = notification.join('<br><br>');
-			setTimeout(modules['notifications'].showNotification.bind(RESUtils, notification, 5000));
+			this.togglePause('pauseAfterEvery');
+			var message = '<p>Time for a break!</p>';
+			message += '<p>Never-Ending Reddit has been paused because you\'ve passed ' + this.pauseAfterPages + ' pages. You can change this number in RES settings.</p>';
+			modules['notifications'].showNotification({
+				moduleID: modules['neverEndingReddit'].moduleID,
+				notificationID: 'pauseAfterEvery',
+				message: message
+			});
 		}
 	},
 	duplicateCheck: function(newHTML) {

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -269,6 +269,8 @@ modules['neverEndingReddit'] = {
 			modules['notifications'].showNotification({
 				moduleID: modules['neverEndingReddit'].moduleID,
 				notificationID: 'pauseAfterEvery',
+				optionKey: 'pauseAfterEvery',
+				closeDelay: 5000,
 				message: message
 			});
 		}


### PR DESCRIPTION
* Rewrote the message of the 'pauseAfterEvery' notification.
* Removed unnecessary cogs from messages, users can use the cog in the title.
* Don't show 'paused' notification when 'pauseAfterEvery' notification is shown, because it's unnecessary and confusing to show them both at once.
* Removed notifyWhenPaused option, because users can use the checkbox in the notification instead.