### PR TITLE
Fix for userTaggerToolTip appearing offscreen

### DIFF
--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -560,7 +560,12 @@ addModule('userTagger', function(module, moduleID) {
 			}
 			document.getElementById('userTaggerColor').selectedIndex = 0;
 		}
-		userTaggerToolTip.setAttribute('style', 'display: block; top: ' + thisXY.y + 'px; left: ' + thisXY.x + 'px; z-index: 20;');
+		userTaggerToolTip.style.display = 'block';
+		if (thisXY.x + userTaggerToolTip.offsetWidth < window.innerWidth) {
+			userTaggerToolTip.setAttribute('style', 'display: block; top: ' + thisXY.y + 'px; left: ' + thisXY.x + 'px; z-index: 20;');
+		} else {
+			userTaggerToolTip.setAttribute('style', 'display: block; top: ' + thisXY.y + 'px; right: ' + (document.body.offsetWidth - thisXY.x)  + 'px; z-index: 20;');
+		}
 		document.getElementById('userTaggerTag').focus();
 		updateOpenLink(document.getElementById('userTaggerLink'));
 		updateTagPreview();


### PR DESCRIPTION
When userTags are edited to when on the very right side of the screen, the tooltip appears partially offscreen. This fix checks for that and moves the tooltip to the left of the userTag instead.