### PR TITLE
RES is adding too many tabmenus

### DIFF
--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -709,26 +709,6 @@ RESUtils.subredditForPost = function (thingEle) {
 	}
 	return postSubreddit;
 };
-
-RESUtils.getHeaderMenuList = function() {
-	var mainMenuUL;
-	if ((/search\?\/?q\=/.test(location.href)) ||
-			(/\/about\/(?:reports|spam|unmoderated)/.test(location.href)) ||
-			(location.href.indexOf('/modqueue') !== -1) ||
-			(location.href.toLowerCase().indexOf('/dashboard') !== -1)) {
-		var hbl = document.getElementById('header-bottom-left');
-		if (hbl) {
-			mainMenuUL = document.createElement('ul');
-			mainMenuUL.setAttribute('class', 'tabmenu viewimages');
-			mainMenuUL.setAttribute('style', 'display: inline-block');
-			hbl.appendChild(mainMenuUL);
-		}
-	} else {
-		mainMenuUL = document.body.querySelector('#header-bottom-left ul.tabmenu');
-	}
-
-	return mainMenuUL;
-};
 RESUtils.getXYpos = function(obj) {
 	var topValue = 0,
 		leftValue = 0;

--- a/lib/modules/floater.js
+++ b/lib/modules/floater.js
@@ -34,7 +34,7 @@ addModule('floater', function(module, moduleID) {
 			},
 			getOffset: function() {
 				if (typeof this._offset !== 'number') {
-					this._offset = 5 + RESUtils.getHeaderOffset() + $(RESUtils.getHeaderMenuList()).height();
+					this._offset = 5 + RESUtils.getHeaderOffset() + $('#header-bottom-left .tabmenu').height();
 				}
 
 				return this._offset;

--- a/lib/modules/hosts/raddit.js
+++ b/lib/modules/hosts/raddit.js
@@ -69,7 +69,7 @@ addLibrary('mediaHosts', 'raddit', {
 		if (modules['showImages'].options['display radd.it'].value === false) return;
 		if (modules['showImages'].options['show playlister toggle'].value === false) return;
 
-		var mainMenuUL = RESUtils.getHeaderMenuList();
+		var mainMenuUL = $('#header-bottom-left ul.tabmenu')[0];
 		if (!mainMenuUL) return;
 		var li = document.createElement('li'),
 			a = document.createElement('a'),

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -323,7 +323,17 @@ addModule('showImages', function(module, moduleID) {
 	var viewImageButton;
 
 	function createImageButtons() {
-		var mainMenuUL = RESUtils.getHeaderMenuList();
+		var mainMenuUL = $('#header-bottom-left ul.tabmenu')[0];
+		// Create new tabmenu on these pages, regardless if one already exists.
+		if ((RESUtils.regexes.search.test(location.href)) ||
+			(/\/about\/(?:reports|spam|unmoderated)/.test(location.href)) ||
+			(location.href.indexOf('/modqueue') !== -1) ||
+			(location.href.toLowerCase().indexOf('/dashboard') !== -1))
+		{
+			mainMenuUL = RESUtils.createElement('ul', null, 'tabmenu viewimages');
+			document.getElementById('header-bottom-left').appendChild(mainMenuUL);
+			mainMenuUL.style.display = 'inline-block'; // Override dashboard's subreddit style.
+		}
 
 		if (mainMenuUL) {
 			var viewImagesLI = document.createElement('li');


### PR DESCRIPTION
Utility function RESUtils.getHeaderMenuList() was adding a new tabmenu every time it was called.

![extra-tabmenus](https://cloud.githubusercontent.com/assets/7245595/11895054/1a456cd0-a5c7-11e5-9638-12bd62d0a251.png)

The name of the function was misleading because it's not only returning the tabmenu, but it's creating one too. There's only one time it needs to create a new element and that's in showImages.js.

With the fix: 
![extra-tabmenus-fix](https://cloud.githubusercontent.com/assets/7245595/11895073/57063d16-a5c7-11e5-8511-a587d78a094b.png)
