### PR TITLE
Highlighted NSFW expandos in nightmode

### DIFF
--- a/lib/modules/nightmode.css
+++ b/lib/modules/nightmode.css
@@ -341,6 +341,14 @@
 	-webkit-filter: grayscale(100%) invert(80%);
 	filter: grayscale(100%) invert(80%);
 }
+/* from white & blue to black and red-ish */
+.res-nightmode.res-highlight-nsfw-expando .thing.over18 .expando-button {
+	-webkit-filter: hue-rotate(-40deg) invert(80%) brightness(70%) saturate(300%);
+	filter: hue-rotate(-40deg) invert(80%) brightness(70%) saturate(300%);
+}
+.res-nightmode.res-highlight-nsfw-expando .thing.over18 .expando-button::before {
+	content: none;
+}
 .res-nightmode .RESdupeimg {
 	color: #eee;
 	font-size: 10px;
@@ -1051,5 +1059,5 @@ body.res-nightmode,
 	color: rgb(210,90,50)
 }
 .res-nightmode .nsfw-stamp {
-	color: hsl(0, 50%, 50%);
+	color: rgb(192,78,81);
 }


### PR DESCRIPTION
In nightmode the CSS filter property on expandos doesn't play well with the NSFW stripes, because it converts them to grayscale:

![nsfw-expando-night-gray](https://cloud.githubusercontent.com/assets/7245595/9566405/1578af44-4f48-11e5-8927-9cc56ce8d426.png)

I couldn't find a solution to make the stripes work, short of adding the old sprite back in.

As a workaround I added some extra filters and removed the stripes, turning the expando itself red:
![nsfw-expandos-night](https://cloud.githubusercontent.com/assets/7245595/9566418/46767fe0-4f48-11e5-8d80-8ba1d11a0478.png)

The [RES expandos](https://s3.amazonaws.com/b.thumbs.redditmedia.com/tBwwK20XXxtpgudWx1L7bDXla-iotv-JA0jgA0Y-FVs.png) have lighter borders and +/- indicators than the text and video expandos, so they're harder to see. It's still usable, but could be better.