### PR TITLE
gfycat controls are in the wrong order

### DIFF
--- a/lib/core/templates.html
+++ b/lib/core/templates.html
@@ -412,11 +412,11 @@
 				</video>
 				</a>
 				<div style="height: 35px;" class="ctrlContainer">
-					<div style="width: 90px; height: 25px; float: right; padding: 5px; display: none;" class="ctrlBox">
-						<div  class="res-icon res-lightweight-player-controls gfyRCtrlFaster" >&#xf14c;</div>
-						<div  class="res-icon res-lightweight-player-controls gfyRCtrlSlower" >&#xf14d;</div>
-						<div  class="res-icon res-lightweight-player-controls gfyRCtrlReverse" style="margin-right: 6px;">&#xf169;</div>
-						<div  class="res-icon res-lightweight-player-controls gfyRCtrlPause" style="marginright: 4px;">&#xf16c;</div>
+					<div style="height: 25px; float: right; padding: 5px; display: none;" class="ctrlBox">
+						<div class="res-icon res-lightweight-player-controls gfyRCtrlPause" style="margin-left: 6px; cursor: pointer;">&#xf16c;</div>
+						<div class="res-icon res-lightweight-player-controls gfyRCtrlReverse" style="margin-left: 6px; cursor: pointer;">&#xf169;</div>
+						<div class="res-icon res-lightweight-player-controls gfyRCtrlSlower" style="margin-left: 6px; cursor: pointer;">&#xf14d;</div>
+						<div class="res-icon res-lightweight-player-controls gfyRCtrlFaster" style="margin-left: 6px; cursor: pointer;">&#xf14c;</div>
 					</div>
 				</div>
 			</div>
@@ -437,9 +437,9 @@
 						<a target="_blank" class="res-icon res-lightweight-player-controls gifyoutube-source-button">Watch Full Video</a>
 					</div>
 					<div class="gifyoutube-controls">
-						<div class="res-icon res-lightweight-player-controls gifyoutubeCtrlSlower" >&#xf169;</div>
-						<div class="res-icon res-lightweight-player-controls gifyoutubeCtrlPause" style="marginright: 4px;">&#xf16c;</div>
-						<div class="res-icon res-lightweight-player-controls gifyoutubeCtrlFaster" >&#xf16d;</div>
+						<div class="res-icon res-lightweight-player-controls gifyoutubeCtrlSlower">&#xf169;</div>
+						<div class="res-icon res-lightweight-player-controls gifyoutubeCtrlPause">&#xf16c;</div>
+						<div class="res-icon res-lightweight-player-controls gifyoutubeCtrlFaster">&#xf16d;</div>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Bug report: https://www.reddit.com/r/RESissues/comments/40svge/bug_gfycat_expando_controls_have_been_reversed/

Solution: changed physical order of buttons.