### PR TITLE
Body class for User Highlighter

### DIFF
--- a/lib/modules/userHighlight.js
+++ b/lib/modules/userHighlight.js
@@ -201,6 +201,8 @@ addModule('userHighlight', function(module, moduleID) {
 				RESUtils.watchForElement('newComments', scanPageForFirstComments);
 				scanPageForFirstComments();
 			}
+
+			RESUtils.bodyClasses.add('res-userHighlight');
 		}
 	};
 
@@ -374,7 +376,7 @@ addModule('userHighlight', function(module, moduleID) {
 			selector = name;
 		}
 		if (container === undefined) {
-			container = '.thing .tagline';
+			container = '.res-userHighlight .tagline';
 		}
 		var color = colorTable[name].color;
 		var hoverColor = colorTable[name].hoverColor;


### PR DESCRIPTION
Allows themes to customize User Highlighter without affecting RES users who have the module disabled. Since this doesn't change CSS specificity it shouldn't cause any visible changes; it's intended to only be discoverable by themers.

This change opens up the possibility for usernames outside of `.thing` to be affected by User Highlighter. However since it only affects specific elements with classes such as `.author.submitter` and `.author.moderator` it shouldn't be a problem.

Tested in /r/naut, modmail, inbox and vanilla reddit.

Addresses these reports:

* https://redd.it/49nwty
* https://redd.it/42dqz0