### PR TITLE
UserInfo friend toggle button fix

### DIFF
--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -98,32 +98,18 @@ addModule('userInfo', function (module, moduleID) { $.extend(true, module, {
 	},
 	showUserInfo: function(def, obj, context) {
 		def.notify('Loading...', '<span class="RESThrobber />');
-		var isFriend = obj.classList.contains('friend'),
-			test = obj.href.match(modules['userTagger'].usernameRE),
-			thisUserName;
+		var test = obj.href.match(modules['userTagger'].usernameRE),
+			thisUserName,
+			throbber = '<span class="RESThrobber"></span>';
 
 		if (test) {
 			thisUserName = test[1];
 		}
 		module.lastOpenedAuthorLink = obj;
-
-		var header = $('<div />');
-		header.append('<a href="/user/' + escapeHTML(thisUserName) + '">/u/' + escapeHTML(thisUserName) + '</a> (<a href="/user/' + escapeHTML(thisUserName) + '/submitted/">Links</a>) (<a href="/user/' + escapeHTML(thisUserName) + '/comments/">Comments</a>)');
-		RESUtils.getUserInfo(function(userInfo) {
-			var friendButton, myID;
-			myID = 't2_' + userInfo.data.id;
-			if (isFriend) {
-				friendButton = '<span class="fancy-toggle-button toggle" style="display: inline-block; margin-left: 12px;"><a class="option active remove" href="#" tabindex="100" onclick="return toggle(this, unfriend(\'' + obj.textContent + '\', \'' + myID + '\', \'friend\'), friend(\'' + obj.textContent + '\', \'' + myID + '\', \'friend\'))">- friends</a><a class="option add" href="#">+ friends</a></span>';
-			} else {
-				friendButton = '<span class="fancy-toggle-button toggle" style="display: inline-block; margin-left: 12px;"><a class="option active add" href="#" tabindex="100" onclick="return toggle(this, friend(\'' + obj.textContent + '\', \'' + myID + '\', \'friend\'), unfriend(\'' + obj.textContent + '\', \'' + myID + '\', \'friend\'))">+ friends</a><a class="option remove" href="#">- friends</a></span>';
-			}
-			header.append(friendButton);
-			def.notify(header, null);
-		});
-
-		def.notify(header, null);
+		def.notify(thisUserName, throbber);
 
 		RESUtils.cache.fetch({
+			key: thisUserName.toLowerCase(),
 			method: 'GET',
 			endpoint: '/user/' + thisUserName + '/about.json',
 			callback: module.renderAuthorInfo.bind(module, def, obj)
@@ -142,6 +128,33 @@ addModule('userInfo', function (module, moduleID) { $.extend(true, module, {
 		var utctime = data.created_utc;
 		var d = new Date(utctime * 1000);
 		data.name = data.name.toLowerCase();
+
+		var header = $('<div />');
+		header.append('<a href="/user/' + escapeHTML(data.name) + '">/u/' + escapeHTML(data.name) + '</a> (<a href="/user/' + escapeHTML(data.name) + '/submitted/">Links</a>) (<a href="/user/' + escapeHTML(data.name) + '/comments/">Comments</a>)');
+		
+		// Add friend button to header.
+		RESUtils.getUserInfo(function(me) {
+			var friendButton, myID = 't2_' + me.data.id;
+			// Check cached value first, or fall back to initial server response.
+			if (data.resCache_friend || (data.is_friend && data.resCache_friend === undefined)) {
+				friendButton = '<span class="fancy-toggle-button toggle" style="display: inline-block; margin-left: 12px;"><a class="option active remove" href="#" tabindex="100" onclick="return toggle(this, unfriend(\'' + data.name + '\', \'' + myID + '\', \'friend\'), friend(\'' + data.name + '\', \'' + myID + '\', \'friend\'))">- friends</a><a class="option add" href="#">+ friends</a></span>';
+			} else {
+				friendButton = '<span class="fancy-toggle-button toggle" style="display: inline-block; margin-left: 12px;"><a class="option active add" href="#" tabindex="100" onclick="return toggle(this, friend(\'' + data.name + '\', \'' + myID + '\', \'friend\'), unfriend(\'' + data.name + '\', \'' + myID + '\', \'friend\'))">+ friends</a><a class="option remove" href="#">- friends</a></span>';
+			}
+			header.append(friendButton);
+			def.notify(header, 'Got friend status, loading details...');
+			header.find('.toggle').click(function (e) {
+				if (e.target.tagName !== 'A') return;
+				// Expire the cache to reset friend status.
+				RESUtils.cache.expire({key: data.name});
+				// New property for the cache.
+				// TRUE if class was 'add' at time of click event.
+				data.resCache_friend = e.target.classList.contains('add');
+			});
+		});
+
+		def.notify(header, 'Getting friend status...');
+		
 		// var userHTML = '<a class="hoverAuthor" href="/user/'+data.name+'">'+data.name+'</a>:';
 		var userHTML = '<div class="authorFieldPair"><div class="authorLabel">Redditor since:</div> <div class="authorDetail">' + RESUtils.niceDate(d, module.options.USDateFormat.value) + ' (' + RESUtils.niceDateDiff(d) + ')</div></div>';
 		userHTML += '<div class="authorFieldPair"><div class="authorLabel">Link Karma:</div> <div class="authorDetail">' + escapeHTML(data.link_karma) + '</div></div>';

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -133,8 +133,7 @@ addModule('userInfo', function (module, moduleID) { $.extend(true, module, {
 		// Add friend button to header.
 		RESUtils.getUserInfo(function(me) {
 			var friendButton, myID = 't2_' + me.data.id;
-			// Check cached value first, or fall back to initial server response.
-			if (data.res_cache_friend || (data.is_friend && data.res_cache_friend === undefined)) {
+			if (data.is_friend) {
 				friendButton = '<span class="fancy-toggle-button toggle" style="display: inline-block; margin-left: 12px;"><a class="option active remove" href="#" tabindex="100" onclick="return toggle(this, unfriend(\'' + data.name + '\', \'' + myID + '\', \'friend\'), friend(\'' + data.name + '\', \'' + myID + '\', \'friend\'))">- friends</a><a class="option add" href="#">+ friends</a></span>';
 			} else {
 				friendButton = '<span class="fancy-toggle-button toggle" style="display: inline-block; margin-left: 12px;"><a class="option active add" href="#" tabindex="100" onclick="return toggle(this, friend(\'' + data.name + '\', \'' + myID + '\', \'friend\'), unfriend(\'' + data.name + '\', \'' + myID + '\', \'friend\'))">+ friends</a><a class="option remove" href="#">- friends</a></span>';
@@ -145,9 +144,6 @@ addModule('userInfo', function (module, moduleID) { $.extend(true, module, {
 				if (e.target.tagName !== 'A') return;
 				// Expire the cache to re-check friend status.
 				RESUtils.cache.expire({key: 'RESUtils.cache.-user-' + data.name + '-about-json'});
-				// New property for the cache.
-				// TRUE if class was 'add' at time of click event.
-				data.res_cache_friend = e.target.classList.contains('add');
 			});
 		});
 

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -99,17 +99,30 @@ addModule('userInfo', function (module, moduleID) { $.extend(true, module, {
 	showUserInfo: function(def, obj, context) {
 		var test = obj.href.match(modules['userTagger'].usernameRE),
 			thisUserName,
+			nameLowerCase,
 			throbber = '<span class="RESThrobber"></span>';
 
 		if (test) {
 			thisUserName = test[1];
+			nameLowerCase = thisUserName.toLowerCase()
 		}
+		
 		module.lastOpenedAuthorLink = obj;
+		
+		// Get the logged in user's ID and store it on first run.
+		if (!module.loggedInID) {
+			// Clear the author's cache so the friend button will have both
+			// author and logged in user's ID.
+			RESUtils.cache.expire({endpoint: '/user/' + nameLowerCase + '/about.json'});
+			RESUtils.getUserInfo(function (me) {
+				module.loggedInID = me.data.id;
+			});
+		}
 		def.notify(thisUserName, throbber);
 
 		RESUtils.cache.fetch({
 			method: 'GET',
-			endpoint: '/user/' + thisUserName.toLowerCase() + '/about.json',
+			endpoint: '/user/' + nameLowerCase + '/about.json',
 			callback: module.renderAuthorInfo.bind(module, def, obj)
 		});
 	},
@@ -125,29 +138,27 @@ addModule('userInfo', function (module, moduleID) { $.extend(true, module, {
 		var userTaggerEnabled = (modules['userTagger'].isEnabled()) && (modules['userTagger'].isMatchURL());
 		var utctime = data.created_utc;
 		var d = new Date(utctime * 1000);
+		var friendButton;
+		var myID = 't2_' + module.loggedInID;
 		data.name = data.name.toLowerCase();
 
 		var header = $('<div />');
 		header.append('<a href="/user/' + escapeHTML(data.name) + '">/u/' + escapeHTML(data.name) + '</a> (<a href="/user/' + escapeHTML(data.name) + '/submitted/">Links</a>) (<a href="/user/' + escapeHTML(data.name) + '/comments/">Comments</a>)');
 		
 		// Add friend button to header.
-		RESUtils.getUserInfo(function(me) {
-			var friendButton, myID = 't2_' + me.data.id;
-			if (data.is_friend) {
-				friendButton = '<span class="fancy-toggle-button toggle" style="display: inline-block; margin-left: 12px;"><a class="option active remove" href="#" tabindex="100" onclick="return toggle(this, unfriend(\'' + data.name + '\', \'' + myID + '\', \'friend\'), friend(\'' + data.name + '\', \'' + myID + '\', \'friend\'))">- friends</a><a class="option add" href="#">+ friends</a></span>';
-			} else {
-				friendButton = '<span class="fancy-toggle-button toggle" style="display: inline-block; margin-left: 12px;"><a class="option active add" href="#" tabindex="100" onclick="return toggle(this, friend(\'' + data.name + '\', \'' + myID + '\', \'friend\'), unfriend(\'' + data.name + '\', \'' + myID + '\', \'friend\'))">+ friends</a><a class="option remove" href="#">- friends</a></span>';
-			}
-			header.append(friendButton);
-			def.notify(header, 'Got friend status, loading details...');
-			header.find('.toggle').click(function (e) {
-				if (e.target.tagName !== 'A') return;
-				// Expire the cache to re-check friend status.
-				RESUtils.cache.expire({key: 'RESUtils.cache.-user-' + data.name + '-about-json'});
-			});
+		if (data.is_friend) {
+			friendButton = '<span class="fancy-toggle-button toggle" style="display: inline-block; margin-left: 12px;"><a class="option active remove" href="#" tabindex="100" onclick="return toggle(this, unfriend(\'' + data.name + '\', \'' + myID + '\', \'friend\'), friend(\'' + data.name + '\', \'' + myID + '\', \'friend\'))">- friends</a><a class="option add" href="#">+ friends</a></span>';
+		} else {
+			friendButton = '<span class="fancy-toggle-button toggle" style="display: inline-block; margin-left: 12px;"><a class="option active add" href="#" tabindex="100" onclick="return toggle(this, friend(\'' + data.name + '\', \'' + myID + '\', \'friend\'), unfriend(\'' + data.name + '\', \'' + myID + '\', \'friend\'))">+ friends</a><a class="option remove" href="#">- friends</a></span>';
+		}
+		header.append(friendButton);
+		header.find('.toggle').click(function (e) {
+			if (e.target.tagName !== 'A') return;
+			// The cache is now outdated, so expire it.
+			RESUtils.cache.expire({endpoint: '/user/' + data.name + '/about.json'});
 		});
 
-		def.notify(header, 'Getting friend status...');
+		def.notify(header, 'Getting friend button...');
 		
 		// var userHTML = '<a class="hoverAuthor" href="/user/'+data.name+'">'+data.name+'</a>:';
 		var userHTML = '<div class="authorFieldPair"><div class="authorLabel">Redditor since:</div> <div class="authorDetail">' + RESUtils.niceDate(d, module.options.USDateFormat.value) + ' (' + RESUtils.niceDateDiff(d) + ')</div></div>';

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -108,9 +108,8 @@ addModule('userInfo', function (module, moduleID) { $.extend(true, module, {
 		def.notify(thisUserName, throbber);
 
 		RESUtils.cache.fetch({
-			key: thisUserName.toLowerCase(),
 			method: 'GET',
-			endpoint: '/user/' + thisUserName + '/about.json',
+			endpoint: '/user/' + thisUserName.toLowerCase() + '/about.json',
 			callback: module.renderAuthorInfo.bind(module, def, obj)
 		});
 	},
@@ -135,7 +134,7 @@ addModule('userInfo', function (module, moduleID) { $.extend(true, module, {
 		RESUtils.getUserInfo(function(me) {
 			var friendButton, myID = 't2_' + me.data.id;
 			// Check cached value first, or fall back to initial server response.
-			if (data.resCache_friend || (data.is_friend && data.resCache_friend === undefined)) {
+			if (data.res_cache_friend || (data.is_friend && data.res_cache_friend === undefined)) {
 				friendButton = '<span class="fancy-toggle-button toggle" style="display: inline-block; margin-left: 12px;"><a class="option active remove" href="#" tabindex="100" onclick="return toggle(this, unfriend(\'' + data.name + '\', \'' + myID + '\', \'friend\'), friend(\'' + data.name + '\', \'' + myID + '\', \'friend\'))">- friends</a><a class="option add" href="#">+ friends</a></span>';
 			} else {
 				friendButton = '<span class="fancy-toggle-button toggle" style="display: inline-block; margin-left: 12px;"><a class="option active add" href="#" tabindex="100" onclick="return toggle(this, friend(\'' + data.name + '\', \'' + myID + '\', \'friend\'), unfriend(\'' + data.name + '\', \'' + myID + '\', \'friend\'))">+ friends</a><a class="option remove" href="#">- friends</a></span>';
@@ -144,11 +143,11 @@ addModule('userInfo', function (module, moduleID) { $.extend(true, module, {
 			def.notify(header, 'Got friend status, loading details...');
 			header.find('.toggle').click(function (e) {
 				if (e.target.tagName !== 'A') return;
-				// Expire the cache to reset friend status.
-				RESUtils.cache.expire({key: data.name});
+				// Expire the cache to re-check friend status.
+				RESUtils.cache.expire({key: 'RESUtils.cache.-user-' + data.name + '-about-json'});
 				// New property for the cache.
 				// TRUE if class was 'add' at time of click event.
-				data.resCache_friend = e.target.classList.contains('add');
+				data.res_cache_friend = e.target.classList.contains('add');
 			});
 		});
 

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -97,7 +97,6 @@ addModule('userInfo', function (module, moduleID) { $.extend(true, module, {
 			.begin();
 	},
 	showUserInfo: function(def, obj, context) {
-		def.notify('Loading...', '<span class="RESThrobber />');
 		var test = obj.href.match(modules['userTagger'].usernameRE),
 			thisUserName,
 			throbber = '<span class="RESThrobber"></span>';

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -104,7 +104,7 @@ addModule('userInfo', function (module, moduleID) { $.extend(true, module, {
 
 		if (test) {
 			thisUserName = test[1];
-			nameLowerCase = thisUserName.toLowerCase()
+			nameLowerCase = thisUserName.toLowerCase();
 		}
 		
 		module.lastOpenedAuthorLink = obj;


### PR DESCRIPTION
Fixes #2447.

Sets correct attribute values on the friend toggle button.

Clicking the friend button expires the cache on the associated user which forces a new check the next time userInfo is opened.

Makes the throbber work the way it was originally intended to. The throbber element needs to be a variable before being passed to def.notify().