### PR TITLE
Expandos lose 'collapsed' class when expanded (master)

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1070,7 +1070,7 @@ addModule('showImages', function(module, moduleID) {
 
 		expandoButton.expandoBox = imgDiv;
 
-		expandoButton.classList.remove('collapsedExpando');
+		expandoButton.classList.remove('collapsed', 'collapsedExpando');
 		expandoButton.classList.add('expanded');
 
 		if (expandoButton.classList.contains('commentImg')) {
@@ -1117,8 +1117,7 @@ addModule('showImages', function(module, moduleID) {
 		}
 
 		expandoButton.expandoBox = wrapperDiv;
-		expandoButton.classList.remove('collapsedExpando');
-		expandoButton.classList.remove('collapsed');
+		expandoButton.classList.remove('collapsed', 'collapsedExpando');
 		expandoButton.classList.add('expanded');
 
 		expandoButton.addEventListener('click', function(e) {
@@ -1191,8 +1190,7 @@ addModule('showImages', function(module, moduleID) {
 		}
 		expandoButton.expandoBox = imgDiv;
 
-		expandoButton.classList.remove('collapsedExpando');
-		expandoButton.classList.remove('collapsed');
+		expandoButton.classList.remove('collapsed', 'collapsedExpando');
 		expandoButton.classList.add('expanded');
 
 		//TODO: Decide how to handle history for this.
@@ -1268,8 +1266,7 @@ addModule('showImages', function(module, moduleID) {
 		playerDiv.appendChild(video);
 
 		expandoButton.expandoBox = wrapperDiv;
-		expandoButton.classList.remove('collapsedExpando');
-		expandoButton.classList.remove('collapsed');
+		expandoButton.classList.remove('collapsed', 'collapsedExpando');
 		expandoButton.classList.add('expanded');
 
 		if (expandoButton.classList.contains('commentImg')) {
@@ -1344,8 +1341,7 @@ addModule('showImages', function(module, moduleID) {
 		}
 		expandoButton.expandoBox = imgDiv;
 
-		expandoButton.classList.remove('collapsedExpando');
-		expandoButton.classList.remove('collapsed');
+		expandoButton.classList.remove('collapsed', 'collapsedExpando');
 		expandoButton.classList.add('expanded');
 
 		if (imageLink.onExpandData) {
@@ -1417,8 +1413,7 @@ addModule('showImages', function(module, moduleID) {
 		}
 		expandoButton.expandoBox = imgDiv;
 
-		expandoButton.classList.remove('collapsedExpando');
-		expandoButton.classList.remove('collapsed');
+		expandoButton.classList.remove('collapsed', 'collapsedExpando');
 		expandoButton.classList.add('expanded');
 
 		module.makeMediaZoomable(video);
@@ -1508,8 +1503,7 @@ addModule('showImages', function(module, moduleID) {
 		}
 
 		expandoButton.expandoBox = mediaDiv;
-		expandoButton.classList.remove('collapsedExpando');
-		expandoButton.classList.remove('collapsed');
+		expandoButton.classList.remove('collapsed', 'collapsedExpando');
 		expandoButton.classList.add('expanded');
 		$(expandoButton).data('associatedImage', video || element);
 
@@ -1594,8 +1588,7 @@ addModule('showImages', function(module, moduleID) {
 
 		expandoButton.expandoBox = noEmbedFrame;
 
-		expandoButton.classList.remove('collapsedExpando');
-		expandoButton.classList.remove('collapsed');
+		expandoButton.classList.remove('collapsed', 'collapsedExpando');
 		expandoButton.classList.add('expanded');
 	}
 


### PR DESCRIPTION
On the first click of an expando the 'collapsed' class doesn't get removed, which is evident if you're using Reddit's new expando CSS.

The fix is on line 173, the other changes are code style.

Edit: I didn't mean to base this on master, but I'm guessing it's still useful.