### PR TITLE
Automatically toggle nightMode after loading neverEndingReddit page

### DIFF
--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -2040,20 +2040,19 @@ RESUtils.addSelfTextObserver = function(ele) {
 	}
 };
 RESUtils.watchForElement = function(type, callback) {
-	switch (type) {
-		case 'siteTable':
-			RESUtils.watchers.siteTable.push(callback);
-			break;
-		case 'newComments':
-			RESUtils.watchers.newComments.push(callback);
-			break;
-		case 'selfText':
-			RESUtils.watchers.selfText.push(callback);
-			break;
-		case 'newCommentsForms':
-			RESUtils.watchers.newCommentsForms.push(callback);
-			break;
+	var validTypes = [
+		'siteTable',
+		'newComments',
+		'selfText',
+		'newCommentsForms'
+	];
+	if (validTypes.indexOf(type) === -1) {
+		throw new TypeError('Invalid type passed to watchForElement: ' + type);
 	}
+	var index = RESUtils.watchers[type].push(callback) - 1;
+	return function () {
+		RESUtils.watchers[type].splice(index, 1);
+	};
 };
 RESUtils.watchers = {
 	siteTable: [],

--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -64,6 +64,16 @@ addModule('nightMode', function(module, moduleID) {
 		// If the module is turned off, disable night mode completely
 		if (!toggle) {
 			module.disableNightMode();
+			// ensure the event handler listening for siteTable changes has been removed.
+			if (module.siteTableSubscription) {
+				module.siteTableSubscription();
+				module.siteTableSubscription = null;
+			}
+		}
+		else {
+			if (!module.siteTableSubscription) {
+				module.siteTableSubscription = RESUtils.watchForElement('siteTable', module.afterNeverEndingLoad);
+			}
 		}
 	},
 	loadDynamicOptions: function() {
@@ -116,6 +126,14 @@ addModule('nightMode', function(module, moduleID) {
 				}
 			);
 		}
+	},
+	afterLoad: function () {
+		// add a subscription to site table loads - save the return so we can remove it later.
+		module.siteTableSubscription = RESUtils.watchForElement('siteTable', module.afterNeverEndingLoad);
+	},
+	afterNeverEndingLoad: function () {
+		// once RES loads a page, do a check to see if automatic nightmode should toggle.
+		modules['nightMode'].handleAutomaticNightMode();
 	},
 	isNightModeOn: function() {
 		return module.isEnabled() && module.options.nightModeOn.value;


### PR DESCRIPTION
- adds an event handler for neverEndingLoad after the module loads
- event handler is removed if the module gets disabled
- when the event fires, perform a call to 'handleAutomaticNightMode'

Fixes #2502 

Also, I should mention, I updated the event firing to use the more modern API -- `initEvent` is [showing a deprecation warning on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Event/initEvent)

I tried this out locally on FireFox -- setting the time to a minute in the future with nightmode off, waiting for a minute and scrolling down -- it seemed to work pretty well.
