### PR TITLE
Fix vote arrows in Nightmode, plus new higher-contrast icons

### DIFF
--- a/lib/modules/nightmode.css
+++ b/lib/modules/nightmode.css
@@ -201,15 +201,19 @@
 .res-nightmode .arrow.upmod,
 .res-nightmode .arrow.down,
 .res-nightmode .arrow.downmod {
-	background-image: url(https://b.thumbs.redditmedia.com/WZDoQsDzUySVTErcweuA3k2HH1HU5-BZNnBXOR4FDwc.png);
+	width: 15px;
+	height: 14px;
+	margin-left: auto;
+	margin-right: auto;
+	background-image: url(http://i.imgur.com/o1IiV1o.png) !important;
 	background-repeat: no-repeat;
 }
-.res-nightmode .arrow.up { background-position: -15px 0; }
-.res-nightmode .arrow.up:hover { background-position: -30px 0; }
-.res-nightmode .arrow.upmod { background-position: 0 0; }
-.res-nightmode .arrow.down { background-position: -15px -14px; }
-.res-nightmode .arrow.down:hover { background-position: -30px -14px; }
-.res-nightmode .arrow.downmod { background-position: 0 -14px; }
+.res-nightmode .arrow.up { background-position: -15px 0 !important; }
+.res-nightmode .arrow.up:hover { background-position: -30px 0 !important; }
+.res-nightmode .arrow.upmod { background-position: 0 0 !important; }
+.res-nightmode .arrow.down { background-position: -15px -14px !important; }
+.res-nightmode .arrow.down:hover { background-position: -30px -14px !important; }
+.res-nightmode .arrow.downmod { background-position: 0 -14px !important; }
 .res-nightmode .dropdown.lightdrop a.choice:hover {
 	background-color: hsl(0,0%,10%);
 }


### PR DESCRIPTION
Subreddits tested include:

1. https://www.reddit.com/r/web_design
* https://www.reddit.com/r/overwatch
* https://www.reddit.com/r/naut
* https://www.reddit.com/r/science
* https://www.reddit.com/r/space

Seems to work as expected. Fixes broken arrows while leaving functional arrows unaffected. More testing wouldn't hurt though.

The new spritesheet has brighter outlines around unvoted arrows to make them stand out better against different backgrounds. The image source will need to be changed to reflect a new file location.

![sprites-nm-vote-02](https://cloud.githubusercontent.com/assets/7245595/13902561/c5a84b64-ee98-11e5-8b59-0de4c344828c.png)