### PR TITLE
Avoid potential double-posting on CTRL+enter

### DIFF
--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -376,6 +376,12 @@ addModule('commentTools', {
 					function(e) {
 						var currentForm = $(e.target).closest('form');
 						var saveButton = currentForm.find('.save')[0] || currentForm.find('#wiki_save_button')[0] || $('.BEFoot button')[0];
+
+						// Avoid potential double-posting
+						if (currentForm.hasClass('usertext')) {
+							$(e.target).val('');
+						}
+
 						RESUtils.click(saveButton);
 					}
 				);

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -378,8 +378,8 @@ addModule('commentTools', {
 						var saveButton = currentForm.find('.save')[0] || currentForm.find('#wiki_save_button')[0] || $('.BEFoot button')[0];
 
 						// Avoid potential double-posting
-						if (currentForm.hasClass('usertext')) {
-							$(e.target).val('');
+						if (currentForm.find('.status').text() === 'posting...') {
+							return;
 						}
 
 						RESUtils.click(saveButton);


### PR DESCRIPTION
This change avoids potential double-posting on CTRL+enter although this means that you lose your comment in the event of an error when posting (internet down, etc. etc.). Not entirely convinced but hopefully this will encourage a more robust solution.
