### PR TITLE
Fix #2497 - Opening a link (consisting of only a hash) in a new tab opens the background page

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -658,6 +658,12 @@ addModule('keyboardNav', function(module, moduleID) {
 		var thisURL = link.getAttribute('href'),
 			button = (module.options.followLinkNewTabFocus.value) ? 0 : 1;
 
+		// we do this because chrome.tabs.create opens URLs consisting solely of fragments (#foo)
+		// relative to the background page instead of the current location
+		if (thisURL.substring(0, 1) === '#') {
+			thisURL = location.pathname + location.search + thisURL;
+		}
+
 		if (module.options.commentsLinkNewTab.value) {
 			var thisJSON = {
 				requestType: 'keyboardNav',


### PR DESCRIPTION
Fixes #2497 

This is a copy of [this pull request](https://github.com/honestbleeps/Reddit-Enhancement-Suite/pull/2526) but up-to-date with the current code base. Sorry for this, Git just wouldn't cooperate!