### PR TITLE
remove reddit expando button for duplicate images

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -654,8 +654,18 @@ addModule('showImages', {
 		} else if (!elem.classList.contains('imgScanned')) {
 			var textFrag = document.createElement('span');
 			textFrag.setAttribute('class', 'RESdupeimg');
+			this.removeRedditExpandoButton(elem);
 			$(textFrag).html('<a class="noKeyNav" href="#img' + parseInt(this.imagesRevealed[href], 10) + '" title="click to scroll to original">[RES ignored duplicate link]</a>');
 			RESUtils.insertAfter(elem, textFrag);
+		}
+	},
+	removeRedditExpandoButton: function(elem) {
+		if (elem.classList.contains('title')) {
+			// remove the default reddit expando button on post listings
+			// we actually remove it from the DOM for a number of reasons, including the
+			// fact that many subreddits style them with display: block !important;, which
+			// overrides a "hide" call here.
+			$(elem).closest('.entry').find('.expando-button.video:not(.commentImg)').remove();
 		}
 	},
 	createImageExpando: function(elem) {
@@ -673,13 +683,7 @@ addModule('showImages', {
 			}
 		}
 
-		if (elem.classList.contains('title')) {
-			// remove the default reddit expando button on post listings
-			// we actually remove it from the DOM for a number of reasons, including the
-			// fact that many subreddits style them with display: block !important;, which
-			// overrides a "hide" call here.
-			$(elem).closest('.entry').find('.expando-button.video:not(.commentImg)').remove();
-		}
+		this.removeRedditExpandoButton(elem);
 
 		// This should not be reached in the case of duplicates
 		elem.name = 'img' + mod.imagesRevealed[href];


### PR DESCRIPTION
for consistency with removing reddit expandos when RES provides the expando

before:

<img width="706" alt="screen shot 2015-11-15 at 12 53 43 pm" src="https://cloud.githubusercontent.com/assets/455632/11170956/f467256a-8b97-11e5-8c81-0d81bc04df0b.png">

after:

<img width="780" alt="screen shot 2015-11-15 at 12 51 22 pm" src="https://cloud.githubusercontent.com/assets/455632/11170935/9acbdeec-8b97-11e5-8e12-13c5dfca9b55.png">