### PR TITLE
Bugfix account for swicther "arrow" dropdown

### DIFF
--- a/lib/css/modules/_accountSwitcher.scss
+++ b/lib/css/modules/_accountSwitcher.scss
@@ -54,7 +54,7 @@
 
 	#RESAccountSwitcherIcon {
 		display: inline-block;
-		vertical-align: bottom;
+		vertical-align: middle;
 		margin-left: 3px;
 
 		.downArrow::after {


### PR DESCRIPTION
Tiny bug fix for the account switcher dropdown.

 When the display style on the account switcher is set to "simple arrow", the arrow icon is misaligned. This fix just switches the arrows vertical align back to middle which fixes it for me.
