### PR TITLE
Graphiq visualizations expando support

### DIFF
--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -107,6 +107,7 @@
 				"modules/modhelper.js",
 				"modules/quickMessage.js",
 				"modules/hosts/imgur.js",
+				"modules/hosts/graphiq.js",
 				"modules/hosts/twitter.js",
 				"modules/hosts/futurism.js",
 				"modules/hosts/gfycat.js",

--- a/Firefox/index.js
+++ b/Firefox/index.js
@@ -231,6 +231,7 @@ pageMod.PageMod({
 		self.data.url('modules/modhelper.js'),
 		self.data.url('modules/quickMessage.js'),
 		self.data.url('modules/hosts/imgur.js'),
+		self.data.url('modules/hosts/graphiq.js'),
 		self.data.url('modules/hosts/twitter.js'),
 		self.data.url('modules/hosts/futurism.js'),
 		self.data.url('modules/hosts/gfycat.js'),

--- a/Safari/Info.plist
+++ b/Safari/Info.plist
@@ -117,6 +117,7 @@
 				<string>modules/modhelper.js</string>
 				<string>modules/quickMessage.js</string>
 				<string>modules/hosts/imgur.js</string>
+				<string>modules/hosts/graphiq.js</string>
 				<string>modules/hosts/twitter.js</string>
 				<string>modules/hosts/futurism.js</string>
 				<string>modules/hosts/gfycat.js</string>

--- a/lib/modules/hosts/graphiq.js
+++ b/lib/modules/hosts/graphiq.js
@@ -1,0 +1,41 @@
+addLibrary('mediaHosts', 'graphiq', {
+	domains: [ 'graphiq.com' ],
+
+	detect: function(href, elem) {
+		return !!href.match(/graphiq.com\/(?:w\/|wlp\/)/);
+	},
+
+	handleLink: function(elem) {
+		var def = $.Deferred();
+		var oembedEndpoint = 'https://oembed.graphiq.com/services/oembed';
+		var vizEndpoint = 'https://www.graphiq.com/w/';
+		RESEnvironment.ajax({
+			method: 'GET',
+			url: oembedEndpoint + '?url=' + encodeURIComponent(elem.href),
+			aggressiveCache: true,
+			onload: function(response) {
+				if (response.status === 200) {
+					var json = JSON.parse(response.responseText);
+					var wid = elem.href.match(/graphiq.com\/(?:w\/|wlp\/)(\w{10,11})/)[1];
+					json._url = vizEndpoint + wid;
+					def.resolve(elem, json);
+				} else {
+					def.reject();
+				}
+			},
+			onerror: function(error) {
+				def.reject();
+			}
+		});
+
+		return def.promise();
+	},
+
+	handleInfo: function(elem, info) {
+		elem.type = 'IFRAME';
+		elem.setAttribute('data-embed', info._url);
+		elem.setAttribute('data-width', info.width);
+		elem.setAttribute('data-height', info.height);
+		return $.Deferred().resolve(elem).promise();
+	}
+});

--- a/node/files.json
+++ b/node/files.json
@@ -79,6 +79,7 @@
 	],
 	"libraries": [
 		"modules/hosts/imgur.js",
+		"modules/hosts/graphiq.js",
 		"modules/hosts/twitter.js",
 		"modules/hosts/futurism.js",
 		"modules/hosts/gfycat.js",


### PR DESCRIPTION
Add support for [Graphiq](https://www.graphiq.com/) visualizations. These are interactive, live-updating data visualizations which are popular with publishers like [USA Today](http://www.usatoday.com/story/news/world/2016/01/31/boko-haram-attack-village/79623914/), [Forbes](http://www.forbes.com/home_usa/), and [NBC](http://www.nbcnews.com/health/health-news/dole-salad-recalled-after-listeria-kills-1-sickens-12-n502311). The expando support can be tested [here](https://www.reddit.com/search?q=site%3Agraphiq.com&sort=top&restrict_sr=&t=all).