### PR TITLE
set hoverDelay to stated default

### DIFF
--- a/lib/modules/messageMenu.js
+++ b/lib/modules/messageMenu.js
@@ -31,7 +31,7 @@ addModule('messageMenu', function(module, moduleID) {
 		},
 		hoverDelay: {
 			type: 'text',
-			value: 1000,
+			value: 800,
 			description: 'Delay, in milliseconds, before hover tooltip loads. Default is 800.',
 			advanced: true
 		},

--- a/lib/modules/messageMenu.js
+++ b/lib/modules/messageMenu.js
@@ -31,8 +31,8 @@ addModule('messageMenu', function(module, moduleID) {
 		},
 		hoverDelay: {
 			type: 'text',
-			value: 800,
-			description: 'Delay, in milliseconds, before hover tooltip loads. Default is 800.',
+			value: 1000,
+			description: 'Delay, in milliseconds, before hover tooltip loads. Default is 1000.',
 			advanced: true
 		},
 		fadeDelay: {


### PR DESCRIPTION
The description says the default value is 800, when it is actually set to 1000.