### PR TITLE
Tolerate status 0 for ajax requests

### DIFF
--- a/lib/browsersupport.js
+++ b/lib/browsersupport.js
@@ -140,7 +140,8 @@ const RESEnvironment = {
 				response = request;
 			}
 
-			if (response.status !== 200) {
+			// some browsers (Edge, Safari) set status to 0 for local resources
+			if (response.status !== 200 && response.status !== 0) {
 				throw new Error(`XHR status ${response.status} - url: ${url}`);
 			}
 

--- a/safari/background.js
+++ b/safari/background.js
@@ -172,8 +172,7 @@ addListener('ajax', async ({ method, url, headers, data, credentials }) => {
 
 	// Only store `status`, `responseText` and `responseURL` fields
 	return {
-		// Safari doesn't set status on requests for local resources...
-		status: request.status === 0 ? 200 : request.status,
+		status: request.status,
 		responseText: request.responseText,
 		responseURL: request.responseURL
 	};


### PR DESCRIPTION
Safari and Edge set the status to 0 for local resources.
jQuery also tolerates this: https://github.com/jquery/jquery/blob/91850ecbbe04ad8f5d89dc050aa1d9002047c435/src/ajax/xhr.js#L16

Related: #2880