### PR TITLE
Redesign of expando buttons

### DIFF
--- a/lib/core/res.css
+++ b/lib/core/res.css
@@ -1168,7 +1168,7 @@ img {
 	max-width: 23px;
 	max-height: 23px;
 	display: inline-block;
-	background-image: url('https://s3.amazonaws.com/b.thumbs.redditmedia.com/tBwwK20XXxtpgudWx1L7bDXla-iotv-JA0jgA0Y-FVs.png');
+	background-image: url('https://i.imgur.com/r06W6bD.png');
 	margin-right: 6px;
 	padding: 0;
 }


### PR DESCRIPTION
Spawned from #2443, this is a redo of the expando buttons that styles them closer to Reddit's icons. Currently all three expandos are based on the same thing (!) which makes them difficult to distinguish at a glance, furthermore there isn't much contrast in the light grey border and `+/-` symbols.

Before / after:
![tbwwk20xxxtpgudwx1l7bdxla-iotv-ja0jga0y-fvs](https://cloud.githubusercontent.com/assets/7245595/9649984/ee969738-523f-11e5-8d68-08dea5a0a063.png) ![sprite-redesign-03](https://cloud.githubusercontent.com/assets/7245595/9649983/ee927dd8-523f-11e5-9e16-5163f106fef9.png)

'Out in the field' comparison:
![expando-buttons-compare](https://cloud.githubusercontent.com/assets/7245595/9650023/73932078-5240-11e5-8600-a0f9e583038a.png)

Using my own URL in the code as a placeholder.