### PR TITLE
Fix styling of highlightTopLevel

### DIFF
--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -235,7 +235,7 @@ modules['styleTweaks'] = {
 			if (this.options.highlightTopLevel.value) {
 				var highlightTopLevelColor = this.options.highlightTopLevelColor.value || this.options.highlightTopLevelColor.default;
 				var highlightTopLevelSize = parseInt(this.options.highlightTopLevelSize.value || this.options.highlightTopLevelSize.default, 10);
-				RESUtils.addCSS('.nestedlisting > .comment + .clearleft:after { content: "" !important; display: block !important; position: relative !important; top: -5px !important; width: 100% !important; height: ' + highlightTopLevelSize + 'px !important; background: ' + highlightTopLevelColor + ' !important; }');
+				RESUtils.addCSS('.nestedlisting > .comment + .clearleft { height: ' + highlightTopLevelSize + 'px !important; margin-bottom: 5px; background: ' + highlightTopLevelColor + ' !important; }');
 			}
 		}
 	},


### PR DESCRIPTION
No longer renders on top of sidebar.

Removed the pseudo element and applied styles directly to div.clearleft.

[Bug report](https://www.reddit.com/r/RESissues/comments/3n3m49/bug_highlighttoplevel_line_drawn_over_sidebar/).