### PR TITLE
Improved commentHoverBorder

### DIFF
--- a/lib/css/modules/_commentBoxes.scss
+++ b/lib/css/modules/_commentBoxes.scss
@@ -41,6 +41,6 @@
 	}
 
 	&.res-commentHoverBorder .content .comment:hover {
-		border: 1px solid #99AAEE !important;
+		outline: 1px solid #99AAEE !important;
 	}
 }

--- a/lib/css/modules/_nightMode.scss
+++ b/lib/css/modules/_nightMode.scss
@@ -711,7 +711,7 @@
 	}
 
 	&.res-commentBoxes.res-commentHoverBorder .comment:hover {
-		border-color: #555 !important;
+		outline-color: #555 !important;
 	}
 
 	.RESDropdownList,


### PR DESCRIPTION
I noticed that commentHoverBorder moves elements when you hover, may I suggest that you swap instead of using border, use outlines as that isn't considered when an elements dimensions are calculated, here's a quick codepen I threw up to demonstrate this. http://codepen.io/Zunon/full/Lpvzeg/