### PR TITLE
Fix: [l=c] link opens two tabs when comment page's URL contains non-ascii character

### DIFF
--- a/lib/modules/singleClick.js
+++ b/lib/modules/singleClick.js
@@ -96,7 +96,7 @@ addModule('singleClick', {
 								requestType: 'singleClick',
 								linkURL: thisLink,
 								openOrder: modules['singleClick'].options.openOrder.value,
-								commentsURL: this.getAttribute('thisComments'),
+								commentsURL: decodeURI(this.getAttribute('thisComments')),
 								button: lcMouseBtn,
 								ctrl: e.ctrlKey
 							};


### PR DESCRIPTION
Because linkURL is decoded but commentsURL is not.