### PR TITLE
keyboardNav: fix moveDownSibling for lock to top

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -922,7 +922,11 @@ addModule('keyboardNav', (module, moduleID) => {
 			}
 		}
 
-		_moveToThing(target, { scrollStyle: 'legacy' });
+		if (module.options.scrollStyle.value === 'top') {
+			_moveToThing(target, { scrollStyle: 'top' });
+		} else {
+			_moveToThing(target, { scrollStyle: 'legacy' });
+		}
 	};
 
 	module.moveUpSibling = function() {


### PR DESCRIPTION
The option "lock to top" doesn't work as described when using the "moveDownSibling" keybind in the
current master. Instead it follows the behavior of legacy.

This small patch fixes that. 