### PR TITLE
Add in npm install into prestart script

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ First time installation:
 
 1. Install [node.js](http://nodejs.org) (version 4+).
 1. Install [Python 2](https://www.python.org/downloads/) (*not* version 3).
-1. Navigate to your RES folder.
-1. Run `npm install`.
+1. Navigate/cd to your RES folder.
+1. Run `npm start`.
 
-Once done, you can build the extension by running `npm start`. This will also start a watch task that will rebuild RES when you make changes (see [Advanced Usage](#details-and-advanced-usage) for more details).
+`npm start` will also start a watch task that will rebuild RES when you make changes (see [Advanced Usage](#details-and-advanced-usage) for more details).
 
 To load the extension into your browser, see [the sections below](#building-in-chrome).
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "external-deps": "gem install scss_lint",
     "preinstall": "npm -v && node -v && python --version && git rev-parse HEAD && git status --porcelain",
-    "prestart": "gulp clean",
+    "prestart": "npm install && gulp clean",
     "start": "cross-env NODE_ENV=development gulp watch --browsers",
     "preonce": "gulp clean",
     "once": "cross-env NODE_ENV=development gulp build --browsers",


### PR DESCRIPTION
In this PR, it removes another command that needs to get run to start up the development environment. Now, `npm install` is run during the pre start script before `gulp clean`. Hope this helps! 

:smile: 