### PR TITLE
Moves #progressIndicator right under content

### DIFF
--- a/lib/core/templates.html
+++ b/lib/core/templates.html
@@ -652,7 +652,7 @@
 			/* set the style for our little loader widget */
 			#progressIndicator {
 				height: 60px;
-				display: -webkit-flex; -webkit-align-items: center; -webkit-justify-content: center; -webkit-flex-direction: column;
+				display: block; -webkit-align-items: center; -webkit-justify-content: center; -webkit-flex-direction: column;
 				display: flex; align-items: center; justify-content: center; flex-direction: column;
 				font-size: 14px; border: 1px solid #999; border-radius: 10px; padding: 10px; background-color: #f0f3fc; cursor: pointer;
 			}


### PR DESCRIPTION
Current behavior puts the progressIndicator div past the end of the sidebar, as opposed the end of the content, if the sidebar height exceeds the height of the content