### PR TITLE
Expandos lose 'collapsed' class when expanded

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1069,7 +1069,7 @@ addModule('showImages', {
 
 		expandoButton.expandoBox = imgDiv;
 
-		expandoButton.classList.remove('collapsedExpando');
+		expandoButton.classList.remove('collapsed', 'collapsedExpando');
 		expandoButton.classList.add('expanded');
 
 		if (expandoButton.classList.contains('commentImg')) {
@@ -1115,8 +1115,7 @@ addModule('showImages', {
 		}
 
 		expandoButton.expandoBox = wrapperDiv;
-		expandoButton.classList.remove('collapsedExpando');
-		expandoButton.classList.remove('collapsed');
+		expandoButton.classList.remove('collapsed', 'collapsedExpando');
 		expandoButton.classList.add('expanded');
 
 		expandoButton.addEventListener('click', function(e) {
@@ -1188,8 +1187,7 @@ addModule('showImages', {
 		}
 		expandoButton.expandoBox = imgDiv;
 
-		expandoButton.classList.remove('collapsedExpando');
-		expandoButton.classList.remove('collapsed');
+		expandoButton.classList.remove('collapsed', 'collapsedExpando');
 		expandoButton.classList.add('expanded');
 
 		//TODO: Decide how to handle history for this.
@@ -1264,8 +1262,7 @@ addModule('showImages', {
 		playerDiv.appendChild(video);
 
 		expandoButton.expandoBox = wrapperDiv;
-		expandoButton.classList.remove('collapsedExpando');
-		expandoButton.classList.remove('collapsed');
+		expandoButton.classList.remove('collapsed', 'collapsedExpando');
 		expandoButton.classList.add('expanded');
 
 		if (expandoButton.classList.contains('commentImg')) {
@@ -1340,8 +1337,7 @@ addModule('showImages', {
 		}
 		expandoButton.expandoBox = imgDiv;
 
-		expandoButton.classList.remove('collapsedExpando');
-		expandoButton.classList.remove('collapsed');
+		expandoButton.classList.remove('collapsed', 'collapsedExpando');
 		expandoButton.classList.add('expanded');
 
 		if (imageLink.onExpandData) {
@@ -1412,8 +1408,7 @@ addModule('showImages', {
 		}
 		expandoButton.expandoBox = imgDiv;
 
-		expandoButton.classList.remove('collapsedExpando');
-		expandoButton.classList.remove('collapsed');
+		expandoButton.classList.remove('collapsed', 'collapsedExpando');
 		expandoButton.classList.add('expanded');
 
 		modules['showImages'].makeMediaZoomable(video);
@@ -1502,8 +1497,7 @@ addModule('showImages', {
 		}
 
 		expandoButton.expandoBox = mediaDiv;
-		expandoButton.classList.remove('collapsedExpando');
-		expandoButton.classList.remove('collapsed');
+		expandoButton.classList.remove('collapsed', 'collapsedExpando');
 		expandoButton.classList.add('expanded');
 		$(expandoButton).data('associatedImage', video || element);
 
@@ -1586,8 +1580,7 @@ addModule('showImages', {
 
 		expandoButton.expandoBox = noEmbedFrame;
 
-		expandoButton.classList.remove('collapsedExpando');
-		expandoButton.classList.remove('collapsed');
+		expandoButton.classList.remove('collapsed', 'collapsedExpando');
 		expandoButton.classList.add('expanded');
 	},
 	visits: [],


### PR DESCRIPTION
On the first click of an expando the 'collapsed' class doesn't get removed, which is evident if you're using Reddit's new expando CSS.

The fix is on line 172, the other changes are code style.