### PR TITLE
Fix showUnreadCount migration

### DIFF
--- a/lib/core/migrate.js
+++ b/lib/core/migrate.js
@@ -174,8 +174,8 @@ var RESOptionsMigrate = {
 		{
 			versionNumber: '4.7.0',
 			go() {
+				RESOptionsMigrate.migrators.generic.forceUpdateOption('orangered', 'showUnreadCount', value => value === false);
 				RESOptionsMigrate.migrators.generic.moveOption('orangered', 'showUnreadCount', 'orangered', 'hideUnreadCount');
-				RESOptionsMigrate.migrators.generic.forceUpdateOption('orangered', 'hideUnreadCount', value => value === false);
 			}
 		}
 	],


### PR DESCRIPTION
If showUnreadCount was not present, the moveOption migrator would fail, so the forceUpdateOption migrator would switch hideUnreadCount on. Reversing the order of the migrators fixes this.