### PR TITLE
Fix #2482 - implement warning about old submissions

### DIFF
--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -428,7 +428,6 @@ addModule('commentTools', {
 						var $span = $('<span></span>')
 							.addClass('old-content-warning')
 							.text('The submission is older than ' + max + ' days!');
-						console.log($body.find('.commentarea .bottom-area:first'));
 						$body.find('.commentarea .bottom-area:first').prepend($span);
 					}
 

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -149,7 +149,8 @@ addModule('commentTools', {
 		oldSubmissionMaxAge: {
 			type: 'text',
 			value: '7',
-			description: 'The maximum age of submissions before showing a warning'
+			description: 'The maximum age of submissions before showing a warning',
+			dependsOn: 'warnOldSubmissions'
 		}
 	},
 	description: 'Provides shortcuts for easier markdown.',

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -140,6 +140,16 @@ addModule('commentTools', {
 			value: true,
 			description: 'Show the comment tools on the ban note textbox.',
 			advanced: true
+		},
+		warnOldSubmissions: {
+			type: 'boolean',
+			value: false,
+			description: 'Show a warning when replying to old submissions'
+		},
+		oldSubmissionMaxAge: {
+			type: 'text',
+			value: '7',
+			description: 'The maximum age of submissions before showing a warning'
 		}
 	},
 	description: 'Provides shortcuts for easier markdown.',
@@ -257,6 +267,9 @@ addModule('commentTools', {
 
 			// Autocomplete
 			RESUtils.addCSS('.selectedItem { color: #fff; background-color: #5f99cf; }');
+
+			// Warn about old submissions
+			RESUtils.addCSS('.old-content-warning { color: red; font-weight: bold; }')
 
 			return RESStorage.loadItem('RESmodules.commentTools.macroDataVersion');
 		}
@@ -396,6 +409,31 @@ addModule('commentTools', {
 
 			if (this.options.subredditAutocomplete.value || this.options.userAutocomplete.value) {
 				this.addAutoCompletePop();
+			}
+
+			// check if the submission or its comments are old and warn the user
+			if (this.options.warnOldSubmissions.value) {
+				var max = parseInt(this.options.oldSubmissionMaxAge.value); // just ignore erroneous values
+				var maxMs = max * 1000 * 60 * 60 * 24; // days to milliseconds
+				var now = new Date();
+				var oldestDate = new Date(now - maxMs);
+				if ($body.is('.comments-page')) {
+					// get submission date and parse it
+					var datetimeStr = $body.find('#siteTable .thing:first time').attr('datetime');
+					var submissionDate = new Date(datetimeStr);
+
+					// warn the user if the submission is older than `max` days
+					if (submissionDate < oldestDate) {
+						var $span = $('<span></span>')
+							.addClass('old-content-warning')
+							.text('The submission is older than ' + max + ' days!');
+						console.log($body.find('.commentarea .bottom-area:first'));
+						$body.find('.commentarea .bottom-area:first').prepend($span);
+					}
+
+					// NOTE: the above will warn the user in the same way when they click "reply" to a
+					// comment because reddit just copies the entire reply form, including the warning!
+				}
 			}
 
 			//Perform initial setup of tools over the whole page

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -270,7 +270,7 @@ addModule('commentTools', {
 			RESUtils.addCSS('.selectedItem { color: #fff; background-color: #5f99cf; }');
 
 			// Warn about old submissions
-			RESUtils.addCSS('.old-content-warning { color: red; font-weight: bold; }')
+			RESUtils.addCSS('.old-content-warning { color: red; font-weight: bold; }');
 
 			return RESStorage.loadItem('RESmodules.commentTools.macroDataVersion');
 		}


### PR DESCRIPTION
Adds two new options to Comment Tools: warnOldSubmissions (boolean, default false) and oldSubmissionMaxAge (integer, default 7).

When users are on the comment page of a submission older than `oldSubmissionMaxAge` days, displays a warning in red between the textarea and the Save button.