### PR TITLE
UserTagger breaks if author href preceded by space

### DIFF
--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -678,6 +678,8 @@ addModule('userTagger', (module, moduleID) => {
 				const test = thisAuthorObj.href.match(module.usernameRE);
 				if (test) {
 					thisAuthor = test[1];
+				} else {
+					return console.error(`Regex failed on ${thisAuthorObj.href}, returning.`);
 				}
 			} else if (thisAuthorObj.getAttribute('data-user')) {
 				thisAuthor = thisAuthorObj.getAttribute('data-user');


### PR DESCRIPTION
[Issue report](https://www.reddit.com/r/RESissues/comments/4c43ww/bug_user_tagger_not_showing_in_sub_even_with/)

UserTagger breaks down when it finds a link formatted like so:

`[username](/u/ username)`