### PR TITLE
Mediahost - load on demand

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -110,6 +110,7 @@
 				"modules/modhelper.js",
 				"modules/quickMessage.js",
 				"modules/hosts/imgur.js",
+				"modules/hosts/xkcd.js",
 				"modules/hosts/pornbot.js",
 				"modules/hosts/coub.js",
 				"modules/hosts/uploadly.js",

--- a/firefox/index.js
+++ b/firefox/index.js
@@ -564,6 +564,7 @@ PageMod({
 		self.data.url('modules/modhelper.js'),
 		self.data.url('modules/quickMessage.js'),
 		self.data.url('modules/hosts/imgur.js'),
+		self.data.url('modules/hosts/xkcd.js'),
 		self.data.url('modules/hosts/pornbot.js'),
 		self.data.url('modules/hosts/coub.js'),
 		self.data.url('modules/hosts/uploadly.js'),

--- a/lib/modules/hosts/xkcd.js
+++ b/lib/modules/hosts/xkcd.js
@@ -3,10 +3,16 @@ addLibrary('mediaHosts', 'xkcd', {
 	logo: 'https://xkcd.com/favicon.ico',
 	detect: href => (/^https?:\/\/(?:www\.|m\.)?xkcd\.com\/([0-9]+)/i).exec(href),
 	async handleLink(elem, [, id]) {
-		// Go get data
+		elem.type = 'IMAGE';
+		elem.imageId = id;
+		// On first expand, init data
+		elem.onFirstExpand = this.initExpando;
+	},
+	async initExpando(elem){
+
 		const data = await RESEnvironment.ajax({
 			url: 'https://noembed.com/embed',
-			data: { url: `http://xkcd.com/${id}/` }, // noembed doesn't believe in the HTTPS urls, so these need to be "http"
+			data: { url: `http://xkcd.com/${elem.imageId}/` }, // noembed doesn't believe in the HTTPS urls, so these need to be "http"
 			type: 'json'
 		});
 
@@ -16,7 +22,6 @@ addLibrary('mediaHosts', 'xkcd', {
 		const img = temp.querySelector('img');
 
 		// Set attributes
-		elem.type = 'IMAGE';
 		elem.imageTitle = img.getAttribute('alt');
 		elem.caption = img.getAttribute('title');
 		elem.src = img.getAttribute('src').replace('https://noembed.com/i/', ''); // remove noembed image proxy & link direct

--- a/lib/modules/hosts/xkcd.js
+++ b/lib/modules/hosts/xkcd.js
@@ -6,7 +6,7 @@ addLibrary('mediaHosts', 'xkcd', {
 		// Go get data
 		const data = await RESEnvironment.ajax({
 			url: 'https://noembed.com/embed',
-			data: { url: `http://xkcd.com/${id}/` }, // noembed doesn't believe in the HTTPS urls, so these need to be "http" 
+			data: { url: `http://xkcd.com/${id}/` }, // noembed doesn't believe in the HTTPS urls, so these need to be "http"
 			type: 'json'
 		});
 

--- a/lib/modules/hosts/xkcd.js
+++ b/lib/modules/hosts/xkcd.js
@@ -1,0 +1,24 @@
+addLibrary('mediaHosts', 'xkcd', {
+	domains: ['xkcd.com'],
+	attribution: false,
+	detect: href => (/^https?:\/\/(?:www\.|m\.)?xkcd\.com\/([0-9]+)/i).exec(href),
+	async handleLink(elem, [, id]) {
+		// Go get data
+		const data = await RESEnvironment.ajax({
+			url: 'https://noembed.com/embed',
+			data: { url: `http://xkcd.com/${id}/` }, // noembed doesn't believe in the HTTPS urls, so these need to be "http" 
+			type: 'json'
+		});
+
+		// documentFragment doesn't support innerHTML, so use div instead
+		const temp = document.createElement("div");
+		temp.innerHTML = data.html;
+		const img = temp.querySelector("img");
+
+		// Set attributes
+		elem.type = 'IMAGE';
+		elem.imageTitle = img.getAttribute("alt");
+		elem.caption = img.getAttribute("title");
+		elem.src = img.getAttribute("src").replace("https://noembed.com/i/", ""); // remove noembed image proxy & link direct
+	}
+});

--- a/lib/modules/hosts/xkcd.js
+++ b/lib/modules/hosts/xkcd.js
@@ -1,6 +1,6 @@
 addLibrary('mediaHosts', 'xkcd', {
 	domains: ['xkcd.com'],
-	attribution: false,
+	logo: 'https://xkcd.com/favicon.ico',
 	detect: href => (/^https?:\/\/(?:www\.|m\.)?xkcd\.com\/([0-9]+)/i).exec(href),
 	async handleLink(elem, [, id]) {
 		// Go get data

--- a/lib/modules/hosts/xkcd.js
+++ b/lib/modules/hosts/xkcd.js
@@ -11,14 +11,14 @@ addLibrary('mediaHosts', 'xkcd', {
 		});
 
 		// documentFragment doesn't support innerHTML, so use div instead
-		const temp = document.createElement("div");
+		const temp = document.createElement('div');
 		temp.innerHTML = data.html;
-		const img = temp.querySelector("img");
+		const img = temp.querySelector('img');
 
 		// Set attributes
 		elem.type = 'IMAGE';
-		elem.imageTitle = img.getAttribute("alt");
-		elem.caption = img.getAttribute("title");
-		elem.src = img.getAttribute("src").replace("https://noembed.com/i/", ""); // remove noembed image proxy & link direct
+		elem.imageTitle = img.getAttribute('alt');
+		elem.caption = img.getAttribute('title');
+		elem.src = img.getAttribute('src').replace('https://noembed.com/i/', ''); // remove noembed image proxy & link direct
 	}
 });

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -817,8 +817,15 @@ addModule('showImages', (module, moduleID) => {
 		updateParentHeight(expandoButton);
 	}
 
-	function generateImageExpando(expandoButton) {
+	async function generateImageExpando(expandoButton) {
+
 		const imageLink = expandoButton.imageLink;
+
+		// Handle init if needed
+		if (typeof imageLink.onFirstExpand === 'function'){
+			await imageLink.onFirstExpand(imageLink);
+		}
+
 		const which = imageLink.galleryStart || 0;
 
 		const imgDiv = document.createElement('div');

--- a/node/files.json
+++ b/node/files.json
@@ -78,6 +78,7 @@
 	],
 	"libraries": [
 		"modules/hosts/imgur.js",
+		"modules/hosts/xkcd.js",
 		"modules/hosts/pornbot.js",
 		"modules/hosts/coub.js",
 		"modules/hosts/uploadly.js",

--- a/safari/Info.plist
+++ b/safari/Info.plist
@@ -117,6 +117,7 @@
 				<string>modules/modhelper.js</string>
 				<string>modules/quickMessage.js</string>
 				<string>modules/hosts/imgur.js</string>
+				<string>modules/hosts/xkcd.js</string>
 				<string>modules/hosts/pornbot.js</string>
 				<string>modules/hosts/coub.js</string>
 				<string>modules/hosts/uploadly.js</string>


### PR DESCRIPTION
Hello,

This is essentially just a slightly altered version of https://github.com/honestbleeps/Reddit-Enhancement-Suite/pull/2815 . The relevant tweaks are in https://github.com/honestbleeps/Reddit-Enhancement-Suite/commit/f23bc78eadb265f32ef8e8e5ce2375ef4302a835

Effectively, the aim of this tweak is to try and avoid making unneeded API calls, as for example when hitting a page like https://www.reddit.com/r/xkcd the previous implementation would be kicking off 15 or so requests no noembed, while chances are I may only actually ever want to look at one or two of the comics.

The current implementation just adds an additional call in the `generateImageExpando` function to the `elem`'s onFirstLoad method, which then calls off and generates everything needs for the standard expando process to take place as normal.

If the approach sounds sane/useful - I'd be happy to add the functionality to all the Expando types. Additionally I'd be tempted to make it a "built in", but optional part of the mediahost's (so people could just add a method like the `initExpando` (unsure if thats a good name)) whenever they wanted to make use of it. (In my view whenever significant processing is needed, or interactions with external API's.

Anyways, just wanted to get a feel for what other people thought of the idea?
