### PR TITLE
New feature: Show Link Title

### DIFF
--- a/lib/core/templates.html
+++ b/lib/core/templates.html
@@ -573,5 +573,25 @@
 				opacity: 1.0;
 			}
 		</style>
+
+		<div id="showLinkTitle">
+			<div class="res-show-link hide">
+				{{#thumbnailSrc}}
+					<span class="res-show-link-thumb"><img src="{{thumbnailSrc}}" alt="thumbnail" /></span>
+				{{/thumbnailSrc}}
+				<a href="#{{linkId}}" class="res-icon toTop" title="Jump to title">&#xF148;</a>
+				<a href="{{settingsHash}}" class="gearIcon" title="Configure this widget"></a>
+				<div class="res-show-link-content">
+					<div class="res-show-link-header">
+						<a href="{{linkHref}}" class="res-show-link-title">{{title}}</a>
+						<a href="{{domainHref}}" class="res-show-link-domain">(<span>{{domain}}</span>)</a>
+					</div>
+					<div class="res-show-link-tagline">
+						Submitted {{time}} by
+						<a href="{{authorHref}}" class="res-show-link-author">{{author}}</a>
+					</div>
+				</div>
+			</div>
+		</div>
 	</body>
 </html>

--- a/lib/css/modules/_pageNavigator.scss
+++ b/lib/css/modules/_pageNavigator.scss
@@ -14,7 +14,7 @@ $content-offsetleft: 54px; // icon width + margins
 	top: 0;
 	left: 15px;
 	color: black;
-	background: padding-box hsl(0, 0%, 100%);
+	background: hsl(0, 0%, 100%);
 	box-sizing: border-box;
 	box-shadow: hsla(0, 0%, 0%, .24) 0 1px 3px, hsla(0, 0%, 0%, .12) 0 3px 3px;
 	transition: all .3s;
@@ -35,7 +35,6 @@ $content-offsetleft: 54px; // icon width + margins
 
 	.res-show-link-thumb {
 		float: left;
-		margin: -5px 0;
 
 		img {
 			vertical-align: top;
@@ -53,7 +52,6 @@ $content-offsetleft: 54px; // icon width + margins
 		text-overflow: ellipsis;
 
 		.res-show-link-title {
-			cursor: pointer;
 			font-weight: bold;
 		}
 	}
@@ -89,18 +87,21 @@ $content-offsetleft: 54px; // icon width + margins
 		height: auto !important;
 	}
 
-	&:hover .res-icon.toTop {
-		font-size: 24px;
-	}
-
 	&.hide {
 		visibility: hidden;
 		opacity: 0;
 	}
 
-	&:hover .res-show-link-tagline,
-	&:hover .gearIcon {
-		visibility: visible;
-		opacity: 1;
+	&:hover {
+
+		.res-show-link-tagline,
+		.gearIcon {
+			visibility: visible;
+			opacity: 1;
+		}
+
+		.toTop {
+			font-size: 24px;
+		}
 	}
 }

--- a/lib/css/modules/_pageNavigator.scss
+++ b/lib/css/modules/_pageNavigator.scss
@@ -1,6 +1,106 @@
+$thumb-width: 100px;
+$content-offsetleft: 54px; // icon width + margins
+
 .pageNavigator {
 	cursor: pointer;
 	padding: 3px;
 	text-align: center;
 	color: #888;
+}
+
+.res-show-link {
+	overflow-y: hidden;
+	position: fixed;
+	top: 0;
+	left: 15px;
+	color: black;
+	background: padding-box hsl(0, 0%, 100%);
+	box-sizing: border-box;
+	box-shadow: hsla(0, 0%, 0%, .24) 0 1px 3px, hsla(0, 0%, 0%, .12) 0 3px 3px;
+	transition: all .3s;
+	z-index: 10000001;
+	font: 11px/1.6 verdana, sans-serif;
+
+	a {
+		color: hsl(206, 100%, 41%);
+	}
+
+	.res-show-link-domain {
+		color: hsl(0, 0%, 50%);
+	}
+
+	.res-show-link-content {
+		margin: 5px 46px 5px $content-offsetleft;
+	}
+
+	.res-show-link-thumb {
+		float: left;
+		margin: -5px 0;
+
+		img {
+			vertical-align: top;
+			width: $thumb-width;
+		}
+
+		~.res-show-link-content {
+			margin-left: $content-offsetleft + $thumb-width;
+		}
+	}
+
+	.res-show-link-header {
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+
+		.res-show-link-title {
+			cursor: pointer;
+			font-weight: bold;
+		}
+	}
+
+	.res-show-link-tagline {
+		visibility: hidden;
+		opacity: 0;
+		transition: all .3s .1s;
+	}
+
+	.toTop {
+		color: hsl(205, 100%, 50%);
+		float: left;
+		margin: 5px 15px 0 15px;
+		width: 24px;
+		height: 24px;
+		text-align: center;
+		vertical-align: middle;
+		transition: font-size .2s .1s;
+
+		&:hover {
+			color: hsl(205, 100%, 35%);
+		}
+	}
+
+	.gearIcon {
+		float: right;
+		margin: 5px 15px 0 15px;
+		visibility: hidden;
+		opacity: 0;
+		transition: all .2s;
+		width: auto !important;
+		height: auto !important;
+	}
+
+	&:hover .res-icon.toTop {
+		font-size: 24px;
+	}
+
+	&.hide {
+		visibility: hidden;
+		opacity: 0;
+	}
+
+	&:hover .res-show-link-tagline,
+	&:hover .gearIcon {
+		visibility: visible;
+		opacity: 1;
+	}
 }

--- a/lib/modules/pageNavigator.js
+++ b/lib/modules/pageNavigator.js
@@ -63,7 +63,7 @@ addModule('pageNavigator', function(module, moduleID) {
 					time: $submission.find('.tagline time').text(),
 					authorHref: $submission.find('.tagline a.author').attr('href'),
 					author: $submission.find('.tagline a.author').text(),
-					settingsHash: modules['settingsNavigation'].makeUrlHash('pageNavigator', 'showLinkTitle'),
+					settingsHash: modules['settingsNavigation'].makeUrlHash('pageNavigator', 'showLink'),
 					isSelf: $submission.hasClass('self')
 				});
 				$('body').append(output);

--- a/lib/modules/pageNavigator.js
+++ b/lib/modules/pageNavigator.js
@@ -1,19 +1,151 @@
 addModule('pageNavigator', function(module, moduleID) {
 	module.moduleName = 'Page Navigator';
 	module.category = 'Browsing';
-	module.description = 'Adds an icon to every page that takes you to the top when clicked.';
+	module.description = 'Provides tools for getting around the page.';
+	module.options = {
+		toTop: {
+			type: 'boolean',
+			value: true,
+			description: 'Add an icon to every page that takes you to the top when clicked.'
+		},
+		showLink: {
+			type: 'boolean',
+			value: true,
+			description: 'Show information about the submission when scrolling up on comments pages.'
+		},
+		showLinkNewTab: {
+			type: 'boolean',
+			value: true,
+			description: 'Open link in new tab.',
+			dependsOn: 'showLink'
+		}
+	};
 	module.go = function() {
 		if ((this.isEnabled()) && (this.isMatchURL())) {
-			addElements();
+			if (module.options.toTop.value) {
+				backToTop();
+			}
+			if (module.options.showLink.value && RESUtils.pageType() === 'comments') {
+				showLinkTitle();
+			}
 		}
 	};
 
-	function addElements() {
-		var backToTop = $('<a class="pageNavigator res-icon" data-id="top" href="#header" alt="back to top">&#xF148;</a>');
-		backToTop.on('click', '[data-id="top"]', function(e) {
+	function backToTop() {
+		const element = $('<a class="pageNavigator res-icon" data-id="top" href="#header" alt="back to top">&#xF148;</a>');
+		element.on('click', '[data-id="top"]', function(e) {
 			e.preventDefault();
 			RESUtils.scrollTo(0, 0);
 		});
-		modules['floater'].addElement(backToTop);
+		modules['floater'].addElement(element);
+	}
+
+	function showLinkTitle() {
+		let oldPos = window.scrollY;
+
+		function showWidget() {
+			$('.res-show-link').css({top: ''}).removeClass('hide');
+		}
+
+		function hideWidget() {
+			$('.res-show-link').css({top: -$('.res-show-link').outerHeight()}).addClass('hide');
+		}
+
+		function renderWidget($submission) {
+			RESTemplates.load('showLinkTitle', function(template) {
+				const output = template.html({
+					linkId: $submission[0].id,
+					thumbnailSrc: $submission.find('.thumbnail img').attr('src'),
+					linkHref: $submission.find('a.title').attr('href'),
+					title: $submission.find('a.title').text(),
+					domainHref: $submission.find('.domain a').attr('href'),
+					domain: $submission.find('.domain a').text(),
+					time: $submission.find('.tagline time').text(),
+					authorHref: $submission.find('.tagline a.author').attr('href'),
+					author: $submission.find('.tagline a.author').text(),
+					settingsHash: modules['settingsNavigation'].makeUrlHash('pageNavigator', 'showLinkTitle'),
+					isSelf: $submission.hasClass('self')
+				});
+				$('body').append(output);
+			});
+		}
+
+		function snapToEdge($linkInfo) {
+			const rightGap = document.body.scrollWidth - $linkInfo[0].getBoundingClientRect().right;
+			if (rightGap <= 15) {
+				$linkInfo.css({right: '15px'});
+			}
+		}
+
+		function resizeListener($linkInfo) {
+			// Shake off 'right' value before checking its proximity again.
+			// Use a timeout because there's no need to listen constantly.
+			let resizeTimeout;
+			window.addEventListener('resize', function() {
+				clearTimeout(resizeTimeout);
+				resizeTimeout = setTimeout(function() {
+					$linkInfo.css({right: ''});
+					snapToEdge($linkInfo);
+				}, 100);
+			}, false);
+		}
+
+		function scrollListener() {
+			let scrollTimeout;
+			window.addEventListener('scroll', function() {
+				clearTimeout(scrollTimeout);
+				scrollTimeout = setTimeout( function() {
+					updateWidget();
+				}, 100);
+			}, false);
+		}
+
+		function updateWidget() {
+			const nowPos = window.scrollY;
+			const commentBounds = $('body > .content > .commentarea > .sitetable')[0].getBoundingClientRect();
+
+			if (nowPos < oldPos && commentBounds.top < 0) {
+				// We have scrolled up while still inside commentarea.
+				showWidget();
+			} else {
+				hideWidget();
+			}
+			oldPos = nowPos;
+		}
+
+		function openNewTabListener($element) {
+			$element.on('click', function(e) {
+				e.preventDefault();
+				RESUtils.openLinkInNewTab($element.attr('href'), true);
+			});
+		}
+
+		const $submission = $('body > .content > .sitetable > .thing');
+		renderWidget($submission);
+
+		const $linkInfo = $('.res-show-link');
+		$linkInfo.find('.toTop').click(function(e) {
+			hideWidget();
+		});
+
+		snapToEdge($linkInfo);
+		resizeListener($linkInfo);
+		scrollListener();
+
+		if (module.options.showLinkNewTab.value) {
+			openNewTabListener($linkInfo.find('.res-show-link-title'));
+		}
+
+		// Set the two heights for the bar.
+		// Due to a Firefox bug with scrollHeight we avoid adding padding to container.
+		// jQuery.height() does extra stuff, use plain CSS instead.
+		const crop = $linkInfo.find('.res-show-link-content').outerHeight(true) - $linkInfo.find('.res-show-link-tagline').outerHeight();
+		$linkInfo.css({height: crop});
+
+		$linkInfo.on('mouseenter', function(e) {
+			$linkInfo.css({height: e.currentTarget.scrollHeight});
+		}).on('mouseleave', function(e) {
+			$linkInfo.css({height: crop});
+		});
 	}
 });


### PR DESCRIPTION
Closes #2736

Scroll up while viewing comments to reveal a small widget showing information about the submission, including thumbnail, title and domain. Hover over the widget to show the submit date and author. Scroll down to hide it.

Here's a demo gif:

![showlinktitle-03](https://cloud.githubusercontent.com/assets/7245595/13485665/e1085728-e155-11e5-8b37-e9f8c3524cb1.gif)

The PR moves the old setting for pageNavigator into a new option, but doesn't create a migration entry. Andytuba said not to worry about it.