### PR TITLE
Removed autoplay and replaced embed.radd.it

### DIFF
--- a/lib/modules/hosts/raddit.js
+++ b/lib/modules/hosts/raddit.js
@@ -7,13 +7,6 @@ modules['showImages'].siteModules['raddit'] = {
 			value: true,
 			type: 'boolean'
 		},
-		// No longer supported.
-		// 'autoplay sidebar playlister': {
-		// 	dependsOn: 'show playlister toggle',
-		// 	description: 'Start playing the radd.it sidebar embed when opening it',
-		// 	type: 'boolean',
-		// 	value: true
-		// },
 		'always show sidebar playlister': {
 			description: 'Always show the radd.it embed in the sidebar when applicable',
 			value: false,
@@ -107,10 +100,6 @@ modules['showImages'].siteModules['raddit'] = {
 
 			var src = document.location.protocol + '//radd.it/' + path + (path.indexOf('?') == -1 ? '?embed' : '&embed');
 
-			// No longer supported.
-			// if (autoplay && modules['showImages'].options['autoplay sidebar playlister']) {
-			// 	src = src + (src.indexOf('?') !== 1 ? '?' : '&') + 'autoplay=1';
-			// }
 			listr = document.createElement('iframe');
 			listr.className = 'RES-raddit';
 			listr.src = src;

--- a/lib/modules/hosts/raddit.js
+++ b/lib/modules/hosts/raddit.js
@@ -20,7 +20,7 @@ modules['showImages'].siteModules['raddit'] = {
 			groups = hashRe.exec(elem.href);
 
 		if (groups) {
-			def.resolve(elem, '//radd.it' + groups[1] + (groups[1].indexOf('?') == -1 ? '?embed' : '&embed'));
+			def.resolve(elem, '//radd.it' + groups[1] + (groups[1].indexOf('?') === -1 ? '?embed' : '&embed'));
 		} else {
 			def.reject();
 		}
@@ -98,7 +98,7 @@ modules['showImages'].siteModules['raddit'] = {
 		} else {						// otherwise, create it.
 			var width = window.getComputedStyle(sb).width;
 
-			var src = document.location.protocol + '//radd.it/' + path + (path.indexOf('?') == -1 ? '?embed' : '&embed');
+			var src = document.location.protocol + '//radd.it/' + path + (path.indexOf('?') === -1 ? '?embed' : '&embed');
 
 			listr = document.createElement('iframe');
 			listr.className = 'RES-raddit';

--- a/lib/modules/hosts/raddit.js
+++ b/lib/modules/hosts/raddit.js
@@ -7,12 +7,13 @@ modules['showImages'].siteModules['raddit'] = {
 			value: true,
 			type: 'boolean'
 		},
-		'autoplay sidebar playlister': {
-			dependsOn: 'show playlister toggle',
-			description: 'Start playing the radd.it sidebar embed when opening it',
-			type: 'boolean',
-			value: true
-		},
+		// No longer supported.
+		// 'autoplay sidebar playlister': {
+		// 	dependsOn: 'show playlister toggle',
+		// 	description: 'Start playing the radd.it sidebar embed when opening it',
+		// 	type: 'boolean',
+		// 	value: true
+		// },
 		'always show sidebar playlister': {
 			description: 'Always show the radd.it embed in the sidebar when applicable',
 			value: false,
@@ -26,7 +27,7 @@ modules['showImages'].siteModules['raddit'] = {
 			groups = hashRe.exec(elem.href);
 
 		if (groups) {
-			def.resolve(elem, '//embed.radd.it' + groups[1]);
+			def.resolve(elem, '//radd.it' + groups[1] + (groups[1].indexOf('?') == -1 ? '?embed' : '&embed'));
 		} else {
 			def.reject();
 		}
@@ -104,10 +105,12 @@ modules['showImages'].siteModules['raddit'] = {
 		} else {						// otherwise, create it.
 			var width = window.getComputedStyle(sb).width;
 
-			var src = document.location.protocol + '//embed.radd.it/' + path;
-			if (autoplay && modules['showImages'].options['autoplay sidebar playlister']) {
-				src = src + (src.indexOf('?') !== 1 ? '?' : '&') + 'autoplay=1';
-			}
+			var src = document.location.protocol + '//radd.it/' + path + (path.indexOf('?') == -1 ? '?embed' : '&embed');
+
+			// No longer supported.
+			// if (autoplay && modules['showImages'].options['autoplay sidebar playlister']) {
+			// 	src = src + (src.indexOf('?') !== 1 ? '?' : '&') + 'autoplay=1';
+			// }
 			listr = document.createElement('iframe');
 			listr.className = 'RES-raddit';
 			listr.src = src;


### PR DESCRIPTION
To save money on its SSL cert, embed.radd.it is no longer supported via HTTPS.  Updated code to use the new ?embed format instead.  Autoplay is no longer supported.  I've removed it from radd.it's options.

All embedded links are currently broken, so please include this in the next release!