### PR TITLE
Exclude showImages on reddit.com/subreddits

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -162,7 +162,8 @@ addModule('showImages', function(module, moduleID) {
 	};
 	module.exclude = [
 		/^https?:\/\/(?:[\-\w\.]+\.)?reddit\.com\/ads\/[\-\w\.\_\?=]*/i,
-		/^https?:\/\/(?:[\-\w\.]+\.)?reddit\.com\/[\-\w\.\/]*\/submit\/?$/i
+		/^https?:\/\/(?:[\-\w\.]+\.)?reddit\.com\/[\-\w\.\/]*\/submit\/?$/i,
+		/^https?:\/\/(?:[\-\w\.]+\.)?reddit\.com\/subreddits/i
 	];
 	module.loadLibraries = function() {
 		return RESUtils.init.await.library('mediaHosts').then(function(siteModules) {


### PR DESCRIPTION
And /subreddits/search. Not only are there no images to show, but it's adding a second tabmenu on that page.