### PR TITLE
appveyor: only test node 5

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 environment:
   matrix:
     - nodejs_version: '5'
-    - nodejs_version: '4'
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install -g npm@latest || (timeout 30 && npm install -g npm@latest)


### PR DESCRIPTION
This is already covered by Travis, and all we really need to know from Appveyor is that _something_ works on Windows, so remove the Node 4 test for performance.