### PR TITLE
Created new module to modify existing links on pages

### DIFF
--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -50,6 +50,7 @@
 				"modules/keyboardNav.js",
 				"modules/about.js",
 				"modules/commandLine.js",
+				"modules/modifyLinks.js",
 				"modules/messageMenu.js",
 				"modules/easterEgg.js",
 				"modules/pageNavigator.js",

--- a/Firefox/index.js
+++ b/Firefox/index.js
@@ -173,6 +173,7 @@ pageMod.PageMod({
 		self.data.url('modules/userTagger.js'),
 		self.data.url('modules/keyboardNav.js'),
 		self.data.url('modules/commandLine.js'),
+		self.data.url('modules/modifyLinks.js'),
 		self.data.url('modules/messageMenu.js'),
 		self.data.url('modules/easterEgg.js'),
 		self.data.url('modules/pageNavigator.js'),

--- a/Safari/Info.plist
+++ b/Safari/Info.plist
@@ -59,6 +59,7 @@
 				<string>modules/userTagger.js</string>
 				<string>modules/keyboardNav.js</string>
 				<string>modules/commandLine.js</string>
+				<string>modules/modifyLinks.js</string>
 				<string>modules/messageMenu.js</string>
 				<string>modules/easterEgg.js</string>
 				<string>modules/pageNavigator.js</string>

--- a/lib/modules/modifyLinks.js
+++ b/lib/modules/modifyLinks.js
@@ -8,7 +8,7 @@ addModule('modifyLinks', function(module, moduleID) {
 				domain: 'wikipedia.org',
 				match: /(\b.m.wikipedia.)\w+/,
 				find: '.m.',
-				replace: '.'
+				replace: '.',
 			},
 		],
 	};

--- a/lib/modules/modifyLinks.js
+++ b/lib/modules/modifyLinks.js
@@ -1,0 +1,29 @@
+addModule('modifyLinks', function(module, moduleID) {
+	module.moduleName = 'Modify Links';
+	module.category = 'Browsing';
+	module.description = 'This module modifies links';
+	module.options = {
+		domains: [
+			{
+				domain: 'wikipedia.org',
+				match: /(\b.m.wikipedia.)\w+/,
+				find: '.m.',
+				replace: '.'
+			},
+		],
+	};
+
+	module.go = function() {
+		if ((module.isEnabled()) && (module.isMatchURL())) {
+			var links = document.getElementsByTagName('a');
+			for (var i = 0; i < this.options.domains.length; i++) {
+				var domain = this.options.domains[i];
+				for (var j = 0; j < links.length; j++) {
+					if (domain.match.test(links[j].hostname)) {
+						links[j].hostname = links[j].hostname.replace(domain.find, domain.replace);
+					}
+				}
+			}
+		}
+	};
+});

--- a/node/files.json
+++ b/node/files.json
@@ -21,6 +21,7 @@
 		"modules/keyboardNav.js",
 		"modules/about.js",
 		"modules/commandLine.js",
+		"modules/modifyLinks.js",
 		"modules/messageMenu.js",
 		"modules/easterEgg.js",
 		"modules/pageNavigator.js",


### PR DESCRIPTION
Hi, 
I often click wikipedia links and am directed to the mobile site instead of the desktop site. After reading some complaints from redditors about mobile wikipedia links (some people even use things like [this](https://chrome.google.com/webstore/detail/mobile2desktop-wikipedia/hgdfjjhaahfdggnecdecjekkimepkpaf/reviews?hl=en)), I thought I would build this module. More sites can be added to options.domains in the following format:

```javascript
{
  domain: 'wikipedia.org',
  match: /(\b.m.wikipedia.)\w+/,
  find: '.m.',
  replace: '.'
},
```

The domain field is unused, but may be useful for reference purposes. Regex can be used in the find, replace, and match fields. I didn't document my code because no other modules seem to be documented. I'm happy to go back and do it, or work on other features if they would be welcomed. Thank you for your consideration.  