### PR TITLE
Replaced deprecated unescape function and added missing semicolons

### DIFF
--- a/lib/vendor/gfycat.js
+++ b/lib/vendor/gfycat.js
@@ -77,7 +77,7 @@
 					var thisParam = params[i].split('=');
 					paramNames[i] = thisParam[0];
 					if (thisParam[1] !== '')
-						paramValues[i] = unescape(thisParam[1]);
+						paramValues[i] = decodeURI(thisParam[1]);
 					else
 						paramValues[i] = 'No Value';
 				}
@@ -95,13 +95,13 @@
 			if (vid.paused) {
 				ctrlPausePlay.innerHTML = '&#xf16b;';
 				ctrlSlower.innerHTML = '&#xf168;';
-				ctrlFaster.innerHTML = '&#xf16e;'
+				ctrlFaster.innerHTML = '&#xf16e;';
 				ctrlSlower.onclick = stepBackward;
 				ctrlFaster.onclick = stepForward;
 			} else {
 				ctrlPausePlay.innerHTML = '&#xf16c;';
 				ctrlSlower.innerHTML = '&#xf14d;';
-				ctrlFaster.innerHTML = '&#xf14c;'
+				ctrlFaster.innerHTML = '&#xf14c;';
 				ctrlSlower.onclick = slower;
 				ctrlFaster.onclick = faster;
 			}

--- a/lib/vendor/gifyoutube.js
+++ b/lib/vendor/gifyoutube.js
@@ -76,7 +76,7 @@
 					var thisParam = params[i].split('=');
 					paramNames[i] = thisParam[0];
 					if (thisParam[1] !== '')
-						paramValues[i] = unescape(thisParam[1]);
+						paramValues[i] = decodeURI(thisParam[1]);
 					else
 						paramValues[i] = 'No Value';
 				}
@@ -94,13 +94,13 @@
 			if (vid.paused) {
 				ctrlPausePlay.innerHTML = '&#xf16b;';
 				ctrlSlower.innerHTML = '&#xf169;';
-				ctrlFaster.innerHTML = '&#xf16d;'
+				ctrlFaster.innerHTML = '&#xf16d;';
 				ctrlSlower.onclick = stepBackward;
 				ctrlFaster.onclick = stepForward;
 			} else {
 				ctrlPausePlay.innerHTML = '&#xf16c;';
 				ctrlSlower.innerHTML = '&#xf169;';
-				ctrlFaster.innerHTML = '&#xf16d;'
+				ctrlFaster.innerHTML = '&#xf16d;';
 				ctrlSlower.onclick = slower;
 				ctrlFaster.onclick = faster;
 			}


### PR DESCRIPTION
- The unescape() function was deprecated in JavaScript version 1.5. Use decodeURI() or decodeURIComponent() instead.

- Added missing semicolons.