### PR TITLE
Sort imageList before showing all

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -495,11 +495,13 @@ addModule('showImages', (module, moduleID) => {
 	}
 
 	function updateRevealedImages(type) {
-		for (const image of imageList) {
-			if ($(image).hasClass(type) || image.imageLink.expandOnViewAll) {
-				revealImage(image, findImageFilter(image.imageLink));
-			}
-		}
+		const imagesReveal = imageList
+			.filter(v => v.classList.contains(type) || v.imageLink.expandOnViewAll)
+			.map(v => [v.getBoundingClientRect().top, v])
+			.sort((a, b) => a[0] - b[0])
+			.map(v => v[1]);
+
+		RESUtils.forEachChunked(imagesReveal, image => { revealImage(image, findImageFilter(image.imageLink)); });
 	}
 
 	function findImageFilter(image) {


### PR DESCRIPTION
Reduces the time before the first image is shown after clicking "Show images", since the `imageList` array may be unordered due to async media-hosts.