### PR TITLE
Don't presume window is the global object for js

### DIFF
--- a/Opera/opera-footer.js
+++ b/Opera/opera-footer.js
@@ -1,6 +1,6 @@
 // It's not great that favico assumes this is the global
 // and that it gets "fixed" at this stage, but it's not terrible.
-window.Favico = this.Favico;
+var Favico = this.Favico;
 
 // Close self-invoking anonymous function
 })();

--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -197,7 +197,7 @@ addModule('orangered', function(module, moduleID) {
 		$('head link[rel="shortcut icon"], head link[rel="icon"]').attr('href', faviconDataurl);
 
 		// Init Favico
-		favicon = new window.Favico();
+		favicon = new Favico();
 
 		if (module.options.resetFaviconOnLeave.value) {
 			// Prevent notification icon from showing up in bookmarks


### PR DESCRIPTION
The bundled Favico lib exports itself by setting `this.Favico = Favico`.

The orangered module then presumes that Favico will be available on the
global `window` object, but that's not the case for Firefox's sandbox.
From [Bug 1208775][]'s discussion, it sounds like we might WONTFIX this.

Simply omitting `window.` works equally well in Chrome and Firefox.

[Bug 1208775]: https://bugzilla.mozilla.org/show_bug.cgi?id=1208775#c3