### PR TITLE
Decode '+' in query strings to ' '

### DIFF
--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -298,7 +298,7 @@ RESUtils.getUrlParams = function(url) {
 		queryString = location.search.substr(1);
 	}
 	while ((m = re.exec(queryString))) {
-		result[decodeURIComponent(m[1])] = decodeURIComponent(m[2]);
+		result[decodeURIComponent(m[1])] = decodeURIComponent(m[2].replace(/\+/g, ' '));
 	}
 	return result;
 };


### PR DESCRIPTION
Fixes #2673 

There's no standard for formatting a query string (you can do basically whatever you want), but the closest thing is [application/x-www-form-urlencoded](https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.1), which states that spaces should be replaced by `+`.