### PR TITLE
Fixed clippy to correctly be disabled.

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1778,7 +1778,7 @@ addModule('showImages', function(module, moduleID) {
 	}
 
 	function setMediaClippyText(elem) {
-		if (!module.options.clippy.value && elem.title) return;
+		if (!module.options.clippy.value || elem.title) return;
 
 		var clippy = [], title;
 		if (module.options.imageZoom.value) {


### PR DESCRIPTION
Was doing `&&` when it should've been `||`.

For example, run the following code in the console to see the difference.

```
var module={options:{clippy:{value:false}}};
elem = {title:''}
if (!module.options.clippy.value && elem.title) console.log('skipped 1');
if (!module.options.clippy.value || elem.title) console.log('skipped 2');
>> skipped 2
```