### PR TITLE
Make vote weights unselectable in comment text

### DIFF
--- a/lib/css/modules/_userTagger.scss
+++ b/lib/css/modules/_userTagger.scss
@@ -80,6 +80,11 @@ a.voteWeight {
 	&:hover {
 		text-decoration: none;
 	}
+
+	// unselectable in comments/markdown for usability
+	.md & {
+		user-select: none;
+	}
 }
 
 #benefits {


### PR DESCRIPTION
This makes it so when you select comment text, the vote weight won't get copied (like `/u/username [+2]`)