### PR TITLE
Fix YouTube video times

### DIFF
--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -262,61 +262,60 @@ addModule('betteReddit', (module, moduleID) => {
 
 				if (!match) return;
 
-				// add quotes so URL creation is doable with just a join...
-				const thisYTID = `"${match[1]}"`;
-
 				const timeMatch = getYoutubeStartTimeRegex.exec(link.href);
 				const titleMatch = titleHasTimeRegex.test(link.textContent);
 				if (timeMatch && !titleMatch) {
 					link.textContent += ` (@${timeMatch[1]})`;
 				}
 
-				const { time, title } = await getVideoInfo(thisYTID);
+				const { info, title } = await getVideoInfo(match[1]);
 
-				link.textContent += ` ${time}`;
+				link.textContent += ` - ${info}`;
 				link.setAttribute('title', `YouTube title: ${title}`);
 			});
 	}
 
-	const getVideoInfo = RESUtils.batch(async thisBatch => {
-		const data = await RESEnvironment.ajax({
-			url: 'http://gdata.youtube.com/feeds/api/videos',
+	const getVideoInfo = RESUtils.batch(async videoIds => {
+		const parts = ['id', 'contentDetails', 'snippet'];
+		if (module.options.videoViewed.value) parts.push('statistics');
+
+		const { items } = await RESEnvironment.ajax({
+			url: 'https://www.googleapis.com/youtube/v3/videos',
 			data: {
-				q: thisBatch.join('|'),
-				v: 2,
-				fields: 'entry(id,title,media:group(yt:duration,yt:videoid,yt:uploaded),yt:statistics)',
-				alt: 'json'
+				id: videoIds.join(','),
+				part: parts.join(','),
+				key: 'AIzaSyB8ufxFN0GapU1hSzIbuOLfnFC0XzJousw'
 			},
-			type: 'json'
+			type: 'json',
+			cacheFor: RESUtils.DAY
 		});
 
-		if (!data.feed || !data.feed.entry) {
-			throw new Error(`Could not find video times: ${JSON.stringify(data)}`);
-		}
+		const results = items.map(({ id, contentDetails, snippet, statistics }) => {
+			const title = snippet.title;
+			const rawDuration = contentDetails.duration; // PT1H11M46S
+			const duration = ['0']
+				.concat(rawDuration.match(/^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/i).slice(1))
+				.map(time => `0${time || 0}`.slice(-2))
+				.filter((time, i, { length }) => +time !== 0 || i >= length - 2)
+				.join(':');
 
-		const results = data.feed.entry.map(entry => {
-			const id = `"${entry['media$group']['yt$videoid']['$t']}"`;
-			const totalSecs = entry['media$group']['yt$duration']['seconds'];
-			const title = entry['title']['$t'];
-			const mins = Math.floor(totalSecs / 60);
-			const secs = `0${totalSecs % 60}`.slice(-2);
-			let time = ` - [${mins}:${secs}]`;
+			let info = `[${duration}]`;
 
 			if (module.options.videoUploaded.value) {
-				const uploaded = entry['media$group']['yt$uploaded']['$t'];
-				time += `[${uploaded.match(/[^T]*/)}]`;
+				const uploaded = snippet.publishedAt; // 2016-01-27T05:49:48.000Z
+				info += `[${uploaded.match(/[^T]*/)}]`;
 			}
 
 			if (module.options.videoViewed.value) {
-				const viewed = entry['yt$statistics']['viewCount'];
-				time += `[Views: ${viewed}]`;
+				const viewed = statistics.viewCount;
+				info += `[Views: ${viewed}]`;
 			}
 
-			return { id, time, title };
+			return { id, info, title };
 		});
 
-		return thisBatch.map(idFromBatch => results.find(({ id }) => id === idFromBatch));
-	}, { size: 8 });
+		return videoIds.map(idFromBatch => results.find(({ id }) => id === idFromBatch));
+	}, { size: 50 });
 
 	function pinSubredditBar() {
 		// Make the subreddit bar at the top of the page a fixed element


### PR DESCRIPTION
Depends on #2684; [diff](https://github.com/erikdesjardins/Reddit-Enhancement-Suite/compare/promise-to-async...fix-videoTimes).

Fixes #2234, closes #376.

The quota will be about 10 million requests per day (one request = up to 50 videos, so 10 million listing pageloads or so), and it's enabled by default...not sure if that'll be enough. I really don't know how often the average user browses reddit. If in doubt, we could just migrate it to off.

Although if we leave it on, funnily enough, we'll probably get better usage statistics than the Chrome webstore gives us...