### PR TITLE
Update #2572: Improved commentHoverBorder

### DIFF
--- a/lib/css/modules/_commentBoxes.scss
+++ b/lib/css/modules/_commentBoxes.scss
@@ -42,6 +42,6 @@
 	}
 
 	&.res-commentHoverBorder .content .comment:hover {
-		border: 1px solid #99AAEE !important;
+		border-color: #99AAEE !important;
 	}
 }

--- a/lib/css/res.scss
+++ b/lib/css/res.scss
@@ -603,12 +603,12 @@ div.usertext-edit {
 
 	tr .deleteButton,
 	.builderWrap .deleteButton {
-		opacity: 0.3;
+		opacity: .3;
 	}
 
 	tr:hover .deleteButton,
 	.builderWrap:hover > .builderTrailingControls .deleteButton {
-		opacity: 1.0;
+		opacity: 1;
 	}
 
 	.handle {


### PR DESCRIPTION
Closes #2572.

Uses `border-color` instead of `outline`.