### PR TITLE
In-line viewer support for imgur.com/gallery URLs

### DIFF
--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -62,10 +62,13 @@ modules['showImages'].siteModules['imgur'] = {
 
 		if ((groups = siteMod.galleryHashRe.exec(href))) {
 			hash = groups[1];
-			def = siteMod._api('gallery/' + encodeURIComponent(hash));
+
+			// was: def = siteMod._api('gallery/' + encodeURIComponent(hash));
+			if (hash.length < 6) href = 'https://imgur.com/a/' + hash;	// imgur IDs < 6 chars are always albums
+			else href = 'https://i.imgur.com/' + hash + '.png';			// extension doesn't matter
 		}
 
-		else if ((groups = siteMod.albumHashRe.exec(href))) {
+		if ((groups = siteMod.albumHashRe.exec(href))) {
 			if (modules['showImages'].options['prefer RES albums'].value === true) {
 				hash = groups[1];
 				elem.imgHash = hash;


### PR DESCRIPTION
Updated handleLink() to make /gallery URLs use the album viewer (if ID is < 6 chars) or (otherwise) the image viewer.

radd.it has been converting URLs this way for over a year and I've seen no exceptions.