### PR TITLE
keyboardNav next/prev sibling works like it did in 4.5.4

### DIFF
--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -962,6 +962,10 @@ RESUtils.scrollToElement = function(element, options) {
 		// (remember, top and bottom are relative to viewport)
 		return;
 	}
+	else if (options.scrollStyle === 'legacy') {
+		// Element not completely in viewport, so scroll to top
+		RESUtils.scrollTo(0, top);
+	}
 	else if (target.top < viewport.yOffset) {
 		// Element starts above viewport
 		// So, align top of element to top of viewport

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -951,7 +951,7 @@ addModule('keyboardNav', {
 			}
 		} while (!target && current.length);
 
-		modules['keyboardNav']._moveToThing(target, { scrollStyle: 'top' });
+		modules['keyboardNav']._moveToThing(target, { scrollStyle: 'legacy' });
 	},
 	moveUpSibling: function() {
 		var selected = modules['selectedEntry'].selected();
@@ -964,7 +964,7 @@ addModule('keyboardNav', {
 			target = current.parent().closest('.thing')[0];
 		}
 
-		modules['keyboardNav']._moveToThing(target, { scrollStyle: 'top' });
+		modules['keyboardNav']._moveToThing(target, { scrollStyle: 'legacy' });
 	},
 	moveUpThread: function() {
 		var selected = modules['selectedEntry'].selected();
@@ -979,7 +979,7 @@ addModule('keyboardNav', {
 		if (!target) {
 			modules['keyboardNav']._moveUp(current);
 		} else {
-			modules['keyboardNav']._moveToThing(target, { scrollStyle: 'top' });
+			modules['keyboardNav']._moveToThing(target, { scrollStyle: 'legacy' });
 		}
 	},
 	moveDownThread: function() {
@@ -993,7 +993,7 @@ addModule('keyboardNav', {
 
 		var target = current.nextAll('.thing').first()[0];
 		if (target) {
-			modules['keyboardNav']._moveToThing(target, { scrollStyle: 'top' });
+			modules['keyboardNav']._moveToThing(target, { scrollStyle: 'legacy' });
 		}
 	},
 	moveToTopComment: function() {
@@ -1001,7 +1001,7 @@ addModule('keyboardNav', {
 		if (!selected) return;
 		var target = $(selected.thing).parents('.thing').last();
 
-		modules['keyboardNav']._moveToThing(target, { scrollStyle: 'top' });
+		modules['keyboardNav']._moveToThing(target, { scrollStyle: 'legacy' });
 	},
 	moveToParent: function() {
 		var selected = modules['selectedEntry'].selected();

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -942,14 +942,18 @@ addModule('keyboardNav', {
 		if (!selected) return;
 
 		var current = $(selected.thing);
-
 		var target;
-		do {
+
+		if (current.hasClass('link')) {
+			target = document.querySelector('.thing.comment');
+		}
+
+		while (!target && current.length) {
 			target = current.nextAll('.thing').first()[0];
 			if (!target) {
 				current = current.parent().closest('.thing');
 			}
-		} while (!target && current.length);
+		}
 
 		modules['keyboardNav']._moveToThing(target, { scrollStyle: 'legacy' });
 	},
@@ -962,6 +966,10 @@ addModule('keyboardNav', {
 		var target = current.prevAll('.thing').first()[0];
 		if (!target) {
 			target = current.parent().closest('.thing')[0];
+		}
+
+		if (!target) {
+			target = document.querySelector('.thing.link');
 		}
 
 		modules['keyboardNav']._moveToThing(target, { scrollStyle: 'legacy' });

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -25,12 +25,16 @@ addModule('keyboardNav', {
 			}, {
 				name: 'lock to top',
 				value: 'top'
+			}, {
+				name: 'legacy',
+				value: 'legacy'
 			}],
 			value: 'directional',
 			description: 'When moving up/down with keynav, when and how should RES scroll the window?' +
 				'<br>Directional: Scroll just enough to bring the selected element into view, if it\'s offscreen.' +
 				'<br>Page up/down: Scroll up/down an entire page after reaching the top or bottom.' +
-				'<br>Lock to top: Always align the selected element to the top of the screen.',
+				'<br>Lock to top: Always align the selected element to the top of the screen.' +
+				'<br>Legacy: If the element is offscreen, lock to top.',
 			advanced: true
 		},
 		commentsLinkNumbers: {


### PR DESCRIPTION
Fixes #2622 and [this issue](https://www.reddit.com/r/RESissues/comments/41ooxs/bug_you_cant_use_the_movedownsibling_keyboard/) (from reddit).

[This](https://github.com/honestbleeps/Reddit-Enhancement-Suite/blob/e83e5e0e01ca21e694922e95e2d6413bf32f9257/lib/modules/keyboardNav.js#L1602) is the behavior (from 4.5.4) that the the 'legacy' scrollStyle mimics.
It wasn't an option for j/k scrolling in 4.5.4, but I guess why not?