### PR TITLE
Implement myrandom link for everyone

### DIFF
--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -28,6 +28,7 @@
 				"vendor/jquery.tokeninput.js",
 				"vendor/HTMLPasteurizer.js",
 				"vendor/snuownd.js",
+				"vendor/myrandom.js",
 				"core/utils.js",
 				"browsersupport.js",
 				"browsersupport-chrome.js",

--- a/Opera/includes/loader.js
+++ b/Opera/includes/loader.js
@@ -31,6 +31,7 @@
 		'vendor/jquery.tokeninput.js',
 		'vendor/HTMLPasteurizer.js',
 		'vendor/snuownd.js',
+		'vendor/myrandom.js',
 
 		'opera-restore-jquery.js',
 

--- a/OperaBlink/manifest.json
+++ b/OperaBlink/manifest.json
@@ -27,6 +27,7 @@
 				"vendor/jquery.tokeninput.js",
 				"vendor/HTMLPasteurizer.js",
 				"vendor/snuownd.js",
+				"vendor/myrandom.js",
 				"core/utils.js",
 				"browsersupport.js",
 				"browsersupport-chrome.js",

--- a/RES.safariextension/Info.plist
+++ b/RES.safariextension/Info.plist
@@ -39,6 +39,7 @@
 				<string>vendor/HTMLPasteurizer.js</string>
 				<string>vendor/snuownd.js</string>
 				<string>vendor/hogan-3.0.2.js</string>
+				<string>vendor/myrandom.js</string>
 				<string>core/utils.js</string>
 				<string>browsersupport.js</string>
 				<string>browsersupport-safari.js</string>

