### PR TITLE
Fix #2725 - highlightFirstCommenter doesn't when "show more comments" in children/replies

### DIFF
--- a/lib/modules/userHighlight.js
+++ b/lib/modules/userHighlight.js
@@ -228,9 +228,6 @@ addModule('userHighlight', function(module, moduleID) {
 
 			if (authorClass === undefined) return;
 
-			var authorDidReply = element.querySelector('.child .' + authorClass);
-			if (!authorDidReply) return;
-
 			var container = '.' + idClass;
 			if (module.options.dontHighlightFirstComment.value) {
 				container += ' .child';


### PR DESCRIPTION
The firstComments object needed to be cleared so that new comments could be checked. I added the highlightedFirstComments object to avoid adding duplicate highlight styles.