### PR TITLE
Implement score hiding

### DIFF
--- a/lib/css/modules/_voteEnhancements.scss
+++ b/lib/css/modules/_voteEnhancements.scss
@@ -36,3 +36,21 @@
 		color: #333;
 	}
 }
+
+.res-voteEnhancements-hideCommentScores {
+	.comment .unvoted .score {
+		display: none;
+	}
+	&.res-voteEnhancements-alwaysHideScores .comment .score {
+		display: none;
+	}
+}
+
+.res-voteEnhancements-hideSubmissionScores {
+	.midcol.unvoted .score {
+		visibility: hidden;
+	}
+	&.res-voteEnhancements-alwaysHideScores .midcol .score {
+		visibility: hidden;
+	}
+}

--- a/lib/modules/voteEnhancements.js
+++ b/lib/modules/voteEnhancements.js
@@ -132,6 +132,24 @@ addModule('voteEnhancements', function(module, moduleID) {
 			type: 'color',
 			value: '#cc0000',
 			description: 'Select a color for the "controversial" comment indicator.'
+		},
+		hideCommentScores: {
+			type: 'boolean',
+			value: false,
+			description: 'Hide comment scores until you vote',
+			bodyClass: true
+		},
+		hideSubmissionScores: {
+			type: 'boolean',
+			value: false,
+			description: 'Hide submission scores until you vote',
+			bodyClass: true
+		},
+		alwaysHideScores: {
+			type: 'boolean',
+			value: false,
+			description: 'Hide scores even after you vote',
+			bodyClass: true
 		}
 	};
 	module.includes = [ 'comments', 'linklist' ];


### PR DESCRIPTION
This is essentially a copy of [this pull request](https://github.com/honestbleeps/Reddit-Enhancement-Suite/pull/2523) but up-to-date with the current code base. Sorry for this, Git just wouldn't cooperate!

---

Implements functionality for hiding scores of comments and/or submissions and the option to hide them until the user has cast their vote. The idea here is to prevent yourself from being influenced by the votes of other users.

Since I've only implemented this in CSS, here are a few limitations of the functionality right now, e.g.
- If you are on a submission's comments page, the score will still be visible in the sidebar.
- The user's scores will always be visible unless: they actively "unvote" their own stuff OR they choose to always hide scores.
- The user's total karma will still be visible.
- No functionality for only hiding one's own scores.

To solve some (or all?) of these limitations, we'd need to write some JavaScript.

The CSS rules are kind of ugly, since I couldn't figure out a cleaner way to implement them.

EDIT(mc10): Fixes #847