### PR TITLE
Fix for userTaggerToolTip appearing offscreen

### DIFF
--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -595,10 +595,11 @@ addModule('userTagger', {
 			}
 			document.getElementById('userTaggerColor').selectedIndex = 0;
 		}
-		if (thisXY.x + 334 < window.innerWidth) {
+		this.userTaggerToolTip.style.display = "block";
+		if (thisXY.x + this.userTaggerToolTip.offsetWidth < window.innerWidth) {
 			this.userTaggerToolTip.setAttribute('style', 'display: block; top: ' + thisXY.y + 'px; left: ' + thisXY.x + 'px; z-index: 20;');
 		} else {
-			this.userTaggerToolTip.setAttribute('style', 'display: block; top: ' + thisXY.y + 'px; right: ' + (window.innerWidth - thisXY.x - 20)  + 'px; z-index: 20;');
+			this.userTaggerToolTip.setAttribute('style', 'display: block; top: ' + thisXY.y + 'px; right: ' + (document.body.offsetWidth - thisXY.x)  + 'px; z-index: 20;');
 		}
 		document.getElementById('userTaggerTag').focus();
 		modules['userTagger'].updateOpenLink(document.getElementById('userTaggerLink'));

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -595,7 +595,11 @@ addModule('userTagger', {
 			}
 			document.getElementById('userTaggerColor').selectedIndex = 0;
 		}
-		this.userTaggerToolTip.setAttribute('style', 'display: block; top: ' + thisXY.y + 'px; left: ' + thisXY.x + 'px; z-index: 20;');
+		if (thisXY.x + $("#userTaggerToolTip").width() < window.innerWidth) {
+			this.userTaggerToolTip.setAttribute('style', 'display: block; top: ' + thisXY.y + 'px; left: ' + thisXY.x + 'px; z-index: 20;');
+		} else {
+			this.userTaggerToolTip.setAttribute('style', 'display: block; top: ' + thisXY.y + 'px; right: ' + (window.innerWidth - thisXY.x - 20)  + 'px; z-index: 20;');
+		}
 		document.getElementById('userTaggerTag').focus();
 		modules['userTagger'].updateOpenLink(document.getElementById('userTaggerLink'));
 		modules['userTagger'].updateTagPreview();

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -595,7 +595,7 @@ addModule('userTagger', {
 			}
 			document.getElementById('userTaggerColor').selectedIndex = 0;
 		}
-		this.userTaggerToolTip.style.display = "block";
+		this.userTaggerToolTip.style.display = 'block';
 		if (thisXY.x + this.userTaggerToolTip.offsetWidth < window.innerWidth) {
 			this.userTaggerToolTip.setAttribute('style', 'display: block; top: ' + thisXY.y + 'px; left: ' + thisXY.x + 'px; z-index: 20;');
 		} else {

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -595,7 +595,7 @@ addModule('userTagger', {
 			}
 			document.getElementById('userTaggerColor').selectedIndex = 0;
 		}
-		if (thisXY.x + $("#userTaggerToolTip").width() < window.innerWidth) {
+		if (thisXY.x + 334 < window.innerWidth) {
 			this.userTaggerToolTip.setAttribute('style', 'display: block; top: ' + thisXY.y + 'px; left: ' + thisXY.x + 'px; z-index: 20;');
 		} else {
 			this.userTaggerToolTip.setAttribute('style', 'display: block; top: ' + thisXY.y + 'px; right: ' + (window.innerWidth - thisXY.x - 20)  + 'px; z-index: 20;');


### PR DESCRIPTION
When userTags are edited to when on the very right side of the screen, the tooltip appears partially offscreen. This fix checks for that and moves the tooltip to the left of the userTag instead.