### PR TITLE
Fix #2497 - Opening a link (consisting of only a hash) in a new tab opens the background page

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -684,6 +684,12 @@ addModule('keyboardNav', {
 		var thisURL = link.getAttribute('href'),
 			button = (this.options.followLinkNewTabFocus.value) ? 0 : 1;
 
+		// we do this because chrome.tabs.create opens URLs consisting solely of fragments (#foo)
+		// relative to the background page instead of the current location
+		if (thisURL.substring(0, 1) === '#') {
+			thisURL = location.href + thisURL;
+		}
+
 		if (this.options.commentsLinkNewTab.value) {
 			var thisJSON = {
 				requestType: 'keyboardNav',

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -687,7 +687,7 @@ addModule('keyboardNav', {
 		// we do this because chrome.tabs.create opens URLs consisting solely of fragments (#foo)
 		// relative to the background page instead of the current location
 		if (thisURL.substring(0, 1) === '#') {
-			thisURL = location.href + thisURL;
+			thisURL = location.pathname + location.search + thisURL;
 		}
 
 		if (this.options.commentsLinkNewTab.value) {


### PR DESCRIPTION
This is a simple fix for #2497