### PR TITLE
singleClick: respect left/middle click opening in fore/background tabs

### DIFF
--- a/lib/modules/singleClick.js
+++ b/lib/modules/singleClick.js
@@ -82,9 +82,10 @@ modules['singleClick'] = {
 					// we have to switch to mousedown because Webkit is being a douche and not triggering click events on middle click.
 					// ?? We should still preventDefault on a click though, maybe?
 					singleClickLink.addEventListener('mousedown', function(e) {
-						e.preventDefault();
-						var lcMouseBtn = (modules['singleClick'].options.openBackground.value) ? 1 : 0;
 						if (e.button !== 2) {
+							e.preventDefault();
+							// if openBackground is enabled, middle click
+							var lcMouseBtn = e.button || (modules['singleClick'].options.openBackground.value ? 1 : 0);
 							// check if it's a relative link (no http://domain) because chrome barfs on these when creating a new tab...
 							var thisLink = $(this).parent().parent().parent().find('a.title').attr('href');
 							if (!/^http/i.test(thisLink)) {


### PR DESCRIPTION
Also fixes [this issue](https://www.reddit.com/r/RESissues/comments/3r0o8p/bug_shiftl_not_working/) because keyboard nav just [clicks the link](https://github.com/honestbleeps/Reddit-Enhancement-Suite/blob/3d453559ea37adf256dd9833a00bae34de81c4d7/lib/modules/keyboardNav.js#L1244).

It should really have the (hacky) link clicking removed, but that's a lot of refactoring that I don't want to do at the moment.