### PR TITLE
readme: remove potentially misleading line about Gulp

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ Thinking about contributing to RES? Awesome! We just ask that you follow a few s
 
 ## Building development versions of the extension
 
-RES is built with [gulp](http://gulpjs.com/).
-
 First time installation:
 
 1. Install [node.js](http://nodejs.org) (version 4+).


### PR DESCRIPTION
It seems to imply that Gulp is one of the things you need to install manually, which is no longer the case.