### PR TITLE
Prevent voteWeight from breaking when users have no tags

### DIFF
--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -286,7 +286,7 @@ addModule('userTagger', function(module, moduleID) {
 	function handleVoteClick(e) {
 		var tags = RESStorage.getItem('RESmodules.userTagger.tags');
 		if (typeof tags !== 'undefined') {
-			module.tags = safeJSON.parse(tags, 'RESmodules.userTagger.tags', true);
+			module.tags = safeJSON.parse(tags, 'RESmodules.userTagger.tags', true) || {};
 		}
 
 		var $this = $(this);


### PR DESCRIPTION
`JSON.parse('null') === null`, so safeJSON doesn't save us.

Broken in master and 4.6.0.