### PR TITLE
RESUtils.cache.fetch is subtly broken

### DIFF
--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -2261,6 +2261,7 @@ RESUtils.hashKeyArray = function(keyArray) {
 						cache.lastCheck = now;
 						RESStorage.setItem(obj.key, JSON.stringify(cache));
 						deferred.resolve(cache.data);
+						delete fetching[obj.key];
 					}
 				});
 			}


### PR DESCRIPTION
...such that you can't send more than one request to an endpoint, even if the cache is expired (since the old promise would still be used, as though the old request was still in progress).