### PR TITLE
Move commentBoxes into new module

### DIFF
--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -50,6 +50,7 @@
 				"modules/keyboardNav.js",
 				"modules/about.js",
 				"modules/commandLine.js",
+				"modules/commentStyle.js",
 				"modules/messageMenu.js",
 				"modules/easterEgg.js",
 				"modules/pageNavigator.js",

--- a/Firefox/index.js
+++ b/Firefox/index.js
@@ -173,6 +173,7 @@ pageMod.PageMod({
 		self.data.url('modules/userTagger.js'),
 		self.data.url('modules/keyboardNav.js'),
 		self.data.url('modules/commandLine.js'),
+		self.data.url('modules/commentStyle.js'),
 		self.data.url('modules/messageMenu.js'),
 		self.data.url('modules/easterEgg.js'),
 		self.data.url('modules/pageNavigator.js'),

--- a/Safari/Info.plist
+++ b/Safari/Info.plist
@@ -59,6 +59,7 @@
 				<string>modules/userTagger.js</string>
 				<string>modules/keyboardNav.js</string>
 				<string>modules/commandLine.js</string>
+				<string>modules/commentStyle.js</string>
 				<string>modules/messageMenu.js</string>
 				<string>modules/easterEgg.js</string>
 				<string>modules/pageNavigator.js</string>

--- a/lib/core/migrate.js
+++ b/lib/core/migrate.js
@@ -176,6 +176,11 @@ var RESOptionsMigrate = {
 			go() {
 				RESOptionsMigrate.migrators.generic.forceUpdateOption('orangered', 'showUnreadCount', value => value === false);
 				RESOptionsMigrate.migrators.generic.moveOption('orangered', 'showUnreadCount', 'orangered', 'hideUnreadCount');
+				RESOptionsMigrate.migrators.generic.moveOption('styleTweaks', 'commentBoxes', 'commentStyle', 'commentBoxes');
+				RESOptionsMigrate.migrators.generic.moveOption('styleTweaks', 'commentRounded', 'commentStyle', 'commentRounded');
+				RESOptionsMigrate.migrators.generic.moveOption('styleTweaks', 'commentHoverBorder', 'commentStyle', 'commentHoverBorder');
+				RESOptionsMigrate.migrators.generic.moveOption('styleTweaks', 'commentIndent', 'commentStyle', 'commentIndent');
+				RESOptionsMigrate.migrators.generic.moveOption('styleTweaks', 'continuity', 'commentStyle', 'continuity');
 			}
 		}
 	],

--- a/lib/css/modules/_commentStyle.scss
+++ b/lib/css/modules/_commentStyle.scss
@@ -7,6 +7,7 @@
 		margin: 0 8px 8px 10px !important;
 		border: 1px solid #e6e6e6 !important;
 		padding: 5px 8px 5px 5px !important;
+		overflow: hidden;
 
 		.comment {
 			margin-right: 0 !important;

--- a/lib/css/res.scss
+++ b/lib/css/res.scss
@@ -1,7 +1,7 @@
 @import 'zindex';
 @import 'fonts/batch';
 @import 'modules/nightMode';
-@import 'modules/commentBoxes';
+@import 'modules/commentStyle';
 @import 'modules/showParent';
 @import 'modules/quickMessage';
 @import 'modules/accountSwitcher';

--- a/lib/modules/commentStyle.js
+++ b/lib/modules/commentStyle.js
@@ -1,0 +1,57 @@
+addModule('commentStyle', function(module, moduleID) {
+	module.moduleName = 'Comment Style';
+	module.category = ['Appearance', 'Comments'];
+	module.description = 'Add readability enhancements to comments.';
+	module.options = {
+		commentBoxes: {
+			type: 'boolean',
+			value: true,
+			description: 'Highlights comment boxes for easier reading / placefinding in large threads.',
+			bodyClass: 'res-commentBoxes'
+		},
+		commentRounded: {
+			type: 'boolean',
+			value: true,
+			description: 'Round corners of comment boxes',
+			advanced: true,
+			dependsOn: 'commentBoxes',
+			bodyClass: 'res-commentBoxes-rounded'
+		},
+		commentHoverBorder: {
+			type: 'boolean',
+			value: false,
+			description: 'Highlight comment box hierarchy on hover (turn off for faster performance)',
+			advanced: true,
+			dependsOn: 'commentBoxes',
+			bodyClass: 'res-commentHoverBorder'
+		},
+		commentIndent: {
+			type: 'text',
+			value: 10,
+			description: 'Indent comments by [x] pixels (only enter the number, no \'px\')',
+			advanced: true,
+			dependsOn: 'commentBoxes'
+		},
+		continuity: {
+			type: 'boolean',
+			value: false,
+			description: 'Show comment continuity lines',
+			advanced: true,
+			dependsOn: 'commentBoxes',
+			bodyClass: 'res-continuity'
+		},
+	};
+
+	module.include = [
+		'comments'
+	];
+
+	module.go = function() {
+		if ((module.isEnabled()) && (module.isMatchURL())) {
+			if (this.options.commentBoxes.value && this.options.commentIndent.value) {
+				// this should override the default of 10px in commentboxes.css because it's added later.
+				RESUtils.addCSS('.res-commentBoxes .comment { margin-left:' + this.options.commentIndent.value + 'px !important; }');
+			}
+		}
+	};
+});

--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -9,50 +9,6 @@ addModule('styleTweaks', function(module, moduleID) {
 			description: 'Moves the username navbar to the top (great on netbooks!)',
 			bodyClass: 'res-navTop'
 		},
-		commentBoxes: {
-			type: 'boolean',
-			value: true,
-			description: 'Highlights comment boxes for easier reading / placefinding in large threads.',
-			bodyClass: 'res-commentBoxes'
-		},
-		/* REMOVED for performance reasons...
-		commentBoxShadows: {
-			type: 'boolean',
-			value: false,
-			description: 'Drop shadows on comment boxes (turn off for faster performance)'
-		},
-		*/
-		commentRounded: {
-			type: 'boolean',
-			value: true,
-			description: 'Round corners of comment boxes',
-			advanced: true,
-			dependsOn: 'commentBoxes',
-			bodyClass: 'res-commentBoxes-rounded'
-		},
-		commentHoverBorder: {
-			type: 'boolean',
-			value: false,
-			description: 'Highlight comment box hierarchy on hover (turn off for faster performance)',
-			advanced: true,
-			dependsOn: 'commentBoxes',
-			bodyClass: 'res-commentHoverBorder'
-		},
-		commentIndent: {
-			type: 'text',
-			value: 10,
-			description: 'Indent comments by [x] pixels (only enter the number, no \'px\')',
-			advanced: true,
-			dependsOn: 'commentBoxes'
-		},
-		continuity: {
-			type: 'boolean',
-			value: false,
-			description: 'Show comment continuity lines',
-			advanced: true,
-			dependsOn: 'commentBoxes',
-			bodyClass: 'res-continuity'
-		},
 		disableAnimations: {
 			type: 'boolean',
 			value: false,
@@ -182,10 +138,6 @@ addModule('styleTweaks', function(module, moduleID) {
 
 	module.beforeLoad = function() {
 		if ((this.isEnabled()) && (this.isMatchURL())) {
-			if (this.options.commentBoxes.value && this.options.commentIndent.value && RESUtils.pageType('comments')) {
-				// this should override the default of 10px in commentboxes.css because it's added later.
-				RESUtils.addCSS('.res-commentBoxes .comment { margin-left:' + this.options.commentIndent.value + 'px !important; }');
-			}
 			if (RESUtils.currentSubreddit()) {
 				curSubReddit = RESUtils.currentSubreddit().toLowerCase();
 			}

--- a/node/files.json
+++ b/node/files.json
@@ -21,6 +21,7 @@
 		"modules/keyboardNav.js",
 		"modules/about.js",
 		"modules/commandLine.js",
+		"modules/commentStyle.js",
 		"modules/messageMenu.js",
 		"modules/easterEgg.js",
 		"modules/pageNavigator.js",


### PR DESCRIPTION
Closes #2597 

The body classes only get added to comment pages, improves organisation in settings console.

Also brings #2676 into 4.7.