### PR TITLE
Fix night mode background colour of code in permalinked posts

### DIFF
--- a/lib/css/modules/_nightMode.scss
+++ b/lib/css/modules/_nightMode.scss
@@ -468,9 +468,13 @@
 
 	.md code,
 	.md pre,
+	.link .md pre,
 	.content .md pre,
+	.new-comment .md pre,
+	.usertext.border .md pre,
 	.link .md :not(pre) > code,
-	.new-comment .md :not(pre) > code {
+	.new-comment .md :not(pre) > code,
+	.usertext.border .md :not(pre) > code {
 		color: inherit;
 		border-color: rgb(88, 105, 123);
 		background-color: rgb(42, 51, 64);


### PR DESCRIPTION
This has been a problem for me since forever. (Not anything to do with the recent night mode changes). The CSS selectors for code/pre tags aren't specific enough all the time.

I went into the inspector and copied out every selector which gave the code a light background colour, so I'm not sure if a couple of these are redundant, but what I do know is that it darkens the background for me as expected.