### PR TITLE
styleTweaks: null-check module.styleToggleCheckbox

### DIFF
--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -248,7 +248,7 @@ addModule('styleTweaks', (module, moduleID) => {
 		} else if (!RESUtils.currentSubreddit()) {
 			RESEnvironment.pageAction.hide();
 		} else {
-			RESEnvironment.pageAction.show(module.styleToggleCheckbox.checked);
+			RESEnvironment.pageAction.show(module.styleToggleCheckbox && module.styleToggleCheckbox.checked);
 		}
 	};
 


### PR DESCRIPTION
Prevents an error if the user has the checkbox disabled (or it's otherwise uninitialized).
(thanks @andytuba)