### PR TITLE
Support for Miiverse posts.

### DIFF
--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -144,6 +144,7 @@
 				"modules/hosts/github.js",
 				"modules/hosts/onedrive.js",
 				"modules/hosts/oddshot.js",
+				"modules/hosts/miiverse.js",
 				"core/init.js"
 			],
 			"css": [

--- a/Opera/includes/loader.js
+++ b/Opera/includes/loader.js
@@ -151,6 +151,7 @@
 		'modules/hosts/github.js',
 		'modules/hosts/onedrive.js',
 		'modules/hosts/oddshot.js',
+		'modules/hosts/miiverse.js',
 
 		'core/init.js',
 

--- a/OperaBlink/manifest.json
+++ b/OperaBlink/manifest.json
@@ -143,6 +143,7 @@
 				"modules/hosts/github.js",
 				"modules/hosts/onedrive.js",
 				"modules/hosts/oddshot.js",
+				"modules/hosts/miiverse.js",
 				"core/init.js"
 			],
 			"css": [

--- a/RES.safariextension/Info.plist
+++ b/RES.safariextension/Info.plist
@@ -154,6 +154,7 @@
 				<string>modules/hosts/github.js</string>
 				<string>modules/hosts/onedrive.js</string>
 				<string>modules/hosts/oddshot.js</string>
+				<string>modules/hosts/miiverse.js</string>
 				<string>core/init.js</string>
 			</array>
 		</dict>
@@ -182,6 +183,7 @@
 				<string>backend.deviantart.com</string>
 				<string>api.tumblr.com</string>
 				<string>noembed.com</string>
+				<string>miiverse.nintendo.net</string>
 			</array>
 			<key>Include Secure Pages</key>
 			<true/>

--- a/XPI/index.js
+++ b/XPI/index.js
@@ -269,6 +269,7 @@ pageMod.PageMod({
 		self.data.url('modules/hosts/github.js'),
 		self.data.url('modules/hosts/onedrive.js'),
 		self.data.url('modules/hosts/oddshot.js'),
+		self.data.url('modules/hosts/miiverse.js'),
 		self.data.url('core/init.js')
 	],
 	contentStyleFile: [

--- a/lib/modules/hosts/miiverse.js
+++ b/lib/modules/hosts/miiverse.js
@@ -25,19 +25,64 @@ modules['showImages'].siteModules['miiverse'] = {
 			generate: function () {
 				var expando = RESUtils.createElement('div', '', 'expando');
 
-				var	miiversePost = RESUtils.createElement('div');
-				miiversePost.className = 'miiverse-post';
-				miiversePost.setAttribute('lang', 'en');
-				miiversePost.setAttribute('data-miiverse-embedded-version', '1');
-				miiversePost.setAttribute('data-miiverse-cite', info);
+				function makePost(omitScript) {
 				
-				var miiverseScript = RESUtils.createElement('script');
-				miiverseScript.setAttribute('async', 'async');
-				miiverseScript.setAttribute('src', 'https://miiverse.nintendo.net/js/embedded.min.js');
-				miiverseScript.setAttribute('charset', 'utf-8');
+					if (omitScript == false) {
+						//generate code needed for Miiverse's embed script.
+						
+						var	miiversePost = RESUtils.createElement('div');
+						miiversePost.className = 'miiverse-post';
+						miiversePost.setAttribute('lang', 'en');
+						miiversePost.setAttribute('data-miiverse-embedded-version', '1');
+						miiversePost.setAttribute('data-miiverse-cite', info);
+						
+						var miiverseScript = RESUtils.createElement('script');
+						miiverseScript.setAttribute('async', 'async');
+						miiverseScript.setAttribute('src', 'https://miiverse.nintendo.net/js/embedded.min.js');
+						miiverseScript.setAttribute('charset', 'utf-8');
+						
+						expando.appendChild(miiversePost);
+						expando.appendChild(miiverseScript);
+					}
+					else {
+						//create the miiverse post manually. Just an iframe with the
+						//original post URL plus '/embed'
+						var postID = 'unknown';
+						
+						var matches = info.match(/\/posts\/([0-9A-Za-z\-_]+)$/);
+						if (matches && matches.length == 2)
+							postID = matches[1];
+						
+						var frame = document.createElement('iframe');
+						frame.className = 'miiverse-post-frame miiverse-post-' + postID;
+						frame.src = info + '/embed';
+						
+						//give it some basic style
+						frame.style.minWidth = '220px';
+						frame.style.maxWidth = '500px';
+						frame.style.width = '98%';
+						frame.style.border = '1px solid #dddddd';
+						
+						expando.appendChild(frame);
+						
+						function handleMessage(event) {
+							//see if we can get the proper height.
+							var matches = event.data.match(/(?:^|,)height:([0-9]+)(?:,|$)/);
+							
+							if (matches.length == 2) {
+								frame.style.height = matches[1] + 'px';
+								frame.scrolling = 'no';
+							}
+							else {
+								frame.style.height = '500px';
+							}
+						}
+
+						window.addEventListener('message', handleMessage, false);
+					}
+				}
 				
-				expando.appendChild(miiversePost);
-				expando.appendChild(miiverseScript);
+				makePost(BrowserDetect.isFirefox());
 
 				return expando;
 			},

--- a/lib/modules/hosts/miiverse.js
+++ b/lib/modules/hosts/miiverse.js
@@ -1,0 +1,49 @@
+
+modules['showImages'].siteModules['miiverse'] = {
+	domains: [ 'miiverse.nintendo.net' ],
+
+	name: 'Miiverse',
+
+	detect: function(href, elem) {
+		return href.indexOf('miiverse.nintendo.net/posts/') !== -1;
+	},
+
+	handleLink: function(elem) {
+		var def = $.Deferred();
+
+		def.resolve(elem, elem.href);
+
+		return def;
+	},
+
+	handleInfo: function(elem, info) {
+		
+		elem.type = 'GENERIC_EXPANDO';
+		elem.expandoClass = ' selftext miiverse';
+		
+		elem.expandoOptions = {
+			generate: function () {
+				var expando = RESUtils.createElement('div', '', 'expando');
+
+				var	miiversePost = RESUtils.createElement('div');
+				miiversePost.className = 'miiverse-post';
+				miiversePost.setAttribute('lang', 'en');
+				miiversePost.setAttribute('data-miiverse-embedded-version', '1');
+				miiversePost.setAttribute('data-miiverse-cite', info);
+				
+				var miiverseScript = RESUtils.createElement('script');
+				miiverseScript.setAttribute('async', 'async');
+				miiverseScript.setAttribute('src', 'https://miiverse.nintendo.net/js/embedded.min.js');
+				miiverseScript.setAttribute('charset', 'utf-8');
+				
+				expando.appendChild(miiversePost);
+				expando.appendChild(miiverseScript);
+
+				return expando;
+			},
+			media: info
+		};
+		
+		return $.Deferred().resolve(elem);
+	}
+};

--- a/lib/modules/hosts/miiverse.js
+++ b/lib/modules/hosts/miiverse.js
@@ -27,7 +27,7 @@ modules['showImages'].siteModules['miiverse'] = {
 
 				function makePost(omitScript) {
 				
-					if (omitScript == false) {
+					if (omitScript === false) {
 						//generate code needed for Miiverse's embed script.
 						
 						var	miiversePost = RESUtils.createElement('div');
@@ -65,7 +65,7 @@ modules['showImages'].siteModules['miiverse'] = {
 						
 						expando.appendChild(frame);
 						
-						function handleMessage(event) {
+						window.addEventListener('message', function(event) {
 							//see if we can get the proper height.
 							var matches = event.data.match(/(?:^|,)height:([0-9]+)(?:,|$)/);
 							
@@ -76,9 +76,7 @@ modules['showImages'].siteModules['miiverse'] = {
 							else {
 								frame.style.height = '500px';
 							}
-						}
-
-						window.addEventListener('message', handleMessage, false);
+						}, false);
 					}
 				}
 				


### PR DESCRIPTION
This makes posts from miiverse.nintendo.net show up like posts from Twitter do. Nintendo provides embed HTML code when viewing a post on Miiverse which is a div tag and a script tag. The modules/hosts/miiverse.js just generates the same div & script tags, and places it in a GENERIC_EXPANDO.