### PR TITLE
Restore grey links by default, add option for colored links

### DIFF
--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -58,6 +58,12 @@ addModule('nightMode', function(module, moduleID) {
 			value: '',
 			listType: 'subreddits',
 			description: 'Allow the subreddits listed to display subreddit styles during night mode if useSubredditStyles is disabled.'
+		},
+		coloredLinks: {
+			type: 'boolean',
+			bodyClass: true,
+			value: false,
+			description: 'Color links blue and purple',
 		}
 	},
 	onToggle: function(toggle) {
@@ -88,6 +94,11 @@ addModule('nightMode', function(module, moduleID) {
 				module.enableNightMode();
 			} else {
 				module.disableNightMode();
+			}
+
+			// Remove in 4.7.0
+			if (module.options.coloredLinks.value) {
+				RESUtils.bodyClasses.add('res-nightMode-coloredLinks');
 			}
 		} else {
 			// Failsafe to disable night mode if the module is disabled

--- a/lib/modules/nightmode.css
+++ b/lib/modules/nightmode.css
@@ -452,6 +452,9 @@
 	color: hsl(210,60%,70%) !important;
 }
 .res-nightmode .thing .title {
+	color: hsl(0,0%,87%);
+}
+.res-nightmode.res-nightMode-coloredLinks .thing .title {
 	color: hsl(210,60%,60%);
 }
 .res-nightmode .tagline a {
@@ -464,7 +467,13 @@
 .res-nightmode .thing.visited .title,
 .res-nightmode .combined-search-page .search-result a:visited,
 .res-nightmode .combined-search-page .search-result a:visited > mark {
-	color: hsl(270,50%,65%); /* see also styleTweaks.js */
+	color: hsl(0,0%,65%); /* see also styleTweaks.js visitedStyle */
+}
+.res-nightmode.res-nightMode-coloredLinks .thing .title:visited,
+.res-nightmode.res-nightMode-coloredLinks .thing.visited .title,
+.res-nightmode.res-nightMode-coloredLinks .combined-search-page .search-result a:visited,
+.res-nightmode.res-nightMode-coloredLinks .combined-search-page .search-result a:visited > mark {
+	color: hsl(270,50%,65%); /* see also styleTweaks.js visitedStyle */
 }
 .res-nightmode .flair-settings ~ .tabpane-content {
 	border-color: hsl(0,0%,10%);

--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -211,7 +211,8 @@ addModule('styleTweaks', {
 			// If not, we still need a visited class for links in comments, like imgur photos for example, or inline image viewer can't make them look different when expanded!
 			if (this.options.visitedStyle.value) {
 				RESUtils.addCSS('.comment a:visited { color:#551a8b }');
-				RESUtils.addCSS('.res-nightmode .comment a:visited { color: hsl(270,50%,65%); }');
+				RESUtils.addCSS('.res-nightmode .comment a:visited { color: hsl(0,0%,65%); }');
+				RESUtils.addCSS('.res-nightmode.res-nightMode-coloredLinks .comment a:visited { color: hsl(270,50%,65%); }');
 			} else {
 				RESUtils.addCSS('.comment .md p > a:visited { color:#551a8b }');
 				RESUtils.addCSS('.res-nightmode .comment .md p > a:visited { color: hsl(270,50%,65%); }');

--- a/lib/modules/stylesheet.js
+++ b/lib/modules/stylesheet.js
@@ -334,7 +334,9 @@ addModule('stylesheet', function(module, moduleID) {
 		if (toggle && !modules['customToggles'].toggleActive(toggle)) return false;
 
 		var subreddit = RESUtils.currentSubreddit();
-		if (!subreddit) return true;
+		if (!subreddit) {
+			return (applyTo !== 'include');
+		}
 
 		subreddit = subreddit.toLowerCase();
 		applyList = typeof applyList === 'string' ? applyList.toLowerCase().split(',') : [];


### PR DESCRIPTION
Closes #2705 
Nobody seems to have reported the issue about "stylehsheets set to only load inside certain subreddits are loading on frontpage"

<img width="1204" alt="screen shot 2016-03-12 at 12 12 25 pm" src="https://cloud.githubusercontent.com/assets/455632/13725098/d25525aa-e84c-11e5-9767-2ab754fe7551.png">
<img width="435" alt="screen shot 2016-03-12 at 12 20 00 pm" src="https://cloud.githubusercontent.com/assets/455632/13725099/d26fb2e4-e84c-11e5-8c2e-138fcb92f047.png">

