### PR TITLE
Simplify module categories

### DIFF
--- a/lib/modules/RESTips.js
+++ b/lib/modules/RESTips.js
@@ -1,7 +1,7 @@
 addModule('RESTips', {
 	moduleID: 'RESTips',
 	moduleName: 'RES Tips and Tricks',
-	category: ['Core', 'About RES'],
+	category: ['About RES'],
 	options: {
 		// any configurable options you have go here...
 		// options must have a type and a value..

--- a/lib/modules/RESTips.js
+++ b/lib/modules/RESTips.js
@@ -1,7 +1,7 @@
 addModule('RESTips', {
 	moduleID: 'RESTips',
 	moduleName: 'RES Tips and Tricks',
-	category: 'Core',
+	category: ['Core', 'About RES'],
 	options: {
 		// any configurable options you have go here...
 		// options must have a type and a value..

--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -1,7 +1,7 @@
 addModule('accountSwitcher', {
 	moduleID: 'accountSwitcher',
 	moduleName: 'Account Switcher',
-	category: 'Users',
+	category: 'My account',
 	options: {
 		keepLoggedIn: {
 			type: 'boolean',

--- a/lib/modules/backupAndRestore.js
+++ b/lib/modules/backupAndRestore.js
@@ -1,6 +1,6 @@
 addModule('backupAndRestore', function(module, moduleID) {
 	module.moduleName = 'Backup & Restore';
-	module.category = 'About RES';
+	module.category = 'Core';
 	module.description = 'Backup and restore your Reddit Enhancement Suite settings.';
 	module.options = {
 		backup: {

--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -1,7 +1,7 @@
 addModule('betteReddit', {
 	moduleID: 'betteReddit',
 	moduleName: 'betteReddit',
-	category: 'UI',
+	category: ['Appearance'],
 	options: {
 		fullCommentsLink: {
 			type: 'boolean',

--- a/lib/modules/commandLine.js
+++ b/lib/modules/commandLine.js
@@ -1,7 +1,7 @@
 addModule('commandLine', function(module, moduleID) {
 	module.moduleName = 'RES Command Line';
 	module.description = 'Command line for navigating reddit, toggling RES settings, and debugging RES';
-	module.category = 'Core';
+	module.category = ['Core'];
 	module.options.launch = {
 		type: 'button',
 		text: 'Launch',

--- a/lib/modules/commentPreview.js
+++ b/lib/modules/commentPreview.js
@@ -1,7 +1,7 @@
 addModule('commentPreview', {
 	moduleID: 'commentPreview',
 	moduleName: 'Live Comment Preview',
-	category: 'Editing',
+	category: 'Comments',
 	options: {
 		enableBigEditor: {
 			type: 'boolean',

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -1,7 +1,7 @@
 addModule('commentTools', {
 	moduleID: 'commentTools',
 	moduleName: 'Comment Tools',
-	category: [ 'Editing', 'Comments', 'Posts' ],
+	category: ['Comments' ],
 	options: {
 		userAutocomplete: {
 			type: 'boolean',

--- a/lib/modules/customToggles.js
+++ b/lib/modules/customToggles.js
@@ -1,6 +1,6 @@
 addModule('customToggles', function (module, moduleID) {
 	module.moduleName = 'Custom Toggles';
-	module.category = 'Core';
+	module.category = ['Core'];
 	module.description = 'Set up custom on/off switches for various parts of RES.';
 
 	module.options.toggle = {

--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -1,7 +1,7 @@
 addModule('dashboard', {
 	moduleID: 'dashboard',
 	moduleName: 'RES Dashboard',
-	category: 'UI',
+	category: 'Productivity',
 	alwaysEnabled: true,
 	options: {
 		menuItem: {

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -1,7 +1,7 @@
 addModule('filteReddit', {
 	moduleID: 'filteReddit',
 	moduleName: 'filteReddit',
-	category: [ 'Filters', 'Posts' ],
+	category: ['Subreddits'],
 	options: {
 		// any configurable options you have go here...
 		// options must have a type and a value..

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -1,7 +1,7 @@
 addModule('filteReddit', {
 	moduleID: 'filteReddit',
 	moduleName: 'filteReddit',
-	category: ['Subreddits'],
+	category: ['Subreddits', 'Submissions'],
 	options: {
 		// any configurable options you have go here...
 		// options must have a type and a value..

--- a/lib/modules/floater.js
+++ b/lib/modules/floater.js
@@ -1,5 +1,5 @@
 addModule('floater', function(module, moduleID) {
-	module.category = 'Core';
+	module.category = ['Productivity'];
 	module.moduleName = 'Floating Islands';
 	module.description = 'Managing free-floating RES elements';
 	module.alwaysEnabled = true;

--- a/lib/modules/hover.js
+++ b/lib/modules/hover.js
@@ -1,6 +1,6 @@
 addModule('hover', function(module, moduleID) {
 	module.moduleName = 'RES Pop-up Hover';
-	module.category = 'Core';
+	module.category = ['Core'];
 	module.description = 'Customize the behavior of the large informational pop-ups which appear when you hover your mouse over certain elements.';
 	module.alwaysEnabled = true;
 

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1,7 +1,7 @@
 addModule('keyboardNav', {
 	moduleID: 'keyboardNav',
 	moduleName: 'Keyboard Navigation',
-	category: [ 'UI' ],
+	category: [ 'Browsing' ],
 	options: {
 		mediaBrowseMode: {
 			type: 'boolean',

--- a/lib/modules/localDate.js
+++ b/lib/modules/localDate.js
@@ -1,7 +1,7 @@
 addModule('localDate', {
 	moduleID: 'localDate',
 	moduleName: 'Local Date',
-	category: [ 'Content' ],
+	category: ['My account'],
 	options: {},
 	description: 'Shows date in your local time zone when you hover over a relative date.',
 	isEnabled: function() {

--- a/lib/modules/logoLink.js
+++ b/lib/modules/logoLink.js
@@ -1,7 +1,7 @@
 addModule('logoLink', {
 	moduleID: 'logoLink',
 	moduleName: 'Logo Link',
-	category: 'Subreddits',
+	category: 'Browsing',
 	options: {
 		redditLogoDestination: {
 			type: 'enum',

--- a/lib/modules/menu.js
+++ b/lib/modules/menu.js
@@ -1,6 +1,6 @@
 addModule('RESMenu', function(module, moduleID) {
 	module.moduleName = 'RES Menu';
-	module.category = 'Core';
+	category: ['Core', 'My account'];
 	module.description = 'The <span class="gearIcon"></span> dropdown menu to manage RES settings and quick options';
 	module.alwaysEnabled = true;
 	module.hidden = true;

--- a/lib/modules/menu.js
+++ b/lib/modules/menu.js
@@ -1,6 +1,6 @@
 addModule('RESMenu', function(module, moduleID) {
 	module.moduleName = 'RES Menu';
-	category: ['Core', 'My account'];
+	module.category = ['Core'];
 	module.description = 'The <span class="gearIcon"></span> dropdown menu to manage RES settings and quick options';
 	module.alwaysEnabled = true;
 	module.hidden = true;

--- a/lib/modules/messageMenu.js
+++ b/lib/modules/messageMenu.js
@@ -1,6 +1,6 @@
 addModule('messageMenu', function(module, moduleID) {
 	module.moduleName = 'Message Menu';
-	module.category = 'Comments';
+	module.category = ['Browsing', 'My account'];
 	module.description = 'Navigate quickly to inboxes and other parts of the reddit messaging system';
 
 	module.options = {

--- a/lib/modules/modhelper.js
+++ b/lib/modules/modhelper.js
@@ -1,7 +1,7 @@
 addModule('modHelper', {
 	moduleID: 'modHelper',
 	moduleName: 'Mod Helper',
-	category: ['About RES', 'Core'],
+	category: ['Core'],
 	description: 'Helps moderators via tips and tricks for playing nice with RES',
 	hidden: true,
 	alwaysEnabled: true,

--- a/lib/modules/modhelper.js
+++ b/lib/modules/modhelper.js
@@ -1,7 +1,7 @@
 addModule('modHelper', {
 	moduleID: 'modHelper',
 	moduleName: 'Mod Helper',
-	category: 'UI',
+	category: ['About RES', 'Core'],
 	description: 'Helps moderators via tips and tricks for playing nice with RES',
 	hidden: true,
 	alwaysEnabled: true,

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -1,7 +1,7 @@
 addModule('neverEndingReddit', {
 	moduleID: 'neverEndingReddit',
 	moduleName: 'Never Ending Reddit',
-	category: 'Posts',
+	category: ['Browsing'],
 	options: {
 		// any configurable options you have go here...
 		// options must have a type and a value..

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -1,7 +1,7 @@
 addModule('newCommentCount', {
 	moduleID: 'newCommentCount',
 	moduleName: 'New Comment Count',
-	category: 'Comments',
+	category: 'Submissions',
 	options: {
 		// any configurable options you have go here...
 		// options must have a type and a value..

--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -4,7 +4,7 @@ addModule('nightMode', function(module, moduleID) {
 	description: 'A darker, more eye-friendly version of Reddit suited for night browsing.\
 		<br><br>Note: Using this on/off switch will disable all features of the night mode module completely.\
 		<br>To simply turn off night mode, use the nightModeOn switch below.',
-	category: 'Style',
+	category: 'Appearance',
 	options: {
 		nightModeOn: {
 			type: 'boolean',

--- a/lib/modules/noParticipation.js
+++ b/lib/modules/noParticipation.js
@@ -11,7 +11,7 @@ addModule('noParticipation', function(module, moduleID) {
 		accidentally participating. \
 		<p><a href="' + urls.moreinfo + '" target="_blank">Find out more about "No Participation".</a></p>';
 
-	module.category = 'Comments';
+	module.category = ['Comments', 'Subreddits'];
 
 	module.options = {
 		disableVoteButtons: {

--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -1,6 +1,6 @@
 addModule('orangered', function(module, moduleID) {
 	module.moduleName = 'Unread Messages';
-	module.category = 'Comments';
+	module.category = 'My account';
 	module.description = 'Helping you get your daily dose of orangereds';
 
 	module.options = {

--- a/lib/modules/pageNavigator.js
+++ b/lib/modules/pageNavigator.js
@@ -1,6 +1,6 @@
 addModule('pageNavigator', {
 	moduleName: 'Post Navigator',
-	category: 'Posts',
+	category: 'Browsing',
 	description: 'Provides a post navigation tool to get you up and down the page',
 	go: function() {
 		if ((this.isEnabled()) && (this.isMatchURL())) {

--- a/lib/modules/presets.js
+++ b/lib/modules/presets.js
@@ -1,6 +1,6 @@
 addModule('presets', function(module, moduleID) {
 	module.moduleName = 'Presets';
-	module.category = 'About RES';
+	module.category = 'Core';
 	module.alwaysEnabled = true;
 	module.description = 'Select from various preset RES configurations. Each preset turns on or off various modules/options, but does not reset your entire configuration.';
 

--- a/lib/modules/quickMessage.js
+++ b/lib/modules/quickMessage.js
@@ -1,6 +1,6 @@
 addModule('quickMessage', function(module, moduleID) {
 	module.moduleName = 'Quick Message';
-	module.category = 'Editing';
+	module.category = ['Users', 'My account'];
 	module.description = 'A pop-up dialog that allows you to send messages from anywhere on reddit. Messages can be sent from the quick message dialog by pressing control-enter or command-enter.';
 	module.options = {
 		openQuickMessage: {

--- a/lib/modules/searchHelper.js
+++ b/lib/modules/searchHelper.js
@@ -1,7 +1,7 @@
 addModule('searchHelper', {
 	moduleID: 'searchHelper',
 	moduleName: 'Search Helper',
-	category: 'Posts',
+	category: 'Browsing',
 	options: {
 		addSearchOptions: {
 			type: 'boolean',

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -1,6 +1,6 @@
 addModule('selectedEntry', function(module, moduleID) {
 	module.moduleName = 'Selected Entry';
-	module.category = [ 'Style', 'Comments', 'Posts' ];
+	module.category = [ 'Appearance', 'Browsing'];
 	module.include = [ 'comments', 'linklist', 'profile', 'inbox', 'search' ];
 	module.description = 'When a post or comment is selected, show extra styling and tools';
 

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -1,6 +1,6 @@
 addModule('settingsConsole', function(module, moduleID) {
 	module.moduleName = 'Settings Console';
-	module.category = 'Core';
+	category: 'Core';
 	module.description = 'Manage your RES settings and preferences';
 	module.alwaysEnabled = true;
 	module.hidden = true;

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -1,6 +1,6 @@
 addModule('settingsConsole', function(module, moduleID) {
 	module.moduleName = 'Settings Console';
-	category: 'Core';
+	module.category = 'Core';
 	module.description = 'Manage your RES settings and preferences';
 	module.alwaysEnabled = true;
 	module.hidden = true;

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -5,7 +5,7 @@
 addModule('showImages', {
 	moduleID: 'showImages',
 	moduleName: 'Inline Image Viewer',
-	category: 'Content',
+	category: ['Productivity', 'Browsing'],
 	options: {
 		conserveMemory: {
 			type: 'boolean',

--- a/lib/modules/showKarma.js
+++ b/lib/modules/showKarma.js
@@ -1,7 +1,7 @@
 addModule('showKarma', {
 	moduleID: 'showKarma',
 	moduleName: 'Show Karma',
-	category: 'Users',
+	category: 'My account',
 	options: {
 		showCommentKarma: {
 			type: 'boolean',

--- a/lib/modules/singleClick.js
+++ b/lib/modules/singleClick.js
@@ -1,7 +1,7 @@
 addModule('singleClick', {
 	moduleID: 'singleClick',
 	moduleName: 'Single Click Opener',
-	category: 'Posts',
+	category: 'Browsing',
 	options: {
 		openOrder: {
 			type: 'enum',

--- a/lib/modules/sourceSnudown.js
+++ b/lib/modules/sourceSnudown.js
@@ -1,7 +1,7 @@
 addModule('sourceSnudown', function(module, moduleID) {
 	module.moduleName = 'Show Snudown Source';
 	module.description = 'Add tool to show the original text on posts and comments, before reddit formats the text.';
-	module.category = 'Editing';
+	module.category = ['Comments'];
 	module.include = [
 		'comments',
 		'inbox',

--- a/lib/modules/spamButton.js
+++ b/lib/modules/spamButton.js
@@ -1,7 +1,7 @@
 addModule('spamButton', {
 	moduleID: 'spamButton',
 	moduleName: 'Spam Button',
-	category: 'Filters',
+	category: 'Submissions',
 	disabledByDefault: true,
 	options: {},
 	description: 'Adds a Spam button to posts for easy reporting.',

--- a/lib/modules/spoilerTags.js
+++ b/lib/modules/spoilerTags.js
@@ -1,6 +1,6 @@
 addModule('spoilerTags', {
 	moduleName: 'Global Spoiler Tags',
-	category: 'UI',
+	category: ['Appearance'],
 	description: 'Hide spoiler-tagged comments on user profiles until moused over.',
 	include: [
 		'profile'

--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -1,7 +1,7 @@
 addModule('styleTweaks', {
 	moduleID: 'styleTweaks',
 	moduleName: 'Style Tweaks',
-	category: 'Style',
+	category: ['Appearance', 'Comments'],
 	description: 'Provides a number of style tweaks to the Reddit interface. Also allow you to disable specific subreddit style (the <a href="/prefs/#show_stylesheets">global setting</a> must be on).',
 	options: {
 		navTop: {

--- a/lib/modules/stylesheet.js
+++ b/lib/modules/stylesheet.js
@@ -1,7 +1,7 @@
 addModule('stylesheet', function(module, moduleID) {
 	module.moduleName = 'Stylesheet Loader';
 	module.description = 'Load stylesheets from other subreddits or load your own CSS snippets.';
-	module.category = 'UI';
+	module.category = 'Appearance';
 	module.exclude = [
 		'prefs',
 		'account',

--- a/lib/modules/submitHelper.js
+++ b/lib/modules/submitHelper.js
@@ -1,6 +1,6 @@
 addModule('submitHelper', function(module, moduleID) {
 	module.moduleName = 'Submission Helper';
-	module.category = 'Editing';
+	module.category = 'Submissions';
 	module.description = 'Provides utilities to help with submitting a post.';
 	module.options = {
 		warnAlreadySubmitted: {

--- a/lib/modules/subredditInfo.js
+++ b/lib/modules/subredditInfo.js
@@ -1,7 +1,7 @@
 addModule('subredditInfo', {
 	moduleID: 'subredditInfo',
 	moduleName: 'Subreddit Info',
-	category: 'Subreddits',
+	category: ['Subreddits'],
 	options: {
 		hoverDelay: {
 			type: 'text',

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -1,7 +1,7 @@
 addModule('subredditManager', {
 	moduleID: 'subredditManager',
 	moduleName: 'Subreddit Manager',
-	category: 'Subreddits',
+	category: ['Subreddits'],
 	options: {
 		subredditShortcut: {
 			type: 'boolean',

--- a/lib/modules/subredditTagger.js
+++ b/lib/modules/subredditTagger.js
@@ -1,7 +1,7 @@
 addModule('subRedditTagger', {
 	moduleID: 'subRedditTagger',
 	moduleName: 'Subreddit Tagger',
-	category: [ 'Filters', 'Posts' ],
+	category: [ 'Subreddits' ],
 	options: {
 		subReddits: {
 			type: 'table',

--- a/lib/modules/tableTools.js
+++ b/lib/modules/tableTools.js
@@ -1,7 +1,7 @@
 ﻿addModule('tableTools', {
 	moduleID: 'tableTools',
 	moduleName: 'Table Tools',
-	category: ['Browsing'],
+	category: ['Productivity', 'Appearance'],
 	description: 'Include additional functionality to Reddit Markdown tables (only sorting at the moment).',
 	options: {
 		sort: {

--- a/lib/modules/tableTools.js
+++ b/lib/modules/tableTools.js
@@ -1,7 +1,7 @@
 ﻿addModule('tableTools', {
 	moduleID: 'tableTools',
 	moduleName: 'Table Tools',
-	category: 'Content',
+	category: ['Browsing'],
 	description: 'Include additional functionality to Reddit Markdown tables (only sorting at the moment).',
 	options: {
 		sort: {

--- a/lib/modules/upload.js
+++ b/lib/modules/upload.js
@@ -1,7 +1,7 @@
 addModule('uploader', {
 	moduleID: 'uploader',
 	moduleName: 'Submit Page Uploader',
-	category: 'Editing',
+	category: ['Submissions'],
 	options: {
 		preferredHost: {
 			type: 'enum',

--- a/lib/modules/uppersAndDowners.js
+++ b/lib/modules/uppersAndDowners.js
@@ -1,7 +1,7 @@
 addModule('uppersAndDowners', {
 	moduleID: 'uppersAndDowners',
 	moduleName: 'Uppers and Downers Enhanced',
-	category: 'UI',
+	category: 'Appearance',
 	options: {
 		showSigns: {
 			type: 'boolean',

--- a/lib/modules/userHighlight.js
+++ b/lib/modules/userHighlight.js
@@ -1,7 +1,7 @@
 addModule('userHighlight', {
 	moduleID: 'userHighlight',
 	moduleName: 'User Highlighter',
-	category: 'Users',
+	category: ['Users', 'Appearance'],
 	description: 'Highlights certain users in comment threads: OP, Admin, Friends, Mod - contributed by MrDerk',
 	options: {
 		highlightOP: {

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -1,7 +1,7 @@
 addModule('userInfo', function (module, moduleID) { $.extend(true, module, {
 	moduleID: 'userInfo',
 	moduleName: 'User Info',
-	category: 'Users',
+	category: ['Users'],
 	options: {
 		hoverInfo: {
 			type: 'boolean',

--- a/lib/modules/userbarHider.js
+++ b/lib/modules/userbarHider.js
@@ -1,7 +1,7 @@
 addModule('userbarHider', function(module, moduleID) {
 	module.moduleName = 'User Bar Hider';
 	module.description = 'Hide the user bar (username, karma, preferences, etc.) in the top right corner. <br> Previously part of Style Tweaks';
-	module.category = 'Users';
+	module.category = ['My account'];
 
 	module.options['userbarState'] = {
 		type: 'enum',

--- a/lib/modules/usernameHider.js
+++ b/lib/modules/usernameHider.js
@@ -1,7 +1,7 @@
 addModule('usernameHider', {
 	moduleID: 'usernameHider',
 	moduleName: 'Username Hider',
-	category: 'Users',
+	category: 'My account',
 	disabledByDefault: true,
 	options: {
 		displayText: {

--- a/lib/modules/voteEnhancements.js
+++ b/lib/modules/voteEnhancements.js
@@ -1,7 +1,7 @@
 addModule('voteEnhancements', function(module, moduleID) {
 	$.extend(module, {
 	moduleName: 'Vote Enhancements',
-	category: [ 'Posts', 'Comments' ],
+	category: [ 'Appearance' ],
 	description: 'Format or show additional information about votes on posts and comments.',
 	options: {
 		estimatePostScore: {

--- a/lib/reddit_enhancement_suite.user.js
+++ b/lib/reddit_enhancement_suite.user.js
@@ -4,7 +4,7 @@ var RESMetadata = {
 	name: 'Reddit Enhancement Suite',
 	version: '4.5.4',
 	defaultModuleID: 'contribute',  // Show this module by default when opening settings
-	categories: [ 'About RES', 'Content', 'Editing', 'Style', 'Filters', 'Posts', 'Comments', 'Subreddits', '*', 'Core' ]
+	categories: [ 'About RES', 'My account', 'Users', 'Comments', 'Submissions', 'Subreddits', 'Appearance', '*', 'Core' ]
 };
 RESMetadata.updatedURL = 'http://redditenhancementsuite.com/whatsnew.html?v=' + RESMetadata.version;
 /*


### PR DESCRIPTION
Closes #2374.

Brings the total number of categories down from 11 to 10. A loose rule I came up with for fighting ambiguity was that for each category, at least half of its modules should be exclusive. If the majority of modules for one category aren't exclusive to it, then either the category is too vague or some modules don't belong there.

The new category list:

1. About RES
2. My account
3. Users
4. Comments
5. Submissions
6. Subreddits
7. Appearance
8. Browsing
9. Productivity
10. Core

These were replaced or removed because I felt they were too specific (filters) or too vague (posts):

* Editing
* Style
* Filters
* Posts
* UI