### PR TITLE
Added an extra class for selected comments

### DIFF
--- a/lib/core/res.css
+++ b/lib/core/res.css
@@ -1741,11 +1741,13 @@ a spinner with a static ring and no overlay.*/
 	display: none; /* hide by default */
 	padding: 10px;
 }
-
 #RESStyleSheetTipPane-contents ul {
-	list-style: disc inside;
+	list-style: initial;
+	margin: 0 0 0 1em;
 }
-
+#RESStyleSheetTipPane-contents li p {
+	margin: .75em 0;
+}
 /* user-select: none; on comment widgets, for usability reasons */
 .md .keyNavAnnotation,
 .md .RESUserTag,

--- a/lib/modules/modhelper.js
+++ b/lib/modules/modhelper.js
@@ -24,8 +24,8 @@ modules['modHelper'] = {
 	},
 	tips: {
 		'no-res-styles': 'It appears you haven\'t done any styling specific to RES.  If you are interested in a quick overview on styling for RES users, please see [our wiki article](/r/Enhancement/wiki/subredditstyling)',
-		'keyNav': 'Styling "RES-keyNav-activeElement"?  This is the element that RES uses for Keyboard Navigation - it indicates the currently selected post, and is crucial to RES functionality. If you don\'t personally care for how it looks, please consider styling it to fit better in your subreddit. Some subs use a transparent background and only a border, for example.',
-		'keyNav-benice': 'It appears that you are hiding the RES-keyNav-activeElement class. This negatively affects RES users by rendering keyboard navigation unusable. It\'s understandable that you may not care for the default appearance, but we politely request that you consider styling it to fit your subreddit, perhaps using an alternate background color, or a border. Even just a one-sided border, e.g. border-right: 3px solid blue; - thank you for your consideration.',
+		'keyNav': 'Styling `RES-keyNav-activeElement`? This is the element RES uses for Keyboard Navigation - it indicates the currently selected post, and is crucial to RES functionality. If you don\'t like the way it looks with your theme, you may style it however you want, as long as Keyboard Navigation remains usable for your visitors.',
+		'keyNav-benice': 'It appears that you are hiding `RES-keyNav-activeElement`. This negatively affects RES users by rendering keyboard navigation unusable. It\'s understandable that you may not care for the default appearance, but we politely request that you consider styling it to fit your subreddit, perhaps using a particular background color or border. Even just a one-sided border, e.g. `border-right: 3px solid blue;` - thank you for your consideration.\n\n\ For convenience we\'ve included `RES-keyNav-activeThing` which can be used as an alternative to `RES-keyNav-activeElement`. It applies to elements with the class `thing` as opposed to `entry`. If you choose to use this, make sure keyboard navigation is usable when [commentBoxes](/r/' + RESUtils.currentSubreddit() + '/about/stylesheet/#!settings/styleTweaks/commentBoxes) is turned off.',
 		'nightmode': 'Want your subreddit to be night mode friendly? Please have a look at [the night mode section of our wiki](/r/Enhancement/wiki/subredditstyling#wiki_res_night_mode_and_your_subreddit)'
 	},
 	doStyleSheetCheck: function() {
@@ -61,7 +61,7 @@ modules['modHelper'] = {
 					(keyNavRule.indexOf('transparent') !== -1) ||
 					(keyNavRule.indexOf('background: none') !== -1) ||
 					(keyNavRule.indexOf('background-color: none') !== -1)
-					) && (keyNavRule.indexOf('border') === -1)) {
+					) && (keyNavRule.indexOf('border') === -1) && (stylesheet.indexOf('.RES-keyNav-activeThing') === -1)) {
 					this.addTipToPane('keyNav-benice');
 				} else {
 					this.addTipToPane('keyNav');

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -189,9 +189,12 @@ addModule('selectedEntry', function(module, moduleID) {
 	function updateActiveElement(selected, last) {
 		if (selected) {
 			selected.entry.classList.add('RES-keyNav-activeElement');
+			// Add a class to thing to provide extra styling options.
+			selected.thing.classList.add('RES-keyNav-activeThing');
 		}
 		if (last) {
 			last.entry.classList.remove('RES-keyNav-activeElement');
+			last.thing.classList.remove('RES-keyNav-activeThing');
 		}
 	}
 


### PR DESCRIPTION
As requested [here](https://www.reddit.com/r/Enhancement/comments/2odnoi/cssis_there_a_reason_the_active/) and [here](https://www.reddit.com/r/Enhancement/comments/3j3jnu/feature_request_put_reskeynavactiveelement_on_the/).

This doesn't change any existing behavior or styling, it just adds a class to `.thing` and leaves it up to themers to do what they will.

I made a demo page with some styling to show what this makes possible (you'll need to get the PR obviously): https://www.reddit.com/r/resdemo/comments/3jbs3b/nested_comments/

Currently, if you want to get the above result without an active class on `.thing`, then you'd need to rewrite a significant portion of the comments' layout, which is a PITA.