### PR TITLE
Force `bottom: auto` on .res-navTop

### DIFF
--- a/lib/css/modules/_styleTweaks.scss
+++ b/lib/css/modules/_styleTweaks.scss
@@ -67,7 +67,7 @@ body:not(.res-styleTweaks-visitedStyle) {
 	#header-bottom-right {
 		top: 19px;
 		border-radius: 0 0 0 3px;
-		bottom: auto;
+		bottom: auto !important;
 	}
 
 	.beta-notice {


### PR DESCRIPTION
This stops the glitch that causes `#header-bottom-right` to become as high as the header on a lot of subreddits. (this is caused by `top: 0` and `bottom: 0` being active at the same time)

It didn't used to do that until a couple of weeks ago, so the order of `<style>` tags must've moved around on reddit's end