### PR TITLE
Rebase #2385: Resume pause when clicking "Open Next Page"

### DIFF
--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -113,16 +113,18 @@ addModule('neverEndingReddit', (module, moduleID) => {
 			NREPause = RESUtils.createElement('div', 'NREPause');
 			NREPause.setAttribute('title', 'Pause / Restart Never Ending Reddit');
 			if (this.options.reversePauseIcon.value) NREPause.classList.add('reversePause');
-			if (isPaused) NREPause.classList.add('paused');
-			NREPause.addEventListener('click', togglePause, false);
+
+			togglePause(isPaused);
+			NREPause.addEventListener('click', () => togglePause(!isPaused));
+
 			modules['floater'].addElement(NREPause);
 		}
 	};
 
 	const pageMarkers = [];
 
-	function togglePause() {
-		isPaused = !isPaused;
+	function togglePause(pause) {
+		isPaused = pause;
 		if (isPaused) {
 			RESEnvironment.storage.set('RESmodules.neverEndingReddit.isPaused', isPaused);
 		} else {
@@ -319,7 +321,9 @@ addModule('neverEndingReddit', (module, moduleID) => {
 			.appendTo(module.progressIndicator);
 
 		const nextpage = $('<a id="NERStaticLink">or open next page</a>')
-			.attr('href', module.nextPageURL);
+			.attr('href', module.nextPageURL)
+			.click(() => togglePause(false)); // resume pause on a new page
+
 		$('<p class="NERWidgetText" />').append(nextpage)
 			.append('&nbsp;(and clear Never-Ending stream)')
 			.appendTo(module.progressIndicator);


### PR DESCRIPTION
Closes #2385.

Also happens to partially fix #2869 - by calling `togglePause` in `go()`, the message in the banner is properly updated when NER is paused.