### PR TITLE
Don't add CSS overflow property to self text

### DIFF
--- a/lib/core/res.css
+++ b/lib/core/res.css
@@ -315,7 +315,7 @@ body.res-console-open {
 	padding-top: 52px;
 }
 /* Allow textarea to be any width without disappearing. */
-body.wiki-page form#editform, form.usertext {
+body.wiki-page form#editform, .comment form.usertext {
 	overflow: auto; /* Same as top-level comment form on vanilla reddit */
 }
 div.usertext-edit {


### PR DESCRIPTION
It was adding extra spacing above self posts (a few pixels).