### PR TITLE
CSS cleanup for subreddit themes

### DIFF
--- a/lib/css/modules/_subredditManager.scss
+++ b/lib/css/modules/_subredditManager.scss
@@ -157,7 +157,6 @@
 
 #RESShortcutsViewport {
 	width: auto;
-	max-height: 20px;
 	overflow: hidden;
 }
 

--- a/lib/css/modules/_subredditManager.scss
+++ b/lib/css/modules/_subredditManager.scss
@@ -286,10 +286,6 @@
 	margin-left: 6px;
 }
 
-h1.redditname {
-	overflow: auto;
-}
-
 .sortAsc,
 .sortDesc {
 	float: right;

--- a/lib/css/modules/_userTagger.scss
+++ b/lib/css/modules/_userTagger.scss
@@ -1,7 +1,3 @@
-.comment .tagline {
-	display: inline;
-}
-
 #userTaggerToolTip {
 	display: none;
 	position: absolute;

--- a/lib/css/modules/_userbarHider.scss
+++ b/lib/css/modules/_userbarHider.scss
@@ -1,41 +1,37 @@
-.res-userbarHider-toggleButtonState-visible,
-.res-userbarHider-userbarState-hidden {
-	#userbarToggle {
-		min-height: 22px;
-		position: absolute;
-		top: auto;
-		bottom: 0;
-		left: -5px;
-		width: 16px;
-		padding-right: 3px;
-		height: 100%;
-		font-size: 15px;
-		border-radius: 4px 0;
-		color: #a1bcd6;
-		display: inline-block;
-		background-color: #dfecf9;
-		border-right: 1px solid #cee3f8;
-		cursor: pointer;
-		text-align: right;
-		line-height: 20px;
+#userbarToggle {
+    min-height: 22px;
+    position: absolute;
+    top: auto;
+    bottom: 0;
+    left: -5px;
+    width: 16px;
+    padding-right: 3px;
+    height: auto;
+    font-size: 15px;
+    border-radius: 4px 0 0 4px;
+    color: #a1bcd6;
+    display: inline-block;
+    background-color: #dfecf9;
+    border-right: 1px solid #cee3f8;
+    cursor: pointer;
+    text-align: right;
+    line-height: 20px;
 
-		.res-nightmode & {
-			background-color: rgb(73, 80, 93);
-			border-right-color: rgb(118, 133, 148);
-		}
+    .res-nightmode & {
+        background-color: rgb(73, 80, 93);
+        border-right-color: rgb(118, 133, 148);
+    }
 
-		&.userbarShow {
-			min-height: 22px;
-			left: -12px;
+    &.userbarShow {
+        min-height: 22px;
 
-			.res-navTop & {
-				top: 0;
-				bottom: auto;
-			}
-		}
-	}
+        .res-navTop & {
+            top: 0;
+            bottom: auto;
+        }
+    }
+}
 
-	#header-bottom-right.res-userbar-toggle > .user {
-		margin-left: 16px;
-	}
+#header-bottom-right.res-userbar-toggle > .user {
+    margin-left: 16px;
 }

--- a/lib/css/modules/_userbarHider.scss
+++ b/lib/css/modules/_userbarHider.scss
@@ -1,37 +1,37 @@
 #userbarToggle {
-    min-height: 22px;
-    position: absolute;
-    top: auto;
-    bottom: 0;
-    left: -5px;
-    width: 16px;
-    padding-right: 3px;
-    height: auto;
-    font-size: 15px;
-    border-radius: 4px 0 0 4px;
-    color: #a1bcd6;
-    display: inline-block;
-    background-color: #dfecf9;
-    border-right: 1px solid #cee3f8;
-    cursor: pointer;
-    text-align: right;
-    line-height: 20px;
+	min-height: 22px;
+	position: absolute;
+	top: auto;
+	bottom: 0;
+	left: -5px;
+	width: 16px;
+	padding-right: 3px;
+	height: auto;
+	font-size: 15px;
+	border-radius: 4px 0 0 4px;
+	color: #a1bcd6;
+	display: inline-block;
+	background-color: #dfecf9;
+	border-right: 1px solid #cee3f8;
+	cursor: pointer;
+	text-align: right;
+	line-height: 20px;
 
-    .res-nightmode & {
-        background-color: rgb(73, 80, 93);
-        border-right-color: rgb(118, 133, 148);
-    }
+	.res-nightmode & {
+		background-color: rgb(73, 80, 93);
+		border-right-color: rgb(118, 133, 148);
+	}
 
-    &.userbarShow {
-        min-height: 22px;
+	&.userbarShow {
+		min-height: 22px;
 
-        .res-navTop & {
-            top: 0;
-            bottom: auto;
-        }
-    }
+		.res-navTop & {
+			top: 0;
+			bottom: auto;
+		}
+	}
 }
 
 #header-bottom-right.res-userbar-toggle > .user {
-    margin-left: 16px;
+	margin-left: 16px;
 }

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -163,7 +163,7 @@ addModule('subredditManager', function(module, moduleID) {
 					isMulti = true;
 				}
 				if ($('#subButtons-' + thisSubredditFragment).length === 0) {
-					var subButtonsWrapper = $('<div id="subButtons-' + thisSubredditFragment + '" class="subButtons" style="margin: 0 !important; top: 0 !important; z-index: 1 !important;"></div>');
+					var subButtonsWrapper = $('<div id="subButtons-' + thisSubredditFragment + '" class="subButtons"></div>');
 					$(subButton).wrap(subButtonsWrapper);
 					// move this wrapper to the end (after any icons that may exist...)
 					if (isMulti) {

--- a/lib/modules/userbarHider.js
+++ b/lib/modules/userbarHider.js
@@ -110,7 +110,7 @@ addModule('userbarHider', function(module, moduleID) {
 			modules['accountSwitcher'].closeAccountMenu();
 			elements.hide();
 		} else {
-            // Unset display.
+			// Unset display.
 			elements.css('display', '');
 		}
 	}

--- a/lib/modules/userbarHider.js
+++ b/lib/modules/userbarHider.js
@@ -108,13 +108,10 @@ addModule('userbarHider', function(module, moduleID) {
 
 		if (userbarHidden) {
 			modules['accountSwitcher'].closeAccountMenu();
-			elements.css('display', 'none');
+			elements.hide();
 		} else {
-			var inlineElements = elements.filter(function(ele) {
-				return ((/mail/.test(ele.className)) || (ele.id === 'openRESPrefs'));
-			});
-			inlineElements.css('display', 'inline');
-			elements.not(inlineElements).css('display', 'inline-block');
+            // Unset display.
+			elements.css('display', '');
 		}
 	}
 


### PR DESCRIPTION
Found these CSS rules while developing a new theme, they appear to be unnecessary and only complicate things.

`max-height: 20px;` is doubled up.

`h1.redditname { overflow: auto; }` only serves to add scrollbars when it overflows.

`.comment .tagline { display: inline; }`, can't think of a good reason to have this, and it causes taglines to not extend all the way to the right.

The inline styles on .subButtons are presumably to prevent tampering, but A) it's not very effective, and B) even Reddit doesn't try to protect the subscribe button, which goes inside .subButtons.

Userbar hider is doing way more work than necessary.