--- a/XPI/index.js
+++ b/XPI/index.js
@@ -153,6 +153,7 @@ pageMod.PageMod({
 		self.data.url('vendor/jquery.tokeninput.js'),
 		self.data.url('vendor/HTMLPasteurizer.js'),
 		self.data.url('vendor/snuownd.js'),
+		self.data.url('vendor/myrandom.js'),
 		self.data.url('core/utils.js'),
 		self.data.url('browsersupport.js'),
 		self.data.url('browsersupport-firefox.js'),

--- a/lib/vendor/myrandom.js
+++ b/lib/vendor/myrandom.js
@@ -1,0 +1,86 @@
+/* myrandom.js
+ * reddit's paywalled myrandom button, for everyone
+ * compatible with Reddit Enhancement Suite's subreddit manager
+ * 1.0.20150923
+ *
+ * By Eli Grey, http://eligrey.com
+ * License: X11/MIT
+ *   See https://gist.github.com/eligrey/ef865687f0e961f20870#file-license-md
+ */
+
+document.addEventListener("DOMContentLoaded", function() {
+	var
+	  cached_subreddits = JSON.parse(localStorage.mySubreddits || "[]")
+	, freshness = +localStorage.mySubredditsLastAccess || 0
+	, stale = localStorage.mySubredditsRefreshInterval || 172800000 // refresh after 48hrs
+	, random_native = document.querySelector(".random.choice")
+	, random_res = document.querySelector(".subbarlink[href='/r/random/']")
+	, myrandom_native = document.querySelector(".gold.choice")
+	, myrandom_res = document.querySelector(".subbarlink[href='/r/myrandom/']")
+	, random_subreddit = function() {
+		return "/r/" + cached_subreddits[Math.floor(Math.random() * cached_subreddits.length)];
+	}
+	, insert_myrandom = function() {
+		var
+		  myrandom = myrandom_native || myrandom_res
+		, random = random_native || random_res
+		;
+		if (cached_subreddits.length) {
+			if (!myrandom) {
+				var
+				// support inserting myrandom into the native subreddit bar or RES's subreddit manager bar
+				  parent = random_native
+				  	? random.parentNode
+				  	: random.parentNode
+				, random_next_sibling = random.nextElementSibling
+				, myrandom_container = random_native
+					? parent.parentNode.insertBefore(document.createElement("li"), parent.nextElementSibling)
+					: parent // RES's subreddit manager bar doesn't use a <ul> like reddit's subreddit bar
+				, separator = myrandom_container.insertBefore(document.createElement("span"), random_next_sibling)
+				;
+				separator.classList.add("separator");
+				separator.appendChild(document.createTextNode("-"));
+				myrandom = myrandom_container.insertBefore(document.createElement("a"), random_next_sibling);
+				myrandom.classList.add("gold", random_native ? "choice" : "subbarlink");
+				myrandom.appendChild(document.createTextNode("myrandom"));
+				myrandom.href = "/myrandom/";
+			}
+			myrandom.addEventListener("click", function(event) {
+				event.preventDefault();
+				location.href = random_subreddit();
+			});
+		}
+	}
+	;
+
+	insert_myrandom();
+
+	if (!localStorage.mySubredditsRefreshInterval) {
+		localStorage.mySubredditsRefreshInterval = stale;
+	}
+
+	if (freshness + stale < Date.now()) {
+		var
+		  req = new XMLHttpRequest
+		, onload = function() {
+			localStorage.mySubreddits = JSON.stringify(cached_subreddits = document
+				.evaluate(
+					  "//ul/a[text()='multireddit of your subscriptions']", req.response, null
+					, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null
+				)
+				.iterateNext()
+				.href
+				.split("/r/")[1]
+				.split("+")
+			);
+			localStorage.mySubredditsLastAccess = Date.now();
+			insert_myrandom();
+		  }
+		;
+
+		req.responseType = "document";
+		req.addEventListener("load", onload);
+		req.open("GET", "/subreddits/");
+		req.send();
+	}
+});

--- a/lib/vendor/myrandom.js
+++ b/lib/vendor/myrandom.js
@@ -1,7 +1,7 @@
 /* myrandom.js
  * reddit's paywalled myrandom button, for everyone
  * compatible with Reddit Enhancement Suite's subreddit manager
- * 1.0.20150923.1
+ * 1.0.20150923.2
  *
  * By Eli Grey, http://eligrey.com
  * License: X11/MIT
@@ -29,9 +29,7 @@ document.addEventListener("DOMContentLoaded", function() {
 			if (!myrandom) {
 				var
 				// support inserting myrandom into the native subreddit bar or RES's subreddit manager bar
-				  parent = random_native
-				  	? random.parentNode
-				  	: random.parentNode
+				  parent = random.parentNode
 				, random_next_sibling = random.nextElementSibling
 				, myrandom_container = random_native
 					? parent.parentNode.insertBefore(document.createElement("li"), parent.nextElementSibling)

--- a/lib/vendor/myrandom.js
+++ b/lib/vendor/myrandom.js
@@ -1,7 +1,7 @@
 /* myrandom.js
  * reddit's paywalled myrandom button, for everyone
  * compatible with Reddit Enhancement Suite's subreddit manager
- * 1.0.20150924
+ * 1.0.20150924.1
  *
  * By Eli Grey, http://eligrey.com
  * License: X11/MIT
@@ -41,7 +41,7 @@ document.addEventListener("DOMContentLoaded", function() {
 				myrandom = myrandom_container.insertBefore(document.createElement("a"), random_next_sibling);
 				myrandom.classList.add(random_native ? "choice" : "subbarlink");
 				myrandom.appendChild(document.createTextNode("myrandom"));
-				myrandom.href = "/myrandom/";
+				myrandom.href = "/r/myrandom/";
 			}
 			myrandom.addEventListener("click", function(event) {
 				event.preventDefault();

--- a/lib/vendor/myrandom.js
+++ b/lib/vendor/myrandom.js
@@ -1,7 +1,7 @@
 /* myrandom.js
  * reddit's paywalled myrandom button, for everyone
  * compatible with Reddit Enhancement Suite's subreddit manager
- * 1.0.20150924.7
+ * 1.0.20151006
  *
  * By Eli Grey, http://eligrey.com
  * License: X11/MIT
@@ -39,8 +39,13 @@ document.addEventListener("DOMContentLoaded", function() {
 		}
 
 		myrandom.addEventListener("click", function(event) {
+			var url = "/r/" + cached_subreddits[Math.floor(Math.random() * cached_subreddits.length)] + "/";
 			event.preventDefault();
-			location.href = "/r/" + cached_subreddits[Math.floor(Math.random() * cached_subreddits.length)] + "/";
+			if (event.which === 2) { // middle click
+				open(url);
+			} else {
+				location.href = url;
+			}
 		});
 	}
 	;

--- a/lib/vendor/myrandom.js
+++ b/lib/vendor/myrandom.js
@@ -1,7 +1,7 @@
 /* myrandom.js
  * reddit's paywalled myrandom button, for everyone
  * compatible with Reddit Enhancement Suite's subreddit manager
- * 1.0.20150924.4
+ * 1.0.20150924.7
  *
  * By Eli Grey, http://eligrey.com
  * License: X11/MIT
@@ -15,36 +15,33 @@ document.addEventListener("DOMContentLoaded", function() {
 	, stale = localStorage.mySubredditsRefreshInterval || 172800000 // refresh after 48hrs
 	, random_native = document.querySelector(".random.choice[href$='/r/random/']")
 	, random_res = document.querySelector(".subbarlink[href$='/r/random/']")
-	, myrandom_native = document.querySelector(".gold.choice[href$='/r/myrandom/']")
+	, myrandom_native = document.querySelector(".choice[href$='/r/myrandom/']")
 	, myrandom_res = document.querySelector(".subbarlink[href$='/r/myrandom/']")
+	, myrandom = myrandom_native || myrandom_res
+	, random = random_native || random_res
 	, insert_myrandom = function() {
-		var
-		  myrandom = myrandom_native || myrandom_res
-		, random = random_native || random_res
-		;
-		if (cached_subreddits.length) {
-			if (!myrandom) {
-				var
-				// support inserting myrandom into the native subreddit bar or RES's subreddit manager bar
-				  parent = random.parentNode
-				, random_next_sibling = random.nextElementSibling
-				, myrandom_container = random_native
-					? parent.parentNode.insertBefore(document.createElement("li"), parent.nextElementSibling)
-					: parent // RES's subreddit manager bar doesn't use a <ul> like reddit's subreddit bar
-				, separator = myrandom_container.insertBefore(document.createElement("span"), random_next_sibling)
-				;
-				separator.classList.add("separator");
-				separator.appendChild(document.createTextNode("-"));
-				myrandom = myrandom_container.insertBefore(document.createElement("a"), random_next_sibling);
-				myrandom.classList.add(random_native ? "choice" : "subbarlink");
-				myrandom.appendChild(document.createTextNode("myrandom"));
-				myrandom.href = "/r/myrandom/";
-			}
-			myrandom.addEventListener("click", function(event) {
-				event.preventDefault();
-				location.href = "/r/" + cached_subreddits[Math.floor(Math.random() * cached_subreddits.length)] + "/";
-			});
+		if (!myrandom) {
+			var
+			// support inserting myrandom into the native subreddit bar or RES's subreddit manager bar
+			  parent = random.parentNode
+			, random_next_sibling = random.nextElementSibling
+			, myrandom_container = random_native
+				? parent.parentNode.insertBefore(document.createElement("li"), parent.nextElementSibling)
+				: parent // RES's subreddit manager bar doesn't use a <ul> like reddit's subreddit bar
+			, separator = myrandom_container.insertBefore(document.createElement("span"), random_next_sibling)
+			;
+			separator.classList.add("separator");
+			separator.appendChild(document.createTextNode("-"));
+			myrandom = myrandom_container.insertBefore(document.createElement("a"), random_next_sibling);
+			myrandom.classList.add(random_native ? "choice" : "subbarlink");
+			myrandom.appendChild(document.createTextNode("myrandom"));
+			myrandom.href = "/r/myrandom/";
 		}
+
+		myrandom.addEventListener("click", function(event) {
+			event.preventDefault();
+			location.href = "/r/" + cached_subreddits[Math.floor(Math.random() * cached_subreddits.length)] + "/";
+		});
 	}
 	;
 
@@ -68,7 +65,6 @@ document.addEventListener("DOMContentLoaded", function() {
 				.split("/r/")[1]
 			).split("+");
 			localStorage.mySubredditsLastAccess = Date.now();
-			insert_myrandom();
 		  }
 		;
 

--- a/lib/vendor/myrandom.js
+++ b/lib/vendor/myrandom.js
@@ -1,7 +1,7 @@
 /* myrandom.js
  * reddit's paywalled myrandom button, for everyone
  * compatible with Reddit Enhancement Suite's subreddit manager
- * 1.0.20150924.1
+ * 1.0.20150924.2
  *
  * By Eli Grey, http://eligrey.com
  * License: X11/MIT
@@ -13,10 +13,10 @@ document.addEventListener("DOMContentLoaded", function() {
 	  cached_subreddits = JSON.parse(localStorage.mySubreddits || "[]")
 	, freshness = +localStorage.mySubredditsLastAccess || 0
 	, stale = localStorage.mySubredditsRefreshInterval || 172800000 // refresh after 48hrs
-	, random_native = document.querySelector(".random.choice")
-	, random_res = document.querySelector(".subbarlink[href='/r/random/']")
-	, myrandom_native = document.querySelector(".gold.choice")
-	, myrandom_res = document.querySelector(".subbarlink[href='/r/myrandom/']")
+	, random_native = document.querySelector(".random.choice[href$='/r/random/']")
+	, random_res = document.querySelector(".subbarlink[href$='/r/random/']")
+	, myrandom_native = document.querySelector(".gold.choice[href$='/r/myrandom/']")
+	, myrandom_res = document.querySelector(".subbarlink[href$='/r/myrandom/']")
 	, random_subreddit = function() {
 		return "/r/" + cached_subreddits[Math.floor(Math.random() * cached_subreddits.length)];
 	}

--- a/lib/vendor/myrandom.js
+++ b/lib/vendor/myrandom.js
@@ -1,7 +1,7 @@
 /* myrandom.js
  * reddit's paywalled myrandom button, for everyone
  * compatible with Reddit Enhancement Suite's subreddit manager
- * 1.0.20150924.2
+ * 1.0.20150924.4
  *
  * By Eli Grey, http://eligrey.com
  * License: X11/MIT
@@ -10,16 +10,13 @@
 
 document.addEventListener("DOMContentLoaded", function() {
 	var
-	  cached_subreddits = JSON.parse(localStorage.mySubreddits || "[]")
+	  cached_subreddits = (localStorage.mySubreddits || "").split("+")
 	, freshness = +localStorage.mySubredditsLastAccess || 0
 	, stale = localStorage.mySubredditsRefreshInterval || 172800000 // refresh after 48hrs
 	, random_native = document.querySelector(".random.choice[href$='/r/random/']")
 	, random_res = document.querySelector(".subbarlink[href$='/r/random/']")
 	, myrandom_native = document.querySelector(".gold.choice[href$='/r/myrandom/']")
 	, myrandom_res = document.querySelector(".subbarlink[href$='/r/myrandom/']")
-	, random_subreddit = function() {
-		return "/r/" + cached_subreddits[Math.floor(Math.random() * cached_subreddits.length)];
-	}
 	, insert_myrandom = function() {
 		var
 		  myrandom = myrandom_native || myrandom_res
@@ -45,7 +42,7 @@ document.addEventListener("DOMContentLoaded", function() {
 			}
 			myrandom.addEventListener("click", function(event) {
 				event.preventDefault();
-				location.href = random_subreddit();
+				location.href = "/r/" + cached_subreddits[Math.floor(Math.random() * cached_subreddits.length)] + "/";
 			});
 		}
 	}
@@ -61,7 +58,7 @@ document.addEventListener("DOMContentLoaded", function() {
 		var
 		  req = new XMLHttpRequest
 		, onload = function() {
-			localStorage.mySubreddits = JSON.stringify(cached_subreddits = req.response
+			cached_subreddits = (localStorage.mySubreddits = req.response
 				.evaluate(
 					  "//ul/a[text()='multireddit of your subscriptions']", req.response, null
 					, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null
@@ -69,8 +66,7 @@ document.addEventListener("DOMContentLoaded", function() {
 				.iterateNext()
 				.href
 				.split("/r/")[1]
-				.split("+")
-			);
+			).split("+");
 			localStorage.mySubredditsLastAccess = Date.now();
 			insert_myrandom();
 		  }

--- a/lib/vendor/myrandom.js
+++ b/lib/vendor/myrandom.js
@@ -1,7 +1,7 @@
 /* myrandom.js
  * reddit's paywalled myrandom button, for everyone
  * compatible with Reddit Enhancement Suite's subreddit manager
- * 1.0.20150923
+ * 1.0.20150923.1
  *
  * By Eli Grey, http://eligrey.com
  * License: X11/MIT
@@ -63,7 +63,7 @@ document.addEventListener("DOMContentLoaded", function() {
 		var
 		  req = new XMLHttpRequest
 		, onload = function() {
-			localStorage.mySubreddits = JSON.stringify(cached_subreddits = document
+			localStorage.mySubreddits = JSON.stringify(cached_subreddits = req.response
 				.evaluate(
 					  "//ul/a[text()='multireddit of your subscriptions']", req.response, null
 					, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null

--- a/lib/vendor/myrandom.js
+++ b/lib/vendor/myrandom.js
@@ -5,7 +5,7 @@
  *
  * By Eli Grey, http://eligrey.com
  * License: X11/MIT
- *   See https://gist.github.com/eligrey/ef865687f0e961f20870#file-license-md
+ *   See https://github.com/eligrey/myrandom.js/blob/master/LICENSE.md
  */
 
 document.addEventListener("DOMContentLoaded", function() {

--- a/lib/vendor/myrandom.js
+++ b/lib/vendor/myrandom.js
@@ -1,7 +1,7 @@
 /* myrandom.js
  * reddit's paywalled myrandom button, for everyone
  * compatible with Reddit Enhancement Suite's subreddit manager
- * 1.0.20150923.2
+ * 1.0.20150924
  *
  * By Eli Grey, http://eligrey.com
  * License: X11/MIT
@@ -39,7 +39,7 @@ document.addEventListener("DOMContentLoaded", function() {
 				separator.classList.add("separator");
 				separator.appendChild(document.createTextNode("-"));
 				myrandom = myrandom_container.insertBefore(document.createElement("a"), random_next_sibling);
-				myrandom.classList.add("gold", random_native ? "choice" : "subbarlink");
+				myrandom.classList.add(random_native ? "choice" : "subbarlink");
 				myrandom.appendChild(document.createTextNode("myrandom"));
 				myrandom.href = "/myrandom/";
 			}


### PR DESCRIPTION
I heard that you guys don't like implementing gold features, so please be aware that this code actually *reduces* the load on reddit's servers as it replaces the myrandom button of gold users with a client-side button. This feature does not harm reddit at all, and was very simple to implement.

If you do not wish to support this feature, I hope you don't mind if I ask the /r/Enhancement community about their opinions regarding your philosophical stance with RES and gold features that can be implemented on the client-side. If enough people in the thread say that they want this feature, I hope that you can look past your philosophical differences and appease your community. Otherwise, the community could become divided among forks. So please think rationally before rejecting this pull request, and fairly weigh any potential benefit and harm to your users as whole.

You already support [user tagging](https://www.reddit.com/r/Enhancement/comments/12vbjl/question_now_that_commentsaving_is_a_feature/) (which is also a gold member feature) and continue to support it. myrandom.js caches a list of all of your subreddits locally as not to introduce any significant additional load on reddit, and can be configured with a very long refresh period if you really don't want any load at all on reddit.

Heck, I could also make it so that it won't work until you manually go to https://www.reddit.com/subreddits/ and that it will only update the cached subreddit list on subsequent visits to that page. This would result in exactly zero additional load on reddit in any circumstances.

Instead of imposing your own absolute philosophical directives onto everyone, how about asking your users what they want themselves? The majority of your users might want something different than what you want.

No offense, but if you honestly feel that artificially limiting features is in your users own best interest, then RES is no better than DRM software. There is a reason that no open source Linux drivers implement user-restricting DRM whenever possible. The only DRM you will find on Linux is closed-source, and for good reason. If it was open source, users would simply rip out what they don't like. You should not be acting on Reddit Inc.'s best interests for Condé Nast's bottom line, you should be acting on your users' best interests for their ability to explore reddit without restrictions. And irregardless, this isn't against Reddit Inc.'s best interests either, as it does not significantly increase server load.

I would also like to add that this also adds a cool feature wherein logged out users can go to a random one of the 50 default subreddits (which not even gold users can reproduce without unsubscribing from everything but the defaults).