### PR TITLE
Fix keyboard nav regression

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -697,7 +697,7 @@ addModule('keyboardNav', {
 
 			RESEnvironment.sendMessage(thisJSON);
 		} else {
-			location.href = this.getAttribute('href');
+			location.href = thisURL;
 		}
 	},
 	drawHelp: function() {


### PR DESCRIPTION
If keyboard nav settings are set to open links in the same tab, it wouldn't work because this was broken sometime down the line.