### PR TITLE
Resolving reported style issues in self-serve area of reddit when in nightmode

### DIFF
--- a/lib/css/modules/_nightMode.scss
+++ b/lib/css/modules/_nightMode.scss
@@ -460,6 +460,28 @@
 		background-color: #181818;
 	}
 
+	.traffic-table tr:nth-of-type(odd).promo-traffic-live {
+		color: #181818;
+	}
+
+	.traffic-table.promocampaign-table tr.active {
+		background-color: #6D2F39;
+		border: 2px dotted #A70000;
+	}
+
+	.sponsored-page .dashboard {
+		color: hsl(0,0%,87%);
+	}
+
+	.sponsored-page .campaign-editor .editor-group,
+	.sponsored-page .editor-group {
+		background-color: #151515;
+	}
+
+	.sponsored-page .campaign-editor .campaign-set {
+		background-color: #666;
+	}
+
 	.report-form {
 		background-color: #666;
 		color: #ccc;


### PR DESCRIPTION
Fixing self-serve area nighmode style defects reported at https://www.reddit.com/r/RESissues/comments/473n43/bug_contrast_issues_in_ad_selfserve_area/

Implemented on RES 4.7.0
Tested in Chrome 48.0.2564.116 & Firefox 44.0.2. Unable to test in Safari.

Campaign Dashboard Before:
![Campaign Dashboard Before](https://i.imgur.com/iQVBu1m.png)
Campaign Dashboard After:
![Campaign Dashboard After](http://i.imgur.com/GQjjZd5.png)

Active Campaign Before:
![Active Campaign Before](https://i.imgur.com/lYFByig.png)
Active Campaign After:
![Active Campaign After](http://i.imgur.com/3DwRGXe.png)

Resolved additional contrast issue in campaign editor where background was white while in night mode causing further contrast issues with the light text
Edit Campaign Before:
![Edit Campaign Before](http://i.imgur.com/ZSOX3SB.png)
Edit Campaign After:
![Edit Campaign After](http://i.imgur.com/9oxRO7N.png)