### PR TITLE
ShowImages tweaks

### DIFF
--- a/lib/core/templates.html
+++ b/lib/core/templates.html
@@ -296,6 +296,7 @@
 
 		<!-- Media Controls -->
 		<script id="mediaControls" type="application/x-template">
+			<span class="res-icon gearIcon" title="Settings" data-action="showImageSettings"></span>
 			<span class="rotateLeft res-icon" title="Rotate image counter-clockwise" data-action="rotateLeft"></span>
 			<span class="rotateRight res-icon" title="Rotate image clockwise" data-action="rotateRight"></span>
 			<span class="imageLookup res-icon" title="Reverse image seach" data-action="imageLookup"></span>

--- a/lib/core/templates.html
+++ b/lib/core/templates.html
@@ -316,11 +316,13 @@
 		<!--video-advanced-->
 		<script id="video-advanced" type="application/x-template">
 			<div class="res-player video video-advanced">
-				<video {{#controls}}controls{{/controls}} {{#autoplay}}autoplay{{/autoplay}} {{#muted}}muted{{/muted}} {{#loop}}loop{{/loop}} poster="{{ poster }}">
-					{{#sources}}
-					<source src="{{ source }}" {{#type}}type="{{ type }}"{{/type}} {{#reverse}}data-reverse="{{ reverse }}"{{/reverse}}>
-					{{/sources}}
-				</video>
+				<a class="madeVisible" target="_blank" href="{{href}}">
+					<video {{#controls}}controls{{/controls}} {{#autoplay}}autoplay{{/autoplay}} {{#muted}}muted{{/muted}} {{#loop}}loop{{/loop}} poster="{{ poster }}">
+						{{#sources}}
+						<source src="{{ source }}" {{#type}}type="{{ type }}"{{/type}} {{#reverse}}data-reverse="{{ reverse }}"{{/reverse}}>
+						{{/sources}}
+					</video>
+				</a>
 				<div class="video-advanced-interface">
 					<div class="video-advanced-progress">
 						<div class="video-advanced-position"></div>

--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -227,8 +227,8 @@ div.madeVisible {
 .RESMediaControls {
 	position: absolute;
 	z-index: 2;
-	border: solid 1px #eee;
-	background: rgba(255, 255, 255, .8);
+	border: 0;
+	background: rgba(0, 0, 0, .3);
 	cursor: pointer;
 
 	// Support multiple positions. top left is default
@@ -259,7 +259,16 @@ div.madeVisible {
 		color: #000;
 
 		&:hover {
-			background: rgba(255, 255, 255, .9);
+			background: rgba(30, 30, 30, .3);
+		}
+
+		&::after {
+			// particularly for .gearIcon
+			color: #eee;
+		}
+
+		&:hover::after {
+			color: #fff;
 		}
 
 		&.rotateLeft {

--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -227,7 +227,7 @@ div.madeVisible {
 .RESMediaControls {
 	position: absolute;
 	z-index: 2;
-	border: 0;
+	border: none;
 	background: rgba(0, 0, 0, .3);
 	cursor: pointer;
 

--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -6,8 +6,21 @@ addLibrary('mediaHosts', 'imgur', {
 			description: 'Prefer RES support for imgur albums rather than reddit\'s built in support',
 			value: true,
 			type: 'boolean'
+		},
+		'preferredImgurLink': {
+			description: 'Which view to request when following a link to imgur.',
+			type: 'enum',
+			value: 'share',
+			values: [{
+				name: 'full page (imgur.com)',
+				value: 'share'
+			}, {
+				name: 'direct image (i.imgur.com)',
+				value: 'direct'
+			}]
 		}
 	},
+	baseURL: 'http://imgur.com/',
 	cdnURL: '//i.imgur.com/',
 	apiPrefix: 'https://api.imgur.com/3/',
 	apiID: '1d8d9b36339e0e2',
@@ -175,8 +188,11 @@ addLibrary('mediaHosts', 'imgur', {
 		};
 	},
 	_handleSingleImage(elem, info) {
+		const siteMod = modules['showImages'].siteModules['imgur'];
+		const baseURL = siteMod.baseURL;
 		return Promise.resolve({
 			src: info.link.replace('http:', 'https:'),
+			href: modules['showImages'].options['preferredImgurLink'].value === 'share' ? `${baseURL}${info.id}` : `${info.link}`,
 			type: 'IMAGE',
 			caption: info.caption,
 			title: info.title
@@ -193,12 +209,8 @@ addLibrary('mediaHosts', 'imgur', {
 		};
 
 		expandoInfo.src = await Promise.all(info.images.map(async info => {
-			const expandoInfo = {
-				href: `${base}#${info.id}`
-			};
-
-			$.extend(true, expandoInfo, await siteMod._handleSingleImage(elem, info));
-
+			const expandoInfo = await siteMod._handleSingleImage(elem, info);
+			expandoInfo.href = modules['showImages'].options['preferredImgurLink'].value === 'share' ? `${base}#${info.id}` : `${info.link}`;
 			return expandoInfo;
 		}));
 
@@ -218,12 +230,15 @@ addLibrary('mediaHosts', 'imgur', {
 		return expandoInfo;
 	},
 	_handleGifv(elem, info) {
+		const siteMod = modules['showImages'].siteModules['imgur'];
+		const baseURL = siteMod.baseURL;
 		const expandoInfo = {};
 
 		expandoInfo.type = 'VIDEO';
 		expandoInfo.expandoOptions = {
 			autoplay: true, // imgurgifv will always be muted, so autoplay is OK
 			controls: false,
+			href: modules['showImages'].options['preferredImgurLink'].value === 'share' ? `${baseURL}${info.id}` : `${info.link}`,
 			downloadurl: info.download,
 			fallback: info.link,
 			loop: true,

--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -161,7 +161,7 @@ addLibrary('mediaHosts', 'imgur', {
 				animated: false,
 				looping: false,
 				ext: extension,
-				link: cdnURL + hash + extension,
+				link: `${cdnURL}${hash}${extension}`,
 				type: mimeType
 			});
 		}

--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -194,8 +194,6 @@ addLibrary('mediaHosts', 'imgur', {
 
 		expandoInfo.src = await Promise.all(info.images.map(async info => {
 			const expandoInfo = {
-				title: info.title,
-				caption: info.description,
 				href: `${base}#${info.id}`
 			};
 

--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -7,7 +7,7 @@ addLibrary('mediaHosts', 'imgur', {
 			value: true,
 			type: 'boolean'
 		},
-		'preferredImgurLink': {
+		preferredImgurLink: {
 			description: 'Which view to request when following a link to imgur.',
 			type: 'enum',
 			value: 'share',

--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -152,7 +152,7 @@ addLibrary('mediaHosts', 'imgur', {
 				gifv: `${cdnURL}${hash}.gifv`,
 				webm: `${cdnURL}${hash}.webm`,
 				mp4: `${cdnURL}${hash}.mp4`,
-				link: `${cdnURL}${hash}.gif`,
+				link: `${cdnURL}${hash}.gifv`,
 				download: `${cdnURL}download/${hash}`
 			});
 		} else {

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1218,6 +1218,7 @@ addModule('showImages', (module, moduleID) => {
 			playbackRate: 1,
 			reversable: false,
 			time: 0,
+			href: expandoButton.imageLink.href,
 			...options
 		};
 

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1508,6 +1508,9 @@ addModule('showImages', (module, moduleID) => {
 
 					RESEnvironment.openNewTab(`https://images.google.com/searchbyimage?image_url=${lookupUrl}`);
 					break;
+				case 'showImageSettings':
+					modules['settingsNavigation'].loadSettingsPage(moduleID, 'mediaControls');
+					break;
 				default:
 					// do nothing if action is unknown
 					break;


### PR DESCRIPTION
<img width="171" alt="screen shot 2016-04-13 at 5 15 18 am" src="https://cloud.githubusercontent.com/assets/455632/14493071/48dbd846-0138-11e6-8348-6d903efdfc0f.png">

* Settings butto added to media controls
* Media controls now white on black
* Imgur Images/albums/gifvs link to imgur share page, optionally link to direct images instead
* imgur gif(v)s link to gifv, imgur can sort it out
* bring back clickable link on videos

