### PR TITLE
Remove deprecated event dispatcher code

### DIFF
--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -450,9 +450,7 @@ addModule('neverEndingReddit', function(module, moduleID) {
 							NERFail(noresultsfound);
 						}
 
-						var e = document.createEvent('Events');
-						e.initEvent('neverEndingLoad', true, true);
-						window.dispatchEvent(e);
+						window.dispatchEvent(new Event('neverEndingLoaded'));
 					}
 				},
 				onerror: function(err) {


### PR DESCRIPTION
Event.initEvent() has been removed from the Web standards. Though some browsers may still support it, it is in the process of being dropped. Do not use it in old or new projects. Pages or Web apps using it may break at any time.

Many methods used with createEvent, such as initCustomEvent, are deprecated. Use event constructors instead.