### PR TITLE
Fix duplicating new comment counts

### DIFF
--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -269,47 +269,90 @@ addModule('newCommentCount', (module, moduleID) => {
 		});
 	}
 
-	function updateCommentCountFromMyComment() {
-		updateCommentCount(true);
+	function updateCommentCountFromMyComment(entry) {
+		const user = RESUtils.loggedInUser();
+		// don't update for user comment count, if detected new comment wasn't from the user
+		if (user && user === $(entry).find(".author").text()) {
+			updateCommentCount(true);
+		}
 	}
 
 	let currentCommentID;
 
-	function updateCommentCount(mycomment) {
-		const IDre = /\/r\/[\w]+\/comments\/([\w]+)\//i;
-		const matches = IDre.exec(location.href);
-		let currentCommentCount = 0;
-		if (matches) {
-			currentCommentID = matches[1];
-			const thisCount = document.querySelector('#siteTable a.comments');
-			if (thisCount) {
-				// split number from the word comments
-				currentCommentCount = thisCount.textContent.replace(/\D/g, '');
-				if (commentCounts[currentCommentID]) {
-					const prevCommentCount = commentCounts[currentCommentID].count;
-					const diff = currentCommentCount - prevCommentCount;
-					const $newString = $(`<span class="newComments">&nbsp;(${diff} new)</span>`);
-					if (diff > 0) $(thisCount).append($newString);
-				}
-				if (isNaN(currentCommentCount)) currentCommentCount = 0;
-				if (mycomment) currentCommentCount++;
-			}
-		}
-		const now = Date.now();
-		if (typeof commentCounts === 'undefined') {
-			commentCounts = {};
-		}
-		if (typeof commentCounts[currentCommentID] === 'undefined') {
-			commentCounts[currentCommentID] = {};
-		}
+	/**
+	 * save an updated CommentCount
+	 *
+	 * @param string commentID - ID of comment to store new count against
+	 * @param int newCommentCount - new number of comments to save
+	 * @return bool 
+	 */
+	function saveCommentCount(commentID, newCommentCount) {
+		// ensure objects exist
+		if (typeof commentCounts === 'undefined') commentCounts = {};
+		if (typeof commentCounts[commentID] === 'undefined') commentCounts[commentID] = {};
+
+		// create patch for change
 		const patch = {
-			count: currentCommentCount,
+			count: !isNaN(newCommentCount) ? newCommentCount : 0,
 			url: location.href.replace(location.hash, ''),
 			title: document.title,
-			updateTime: now
+			updateTime: Date.now()
 		};
-		Object.assign(commentCounts[currentCommentID], patch);
-		RESEnvironment.storage.patch('RESmodules.newCommentCount.counts', { [currentCommentID]: patch });
+		Object.assign(commentCounts[commentID], patch);
+		RESEnvironment.storage.patch('RESmodules.newCommentCount.counts', { [commentID]: patch });
+
+		return true;
+	}
+
+	/**
+	 * Show new comments count to user
+	 *
+	 * @param int currentCommentCount - number of comments found on this page
+	 */
+	function showNewComments(currentCommentCount) {
+		const prevCommentCount = commentCounts[currentCommentID].count;
+		const diff = currentCommentCount - prevCommentCount;
+		const $newString = $(`<span class="newComments">&nbsp;(${diff} new)</span>`);
+		if (diff > 0) $('#siteTable a.comments').append($newString);
+	}
+
+	/**
+	 * Handle updating page's comment counts
+	 *
+	 * @param bool mycomment - was this triggered by a users comments
+	 * @return bool 
+	 */
+	function updateCommentCount(mycomment) {
+
+		// If currentCommentID is already defined, comment counts for this page have already been stored
+		if (currentCommentID) {
+			if (mycomment) {
+				return saveCommentCount(currentCommentID, parseInt(commentCounts[currentCommentID].count) + 1);
+			}
+			return false;
+		}
+
+		// Check this is a comment page, and grab comment id
+		const IDre = /\/r\/[\w]+\/comments\/([\w]+)\//i;
+		const matches = IDre.exec(location.href);
+		
+		if (matches) {
+			// set comment id for general use
+			currentCommentID = matches[1];
+
+			// get new count of comments for this page
+			const thisCount = document.querySelector('#siteTable a.comments');
+			let currentCommentCount = thisCount.textContent.replace(/\D/g, '');
+
+			// if there was an old count, show "new" comment count to user
+			if (commentCounts[currentCommentID]) {
+				showNewComments(currentCommentCount);
+			}
+
+			// Update settings with new comment count
+			return saveCommentCount(currentCommentID, currentCommentCount);
+		}
+		return false;
 	}
 
 	async function cleanCache() {

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -272,7 +272,7 @@ addModule('newCommentCount', (module, moduleID) => {
 	function updateCommentCountFromMyComment(entry) {
 		const user = RESUtils.loggedInUser();
 		// don't update for user comment count, if detected new comment wasn't from the user
-		if (user && user === $(entry).find(".author").text()) {
+		if (user && user === $(entry).find('.author').text()) {
 			updateCommentCount(true);
 		}
 	}
@@ -282,9 +282,9 @@ addModule('newCommentCount', (module, moduleID) => {
 	/**
 	 * save an updated CommentCount
 	 *
-	 * @param string commentID - ID of comment to store new count against
-	 * @param int newCommentCount - new number of comments to save
-	 * @return bool 
+	 * @param {string} commentID - ID of comment to store new count against
+	 * @param {int} newCommentCount - new number of comments to save
+	 * @returns {bool}
 	 */
 	function saveCommentCount(commentID, newCommentCount) {
 		// ensure objects exist
@@ -307,7 +307,8 @@ addModule('newCommentCount', (module, moduleID) => {
 	/**
 	 * Show new comments count to user
 	 *
-	 * @param int currentCommentCount - number of comments found on this page
+	 * @param {int} currentCommentCount - number of comments found on this page
+	 * @returns {void}
 	 */
 	function showNewComments(currentCommentCount) {
 		const prevCommentCount = commentCounts[currentCommentID].count;
@@ -319,15 +320,14 @@ addModule('newCommentCount', (module, moduleID) => {
 	/**
 	 * Handle updating page's comment counts
 	 *
-	 * @param bool mycomment - was this triggered by a users comments
-	 * @return bool 
+	 * @param {bool} mycomment - was this triggered by a users comments
+	 * @returns {bool}
 	 */
 	function updateCommentCount(mycomment) {
-
 		// If currentCommentID is already defined, comment counts for this page have already been stored
 		if (currentCommentID) {
 			if (mycomment) {
-				return saveCommentCount(currentCommentID, parseInt(commentCounts[currentCommentID].count) + 1);
+				return saveCommentCount(currentCommentID, parseInt(commentCounts[currentCommentID].count) + 1, 10);
 			}
 			return false;
 		}
@@ -335,14 +335,14 @@ addModule('newCommentCount', (module, moduleID) => {
 		// Check this is a comment page, and grab comment id
 		const IDre = /\/r\/[\w]+\/comments\/([\w]+)\//i;
 		const matches = IDre.exec(location.href);
-		
+
 		if (matches) {
 			// set comment id for general use
 			currentCommentID = matches[1];
 
 			// get new count of comments for this page
 			const thisCount = document.querySelector('#siteTable a.comments');
-			let currentCommentCount = thisCount.textContent.replace(/\D/g, '');
+			const currentCommentCount = thisCount.textContent.replace(/\D/g, '');
 
 			// if there was an old count, show "new" comment count to user
 			if (commentCounts[currentCommentID]) {

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -313,8 +313,7 @@ addModule('newCommentCount', (module, moduleID) => {
 	function showNewComments(currentCommentCount) {
 		const prevCommentCount = commentCounts[currentCommentID].count;
 		const diff = currentCommentCount - prevCommentCount;
-		const $newString = $(`<span class="newComments">&nbsp;(${diff} new)</span>`);
-		if (diff > 0) $('#siteTable a.comments').append($newString);
+		if (diff > 0) $('#siteTable a.comments').append(`<span class="newComments">&nbsp;(${diff} new)</span>`);
 	}
 
 	/**

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -327,7 +327,7 @@ addModule('newCommentCount', (module, moduleID) => {
 		// If currentCommentID is already defined, comment counts for this page have already been stored
 		if (currentCommentID) {
 			if (mycomment) {
-				return saveCommentCount(currentCommentID, parseInt(commentCounts[currentCommentID].count) + 1, 10);
+				return saveCommentCount(currentCommentID, parseInt(commentCounts[currentCommentID].count, 10) + 1);
 			}
 			return false;
 		}

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -272,7 +272,7 @@ addModule('newCommentCount', (module, moduleID) => {
 	function updateCommentCountFromMyComment(entry) {
 		const user = RESUtils.loggedInUser();
 		// don't update for user comment count, if detected new comment wasn't from the user
-		if (user && user === $(entry).find('.author').text()) {
+		if (user && user === new RESUtils.thing(entry).getAuthor()) {
 			updateCommentCount(true);
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/honestbleeps/Reddit-Enhancement-Suite/issues/2867

It appears a couple of issues were at play with this one.

* The `updateCommentCountFromMyComment` didn't check that the new comments added were actually by the user (so expanding a collapsed comment would run the `updateCommentCount` logic multiple times)
* The `updateCommentCount` was appending a new "new comments" section each time it got run
* Also, it was counting the numbers within the new comment section (since .textContent returned the child text to), which is why the numbers went so crazy.


Have refactored it a bit (mostly to get my head around it), and it all appears to be working correctly for me.

* `updateCommentCountFromMyComment` - new checks the user is logged in & made the triggering post, before calling in to `updateCommentCount`
* `updateCommentCount` will check if `currentCommentID` is already defined, if so it will only allow the `mycomment` logic to run, thus ensures the rest can't be rerun accidentally.
* "mycomment" mode just increments the counter and calls save.
* save count logic and show count logic now live in there own functions.

Hope this all looks sane :)