### PR TITLE
Enhance UX for ignoring users

### DIFF
--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -431,7 +431,7 @@ RESUtils.thing.prototype = {
 		}
 	},
 	isComment: function() {
-		return this.entry.classList.contains('comment');
+		return this.thing.classList.contains('comment');
 	},
 
 	getTitle: function() {

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -266,7 +266,8 @@ RESUtils.regexes = {
 	subreddit: /^https?:\/\/(?:[\-\w\.]+\.)?reddit\.com\/r\/([\w\.\+]+)/i,
 	subredditPostListing: /^https?:\/\/(?:[\-\w\.]+\.)?reddit\.com\/r\/([\w\.\+]+)(?:\/(new|rising|controversial|top))?\/?(?:\?.*)?$/i,
 	multireddit: /^https?:\/\/(?:[\-\w\.]+\.)?reddit\.com\/((?:me|user\/[\-\w\.#=]*)\/(?:m|f)\/([\w\.\+]+))/i,
-	domain: /^https?:\/\/(?:[\-\w\.]+\.)?reddit\.com\/domain\/([\w\.\+]+)/i
+	domain: /^https?:\/\/(?:[\-\w\.]+\.)?reddit\.com\/domain\/([\w\.\+]+)/i,
+	front: /^https?:\/\/(?:[\-\w\.]+\.)?reddit\.com\/?(?:[?#]|$)/i
 };
 RESUtils.verifyHash = function(hash) {
 	if ($.inArray(RESUtils.hashCode(hash), RESUtils.problemHashes) !== -1) {

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -739,9 +739,9 @@ modules['userTagger'] = {
 				this.tags[username].ignore = true;
 				
 				// Display a notification. If user is viewing inbox, explain how to block users.
-				notificationMessage = '<p>Now ignoring content posted by ' + username + '.</p>'
+				notificationMessage = '<p>Now ignoring content posted by ' + username + '.</p>';
 				if (RESUtils.isPageType('inbox')) {
-					notificationMessage += '<p>If you wish to block ' + username + ' from sending you messages, go to <a href="/message/messages/">your messages</a> and click \'block user\' underneath their last message.</p>'
+					notificationMessage += '<p>If you wish to block ' + username + ' from sending you messages, go to <a href="/message/messages/">your messages</a> and click \'block user\' underneath their last message.</p>';
 					notificationMessage += '<p><a href="https://redd.it/ijfps">About blocking users</a>.</p>';
 					closeDelay = 5000;
 				}
@@ -805,7 +805,7 @@ modules['userTagger'] = {
 			thisTag = null,
 			thisColor = null,
 			thisIgnore = null,
-			thisAuthor, thisPost, thisComment, test, noTag;
+			thisAuthor, test, noTag;
 
 		// var thisAuthorObj = this.authors[authorNum];
 		if ((thisAuthorObj) && (!(thisAuthorObj.classList.contains('userTagged'))) && (typeof thisAuthorObj !== 'undefined') && (thisAuthorObj !== null)) {

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -283,7 +283,7 @@ modules['userTagger'] = {
 			this.registerCommandLine();
 			
 			// ignore posts on: (front|subredditPostListing|multireddit|search).
-			if (RESUtils.matchesPageRegex(modules['userTagger'].regexes.front, RESUtils.regexes.subredditPostListing, RESUtils.regexes.multireddit, RESUtils.regexes.search)) {
+			if (RESUtils.matchesPageRegex(RESUtils.regexes.front, RESUtils.regexes.subredditPostListing, RESUtils.regexes.multireddit, RESUtils.regexes.search)) {
 				this.ignoredContentType = 'submission';
 			}
 			// ignore comments on:
@@ -925,9 +925,6 @@ modules['userTagger'] = {
 				}
 			}
 		}
-	},
-	regexes: {
-		front: /^https?:\/\/(?:[\-\w\.]+\.)?reddit\.com\/?$/i
 	},
 	ignorePost: function(thing) {
 		var title;

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -13,7 +13,12 @@ modules['userTagger'] = {
 		hardIgnore: {
 			type: 'boolean',
 			value: false,
-			description: 'When "hard ignore" is off, only post titles and comment text is hidden. When it is on, the entire post is hidden (or for comments, collapsed).'
+			description: 'Completely remove links and comments posted by ignored users. If an ignored comment has replies, collapse it and hide its contents instead of removing it.'
+		},
+		showIgnored: {
+			type: 'boolean',
+			value: true,
+			description: 'Provide a link to reveal an ignored link or comment. The hardIgnore option overrides this.'
 		},
 		colorUser: {
 			type: 'boolean',
@@ -46,7 +51,7 @@ modules['userTagger'] = {
 			advanced: true
 		}
 	},
-	description: 'Adds a great deal of customization around users - tagging them, ignoring them, and more. You can manage tagged users on <a href="/r/Dashboard/#userTaggerContents">Manage User Tags</a>.',
+	description: '<p>Adds a great deal of customization around users - tagging them, ignoring them, and more. You can manage tagged users on <a href="/r/Dashboard/#userTaggerContents">Manage User Tags</a>.</p><p><b>Ignoring users:</b> users will <i>not</i> be ignored in modmail, moderation queue or your inbox.</p>',
 	isEnabled: function() {
 		return RESUtils.options.getModulePrefs(this.moduleID);
 	},
@@ -67,12 +72,10 @@ modules['userTagger'] = {
 			css += '#userTaggerToolTip input[type=submit] { cursor: pointer; position: absolute; right: 16px; bottom: 16px; padding: 3px 5px; font-size: 12px; color: #fff; border: 1px solid #636363; border-radius: 3px; background-color: #5cc410; } ';
 			css += '#userTaggerToolTip .toggleButton { margin-top: 5px; margin-bottom: 5px; float: left; }';
 			css += '#userTaggerClose { position: absolute; right: 7px; top: 7px; z-index: 11; }';
-
-			css += '.ignoredUserComment { color: #CACACA; padding: 3px; font-size: 10px; }';
-			css += '.ignoredUserPost { color: #CACACA; padding: 3px; font-size: 10px; }';
+			css += '.res-ignored-message { color: rgb(170,170,170); cursor: default; }';
+			css += '.res-ignored-message .res-icon { font-size: inherit; }';
 			css += 'a.voteWeight { text-decoration: none; color: #369; }';
 			css += 'a.voteWeight:hover { text-decoration: none; }';
-
 			css += '#benefits { width: 200px; margin-left: 0; }';
 			css += '#userTaggerToolTip #userTaggerVoteWeight { width: 30px; }';
 			css += '.RESUserTag { color: black; }';
@@ -278,6 +281,15 @@ modules['userTagger'] = {
 			}
 
 			this.registerCommandLine();
+			
+			// ignore posts on: (front|subredditPostListing|multireddit|search).
+			if (RESUtils.matchesPageRegex(modules['userTagger'].regexes.front, RESUtils.regexes.subredditPostListing, RESUtils.regexes.multireddit, RESUtils.regexes.search)) {
+				this.ignoredContentType = 'submission';
+			}
+			// ignore comments on:
+			else if (RESUtils.isPageType('comments')) {
+				this.ignoredContentType = 'comment';
+			}
 		}
 	},
 	registerCommandLine: function() {
@@ -710,6 +722,7 @@ modules['userTagger'] = {
 		}
 	},
 	setUserTag: function(username, tag, color, ignore, link, votes, noclick) {
+		var notificationMessage, closeDelay;
 		username = username.toLowerCase();
 		if (((tag !== null) && (tag !== '')) || (ignore)) {
 			if (tag === '') {
@@ -724,6 +737,20 @@ modules['userTagger'] = {
 			var bgColor = (color === 'none') ? 'transparent' : color;
 			if (ignore) {
 				this.tags[username].ignore = true;
+				
+				// Display a notification. If user is viewing inbox, explain how to block users.
+				notificationMessage = '<p>Now ignoring content posted by ' + username + '.</p>'
+				if (RESUtils.isPageType('inbox')) {
+					notificationMessage += '<p>If you wish to block ' + username + ' from sending you messages, go to <a href="/message/messages/">your messages</a> and click \'block user\' underneath their last message.</p>'
+					notificationMessage += '<p><a href="https://redd.it/ijfps">About blocking users</a>.</p>';
+					closeDelay = 5000;
+				}
+				modules['notifications'].showNotification({
+					moduleID: modules['userTagger'].moduleID,
+					notificationID: 'addedToIgnoreList',
+					message: notificationMessage,
+					closeDelay: closeDelay
+				});
 			} else {
 				delete this.tags[username].ignore;
 			}
@@ -876,63 +903,22 @@ modules['userTagger'] = {
 						}
 					}
 					RESUtils.insertAfter(thisAuthorObj, userTagFrag);
+					
+					// Ignore content from certain users.
+					// For blocking users from sending messages to other users, see reddit's built-in block feature.
 					if (typeof noEdit === 'undefined' || !noEdit) {
-						thisIgnore = userObject[thisAuthor].ignore && thisAuthorObj.classList.contains('author');
-						if (thisIgnore && (RESUtils.pageType() !== 'profile')) {
-							if (this.options.hardIgnore.value) {
-								if (RESUtils.pageType() === 'comments') {
-									thisComment = modules['userTagger'].ignoreComment(thisAuthorObj, thisAuthor);
-									if (thisComment) {
-										// collapse comment as well
-										var toggle = thisComment.parentNode.querySelector('a.expand');
-										RESUtils.click(toggle);
-									}
-								} else {
-									thisPost = $(thisAuthorObj).closest('.thing').get(0);
-
-									if (thisPost) {
-										// hide post block first...
-										thisPost.style.display = 'none';
-										// hide associated voting block...
-										if (thisPost.previousSibling) {
-											thisPost.previousSibling.style.display = 'none';
-										}
-									}
-								}
-							} else {
-								if (RESUtils.pageType() === 'comments') {
-									// ignore comment
-									modules['userTagger'].ignoreComment(thisAuthorObj, thisAuthor);
-								} else {
-									var $thisPost, $thisMessage;
-									if (RESUtils.pageType() === 'inbox') {
-										$thisMessage = $(thisAuthorObj).closest('.thing');
-										$thisPost = $thisMessage.find('.md');
-
-										// If message, ignore message title also
-										if (!$thisMessage.is('.was-comment')) {
-											$thisMessage.find('.subject').text('Ignored message');
-										}
-									} else {
-										$thisPost = $(thisAuthorObj).closest('.thing').find('p.title');
-									}
-									thisPost = $thisPost[0];
-
-									if (thisPost) {
-										var showLink = document.createElement('a');
-										showLink.textContent = 'show anyway?';
-										showLink.setAttribute('href','#');
-										showLink.addEventListener('click', function(e) {
-											$(this).parent().html($(this).parent().attr('data-original')).removeClass('ignoredUserPost').addClass('md');
-											e.preventDefault();
-										});
-										thisPost.setAttribute('data-original', thisPost.innerHTML);
-										thisPost.textContent = thisAuthor + ' is an ignored user. ';
-										thisPost.appendChild(showLink);
-
-										thisPost.setAttribute('class', 'ignoredUserPost');
-									}
-								}
+						// Tagline contains relevant author.
+						// We don't want this to work on the inbox where parent node is something else.
+						thisIgnore = userObject[thisAuthor].ignore && ($(thisAuthorObj).parent().hasClass('tagline') || $(thisAuthorObj).parent().hasClass('search-author'));
+						
+						if (thisIgnore) {
+							var thing = RESUtils.thing(thisAuthorObj);
+							thing['element'].classList.add('res-ignored-content');
+							if (modules['userTagger'].ignoredContentType === 'submission' && thing.isPost()) {
+								modules['userTagger'].ignorePost(thing);
+							}
+							else if (modules['userTagger'].ignoredContentType === 'comment' && thing.isComment()) {
+								modules['userTagger'].ignoreComment(thing);
 							}
 						}
 					}
@@ -940,25 +926,68 @@ modules['userTagger'] = {
 			}
 		}
 	},
-	ignoreComment: function(thisAuthorObj, thisAuthor){
-		var thisComment = thisAuthorObj.parentNode.parentNode.querySelector('.usertext');
-		if (thisComment) {
-			var showLink = document.createElement('a');
-			showLink.textContent = 'show anyway?';
-			showLink.setAttribute('href','#');
-			showLink.addEventListener('click', function(e) {
-				$(this).parent().html($(this).parent().attr('data-original')).removeClass('ignoredUserComment');
-				e.preventDefault();
-			});
-			// store original
-			thisComment.setAttribute('data-original', thisComment.innerHTML);
-			// remove comment
-			thisComment.textContent = thisAuthor + ' is an ignored user.';
-			thisComment.appendChild(showLink);
-			thisComment.classList.add('ignoredUserComment');
-			return thisComment;
+	regexes: {
+		front: /^https?:\/\/(?:[\-\w\.]+\.)?reddit\.com\/?$/i
+	},
+	ignorePost: function(thing) {
+		var title;
+		if (modules['userTagger'].options.hardIgnore.value) {
+			thing['element'].parentNode.removeChild(thing['element']);
+		} else {
+			title = thing.entry.querySelector('p.title');
+			if (title === null) {
+				title = thing.querySelector('.search-result-header');
+				$(thing['element']).find('.search-result-body > .md, .search-expando-button, .search-result-footer').hide();
+			}
+			title.setAttribute('data-original', title.innerHTML);
+			title.innerHTML = '';
+			title.classList.remove('title');
+			$(thing['element']).find('.expando-button, .usertext-body, a.thumbnail').hide();
+			title.appendChild(modules['userTagger'].ignoredPlaceholder(thing, title));
 		}
-		return false;
+	},
+	ignoreComment: function(thing) {
+		var body, toggleComment;
+		if (modules['userTagger'].options.hardIgnore.value) {
+			if (!$(thing['element']).children('.child').children().length) {
+				thing['element'].parentNode.removeChild(thing['element']);
+			}
+			else if (thing['element'].classList.contains('noncollapsed')) {
+				toggleComment = thing.entry.querySelector('a.expand');
+				RESUtils.click(toggleComment);
+			}
+		}
+		body = thing.entry.querySelector('.md-container > .md');
+		body.setAttribute('data-original', body.innerHTML);
+		body.innerHTML = '';
+		$(thing['element']).find('.buttons').hide();
+		body.appendChild(modules['userTagger'].ignoredPlaceholder(thing, body));
+	},
+	// Inline message to indicate when content has been softly hidden.
+	ignoredPlaceholder: function(thing, target) {
+		var wrapper = RESUtils.createElement('span', null, 'res-ignored-message');
+		var icon = RESUtils.createElement('span', null, 'res-icon', '\uF093');
+		var text = RESUtils.createElement('span', null, null, ' ignored. ');
+		var button = RESUtils.createElement('a', null, null, 'Show anyway.');
+		button.setAttribute('href', '#');
+		wrapper.appendChild(icon);
+		wrapper.appendChild(text);
+		// Click to unhide ignored content.
+		if (modules['userTagger'].options.showIgnored.value) {
+			wrapper.appendChild(button);
+			button.addEventListener('click', function(e) {
+				e.preventDefault();
+				target.innerHTML = target.getAttribute('data-original');
+				thing['element'].classList.remove('res-ignored-content');
+				if (thing.isPost()) {
+					target.classList.add('title');
+					$(thing['element']).find('.expando-button, .usertext-body, .search-result-body > .md, .search-expando-button, a.thumbnail, .search-result-footer').show();
+				} else {
+					$(thing['element']).find('.buttons').show();
+				}
+			}, false);
+		}
+		return wrapper;
 	},
 	colorUser: function(obj, author, votes) {
 		if (this.options.colorUser.value) {


### PR DESCRIPTION
- Now works with new search page.
- No longer hides inbox messages.
- No longer hides comments in mod mail.
- No longer hides links in mod queue (mod/about/modqueue). (Fixes #1245)
- Added a batch icon to signify ignored content.
- Added an option to include or exclude the 'show anyway' link. (Fixes #2326)
- hardIgnore now removes childless comments.
- Added notification when adding someone to ignore list. (#1247)
- Changed and added wording in userTagger module settings.

The existing code was quite old, so I rewrote it with the help of utils.js, while using the same general approach as before.
## Screenshots

**Link listings | hardignore off | showIgnored on:**
![ignore-user-search-legacy](https://cloud.githubusercontent.com/assets/7245595/9548061/90b67852-4de1-11e5-948b-c9a679be6621.png)

**Search:**
![ignore-user-search](https://cloud.githubusercontent.com/assets/7245595/9548090/c1ef207c-4de1-11e5-81a7-e0b68256a704.png)

**Comments:**
![ignore-user-comments](https://cloud.githubusercontent.com/assets/7245595/9548102/d0b03204-4de1-11e5-93c3-12c6a94e7e6a.png)

**Comments | hardIgnore on:** (notice the one missing comment)
![ignore-user-comments-hard](https://cloud.githubusercontent.com/assets/7245595/9548446/def063be-4de3-11e5-9d27-b02b2b18489e.png)

**Notification:**
![ignore-user-notification](https://cloud.githubusercontent.com/assets/7245595/9548112/e6145152-4de1-11e5-8c52-1e69c50121f7.png)
