### PR TITLE
Hover cards open more reliably, and use fadeElementOut

### DIFF
--- a/lib/modules/hover.js
+++ b/lib/modules/hover.js
@@ -168,7 +168,7 @@ addModule('hover', function(module, moduleID) {
 		},
 		target: function(element) {
 			if (typeof element !== 'undefined') {
-				this.close(true);
+				this.close();
 				this._target = element;
 			}
 
@@ -259,7 +259,6 @@ addModule('hover', function(module, moduleID) {
 
 				$container.show().css({ opacity: 1 }); // nvm fade in, too much trouble
 				modules['styleTweaks'].setSRStyleToggleVisibility(false, moduleID + '.' + this.instanceID);
-				this.visible = true;
 			}).bind(this));
 		},
 		_populate: function($container/*,  ...contents*/) {
@@ -295,8 +294,9 @@ addModule('hover', function(module, moduleID) {
 			});
 		},
 
-		cancelShow: function() {
-			this.close(true);
+		cancelShow: function(fade) {
+			fade = (typeof fade === 'boolean') ? fade : false;
+			this.close(fade);
 		},
 		addShowListeners: function() {
 			$(this._target)
@@ -309,6 +309,12 @@ addModule('hover', function(module, moduleID) {
 				.off('mouseleave', this.cancelShow);
 		},
 		startShowTimer: function() {
+			this.mouseEvent = 'enter';
+
+			if (this.visible && this.mouseEvent === 'enter') {
+				// Close and reopen container.
+				this.cancelShow();
+			}
 			this.cancelShowTimer();
 			this.showTimer = setTimeout(this.afterShowTimer, this._options.openDelay);
 		},
@@ -320,10 +326,12 @@ addModule('hover', function(module, moduleID) {
 			this.cancelShowTimer();
 			this.clearShowListeners();
 			this.open();
+			this.visible = true;
 
 			$(this._target).on('mouseleave', this.startHideTimer);
 		},
 		startHideTimer: function() {
+			this.mouseEvent = 'leave';
 			clearTimeout(this.hideTimer);
 			this.hideTimer = setTimeout(this.afterHideTimer, this._options.fadeDelay);
 		},
@@ -334,7 +342,8 @@ addModule('hover', function(module, moduleID) {
 		},
 		afterHideTimer: function() {
 			this.cancelHideTimer();
-			this.close();
+			this.close(true);
+			this.visible = false;
 		},
 		close: function(fade) {
 			if (!this._enabled) return false;
@@ -344,19 +353,13 @@ addModule('hover', function(module, moduleID) {
 			this.cancelHideTimer();
 
 			if (!this.visible) return;
-			this.visible = false;
 
 			this.getContainer((function($container) {
-				var afterHide = function () {
-					$container.css({ 'width': '', 'height': '' });
-				};
-
+				console.log(fade);
 				if (fade) {
-					$container.css('width', $container.width());
-					$container.css('height', $container.height());
-					RESUtils.fadeElementOut($container[0], this._options.fadeSpeed, afterHide);
+					RESUtils.fadeElementOut($container[0], this._options.fadeSpeed);
 				} else {
-					$container.hide(afterHide);
+					$container.hide();
 				}
 			}).bind(this));
 

--- a/lib/modules/hover.js
+++ b/lib/modules/hover.js
@@ -355,7 +355,6 @@ addModule('hover', function(module, moduleID) {
 			if (!this.visible) return;
 
 			this.getContainer((function($container) {
-				console.log(fade);
 				if (fade) {
 					RESUtils.fadeElementOut($container[0], this._options.fadeSpeed);
 				} else {


### PR DESCRIPTION
For Subreddit Info and User Info I like to have a short open delay and longer fade delay, but currently that causes this kind of thing to happen: https://imgrush.com/opq6CoX2YGVs

In that situation close() fires after open(), which prevents the card from ever appearing, unless you hover off the link and back over it. My solution is to check if the latest event type is `mouseenter`, and if so, close and reopen the card.

I also replaced the animated shrinking effect on close() with a simple fade, which affects all hover objects including the cog menu. I hope that's okay.