### PR TITLE
Remove some unnecessary CSS from .usertext elements

### DIFF
--- a/lib/core/res.css
+++ b/lib/core/res.css
@@ -314,10 +314,6 @@ body.res-console-open {
 #BigEditor .BELeft .RESDialogContents {
 	padding-top: 52px;
 }
-/* Allow textarea to be any width without disappearing. */
-body.wiki-page form#editform, .comment form.usertext {
-	overflow: auto; /* Same as top-level comment form on vanilla reddit */
-}
 div.usertext-edit {
 	width: auto;
 	max-width: 500px;

--- a/lib/core/res.css
+++ b/lib/core/res.css
@@ -319,10 +319,6 @@ div.usertext-edit {
 	max-width: 500px;
 	padding: 0px;
 }
-/* Correct reddit's miscalculation of textarea width when editing a comment. */
-.usertext-body > .md {
-	padding-right: 1px;
-}
 .usertext-edit .md,
 .wiki-page #editform textarea {
 	clear: left;


### PR DESCRIPTION
Edit: Fixes #2624

https://i.imgur.com/Wfm6Yt4.png

A workaround has been added to /r/resupdates, which fixes that specific issue. However there's other ways this bug can crop up, so the best solution is to nix the offending CSS from RES. It was only acting as an extra safeguard anyway, we should be able to live without it.