### PR TITLE
Use getURL() instead of manual URL construction

### DIFF
--- a/Chrome/browsersupport-chrome.js
+++ b/Chrome/browsersupport-chrome.js
@@ -113,8 +113,7 @@ RESLoadResourceAsText = function(filename, callback) {
 			callback(this.responseText);
 		}
 	};
-	var id = chrome.i18n.getMessage('@@extension_id');
-	xhr.open('GET', 'chrome-extension://' + id + '/' + filename);
+	xhr.open('GET', chrome.runtime.getURL(filename));
 	xhr.send();
 };
 


### PR DESCRIPTION
This is more idiomatic, and it works in Firefox today.

The current code will not work in Firefox until these bugs are resolved:

https://bugzilla.mozilla.org/1208761:
  chrome.i18n is undefined in content scripts

https://bugzilla.mozilla.org/1208763:
  Treat chrome-extension:// and moz-extension:// schemes as equivalent

This obsoletes #2463