### PR TITLE
Add "gifv" support for giphy

### DIFF
--- a/lib/core/templates.html
+++ b/lib/core/templates.html
@@ -435,12 +435,16 @@
 				</video>
 				</a>
 				<div style="height: 35px;" class="ctrlContainer">
-					<div class="imgurgifv-brand">
-						<img src="//imgur.com/favicon.ico">
-					</div>
+					<a href="{{ siteUrl }}" target="_blank">
+						<div class="imgurgifv-brand">
+							<img src="{{ siteIcon }}" title="view on {{ siteName }}" />
+						</div>
+					</a>
+					{{#downloadurl}}
 					<div class="imgurgifv-download">
 						<a href="{{ downloadurl }}">download</a>
 					</div>
+					{{/downloadurl}}
 				</div>
 			</div>
 		</script>

--- a/lib/modules/hosts/giphy.js
+++ b/lib/modules/hosts/giphy.js
@@ -1,70 +1,96 @@
 addLibrary('mediaHosts', 'giphy', {
 	domains: ['giphy.com'],
-	detect: function(href, elem) {
-		return href.indexOf('giphy.com') !== -1;
-	},
-	handleLink: function(elem) {
-		var def = $.Deferred();
 
-		var hashRe = /^http:\/\/(?:www\.)?giphy\.com\/gifs\/(.*?)(\/html5)?$/i;
-		var groups = hashRe.exec(elem.href);
+	// URL examples with each regex
+
+	// https://giphy.com/gifs/6b9QApjUesyOs
+	mainSiteRe: /^https?:\/\/(?:www\.)?giphy\.com\/gifs\/(\w+)/i,
+	// https://giphy.com/gifs/convert-printable-gifprint-6b9QApjUesyOs
+	longMainSiteRe: /^https?:\/\/(?:www\.)?giphy\.com\/gifs\/(?:[a-z0-9-]+)-(\w+)/i,
+	// https://media.giphy.com/media/6b9QApjUesyOs/giphy.gif
+	// https://media0.giphy.com/media/6b9QApjUesyOs/giphy.gif
+	longDirectRe: /^https?:\/\/media[0-9]*\.?giphy\.com\/media\/(\w+)/i,
+	// https://i.giphy.com/6b9QApjUesyOs.gif
+	shortDirectRe: /^https?:\/\/i\.giphy\.com\/(\w+)/i,
+
+	detect: (href, elem) => href.indexOf('giphy.com') !== -1,
+
+	handleLink(elem) {
+		const def = $.Deferred();
+		const siteMod = modules['showImages'].siteModules['giphy'];
+		const groups =  siteMod.longMainSiteRe.exec(elem.href) || siteMod.mainSiteRe.exec(elem.href) ||
+						siteMod.longDirectRe.exec(elem.href) || siteMod.shortDirectRe.exec(elem.href);
 
 		if (!groups) return def.reject();
 
-		var isHtml5 = (groups[2]) ? true : false;
-		var giphyUrl = location.protocol + '//giphy.com/gifs/' + groups[1];
-		var mp4Url = location.protocol + '//media.giphy.com/media/' + groups[1] + '/giphy.mp4';
-		var gifUrl = location.protocol + '//media.giphy.com/media/' + groups[1] + '/giphy.gif';
+		const giphyUrl = location.protocol + '//giphy.com/gifs/' + groups[1];
+		const mp4Url = location.protocol + '//media.giphy.com/media/' + groups[1] + '/giphy.mp4';
+		const gifUrl = location.protocol + '//media.giphy.com/media/' + groups[1] + '/giphy.gif';
 
-		def.resolve(elem, { isHtml5: isHtml5, giphyUrl: giphyUrl, mp4Url: mp4Url, gifUrl: gifUrl });
+		def.resolve(elem, { giphyUrl, mp4Url, gifUrl });
 
 		return def.promise();
 	},
-	handleInfo: function(elem, info) {
-		if (info.isHtml5) {
 
-			// html5 video player
-			var generate = function(options) {
-				var template = RESTemplates.getSync('GiphyUI');
-				var video = {
-					loop: true,
-					autoplay: true,
-					muted: true,
-					giphyUrl: info.giphyUrl,
-					brand: {
-						'url': info.giphyUrl,
-						'name': 'Giphy',
-						'img': ''
-					}
-				};
-				video.sources = [
-					{
-						'source': info.mp4Url,
-						'type': 'video/mp4'
-					}
-				];
-				var element = template.html(video)[0];
-				new MediaPlayer(element);
-				return element;
-			};
+	handleInfo(elem, info) {
+		let def = modules['showImages'].siteModules['giphy']._handleGifv(elem, info);
 
-			elem.type = 'GENERIC_EXPANDO';
-			elem.expandoClass = ' video-muted';
-			elem.expandoOptions = {
-				generate: generate,
-				media: info
-			};
-
+		if (def) {
+			def = def.then(function(expandoInfo) {
+				$.extend(true, elem, expandoInfo);
+				return elem;
+			});
 		} else {
-
-			// gif
-			elem.type = 'IMAGE';
-			elem.src = info.gifUrl;
+			def = $.Deferred().reject();
+			// console.log('ERROR', info);
+			// console.log(arguments.callee.caller);
 		}
 
-		if (RESUtils.pageType() === 'linklist') {
-			$(elem).closest('.thing').find('.thumbnail').attr('href', elem.href);
-		}
-		return $.Deferred().resolve(elem).promise();
-	}
+		return def.promise();
+	},
+
+	// Based off imgur.js' gifv functions
+	_handleGifv(elem, info) {
+		var siteMod = modules['showImages'].siteModules['giphy'],
+			expandoInfo = {};
+		expandoInfo.type = 'GENERIC_EXPANDO';
+		expandoInfo.subtype = 'VIDEO';
+		// open via 'view all images'
+		expandoInfo.expandOnViewAll = true;
+		expandoInfo.expandoClass = ' video-muted';
+
+		expandoInfo.expandoOptions = {
+			generate: siteMod._generateGifv.bind(siteMod, elem, info),
+			media: info
+		};
+
+		return $.Deferred().resolve(expandoInfo).promise();
+	},
+
+	_generateGifv(elem, info) {
+		var template = RESTemplates.getSync('imgurgifvUI');
+		var video = {
+			siteName: 'giphy',
+			siteIcon: '//giphy.com/favicon.ico',
+			siteUrl: info.giphyUrl,
+			loop: true,
+			autoplay: true, // imgurgifv will always be muted, so autoplay is OK
+			muted: true,
+			directurl: elem.href,
+		};
+		video.sources = [
+			{
+				'source': info.mp4Url,
+				'type': 'video/mp4',
+				'class': 'imgurgifvmp4src'
+			}
+		];
+		var element = template.html(video)[0],
+			v = element.querySelector('video');
+
+		// set the max width to the width of the entry area
+		v.style.maxWidth = $(elem).closest('.entry').width() + 'px';
+		new window.imgurgifvObject(element, elem.href, info.gifUrl);
+		return element;
+	},
 });

--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -314,6 +314,9 @@ addLibrary('mediaHosts', 'imgur', {
 	_generateGifv: function(elem, info) {
 		var template = RESTemplates.getSync('imgurgifvUI');
 		var video = {
+			siteName: 'imgur',
+			siteIcon: '//imgur.com/favicon.ico',
+			siteUrl: '//imgur.com/' + info.id,
 			loop: true,
 			autoplay: true, // imgurgifv will always be muted, so autoplay is OK
 			muted: true,

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1983,7 +1983,7 @@ addModule('showImages', function(module, moduleID) {
 		'default': {
 			domains: [],
 			acceptRegex: /^[^#]+?\.(gif|jpe?g|png)(?:[?&#_].*|$)/i,
-			rejectRegex: /(?:wikipedia\.org\/wiki|(?:i\.|m\.)?imgur\.com|photobucket\.com|gifsound\.com|gfycat\.com|\/wiki\/File:.*|reddit\.com|onedrive\.live\.com|500px\.(?:com|net|org)|(?:www\.|share\.)?gifyoutube\.com)|futurism\.co/i,
+			rejectRegex: /(?:wikipedia\.org\/wiki|(?:i\.|m\.)?imgur\.com|photobucket\.com|gifsound\.com|gfycat\.com|\/wiki\/File:.*|reddit\.com|onedrive\.live\.com|500px\.(?:com|net|org)|(?:www\.|share\.)?gifyoutube\.com)|futurism\.co|giphy\.com/i,
 			detect: function(href, elem) {
 				var siteMod = module.siteModules['default'];
 				return (siteMod.acceptRegex.test(href) && !siteMod.rejectRegex.test(href));


### PR DESCRIPTION
This PR overhauls the site module for giphy.com to make the expandos act like imgur's "gifv" expandos. All of their gifvs are now available in MP4 (but not WebM yet sadly) so this is possible.

It uses most of the same code/templating from the imgur module - I noticed there's some code there for a mediacrush-based giphy player but it doesn't seem to be used anywhere.

RegExes are not my strong suit but I've gone through a bunch of gifs on the [domain listing](https://www.reddit.com/domain/giphy.com/) and it seems to work pretty thoroughly.
