### PR TITLE
Fix #2785 - support for flic.kr shortlinks

### DIFF
--- a/lib/modules/hosts/flickr.js
+++ b/lib/modules/hosts/flickr.js
@@ -1,7 +1,10 @@
 addLibrary('mediaHosts', 'flickr', {
 	domains: ['flickr.com', 'flic.kr'],
 	logo: '//s.yimg.com/pw/favicon.ico',
-	detect: href => ((/^https?:\/\/(?:\w+\.)?flickr\.com\/(?:.+)\/(\d{10,})(?:\/|$)/i).test(href) || (/^https?:\/\/(?:\w+\.)?flic\.kr\/p\/(\w+)(?:\/|$)/i).test(href)),
+	detect: href => (
+		(/^https?:\/\/(?:\w+\.)?flickr\.com\/(?:.+)\/(\d{10,})(?:\/|$)/i).test(href) ||
+		(/^https?:\/\/(?:\w+\.)?flic\.kr\/p\/(\w+)(?:\/|$)/i).test(href)
+	),
 	async handleLink(elem) {
 		// noembed.com does not yet support flickr shortlink.
 		// This fix can be removed once it's fixed.

--- a/lib/modules/hosts/flickr.js
+++ b/lib/modules/hosts/flickr.js
@@ -7,12 +7,10 @@ addLibrary('mediaHosts', 'flickr', {
 	),
 	async handleLink(elem) {
 		// noembed.com does not yet support flickr shortlink.
-		// This fix can be removed once it's fixed.
-		elem.href = elem.href.replace('flic.kr', 'flickr.com');
-
+		// We fix this by replacing the URL as of now, when support is added this can be safely removed.
 		const info = await RESEnvironment.ajax({
 			url: 'https://noembed.com/embed',
-			data: { url: elem.href },
+			data: { url: elem.href.replace('flic.kr', 'flickr.com') },
 			type: 'json'
 		});
 

--- a/lib/modules/hosts/flickr.js
+++ b/lib/modules/hosts/flickr.js
@@ -1,8 +1,13 @@
 addLibrary('mediaHosts', 'flickr', {
-	domains: ['flickr.com'],
+	domains: ['flickr.com', 'flic.kr'],
 	logo: '//s.yimg.com/pw/favicon.ico',
-	detect: href => (/^https?:\/\/(?:\w+\.)?flickr\.com\/(?:.+)\/(\d{10,})(?:\/|$)/i).test(href),
+	detect: href => ((/^https?:\/\/(?:\w+\.)?flickr\.com\/(?:.+)\/(\d{10,})(?:\/|$)/i).test(href) || (/^https?:\/\/(?:\w+\.)?flic\.kr\/p\/(\w+)(?:\/|$)/i).test(href)),
 	async handleLink(elem) {
+
+		// noembed.com does not yet support flickr shortlink.
+		// This fix can be removed once it's fixed.
+		elem.href = elem.href.replace('flic.kr','flickr.com');
+
 		const info = await RESEnvironment.ajax({
 			url: 'https://noembed.com/embed',
 			data: { url: elem.href },

--- a/lib/modules/hosts/flickr.js
+++ b/lib/modules/hosts/flickr.js
@@ -3,10 +3,9 @@ addLibrary('mediaHosts', 'flickr', {
 	logo: '//s.yimg.com/pw/favicon.ico',
 	detect: href => ((/^https?:\/\/(?:\w+\.)?flickr\.com\/(?:.+)\/(\d{10,})(?:\/|$)/i).test(href) || (/^https?:\/\/(?:\w+\.)?flic\.kr\/p\/(\w+)(?:\/|$)/i).test(href)),
 	async handleLink(elem) {
-
 		// noembed.com does not yet support flickr shortlink.
 		// This fix can be removed once it's fixed.
-		elem.href = elem.href.replace('flic.kr','flickr.com');
+		elem.href = elem.href.replace('flic.kr', 'flickr.com');
 
 		const info = await RESEnvironment.ajax({
 			url: 'https://noembed.com/embed',


### PR DESCRIPTION
Fixes #2785 Adds support for flic.kr. When https://github.com/leedo/noembed/issues/60 is fixed we can remove some code