### PR TITLE
Separate gallery from image

### DIFF
--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { $ } from '../vendor';
 import * as Metadata from './metadata';
 import * as Modules from './modules';
@@ -90,8 +89,8 @@ export const loadOptions = loadDynamicOptions
 		_loadModulePrefs(),
 	]));
 
-export const addOptionsBodyClasses = loadOptions
-	.then(() => _addOptionsBodyClasses());
+export const addModuleBodyClasses = loadOptions
+	.then(() => _addModuleBodyClasses());
 
 export const always = Promise.all([loadOptions, headReady])
 	.then(() => allModules('always'));
@@ -126,15 +125,17 @@ function allModules(key, checkShouldRun = false) {
 	);
 }
 
-// Adds body classes for enabled options that have `bodyClass: true`
+// Adds body classes for modules or enabled options that have `bodyClass: true`
 // In the form `res-moduleId-optionKey` for boolean options
 // and `res-moduleId-optionKey-optionValue` for enum options
 // spaces in enum option values will be replaced with underscores
-function _addOptionsBodyClasses() {
+function _addModuleBodyClasses() {
 	for (const module of Modules.all()) {
-		if (!Modules.isRunning(module) || _.isEmpty(module.options)) continue;
+		if (!Modules.isRunning(module)) continue;
 
-		for (const [optId, opt] of Object.entries(module.options)) {
+		if (module.bodyClass) BodyClasses.add(`res-${module.moduleID}`);
+
+		for (const [optId, opt] of Object.entries(module.options || {})) {
 			if (!(opt.bodyClass && opt.value)) continue;
 
 			if (opt.type !== 'enum' && opt.type !== 'boolean') {
@@ -219,6 +220,6 @@ function setupProfiling() {
 		`beforeLoad stalled for ${diff('headReady', 'loadOptions')}`,
 		`go stalled for ${diff('bodyReady', 'beforeLoad')}`,
 		`afterLoad stalled for ${diff('contentLoaded', 'go')}`,
-		`addOptionsBodyClasses was late by ${diff('bodyStart', 'loadOptions')}`,
+		`addModuleBodyClasses was late by ${diff('bodyStart', 'loadOptions')}`,
 	].reduce((acc, line) => `${acc}<div>${line}</div>`, '')));
 }

--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -217,6 +217,12 @@ img {
 		display: none !important;
 	}
 
+	.res-title,
+	.res-caption,
+	.res-credits {
+		max-width: 700px;
+	}
+
 	.res-title {
 		font-size: 13px;
 	}
@@ -232,18 +238,12 @@ img {
 }
 
 .res-gallery {
-	.res-gallery-title,
-	.res-gallery-caption {
-		max-width: 700px;
-	}
-
 	.res-gallery-title {
 		margin: 3px;
 		font-size: 15px;
 	}
 
 	.res-gallery-caption {
-		max-width: 700px;
 		margin-bottom: 3px;
 		font-size: 12px;
 	}
@@ -289,11 +289,6 @@ img {
 .res-image {
 	a {
 		display: inline-block;
-	}
-
-	.res-image-title,
-	.res-image-caption {
-		max-width: 700px;
 	}
 
 	.res-image-media {

--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -72,24 +72,10 @@ img {
 	&.video-muted.expanded:hover { background-position: 0 _(11); }
 }
 
-.madeVisible {
-	clear: left;
-	display: block;
-	overflow: hidden;
-	user-select: none;
-
-	&.usertext-body {
-		user-select: text; // Allow selection if is a text expando
-	}
-
-	a.madeVisible {
-		display: inline-block;
-		overflow: hidden;
-	}
-}
-
 .res-expando-siteAttribution {
-	.madeVisible > & {
+	display: block;
+
+	.res-expando > & {
 		clear: left;
 		margin: .5em;
 
@@ -108,119 +94,17 @@ img {
 	}
 }
 
-.RESImage {
-	display: block !important;
-
-	&.loaded {
-		position: absolute;
-	}
-
-	&.RESImageError {
-		content: '';
-
-		&::after {
-			content: 'Loading of image ' attr(src) ' failed. Click to view directly';
-		}
-	}
-}
-
-.RESImagePlaceholder {
-	float: left;
-	display: block !important;
-}
-
 .RESdupeimg {
 	color: #000;
 	font-size: 10px;
 	user-select: none;
 }
 
-.RESClear {
-	clear: both;
-	margin-bottom: 10px;
-}
-
-.RESGalleryControls {
-	margin-bottom: 10px;
-
-	span {
-		line-height: 16px;
-		vertical-align: bottom;
-		padding: 0 5px;
-		font-size: 11px;
-	}
-
-	.next,
-	.previous {
-		&::after {
-			font: normal 18px/16px Batch;
-			content: '\F158';
-			cursor: pointer;
-			display: inline-block;
-			vertical-align: middle;
-			color: #90acff;
-			width: 16px;
-		}
-
-		&:hover::after {
-			color: #6286f4;
-		}
-	}
-
-	.end::after {
-		content: '\F157';
-	}
-
-	.next:not(.end)::after,
-	.previous.end::after {
-		transform: scaleX(-1);
-	}
-}
-
-.imgTitle,
-.md h3.imgTitle {
-	font-size: 13px;
-	margin: 0;
-}
-
-h4.imgCaptions,
-.md h4.imgCaptions {
-	font-size: 11px;
-	font-weight: bold;
-	margin: 0;
-}
-
-div.imgCaptions,
-.md div.imgCaptions {
-	font-size: 11px;
-	white-space: pre-wrap;
-}
-
-.imgCredits {
-	font-size: 11px;
-	padding: 2px;
-}
-
-body:not(.res-showImages-displayImageCaptions) {
-	.imgTitle,
-	.imgCaptions {
-		display: none;
-	}
-}
-
-a.madeVisible,
-div.madeVisible {
+.res-media-rotatable,
+.res-media-movable {
 	position: relative;
-
-	.RESMediaControls {
-		opacity: 0;
-	}
-
-	&:hover .RESMediaControls {
-		opacity: .8;
-		transition: opacity 300ms;
-	}
 }
+
 
 .RESMediaControls {
 	position: absolute;
@@ -255,6 +139,7 @@ div.madeVisible {
 		vertical-align: middle;
 		font-size: 1rem;
 		color: #000;
+		cursor: pointer;
 
 		&:hover {
 			background: rgba(30, 30, 30, .3);
@@ -285,22 +170,152 @@ div.madeVisible {
 			content: '\F178';
 		}
 	}
-}
 
-.res-player {
-	position: absolute;
+	.res-media-rotatable & {
+		opacity: 0;
+	}
 
-	// Hide "lookup" button on video's
-	.RESMediaControls .imageLookup {
+	.res-media-rotatable:hover & {
+		opacity: .8;
+		transition: opacity 300ms;
+	}
+
+	.res-media-load-error ~ & {
 		display: none;
 	}
 }
 
-// video-advanced
-.video-advanced {
-	overflow: hidden;
+.res-expando {
+	display: block;
 
-	> a.madeVisible,
+	.usertext-body {
+		user-select: text; // Allow selection if is a text expando
+	}
+
+	.res-expando-media {
+		display: inline-block;
+
+		.usertext-body &,
+		.selftext.expanded ~ * & {
+			max-width: 100%;
+		}
+	}
+
+	.res-expando-independent {
+		z-index: 1;
+		position: absolute;
+	}
+
+	&[hidden],
+	[hidden] {
+		display: none !important;
+	}
+
+	.res-title {
+		font-size: 13px;
+	}
+
+	.res-caption {
+		font-size: 11px;
+		white-space: pre-wrap;
+	}
+
+	.res-credits {
+		font-size: 10px;
+	}
+}
+
+// Override native expando-class, since it restricts the size of inner expandos
+.expando {
+	position: initial !important;
+}
+
+.res-gallery {
+	.res-gallery-title,
+	.res-gallery-caption {
+		max-width: 700px;
+	}
+
+	.res-gallery-title {
+		margin: 3px;
+		font-size: 15px;
+	}
+
+	.res-gallery-caption {
+		max-width: 700px;
+		margin-bottom: 3px;
+		font-size: 12px;
+	}
+
+	.res-gallery-individual-controls {
+		display: flex;
+		align-items: center;
+		margin: 4px 0 4px 10px;
+
+		&[last-piece=true] .res-gallery-next::after,
+		&[first-piece=true] .res-gallery-prev::after {
+			content: '\F157';
+		}
+
+		&[last-piece=false] .res-gallery-next::after,
+		&[last-piece=true] .res-gallery-prev::after {
+			transform: scaleX(-1);
+		}
+	}
+
+	.res-gallery-below {
+		margin: 0 5px 5px 5px;
+		font-size: 11px;
+
+		> div {
+			display: flex;
+			justify-content: space-between;
+			padding-top: 3px;
+		}
+
+		.res-gallery-increase-concurrent {
+			cursor: pointer;
+		}
+	}
+
+	&:not(.res-gallery-slideshow) {
+		.res-gallery-individual-controls {
+			display: none;
+		}
+	}
+}
+
+.res-image {
+	a {
+		display: inline-block;
+	}
+
+	.res-image-title,
+	.res-image-caption {
+		max-width: 700px;
+	}
+
+	.res-image-media {
+		display: block !important;
+		user-select: none;
+
+		&.res-media-load-error {
+			content: '';
+
+			&::after {
+				content: 'Loading of image ' attr(src) ' failed. Click to view directly';
+			}
+		}
+	}
+}
+
+.video-advanced {
+	.video-advanced-container {
+		overflow: hidden;
+		position: relative;
+		display: inline-block;
+	}
+
 	video {
 		display: block;
 	}
@@ -443,10 +458,6 @@ div.madeVisible {
 		width: 100%;
 	}
 
-	[hidden] {
-		display: none !important;
-	}
-
 	&.playing .video-advanced-toggle-pause::after { content: '\f16c'; }
 	&:not(.playing) .video-advanced-toggle-pause::after { content: '\f16b'; }
 
@@ -462,7 +473,7 @@ div.madeVisible {
 }
 
 // style expando text content in comments
-.commentarea div.usertext-body.madeVisible .md {
+.commentarea .res-expando div.usertext-body .md {
 	background-color: #fafafa;
 	border: 1px solid #369;
 	border-radius: 7px;

--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -186,8 +186,8 @@ img {
 		transition: opacity 300ms;
 	}
 
-	.res-media-load-error ~ & {
-		display: none;
+	.res-media-load-error & {
+		display: none !important;
 	}
 }
 
@@ -204,6 +204,10 @@ img {
 		.usertext-body &,
 		.selftext.expanded ~ * & {
 			max-width: 100%;
+		}
+
+		> * {
+			display: inline-block;
 		}
 	}
 
@@ -295,7 +299,7 @@ img {
 		display: block !important;
 		user-select: none;
 
-		&.res-media-load-error {
+		@at-root .res-media-load-error#{&} {
 			content: '';
 
 			&::after {

--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -1,3 +1,9 @@
+.res-showImages {
+	// Override native expando-class, since it restricts the size of inner expandos
+	.expando {
+		position: initial !important;
+	}
+}
 
 //Image Viewer
 img {
@@ -225,11 +231,6 @@ img {
 	}
 }
 
-// Override native expando-class, since it restricts the size of inner expandos
-.expando {
-	position: initial !important;
-}
-
 .res-gallery {
 	.res-gallery-title,
 	.res-gallery-caption {
@@ -253,12 +254,12 @@ img {
 		margin: 4px 0 4px 10px;
 
 		&[last-piece=true] .res-gallery-next::after,
-		&[first-piece=true] .res-gallery-prev::after {
+		&[first-piece=true] .res-gallery-previous::after {
 			content: '\F157';
 		}
 
-		&[last-piece=false] .res-gallery-next::after,
-		&[last-piece=true] .res-gallery-prev::after {
+		&[last-piece=true] .res-gallery-next,
+		&[first-piece=true] .res-gallery-previous {
 			transform: scaleX(-1);
 		}
 	}
@@ -314,6 +315,14 @@ img {
 		overflow: hidden;
 		position: relative;
 		display: inline-block;
+
+		&:hover .video-advanced-interface:not(.video-advanced-push-below) {
+			display: block;
+			background: linear-gradient(rgba(255, 255, 255, 0), rgba(0, 0, 0, .6));
+			position: absolute;
+			bottom: 0;
+			width: 100%;
+		}
 	}
 
 	video {
@@ -392,7 +401,7 @@ img {
 			}
 
 			.video-advanced-error {
-				color: red;
+				color: coral;
 			}
 
 			.video-advanced-controls {
@@ -448,14 +457,6 @@ img {
 				display: none !important;
 			}
 		}
-	}
-
-	&:hover .video-advanced-interface:not(.video-advanced-push-below) {
-		display: block;
-		background: linear-gradient(rgba(255, 255, 255, 0), rgba(0, 0, 0, .6));
-		position: absolute;
-		bottom: 0;
-		width: 100%;
 	}
 
 	&.playing .video-advanced-toggle-pause::after { content: '\f16c'; }

--- a/lib/css/res.scss
+++ b/lib/css/res.scss
@@ -1867,3 +1867,29 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 		margin: .75em 0;
 	}
 }
+
+.res-step {
+	&::after {
+		font: normal 18px/16px Batch;
+		content: '\F158';
+		cursor: pointer;
+		display: inline-block;
+		vertical-align: middle;
+		color: #90acff;
+		width: 16px;
+	}
+
+	&:hover::after {
+		color: #6286f4;
+	}
+
+	&.res-step-reverse::after {
+		transform: scaleX(-1);
+	}
+}
+
+.res-step-progress {
+	font-size: 13px;
+	min-width: 60px;
+	text-align: center;
+}

--- a/lib/modules/hosts/defaultAudio.js
+++ b/lib/modules/hosts/defaultAudio.js
@@ -1,5 +1,3 @@
-import { $ } from '../../vendor';
-
 export default {
 	moduleID: 'defaultAudio',
 	name: 'defaultAudio',
@@ -32,11 +30,10 @@ export default {
 		elem.expandoOptions = {
 			autoplay: true,
 			loop: false,
+			sources: [{
+				file: elem.href,
+				type: format,
+			}],
 		};
-
-		$(elem).data('sources', [{
-			file: elem.href,
-			type: format,
-		}]);
 	},
 };

--- a/lib/modules/hosts/onedrive.js
+++ b/lib/modules/hosts/onedrive.js
@@ -1,4 +1,3 @@
-import { $ } from '../../vendor';
 import { DAY } from '../../utils';
 import { Permissions, ajax } from '../../environment';
 
@@ -99,11 +98,11 @@ export default {
 					elem.expandoOptions = {
 						autoplay: true,
 						loop: false,
+						sources: [{
+							file: json['@content.downloadUrl'],
+							type: json.file.mimeType,
+						}],
 					};
-					$(elem).data('sources', [{
-						file: json['@content.downloadUrl'],
-						type: json.file.mimeType,
-					}]);
 					break;
 				default:
 					throw new Error(`Invalid type: ${type}`);

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1104,7 +1104,7 @@ function imageResize(factor) {
 	const selected = SelectedEntry.selectedEle();
 	if (!selected) return;
 
-	const images = $(selected.entry).find('.RESImage, .madeVisible video');
+	const images = $(selected.entry).find('.res-media-resizable');
 
 	for (const image of Array.from(images)) {
 		const thisWidth = $(image).width();
@@ -1141,7 +1141,7 @@ module.imageMoveRight = function() {
 };
 
 function imageMove(deltaX, deltaY) {
-	const images = $(document).find('.RESImage');
+	const images = $(document).find('.res-media-movable');
 	if (images.length === 0) {
 		return false;
 	}
@@ -1165,7 +1165,7 @@ module.previousGalleryImage = function() {
 	const selected = SelectedEntry.selectedEle();
 	if (!selected) return;
 
-	const previousButton = selected.entry.querySelector('.RESGalleryControls .previous');
+	const previousButton = selected.entry.querySelector('.res-gallery-previous');
 	if (previousButton) {
 		click(previousButton);
 	}
@@ -1175,7 +1175,7 @@ module.nextGalleryImage = function() {
 	const selected = SelectedEntry.selectedEle();
 	if (!selected) return;
 
-	const nextButton = selected.entry.querySelector('.RESGalleryControls .next');
+	const nextButton = selected.entry.querySelector('.res-gallery-next');
 	if (nextButton) {
 		click(nextButton);
 	}
@@ -1515,7 +1515,7 @@ function getCommentLinks(entry) {
 		entry = selected && selected.entry;
 	}
 
-	return Array.from(entry.querySelectorAll('div.md a:not(.expando-button):not(.madeVisible):not(.toggleImage):not(.noKeyNav):not([href^="javascript:"]):not([href="#"])'))
+	return Array.from(entry.querySelectorAll('div.md a:not(.expando-button):not(.toggleImage):not(.noKeyNav):not([href^="javascript:"]):not([href="#"])'))
 		.filter(link => !isCommentCode(link) && !isEmptyLink(link));
 }
 

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -48,6 +48,7 @@ module.moduleID = 'showImages';
 module.moduleName = 'Inline Image Viewer';
 module.category = ['Productivity', 'Browsing'];
 module.description = 'Opens images inline in your browser with the click of a button. Also has configuration options, check it out!';
+module.bodyClass = true;
 module.options = {
 	conserveMemory: {
 		type: 'boolean',
@@ -56,8 +57,8 @@ module.options = {
 	},
 	preloadImages: {
 		type: 'boolean',
-		value: false,
-		description: 'Preload gallery images for faster browsing. Beware: this is at the expense of lots of bandwidth usage.',
+		value: true,
+		description: 'Preload 2 gallery pieces for faster browsing.',
 	},
 	bufferScreens: {
 		type: 'text',
@@ -366,8 +367,8 @@ function enableConserveMemory() {
 		const minimumBottom = viewportHeight * bufferScreens * -1;
 
 		const isWithinBuffer = ele => {
-			const boundingBox = ele.getBoundingClientRect();
-			return boundingBox.top <= maximumTop && boundingBox.bottom >= minimumBottom;
+			const { bottom, top } = ele.getBoundingClientRect();
+			return top <= maximumTop && bottom >= minimumBottom;
 		};
 
 		// Destroy collapsed when beyond buffer
@@ -910,7 +911,7 @@ async function rewriteMediaHostOptions(imageLink) {
 		imageLink.type = 'GALLERY';
 	}
 
-	// TODO This ought to be placed somewhere more suitable, as site attribution is not updated
+	// This ought to be placed somewhere more suitable, as site attribution is not updated
 	if (module.options.convertGifstoGfycat.value &&
 		imageLink.type === 'IMAGE' &&
 		(/^(http|https|ftp):\/\/.*\.gif($|\/?)/).test(imageLink.src)) {
@@ -935,7 +936,7 @@ async function rewriteMediaHostOptions(imageLink) {
 		site: imageLink.site,
 		src: imageLink.src,
 		// $.extend on some mediaHosts causes null to be converted to a string on title
-		title: imageLink.imageTitle || (imageLink.title === "null" ? null : imageLink.title),
+		title: imageLink.imageTitle || (imageLink.title === 'null' ? null : imageLink.title),
 		type: imageLink.type,
 		...imageLink.expandoOptions,
 	};
@@ -948,43 +949,33 @@ async function rewriteMediaHostOptions(imageLink) {
 	}
 
 	if (options.type === 'TEXT') {
-		// filter out iframes, as they will not survive safeHTML
-		// TODO: make safeHTML handle iframes acceptably?
-		options.src = options.src.replace(/<iframe/ig, '&lt;iframe');
 		const html = $('<span>').safeHtml(options.src);
 		options.src = html ? html.html() : '';
 	}
 
-	if (options.type === 'AUDIO' && typeof imageLink.src === 'undefined') {
+	if (options.type === 'AUDIO' && typeof imageLink.sources === 'undefined') {
 		options.sources = $(imageLink).data('sources');
 	}
 
 	if (options.type === 'IFRAME') {
 		options = {
-			...options,
 			pause: imageLink.getAttribute('data-pause'),
 			play: imageLink.getAttribute('data-play'),
 			width: imageLink.getAttribute('data-width'),
 			maxwidth: imageLink.getAttribute('data-maxwidth'),
 			height: imageLink.getAttribute('data-height'),
 			embed: imageLink.getAttribute('data-embed'),
-		};
-	}
-
-	if (options.type === 'GENERIC_EXPANDO') {
-		options = {
 			...options,
-			...imageLink.expandoOptions,
 		};
 	}
 
 	if (options.type === 'GALLERY') {
-		options.pieces = await Promise.all(options.src.map(async piece => {
-			// TODO Fix mediaHosts (onedrive, min.us, etc) which does not provide type for the individual pieces
+		options.pieces = await Promise.all(options.src.map(piece => {
+			// Fix mediaHosts (onedrive, min.us, etc) which does not provide type for the individual pieces
 			piece.type = piece.type || 'IMAGE';
 			piece.href = piece.href || piece.src;
 
-			return await rewriteMediaHostOptions(piece);
+			return rewriteMediaHostOptions(piece);
 		}));
 	}
 
@@ -994,7 +985,7 @@ async function rewriteMediaHostOptions(imageLink) {
 async function buildExpandoBox(expandoButton) {
 	const imageLink = expandoButton.imageLink;
 	const options = {
-		loadHeight: 50,
+		loadHeight: 20, // gives an indication that the expando is opened
 		textMaxWidth: imageLink.parentElement.getBoundingClientRect().width,
 	};
 
@@ -1066,7 +1057,6 @@ function generateGallery(options) {
 	const msgPosition = individualCtrl.querySelector('.res-gallery-position');
 	const ctrlConcurrentIncrease = element.querySelector('.res-gallery-increase-concurrent');
 
-	// TODO Preload all, as earlier implementation does?
 	const preloadCount = module.options.preloadImages.value ? 2 : 0;
 
 	const filmstripActive = module.options.loadAllInAlbum.value;
@@ -1155,25 +1145,18 @@ function generateGallery(options) {
 	ctrlPrev.addEventListener('click', () => { changeSlideshowPiece(-1); });
 	ctrlNext.addEventListener('click', () => { changeSlideshowPiece(1); });
 
-	ctrlConcurrentIncrease.addEventListener('click', () => {
-		if (!showFilmstrip) {
-			element.classList.remove('res-gallery-slideshow');
-			filmstripMaxCount = 10;
-			showFilmstrip = true;
-			// Show from first piece
-			lastRevealedPiece = null;
-		}
+	ctrlConcurrentIncrease.addEventListener('click', expandFilmstrip);
 
-		expandFilmstrip();
-	});
-
-	piecesContainer.addEventListener('resize', () => {
+	piecesContainer.addEventListener('resize', ({ detail }) => {
+		let minHeight = '';
 		if (!filmstripActive) {
-			// Avoid having the container unnecessarily resize when switching piece by keeping the largest
-			const currentMin = parseFloat(piecesContainer.style.minHeight, 10) || 0;
-			const newHeight = piecesContainer.getBoundingClientRect().height;
-			piecesContainer.style.minHeight = `${Math.max(currentMin, newHeight)}px`;
+			if (!(detail && detail.manual)) {
+				// Avoid having the container unnecessarily resize when switching piece by keeping the largest
+				const currentMin = parseFloat(piecesContainer.style.minHeight, 10) || 0;
+				minHeight = `${Math.max(currentMin, piecesContainer.getBoundingClientRect().height)}px`;
+			}
 		}
+		piecesContainer.style.minHeight = minHeight;
 	});
 
 	if (filmstripActive || pieces.length === 1) {
@@ -1258,7 +1241,7 @@ function generateIframe(options) {
 			try {
 				iframeNode.contentWindow.postMessage(options.play, '*');
 			} catch (e) {
-				console.error('Could not post "play" command to iframe', options.embed);
+				console.error('Could not post "play" command to iframe', options.embed, e);
 			}
 		}
 	};
@@ -1270,7 +1253,7 @@ function generateIframe(options) {
 				iframeNode.contentWindow.postMessage(options.pause, '*');
 				removeInstead = false;
 			} catch (e) {
-				console.error('Could not post "pause" command to  iframe', options.embed);
+				console.error('Could not post "pause" command to  iframe', options.embed, e);
 			}
 		}
 		return removeInstead;
@@ -1324,7 +1307,7 @@ function generateGeneric(options) {
 	return mediaDiv;
 }
 
-// TODO Correctness not considered since it is not in use
+// XXX Correctness not considered since it is not in use
 async function generateNoEmbed(options) {
 	const noEmbedFrame = document.createElement('iframe');
 	// not all noEmbed responses have a height and width, so if
@@ -1408,9 +1391,8 @@ function setMediaControls(media, lookupUrl) {
 	element.appendChild(media);
 
 	let rotationState = 0;
-	let rotationChanged = false;
 
-	function hookInResizeListener() {
+	const hookInResizeListener = _.once(() => {
 		media.addEventListener('resize', () => {
 			const horizontal = rotationState % 2 === 0;
 			const height = horizontal ? media.clientHeight : media.clientWidth;
@@ -1421,13 +1403,10 @@ function setMediaControls(media, lookupUrl) {
 
 			media.style.position = 'absolute';
 		});
-	}
+	});
 
 	controls.addEventListener('click', e => {
-		if (!rotationChanged) {
-			rotationChanged = true;
-			hookInResizeListener();
-		}
+		hookInResizeListener();
 
 		switch (e.target.dataset.action) {
 			case 'rotateLeft':
@@ -1496,14 +1475,14 @@ function setMediaClippyText(elem) {
 
 function makeMediaZoomable(mediaTag) {
 	if (!module.options.imageZoom.value) return;
-	mediaTag.classList.add('res-media-resizeable');
+	mediaTag.classList.add('res-media-resizable');
 
 	let dragTargetData;
 
 	function getDragSize(e) {
-		const rc = e.target.getBoundingClientRect();
+		const { left, top } = e.target.getBoundingClientRect();
 		const p = Math.pow;
-		const dragSize = p(p(e.clientX - rc.left, 2) + p(e.clientY - rc.top, 2), 0.5);
+		const dragSize = p(p(e.clientX - left, 2) + p(e.clientY - top, 2), 0.5);
 
 		return Math.round(dragSize);
 	}
@@ -1655,12 +1634,11 @@ function videoAdvanced(options) {
 		ctrlTimeDecrease.addEventListener('click', () => { vid.currentTime -= 1 / frameRate; });
 		ctrlTimeIncrease.addEventListener('click', () => { vid.currentTime += 1 / frameRate; });
 
-		vid.addEventListener('timeupdate', () => { indicatorPosition.style.left = `${(vid.currentTime / vid.duration) * 100}%`; });
-		vid.addEventListener('timeupdate', () => { msgTime.innerHTML = `${vid.currentTime.toFixed(2).replace('.', '.<wbr>')}s`; });
 		vid.addEventListener('ratechange', () => { msgSpeed.innerHTML = `${vid.playbackRate.toFixed(2).replace('.', '.<wbr>')}x`; });
-		vid.addEventListener('loadedmetadata', () => { ctrlContainer.hidden = false; });
-		vid.addEventListener('pause', () => { element.classList.remove('playing'); });
-		vid.addEventListener('play', () => { element.classList.add('playing'); });
+		vid.addEventListener('timeupdate', () => {
+			indicatorPosition.style.left = `${(vid.currentTime / vid.duration) * 100}%`;
+			msgTime.innerHTML = `${vid.currentTime.toFixed(2).replace('.', '.<wbr>')}s`;
+		});
 
 		progress.addEventListener('mousemove', e => {
 			let left = e.offsetX;
@@ -1670,9 +1648,14 @@ function videoAdvanced(options) {
 			if (e.buttons === 1 /* left mouse button */) ctrlPosition.click();
 		});
 		ctrlPosition.addEventListener('click', e => {
-			const percentage = e.target.offsetLeft / progress.clientWidth;
+			const percentage = (e.target.offsetLeft + e.target.clientWidth / 2) / progress.clientWidth;
 			vid.currentTime = vid.duration * percentage;
 		});
+	}
+
+	if (advancedControls) {
+		Promise.all([waitForEvent(element, 'mouseenter'), waitForEvent(vid, 'loadedmetadata')])
+			.then(_.once(setAdvancedControls));
 	}
 
 	function sourceErrorFallback() {
@@ -1689,34 +1672,32 @@ function videoAdvanced(options) {
 	const lastSource = sourceElements[sourceElements.length - 1];
 	lastSource.addEventListener('error', sourceErrorFallback, false);
 
-	vid.addEventListener('loadedmetadata', () => { vid.currentTime = time; });
-	vid.playbackRate = playbackRate;
+	vid.addEventListener('pause', () => { element.classList.remove('playing'); });
+	vid.addEventListener('play', () => { element.classList.add('playing'); });
 
-	if (advancedControls) {
-		setAdvancedControls();
-	}
+	vid.addEventListener('loadedmetadata', () => { if (time !== vid.currentTime) vid.currentTime = time; });
+	vid.playbackRate = playbackRate;
 
 	// Ignore events which might be meant for controls
 	vid.addEventListener('mousedown', e => {
 		if (vid.hasAttribute('controls')) {
-			const rc = vid.getBoundingClientRect();
+			const { height, top } = vid.getBoundingClientRect();
 			let controlsBottomHeight = 0;
-			if (process.env.BUILD_TARGET === 'edge') controlsBottomHeight = 0.5 * rc.height;
+			if (process.env.BUILD_TARGET === 'edge') controlsBottomHeight = 0.5 * height;
 			if (process.env.BUILD_TARGET === 'firefox') controlsBottomHeight = 40;
-			if ((rc.height - controlsBottomHeight) < (e.clientY - rc.top)) {
+			if ((height - controlsBottomHeight) < (e.clientY - top)) {
 				e.stopImmediatePropagation();
-				// FIXME (Firefox) Since anchor is parent, it will be fired on click
 			}
 		}
 	});
+
+	vid.style.maxWidth = `${module.options.maxWidth.value}px`;
+	vid.style.maxHeight = `${module.options.maxHeight.value}px`;
 
 	makeMediaZoomable(vid);
 	makeMediaMovable(element);
 	setMediaControls(vid);
 	setMediaClippyText(vid);
-
-	vid.style.maxWidth = `${module.options.maxWidth.value}px`;
-	vid.style.maxHeight = `${module.options.maxHeight.value}px`;
 
 	element.collapse = () => { autoplay = !vid.paused; if (!vid.paused) vid.pause(); };
 	element.expand = () => { if (autoplay) vid.play(); };
@@ -1739,7 +1720,7 @@ export function resizeMedia(ele, newWidth) {
 	ele.style.maxHeight = '';
 	ele.style.height = 'auto';
 
-	ele.dispatchEvent(new CustomEvent('resize', { bubbles: true }));
+	ele.dispatchEvent(new CustomEvent('resize', { bubbles: true, detail: { manual: true } }));
 }
 
 function rotateMedia(ele, rotationState) {

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -50,15 +50,15 @@ module.category = ['Productivity', 'Browsing'];
 module.description = 'Opens images inline in your browser with the click of a button. Also has configuration options, check it out!';
 module.bodyClass = true;
 module.options = {
+	galleryPreloadCount: {
+		type: 'text',
+		value: 2,
+		description: 'Number of preloaded gallery pieces for faster browsing.',
+	},
 	conserveMemory: {
 		type: 'boolean',
 		value: true,
 		description: 'Conserve memory by temporarily hiding images when they are offscreen.',
-	},
-	preloadImages: {
-		type: 'boolean',
-		value: true,
-		description: 'Preload 2 gallery pieces for faster browsing.',
 	},
 	bufferScreens: {
 		type: 'text',
@@ -357,8 +357,6 @@ const mediaStates = {
  * @returns {void}
  */
 function enableConserveMemory() {
-	// hide any expanded images that are further than bufferScreens above or below viewport
-	// show any expanded images that are within bufferScreens of viewport
 	window.addEventListener('scroll', _.debounce(() => {
 		const bufferScreens = module.options.bufferScreens.value || 2;
 		const viewportHeight = window.innerHeight;
@@ -394,11 +392,12 @@ function lazyDestroy(testKeepLoaded) {
 
 function lazyUnload(testKeepLoaded) {
 	for (const { media, data } of this) {
-		if (!media.unload || !media.restore) return;
+		if (!media.unload || !media.restore) continue;
 
-		if (testKeepLoaded(data) && media.state === mediaStates.UNLOADED) {
+		const keepLoaded = testKeepLoaded(data);
+		if (keepLoaded && media.state === mediaStates.UNLOADED) {
 			media.restore();
-		} else if (media.state === mediaStates.LOADED) {
+		} else if (!keepLoaded && media.state === mediaStates.LOADED) {
 			media.unload();
 		}
 	}
@@ -1049,7 +1048,7 @@ function generateGallery(options) {
 	const msgPosition = individualCtrl.querySelector('.res-gallery-position');
 	const ctrlConcurrentIncrease = element.querySelector('.res-gallery-increase-concurrent');
 
-	const preloadCount = module.options.preloadImages.value ? 2 : 0;
+	const preloadCount = parseInt(module.options.galleryPreloadCount.value, 10) || 0;
 
 	const filmstripActive = module.options.loadAllInAlbum.value;
 	const filmstripMaxCount = parseInt(module.options.dontLoadAlbumsBiggerThan.value, 10) || Infinity;
@@ -1064,6 +1063,7 @@ function generateGallery(options) {
 		piece.media.hidden = false;
 		if (!piece.media.parentElement) piecesContainer.appendChild(piece.media);
 		if (piece.media.expand) piece.media.expand();
+		piecesContainer.dispatchEvent(new CustomEvent('resize', { bubbles: true }));
 	}
 
 	function preloadAhead() {
@@ -1161,27 +1161,27 @@ function generateGallery(options) {
 }
 
 function generateImage(options) {
-	const transparentGif = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
-	let state = mediaStates.NONE;
-
 	options.openInNewWindow = module.options.openInNewWindow.value;
 
 	const element = $(imageTemplate(options))[0];
 	const image = element.querySelector('img');
 
+	const transparentGif = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
+	element.state = mediaStates.NONE;
+
 	image.addEventListener('error', () => {
-		image.classList.add('res-media-load-error');
+		element.classList.add('res-media-load-error');
 		image.title = '';
 
 		image.dispatchEvent(new CustomEvent('resize', { bubbles: true }));
 	});
 	image.addEventListener('load', () => {
-		if (state !== mediaStates.UNLOADED) {
+		if (element.state !== mediaStates.UNLOADED) {
 			if (module.options.displayOriginalResolution.value && image.naturalWidth && image.naturalHeight) {
 				image.title = `${image.naturalWidth} × ${image.naturalHeight} px`;
 			}
 
-			state = mediaStates.LOADED;
+			element.state = mediaStates.LOADED;
 
 			image.dispatchEvent(new CustomEvent('resize', { bubbles: true }));
 		}
@@ -1191,14 +1191,14 @@ function generateImage(options) {
 	image.style.maxHeight = `${module.options.maxHeight.value}px`;
 
 	element.unload = () => {
-		state = mediaStates.UNLOADED;
+		element.state = mediaStates.UNLOADED;
 
 		image.src = transparentGif;
 		image.style.height = `${image.clientHeight}px`;
 		image.style.width = `${image.clientWidth}px`;
 	};
 	element.restore = () => {
-		state = mediaStates.LOADED;
+		element.state = mediaStates.LOADED;
 
 		image.src = options.src;
 		image.style.height = '';
@@ -1653,7 +1653,7 @@ function videoAdvanced(options) {
 			$(element).replaceWith(generateImage({
 				...options,
 				src: fallback,
-			}), element);
+			}));
 		} else {
 			msgError.hidden = false;
 		}

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -941,15 +941,12 @@ async function rewriteMediaHostOptions(imageLink) {
 	};
 
 	if (options.type === 'IMAGE' || options.type === 'TEXT' || options.type === 'GALLERY') {
-		let html = $('<span>').safeHtml(options.credits);
-		options.credits = html ? html.html() : null;
-		html = $('<span>').safeHtml(options.caption);
-		options.caption = html ? html.html() : null;
+		options.credits = $('<span>').safeHtml(options.credits).html();
+		options.caption = $('<span>').safeHtml(options.caption).html();
 	}
 
 	if (options.type === 'TEXT') {
-		const html = $('<span>').safeHtml(options.src);
-		options.src = html ? html.html() : '';
+		options.src = $('<span>').safeHtml(options.src).html();
 	}
 
 	if (options.type === 'IFRAME') {

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -317,7 +317,6 @@ module.beforeLoad = function() {
 	generateDomainModuleMap();
 };
 
-
 module.go = function() {
 	if (this.options.conserveMemory.value) {
 		enableConserveMemory();
@@ -373,28 +372,28 @@ function enableConserveMemory() {
 
 		// Destroy collapsed when beyond buffer
 		Array.from(activeImageList)
-			.filter(v => v.matches('.collapsed'))
+			.filter(v => v.classList.contains('collapsed'))
 			.map(v => ({ expando: v, data: v }))
 			::lazyDestroy(isWithinBuffer);
 
 		// Unload expanded when beyond buffer
 		Array.from(activeImageList)
-			.filter(v => v.matches('.expanded'))
+			.filter(v => v.classList.contains('expanded'))
 			.map(v => ({ media: v.mediaElement, data: v }))
 			::lazyUnload(isWithinBuffer);
 	}, 300), false);
 }
 
 function lazyDestroy(testKeepLoaded) {
-	this.forEach(({ expando, data }) => {
+	for (const { expando, data } of this) {
 		if (!testKeepLoaded(data)) {
 			expando.destroy();
 		}
-	});
+	}
 }
 
 function lazyUnload(testKeepLoaded) {
-	this.forEach(({ media, data }) => {
+	for (const { media, data } of this) {
 		if (!media.unload || !media.restore) return;
 
 		if (testKeepLoaded(data) && media.state === mediaStates.UNLOADED) {
@@ -402,7 +401,7 @@ function lazyUnload(testKeepLoaded) {
 		} else if (media.state === mediaStates.LOADED) {
 			media.unload();
 		}
-	});
+	}
 }
 
 function findAllImagesInSelfText(ele) {
@@ -953,10 +952,6 @@ async function rewriteMediaHostOptions(imageLink) {
 		options.src = html ? html.html() : '';
 	}
 
-	if (options.type === 'AUDIO' && typeof imageLink.sources === 'undefined') {
-		options.sources = $(imageLink).data('sources');
-	}
-
 	if (options.type === 'IFRAME') {
 		options = {
 			pause: imageLink.getAttribute('data-pause'),
@@ -1133,7 +1128,6 @@ function generateGallery(options) {
 				.map(piece => ({ media: piece.media, data: piece }))
 				::lazyUnload(piece => {
 					const index = pieces.indexOf(piece);
-					console.log(index, index >= newIndex - preloadCount && index <= newIndex + preloadCount);
 					return index >= newIndex - preloadCount && index <= newIndex + preloadCount;
 				});
 		}
@@ -1387,7 +1381,7 @@ function setMediaControls(media, lookupUrl) {
 
 	const element = $(mediaControlsTemplate(options))[0];
 	const controls = element.querySelector('.RESMediaControls');
-	media.parentElement.replaceChild(element, media);
+	$(media).replaceWith(element);
 	element.appendChild(media);
 
 	let rotationState = 0;
@@ -1481,8 +1475,7 @@ function makeMediaZoomable(mediaTag) {
 
 	function getDragSize(e) {
 		const { left, top } = e.target.getBoundingClientRect();
-		const p = Math.pow;
-		const dragSize = p(p(e.clientX - left, 2) + p(e.clientY - top, 2), 0.5);
+		const dragSize = Math.hypot(e.clientX - left, e.clientY - top);
 
 		return Math.round(dragSize);
 	}
@@ -1655,12 +1648,12 @@ function videoAdvanced(options) {
 
 	if (advancedControls) {
 		Promise.all([waitForEvent(element, 'mouseenter'), waitForEvent(vid, 'loadedmetadata')])
-			.then(_.once(setAdvancedControls));
+			.then(setAdvancedControls);
 	}
 
 	function sourceErrorFallback() {
 		if (fallback) {
-			element.parentElement.replaceChild(generateImage({
+			$(element).replaceWith(generateImage({
 				...options,
 				src: fallback,
 			}), element);

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -5,8 +5,13 @@
 
 import _ from 'lodash';
 import { flow, forEach, keyBy, map, tap } from 'lodash/fp';
+import audioTemplate from '../templates/audio.mustache';
+import expandoTemplate from '../templates/expando.mustache';
+import galleryTemplate from '../templates/gallery.mustache';
+import imageTemplate from '../templates/image.mustache';
 import mediaControlsTemplate from '../templates/mediaControls.mustache';
 import siteAttributionTemplate from '../templates/siteAttribution.mustache';
+import textTemplate from '../templates/text.mustache';
 import videoAdvancedTemplate from '../templates/videoAdvanced.mustache';
 import * as Modules from '../core/modules';
 import { $ } from '../vendor';
@@ -19,9 +24,9 @@ import {
 	isCurrentSubreddit,
 	isPageType,
 	objectValidator,
-	randomHash,
-	range,
 	regexes,
+	seq,
+	waitForEvent,
 	watchForElement,
 } from '../utils';
 import { addURLToHistory, ajax, isPrivateBrowsing, openNewTab } from '../environment';
@@ -195,7 +200,6 @@ module.options = {
 		value: true,
 		description: 'Retrieve image captions/attribution information.',
 		advanced: true,
-		bodyClass: true,
 	},
 	loadAllInAlbum: {
 		type: 'boolean',
@@ -206,7 +210,7 @@ module.options = {
 		dependsOn: 'loadAllInAlbum',
 		type: 'text',
 		value: 30,
-		description: 'Use the \'slideshow\' style for albums with more images than this number. (0 for always use \'filmstrip\')',
+		description: 'Limit the number of images initally shown in a \'filmstrip\' by this number. (0 for no limit)',
 	},
 	convertGifstoGfycat: {
 		type: 'boolean',
@@ -312,9 +316,10 @@ module.beforeLoad = function() {
 	generateDomainModuleMap();
 };
 
+
 module.go = function() {
 	if (this.options.conserveMemory.value) {
-		window.addEventListener('scroll', _.debounce(lazyUnload, 300), false);
+		enableConserveMemory();
 	}
 
 	watchForElement('siteTable', findAllImages);
@@ -338,109 +343,65 @@ module.go = function() {
 	}
 };
 
+const mediaStates = {
+	NONE: 0,
+	LOADED: 1,
+	UNLOADED: 2,
+};
+
 /**
- * lazyUnload
+ * enableConserveMemory
  * attempt to unload collapsed expando's & images that are off screen in order
  * to save memory
  *
  * @returns {void}
  */
-function lazyUnload() {
+function enableConserveMemory() {
 	// hide any expanded images that are further than bufferScreens above or below viewport
 	// show any expanded images that are within bufferScreens of viewport
-	const bufferScreens = module.options.bufferScreens.value || 2;
-	const viewportHeight = $(window).height();
-	const maximumTop = viewportHeight * (bufferScreens + 1);
-	const minimumBottom = viewportHeight * bufferScreens * -1;
+	window.addEventListener('scroll', _.debounce(() => {
+		const bufferScreens = module.options.bufferScreens.value || 2;
+		const viewportHeight = window.innerHeight;
+		const maximumTop = viewportHeight * (bufferScreens + 1);
+		const minimumBottom = viewportHeight * bufferScreens * -1;
 
-	for (const image of activeImageList) {
-		// If image has no expandoBox, remove from this list
-		if (!image.expandoBox) {
-			activeImageList.delete(image);
-		}
+		const isWithinBuffer = ele => {
+			const boundingBox = ele.getBoundingClientRect();
+			return boundingBox.top <= maximumTop && boundingBox.bottom >= minimumBottom;
+		};
 
-		// If the expando is collapsed, clean it up if possible
-		if (image.classList.contains('collapsed')) {
-			const boundingBox = image.getBoundingClientRect();
-			if (boundingBox.top > maximumTop || boundingBox.bottom < minimumBottom) {
-				// Destroy collapsed expando
-				unloadCollapsedExpando(image);
-			}
-		} else if (image.classList.contains('expanded') && image.imageLink.media) {
-			// is open and is an image - swap out for handle unload/reload of image asset
-			const boundingBox = image.imageLink.media.getBoundingClientRect();
-			if (boundingBox.top > maximumTop || boundingBox.bottom < minimumBottom) {
-				unloadRevealedImage(image);
-			} else {
-				reloadRevealedImage(image);
-			}
-		}
-	}
+		// Destroy collapsed when beyond buffer
+		Array.from(activeImageList)
+			.filter(v => v.matches('.collapsed'))
+			.map(v => ({ expando: v, data: v }))
+			::lazyDestroy(isWithinBuffer);
+
+		// Unload expanded when beyond buffer
+		Array.from(activeImageList)
+			.filter(v => v.matches('.expanded'))
+			.map(v => ({ media: v.mediaElement, data: v }))
+			::lazyUnload(isWithinBuffer);
+	}, 300), false);
 }
 
-const transparentGif = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
-
-/**
- * unloadCollapsedExpando
- * attempt to unload collapsed expandos in order to conserve memory
- *
- * @param {node} image - expando node to unload
- * @returns {void}
- */
-function unloadCollapsedExpando(image) {
-	// destroy media reference if one exists (images)
-	if (image.imageLink.media) {
-		image.imageLink.media.src = transparentGif;
-		image.imageLink.media = null;
-	}
-
-	// unload iframe if there is one (in case somthing still holds a reference to it)
-	const iframe = image.expandoBox.querySelector('iframe');
-	if (iframe) iframe.src = 'about:blank';
-
-	// remove expando container
-	// use jQuery as this will attempt to remove any jQuery events & data attributes in use.
-	$(image.expandoBox).remove();
-	image.expandoBox = null;
-
-	// clear associatedImage
-	const associatedImage = $(image).data('associatedImage');
-	// if has associatedImage
-	if (associatedImage) {
-		// destroy placeholder (and its own data)
-		$($(associatedImage).data('imagePlaceholder')).remove();
-		// clear any data / listeners jquery has
-		$(associatedImage).remove();
-	}
-	// clear associatedImage data reference from "image" itself
-	$(image).removeData('associatedImage');
-
-	// remove from activeImageList
-	activeImageList.delete(image);
+function lazyDestroy(testKeepLoaded) {
+	this.forEach(({ expando, data }) => {
+		if (!testKeepLoaded(data)) {
+			expando.destroy();
+		}
+	});
 }
 
-function unloadRevealedImage(ele) {
-	if (ele.imageLink && ele.imageLink.media) {
-		const $img = $(ele.imageLink.media);
-		const src = $img.attr('src');
-		// only hide the image if it hasn't been hidden and it's loaded
-		if (src !== transparentGif && $img.data('loaded')) {
-			// preserve src
-			$img.data('src', src);
-			// swap img with transparent gif to save memory
-			$img.attr('src', transparentGif);
-		}
-	}
-}
+function lazyUnload(testKeepLoaded) {
+	this.forEach(({ media, data }) => {
+		if (!media.unload || !media.restore) return;
 
-function reloadRevealedImage(ele) {
-	if (ele.imageLink && ele.imageLink.media) {
-		const $img = $(ele.imageLink.media);
-		const src = $img.data('src');
-		if (src && ($img.attr('src') === transparentGif)) {
-			$img.attr('src', src);
+		if (testKeepLoaded(data) && media.state === mediaStates.UNLOADED) {
+			media.restore();
+		} else if (media.state === mediaStates.LOADED) {
+			media.unload();
 		}
-	}
+	});
 }
 
 function findAllImagesInSelfText(ele) {
@@ -857,6 +818,32 @@ function createImageExpando(elem) {
 		// also since this may have come from an asynchronous call, we need to update the view images count.
 		updateImageButtons(imageList.length);
 	}
+
+	function updateParentFromExpandoResize() {
+		function updateParentHeight(basisHeight) {
+			// .expando-button causes a line break
+			const expandoHeight = Array.from(parent.querySelectorAll('.res-expando, .expando-button'))
+				.reduce((a, b) => a + b.getBoundingClientRect().height, 0);
+
+			parent.style.maxHeight = `${basisHeight + expandoHeight}px`;
+		}
+
+		const type = $(expandLink).closest('body:not(.comments-page) .expando')[0] || $(expandLink).closest('.thing')[0];
+		const parent = $(expandLink).closest('.md')[0];
+
+		if (parent && type) {
+			const selfMax = parseInt(module.options.selfTextMaxHeight.value, 10);
+			const commentMax = parseInt(module.options.commentMaxHeight.value, 10);
+
+			if (type.classList.contains('expando') && selfMax) {
+				expandLink.expandoBox.addEventListener('resize', () => { updateParentHeight(selfMax); });
+			} else if (type.classList.contains('comment') && commentMax) {
+				expandLink.expandoBox.addEventListener('resize', () => { updateParentHeight(commentMax); });
+			}
+		}
+	}
+
+	if (module.options.autoMaxHeight.value) updateParentFromExpandoResize();
 }
 
 async function revealImage(expandoButton, showHide) {
@@ -867,462 +854,436 @@ async function revealImage(expandoButton, showHide) {
 	}
 	// showhide = false means hide, true means show!
 
-	const imageLink = expandoButton.imageLink;
-
-	if (typeof siteModules[imageLink.site] === 'undefined') {
-		console.log(`something went wrong scanning image from site: ${imageLink.site}`);
+	const site = expandoButton.imageLink.site;
+	if (typeof siteModules[site] === 'undefined') {
+		console.log(`something went wrong scanning image from site: ${site}`);
 		return false;
 	}
-	if (expandoButton.expandoBox && expandoButton.expandoBox.classList.contains('madeVisible')) {
-		const isMedia = (imageLink.type === 'AUDIO' || imageLink.type === 'VIDEO');
 
-		let mediaTag;
-		if (isMedia) {
-			mediaTag = expandoButton.expandoBox.querySelector(imageLink.type);
-		}
-
-		if (!showHide) {
-			$(expandoButton).removeClass('expanded').addClass('collapsed collapsedExpando');
-			expandoButton.expandoBox.style.display = 'none';
-
-			if (isMedia && mediaTag) {
-				mediaTag.wasPaused = mediaTag.paused;
-				mediaTag.pause();
-			}
-		} else {
-			$(expandoButton).addClass('expanded').removeClass('collapsed collapsedExpando');
-			expandoButton.expandoBox.style.display = 'block';
-
-			const associatedImage = $(expandoButton).data('associatedImage');
-
-			if (associatedImage) {
-				syncPlaceholder(associatedImage);
-			}
-
-			if (isMedia && mediaTag) {
-				if (!mediaTag.wasPaused) {
-					mediaTag.play();
-				}
-			}
-		}
-	} else if (showHide) {
-		if (module.options.convertGifstoGfycat.value &&
-				imageLink.type === 'IMAGE' &&
-			(/^(http|https|ftp):\/\/.*\.gif($|\/?)/).test(imageLink.src)) {
-			const { gfyName: id } = await ajax({
-				type: 'json',
-				url: '//upload.gfycat.com/transcodeRelease',
-				data: { fetchUrl: imageLink.src },
-				cacheFor: DAY,
-			});
-
-			if (id) await gfycat.handleLink(imageLink, [undefined, id]);
-		}
-
-		// TODO: flash
-		switch (imageLink.type) {
-			case 'IMAGE':
-			case 'GALLERY':
-				generateImageExpando(expandoButton);
-				break;
-			case 'TEXT':
-				generateTextExpando(expandoButton);
-				break;
-			case 'IFRAME':
-				generateIframeExpando(expandoButton);
-				break;
-			case 'VIDEO':
-				generateVideoExpando(expandoButton, imageLink.expandoOptions);
-				break;
-			case 'AUDIO':
-				generateAudioExpando(expandoButton);
-				break;
-			case 'NOEMBED':
-				generateNoEmbedExpando(expandoButton);
-				break;
-			case 'GENERIC_EXPANDO':
-				generateGenericExpando(expandoButton, imageLink.expandoOptions);
-				break;
-			default:
-				throw new Error(`Invalid expando type: ${imageLink.type}`);
-		}
-
-		if (module.options.showSiteAttribution.value && expandoButton.imageLink.classList.contains('title')) {
-			addSiteAttribution(imageLink.site, expandoButton.expandoBox);
-		}
-
-		// Set value so we can very quickly tell if the expando markup has been generated
-		// Currently used by `lazyUnload`
-		activeImageList.add(expandoButton);
-	}
-	updateParentHeight(expandoButton);
-}
-
-function generateImageExpando(expandoButton) {
-	const imageLink = expandoButton.imageLink;
-	const which = imageLink.galleryStart || 0;
-
-	const imgDiv = document.createElement('div');
-	imgDiv.classList.add('madeVisible');
-	imgDiv.currentImage = which;
-	imgDiv.sources = [];
-
-	// Test for a single image or an album/array of image
-	if (Array.isArray(imageLink.src)) {
-		imgDiv.sources = imageLink.src;
-
-		// Also preload images for an album if the option is on.
-		if (module.options.preloadImages.value) {
-			preloadImages(imageLink.src, 0);
-		}
-	} else {
-		// Only the image is left to display, pack it like a single-image album with no caption or title
-		const singleImage = {
-			src: imageLink.src,
-			href: imageLink.href,
-		};
-		imgDiv.sources[0] = singleImage;
+	if (!expandoButton.expandoBox) {
+		if (showHide) await buildExpandoBox(expandoButton);
+		else return false;
 	}
 
-	let header;
-	if ('imageTitle' in imageLink) {
-		header = document.createElement('h3');
-		header.classList.add('imgTitle');
-		$(header).safeHtml(imageLink.imageTitle);
-		imgDiv.appendChild(header);
-	}
+	function expand() {
+		$(expandoButton).addClass('expanded').removeClass('collapsed collapsedExpando');
 
-	if ('caption' in imageLink) {
-		const captions = document.createElement('div');
-		captions.className = 'imgCaptions';
-		$(captions).safeHtml(imageLink.caption);
-		imgDiv.appendChild(captions);
-	}
-
-	if ('credits' in imageLink) {
-		const credits = document.createElement('div');
-		credits.className = 'imgCredits';
-		$(credits).safeHtml(imageLink.credits);
-		imgDiv.appendChild(credits);
-	}
-
-	let leftButton, rightButton;
-
-	switch (imageLink.type) {
-		case 'GALLERY':
-			const loadAllInAlbum = module.options.loadAllInAlbum.value;
-			const dontLoadAlbumsBiggerThan = parseInt(module.options.dontLoadAlbumsBiggerThan.value, 10) || 0;
-			if (loadAllInAlbum && (dontLoadAlbumsBiggerThan <= 0 || imgDiv.sources.length <= dontLoadAlbumsBiggerThan)) {
-				if (imgDiv.sources.length > 1) {
-					const albumLength = ` (${imgDiv.sources.length} images)`;
-					if (header) {
-						$(header).append(albumLength);
-					}
-				}
-
-				for (const imgNum of range(0, imgDiv.sources.length)) {
-					addImage(imgDiv, imgNum);
-				}
-				break;
+		if (!expandoButton.expandoBox.parentElement) {
+			if (expandoButton.classList.contains('commentImg')) {
+				$(expandoButton).after(expandoButton.expandoBox);
 			} else {
-				// If we're using the traditional album view, add the controls then fall through to add the IMAGE
-				const controlWrapper = document.createElement('div');
-				controlWrapper.className = 'RESGalleryControls';
-
-				leftButton = document.createElement('a');
-				leftButton.className = 'previous noKeyNav';
-				leftButton.addEventListener('click', e => {
-					const topWrapper = e.target.parentElement.parentElement;
-					if (topWrapper.currentImage === 0) {
-						topWrapper.currentImage = topWrapper.sources.length - 1;
-					} else {
-						topWrapper.currentImage -= 1;
-					}
-					adjustGalleryDisplay(topWrapper);
-				});
-				controlWrapper.appendChild(leftButton);
-
-				const posLabel = document.createElement('span');
-				posLabel.className = 'RESGalleryLabel';
-				const niceWhich = ((which + 1 < 10) && (imgDiv.sources.length >= 10)) ? `0${which + 1}` : (which + 1);
-				if (imgDiv.sources.length) {
-					posLabel.textContent = `${niceWhich} of ${imgDiv.sources.length}`;
-				} else {
-					posLabel.textContent = 'Whoops, this gallery seems to be empty.';
-				}
-				controlWrapper.appendChild(posLabel);
-
-				if (loadAllInAlbum && dontLoadAlbumsBiggerThan > 0 && dontLoadAlbumsBiggerThan < imgDiv.sources.length) {
-					const largeAlbum = $('<span />').attr('title', `Album has more than ${dontLoadAlbumsBiggerThan} images. \nClick to adjust settings.`);
-					const largeAlbumSettings = SettingsNavigation.makeUrlHashLink('showImages', 'dontLoadAlbumsBiggerThan', '*', 'RESGalleryLargeInfo');
-					largeAlbum.append(largeAlbumSettings);
-
-					largeAlbum.appendTo(controlWrapper);
-				}
-
-				rightButton = document.createElement('a');
-				rightButton.className = 'next noKeyNav';
-				rightButton.addEventListener('click', e => {
-					const topWrapper = e.target.parentElement.parentElement;
-					if (+topWrapper.currentImage === topWrapper.sources.length - 1) {
-						topWrapper.currentImage = 0;
-					} else {
-						topWrapper.currentImage += 1;
-					}
-					adjustGalleryDisplay(topWrapper);
-				});
-				controlWrapper.appendChild(rightButton);
-
-				if (!imgDiv.sources.length) {
-					$(leftButton).css('visibility', 'hidden');
-					$(rightButton).css('visibility', 'hidden');
-				}
-
-				imgDiv.appendChild(controlWrapper);
+				expandoButton.parentElement.appendChild(expandoButton.expandoBox);
 			}
-			/* falls through */
-		case 'IMAGE':
-			addImage(imgDiv, which, this);
-			break;
-		default:
-			throw new Error(`Invalid image expando type: ${imageLink.type}`);
+		} else {
+			expandoButton.expandoBox.hidden = false;
+		}
+
+		if (expandoButton.mediaElement.expand) expandoButton.mediaElement.expand();
 	}
 
-	function addImage(container, sourceNumber) {
-		const sourceImage = container.sources[sourceNumber];
+	function collapse() {
+		$(expandoButton).removeClass('expanded').addClass('collapsed collapsedExpando');
 
-		const paragraph = document.createElement('p');
+		expandoButton.expandoBox.hidden = true;
 
-		if (!sourceImage) {
-			return;
-		}
-		if ('title' in sourceImage) {
-			const imageTitle = document.createElement('h4');
-			imageTitle.className = 'imgCaptions';
-			$(imageTitle).safeHtml(sourceImage.title);
-			paragraph.appendChild(imageTitle);
-		}
-
-		if ('caption' in sourceImage) {
-			const imageCaptions = document.createElement('div');
-			imageCaptions.className = 'imgCaptions';
-			$(imageCaptions).safeHtml(sourceImage.caption);
-			paragraph.appendChild(imageCaptions);
-		}
-
-		const imageAnchor = document.createElement('a');
-		imageAnchor.classList.add('madeVisible');
-		imageAnchor.href = sourceImage.href || sourceImage.src;
-		if (module.options.openInNewWindow.value) {
-			imageAnchor.target = '_blank';
-		}
-		const media = this::(/* sourceImage.expandoOptions && sourceImage.expandoOptions.generate || */ generateImage)(sourceImage);
-
-		$(expandoButton).data('associatedImage', media);
-		imageLink.media = media;
-		imageAnchor.appendChild(media);
-		makeMediaZoomable(media);
-		makeMediaMovable(media);
-		trackMediaLoad(imageLink, media);
-		paragraph.appendChild(imageAnchor);
-
-		container.appendChild(paragraph);
-	}
-
-	function generateImage(sourceImage) {
-		const image = document.createElement('img');
-		// Unfortunately it is impossible to use a global event handler for these.
-		image.onerror = function() {
-			image.classList.add('RESImageError');
-		};
-		image.onload = function() {
-			image.classList.remove('RESImageError');
-			if (module.options.displayOriginalResolution.value && this.naturalWidth && this.naturalHeight) {
-				this.title = `${this.naturalWidth} × ${this.naturalHeight} px`;
+		if (expandoButton.mediaElement.collapse) {
+			const removeInstead = expandoButton.mediaElement.collapse();
+			if (removeInstead) {
+				expandoButton.destroy();
 			}
-		};
-		image.classList.add('RESImage');
-		image.id = `RESImage-${randomHash()}`;
-		image.src = sourceImage.src;
-		image.style.maxWidth = `${module.options.maxWidth.value}px`;
-		image.style.maxHeight = `${module.options.maxHeight.value}px`;
-		return image;
+		}
 	}
 
-	// Adjusts the images for the gallery navigation buttons as well as the "n of m" display.
-
-	function adjustGalleryDisplay(topLevel) {
-		const source = topLevel.sources[topLevel.currentImage];
-		const image = topLevel.querySelector('img.RESImage');
-		const imageAnchor = image.parentElement;
-		const paragraph = imageAnchor.parentElement;
-
-		// if it's a gif file, blank out the image so there's no confusion about loading...
-		if (image.src.toLowerCase().substr(-4) === '.gif') {
-			image.src = transparentGif;
-		}
-		imageAnchor.classList.add('csspinner');
-		imageAnchor.classList.add('ringed');
-
-		// set 'loaded' to false since we're about to load a new image
-		$(image).data('loaded', false);
-		image.src = source.src;
-		imageAnchor.href = source.href || imageLink.href;
-		const paddedImageNumber = ((topLevel.currentImage + 1 < 10) && (imgDiv.sources.length >= 10)) ? `0${topLevel.currentImage + 1}` : topLevel.currentImage + 1;
-		if (imgDiv.sources.length) {
-			topLevel.querySelector('.RESGalleryLabel').textContent = `${paddedImageNumber} of ${imgDiv.sources.length}`;
-		} else {
-			topLevel.querySelector('.RESGalleryLabel').textContent = 'Whoops, this gallery seems to be empty.';
-		}
-		if (topLevel.currentImage === 0) {
-			leftButton.classList.add('end');
-			rightButton.classList.remove('end');
-		} else if (topLevel.currentImage === topLevel.sources.length - 1) {
-			leftButton.classList.remove('end');
-			rightButton.classList.add('end');
-		} else {
-			leftButton.classList.remove('end');
-			rightButton.classList.remove('end');
-		}
-
-		$(paragraph).find('.imgCaptions').empty();
-		const imageTitle = paragraph.querySelector('h4.imgCaptions');
-		if (imageTitle) $(imageTitle).safeHtml(source.title);
-		const imageCaptions = paragraph.querySelector('div.imgCaptions');
-		if (imageCaptions) $(imageCaptions).safeHtml(source.caption);
+	if (isPageType('comments')) {
+		// Execute expando collapse procedure when comment is collapsed
+		$(expandoButton).parents('.comment').find('> .entry .tagline > .expand').click(collapse);
 	}
 
-	expandoButton.expandoBox = imgDiv;
-
-	expandoButton.classList.remove('collapsed', 'collapsedExpando');
-	expandoButton.classList.add('expanded');
-
-	if (expandoButton.classList.contains('commentImg')) {
-		$(expandoButton).after(imgDiv);
-	} else {
-		expandoButton.parentNode.appendChild(imgDiv);
-	}
+	if (showHide) expand();
+	else collapse();
 }
 
-/*
- * Recursively loads the images synchronously.
- */
-function preloadImages(srcs, i) {
-	let _i = i;
-	const img = new Image();
-	img.onload = img.onerror = function() {
-		_i++;
-		if (typeof srcs[_i] === 'undefined') {
-			return;
+// TODO Rewrite the mediaHost modules
+async function rewriteMediaHostOptions(imageLink) {
+	if (imageLink.type === 'IMAGE' && Array.isArray(imageLink.src)) {
+		// required by: tumblr
+		imageLink.type = 'GALLERY';
+	}
+
+	// TODO This ought to be placed somewhere more suitable, as site attribution is not updated
+	if (module.options.convertGifstoGfycat.value &&
+		imageLink.type === 'IMAGE' &&
+		(/^(http|https|ftp):\/\/.*\.gif($|\/?)/).test(imageLink.src)) {
+		const { gfyName: id } = await ajax({
+			type: 'json',
+			url: '//upload.gfycat.com/transcodeRelease',
+			data: { fetchUrl: imageLink.src },
+			cacheFor: DAY,
+		});
+
+		if (id) {
+			imageLink.href = imageLink.href || imageLink.src;
+			await gfycat.handleLink(imageLink, [undefined, id]);
 		}
-		preloadImages(srcs, _i);
+	}
+
+	// Let's not bring the expando / imageLink element any further
+	let options = {
+		caption: module.options.displayImageCaptions.value ? imageLink.caption : null,
+		credits: imageLink.credits,
+		href: imageLink.href,
+		site: imageLink.site,
+		src: imageLink.src,
+		// $.extend on some mediaHosts causes null to be converted to a string on title
+		title: imageLink.imageTitle || (imageLink.title === "null" ? null : imageLink.title),
+		type: imageLink.type,
+		...imageLink.expandoOptions,
 	};
-	img.src = srcs[i].src;
+
+	if (options.type === 'IMAGE' || options.type === 'TEXT' || options.type === 'GALLERY') {
+		let html = $('<span>').safeHtml(options.credits);
+		options.credits = html ? html.html() : null;
+		html = $('<span>').safeHtml(options.caption);
+		options.caption = html ? html.html() : null;
+	}
+
+	if (options.type === 'TEXT') {
+		// filter out iframes, as they will not survive safeHTML
+		// TODO: make safeHTML handle iframes acceptably?
+		options.src = options.src.replace(/<iframe/ig, '&lt;iframe');
+		const html = $('<span>').safeHtml(options.src);
+		options.src = html ? html.html() : '';
+	}
+
+	if (options.type === 'AUDIO' && typeof imageLink.src === 'undefined') {
+		options.sources = $(imageLink).data('sources');
+	}
+
+	if (options.type === 'IFRAME') {
+		options = {
+			...options,
+			pause: imageLink.getAttribute('data-pause'),
+			play: imageLink.getAttribute('data-play'),
+			width: imageLink.getAttribute('data-width'),
+			maxwidth: imageLink.getAttribute('data-maxwidth'),
+			height: imageLink.getAttribute('data-height'),
+			embed: imageLink.getAttribute('data-embed'),
+		};
+	}
+
+	if (options.type === 'GENERIC_EXPANDO') {
+		options = {
+			...options,
+			...imageLink.expandoOptions,
+		};
+	}
+
+	if (options.type === 'GALLERY') {
+		options.pieces = await Promise.all(options.src.map(async piece => {
+			// TODO Fix mediaHosts (onedrive, min.us, etc) which does not provide type for the individual pieces
+			piece.type = piece.type || 'IMAGE';
+			piece.href = piece.href || piece.src;
+
+			return await rewriteMediaHostOptions(piece);
+		}));
+	}
+
+	return options;
 }
 
-function generateIframeExpando(expandoButton) {
+async function buildExpandoBox(expandoButton) {
 	const imageLink = expandoButton.imageLink;
-	const wrapperDiv = document.createElement('div');
-	imageLink.wrapperDiv = wrapperDiv;
+	const options = {
+		loadHeight: 50,
+		textMaxWidth: imageLink.parentElement.getBoundingClientRect().width,
+	};
 
-	wrapperDiv.className = 'madeVisible';
+	const expando = expandoButton.expandoBox = $(expandoTemplate(options))[0];
+	const mediaContainer = expando.querySelector('.res-expando-media');
+
+	mediaContainer.addEventListener('resize', () => {
+		if (mediaContainer.clientHeight === 0 || mediaContainer.clientWidth === 0) {
+			console.error('Received bad resize');
+			return;
+		}
+
+		// Await giving it 'position: absolute' till there's a size ready
+		mediaContainer.classList.add('res-expando-independent');
+
+		// Set the childs size(which is position: absolute) height to the parent element
+		expando.style.height = `${mediaContainer.clientHeight}px`;
+		expando.style.width = `${mediaContainer.clientWidth}px`;
+	});
+
+	const mediaOptions = await rewriteMediaHostOptions(imageLink);
+	const media = expandoButton.mediaElement = generateMedia(mediaOptions);
+
+	mediaContainer.appendChild(media);
+
+	// TODO Replace mediaHosts onExpand (twitter, etc)
+	if (imageLink.onExpand) {
+		imageLink.onExpand({ wrapperDiv: expando });
+	}
+
+	trackMediaLoad(imageLink);
+
+	if (module.options.showSiteAttribution.value && imageLink.classList.contains('title')) {
+		addSiteAttribution(imageLink.site, media);
+	}
+
+	expandoButton.destroy = () => {
+		if (expandoButton.expandoBox) expandoButton.expandoBox.remove();
+		delete expandoButton.expandoBox;
+		delete expandoButton.mediaElement;
+		activeImageList.delete(expandoButton);
+	};
+
+	activeImageList.add(expandoButton);
+}
+
+function generateMedia(options) {
+	const mediaGenerators = {
+		GALLERY: generateGallery,
+		IMAGE: generateImage,
+		TEXT: generateText,
+		IFRAME: generateIframe,
+		VIDEO: generateVideo,
+		AUDIO: generateAudio,
+		NOEMBED: generateNoEmbed,
+		GENERIC_EXPANDO: generateGeneric,
+	};
+
+	return mediaGenerators[options.type](options);
+}
+
+function generateGallery(options) {
+	const element = $(galleryTemplate(options))[0];
+
+	const piecesContainer = element.querySelector('.res-gallery-pieces');
+	const individualCtrl = element.querySelector('.res-gallery-individual-controls');
+	const ctrlPrev = individualCtrl.querySelector('.res-gallery-previous');
+	const ctrlNext = individualCtrl.querySelector('.res-gallery-next');
+	const msgPosition = individualCtrl.querySelector('.res-gallery-position');
+	const ctrlConcurrentIncrease = element.querySelector('.res-gallery-increase-concurrent');
+
+	// TODO Preload all, as earlier implementation does?
+	const preloadCount = module.options.preloadImages.value ? 2 : 0;
+
+	const filmstripActive = module.options.loadAllInAlbum.value;
+	const filmstripMaxCount = parseInt(module.options.dontLoadAlbumsBiggerThan.value, 10) || Infinity;
+
+	const pieces = options.pieces.map(src => ({ options: src, media: null }));
+	let lastRevealedPiece = null;
+
+	function revealPiece(piece) {
+		lastRevealedPiece = piece;
+
+		piece.media = piece.media || generateMedia(piece.options);
+		piece.media.hidden = false;
+		if (!piece.media.parentElement) piecesContainer.appendChild(piece.media);
+		if (piece.media.expand) piece.media.expand();
+	}
+
+	function preloadAhead() {
+		const preloadFrom = pieces.indexOf(lastRevealedPiece) + 1;
+		const preloadTo = Math.min(preloadFrom + preloadCount, pieces.length);
+
+		let previous = null;
+		seq(pieces.slice(preloadFrom, preloadTo), async piece => {
+			if (previous && previous.ready) { await previous.ready; }
+			if (!piece.media) piece.media = previous = generateMedia(piece.options);
+		});
+	}
+
+	async function expandFilmstrip() {
+		const revealFrom = pieces.indexOf(lastRevealedPiece) + 1;
+		const revealTo = Math.min(revealFrom + filmstripMaxCount, pieces.length);
+
+		ctrlConcurrentIncrease.hidden = true;
+
+		await seq(pieces.slice(revealFrom, revealTo), async piece => {
+			if (lastRevealedPiece && lastRevealedPiece.media && lastRevealedPiece.media.ready) {
+				await lastRevealedPiece.media.ready;
+			}
+			revealPiece(piece);
+		});
+
+		if (revealTo < pieces.length) {
+			ctrlConcurrentIncrease.innerText = `Show next ${Math.min(filmstripMaxCount, pieces.length - revealTo)} pieces`;
+			ctrlConcurrentIncrease.hidden = false;
+		}
+
+		preloadAhead();
+	}
+
+	async function changeSlideshowPiece(step) {
+		const lastRevealedPieceIndex = lastRevealedPiece ? pieces.indexOf(lastRevealedPiece) : 0;
+
+		if (lastRevealedPiece && lastRevealedPiece.media) {
+			const removeInstead = lastRevealedPiece.media.collapse && lastRevealedPiece.media.collapse();
+			if (removeInstead) {
+				lastRevealedPiece.media.remove();
+			} else {
+				lastRevealedPiece.media.hidden = true;
+			}
+		}
+
+		let newIndex = lastRevealedPieceIndex + step;
+		// Allow wrap-around
+		newIndex = ((newIndex % pieces.length) + pieces.length) % pieces.length;
+
+		individualCtrl.setAttribute('first-piece', newIndex === 0);
+		individualCtrl.setAttribute('last-piece', newIndex === pieces.length - 1);
+		msgPosition.innerText = newIndex + 1;
+
+		revealPiece(pieces[newIndex]);
+
+		if (module.options.conserveMemory.value) {
+			pieces.filter(piece => piece.media)
+				.map(piece => ({ media: piece.media, data: piece }))
+				::lazyUnload(piece => {
+					const index = pieces.indexOf(piece);
+					console.log(index, index >= newIndex - preloadCount && index <= newIndex + preloadCount);
+					return index >= newIndex - preloadCount && index <= newIndex + preloadCount;
+				});
+		}
+
+		if (lastRevealedPiece.media.ready) await lastRevealedPiece.media.ready;
+		preloadAhead();
+	}
+
+	ctrlPrev.addEventListener('click', () => { changeSlideshowPiece(-1); });
+	ctrlNext.addEventListener('click', () => { changeSlideshowPiece(1); });
+
+	ctrlConcurrentIncrease.addEventListener('click', () => {
+		if (!showFilmstrip) {
+			element.classList.remove('res-gallery-slideshow');
+			filmstripMaxCount = 10;
+			showFilmstrip = true;
+			// Show from first piece
+			lastRevealedPiece = null;
+		}
+
+		expandFilmstrip();
+	});
+
+	piecesContainer.addEventListener('resize', () => {
+		if (!filmstripActive) {
+			// Avoid having the container unnecessarily resize when switching piece by keeping the largest
+			const currentMin = parseFloat(piecesContainer.style.minHeight, 10) || 0;
+			const newHeight = piecesContainer.getBoundingClientRect().height;
+			piecesContainer.style.minHeight = `${Math.max(currentMin, newHeight)}px`;
+		}
+	});
+
+	if (filmstripActive || pieces.length === 1) {
+		expandFilmstrip();
+	} else {
+		element.classList.add('res-gallery-slideshow');
+		changeSlideshowPiece(0);
+	}
+
+	return element;
+}
+
+function generateImage(options) {
+	const transparentGif = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
+	let state = mediaStates.NONE;
+
+	options.openInNewWindow = module.options.openInNewWindow.value;
+
+	const element = $(imageTemplate(options))[0];
+	const image = element.querySelector('img');
+
+	image.addEventListener('error', () => {
+		image.classList.add('res-media-load-error');
+		image.title = '';
+
+		image.dispatchEvent(new CustomEvent('resize', { bubbles: true }));
+	});
+	image.addEventListener('load', () => {
+		if (state !== mediaStates.UNLOADED) {
+			if (module.options.displayOriginalResolution.value && image.naturalWidth && image.naturalHeight) {
+				image.title = `${image.naturalWidth} × ${image.naturalHeight} px`;
+			}
+
+			state = mediaStates.LOADED;
+
+			image.dispatchEvent(new CustomEvent('resize', { bubbles: true }));
+		}
+	});
+
+	image.style.maxWidth = `${module.options.maxWidth.value}px`;
+	image.style.maxHeight = `${module.options.maxHeight.value}px`;
+
+	element.unload = () => {
+		state = mediaStates.UNLOADED;
+
+		image.src = transparentGif;
+		image.style.height = `${image.clientHeight}px`;
+		image.style.width = `${image.clientWidth}px`;
+	};
+	element.restore = () => {
+		state = mediaStates.LOADED;
+
+		image.src = options.src;
+		image.style.height = '';
+		image.style.width = '';
+	};
+
+	element.collapse = element.unload;
+	element.expand = element.restore;
+
+	element.ready = waitForEvent(image, 'load', 'error');
+
+	makeMediaZoomable(image);
+	makeMediaMovable(element);
+	setMediaControls(image, options.src);
+	setMediaClippyText(image);
+
+	return element;
+}
+
+function generateIframe(options) {
 	const iframeNode = document.createElement('iframe');
-	iframeNode.setAttribute('width', imageLink.getAttribute('data-width') || '640');
-	iframeNode.setAttribute('height', imageLink.getAttribute('data-height') || '360');
-	iframeNode.style.maxWidth = imageLink.getAttribute('data-maxwidth') || '100%';
-	iframeNode.setAttribute('src', imageLink.getAttribute('data-embed'));
+	iframeNode.setAttribute('width', options.width || '640');
+	iframeNode.setAttribute('height', options.height || '360');
+	iframeNode.style.maxWidth = options.maxwidth || '100%';
+	iframeNode.setAttribute('src', options.embed);
 	iframeNode.setAttribute('frameborder', '0');
 	iframeNode.setAttribute('allowfullscreen', '');
-	wrapperDiv.appendChild(iframeNode);
 
-	if (expandoButton.classList.contains('commentImg')) {
-		$(expandoButton).after(wrapperDiv);
-	} else {
-		expandoButton.parentNode.appendChild(wrapperDiv);
-	}
-
-	expandoButton.expandoBox = wrapperDiv;
-	expandoButton.classList.remove('collapsed', 'collapsedExpando');
-	expandoButton.classList.add('expanded');
-
-	expandoButton.addEventListener('click', e => {
-		let msg = null;
-		if (!e.target.className.includes('expanded')) {
-			msg = imageLink.getAttribute('data-pause');
-		} else {
-			msg = imageLink.getAttribute('data-play');
+	iframeNode.expand = () => {
+		if (options.play) {
+			try {
+				iframeNode.contentWindow.postMessage(options.play, '*');
+			} catch (e) {
+				console.error('Could not post "play" command to iframe', options.embed);
+			}
 		}
-		// Pass message to iframe
-		if (msg !== null) $(wrapperDiv).children('iframe')[0].contentWindow.postMessage(msg, '*');
-	}, false);
+	};
 
-	// Pause if comment (or any parent of comment) is collapsed
-	if (isPageType('comments')) {
-		$(expandoButton).parents('.comment').find('> .entry .tagline > .expand').click(() => {
-			$(wrapperDiv).children('iframe')[0].contentWindow.postMessage(imageLink.getAttribute('data-pause'), '*');
-		});
-	}
+	iframeNode.collapse = () => {
+		let removeInstead = true;
+		if (isPageType('comments') && options.pause) {
+			try {
+				iframeNode.contentWindow.postMessage(options.pause, '*');
+				removeInstead = false;
+			} catch (e) {
+				console.error('Could not post "pause" command to  iframe', options.embed);
+			}
+		}
+		return removeInstead;
+	};
 
-	// Delete iframe on close of built-in reddit expando's (if this is part of a linklist page), as they get regenerated on open anyway
-	if (isPageType('linklist', 'modqueue')) {
-		$(expandoButton).closest('div.entry').children('.expando-button:first').click(() => {
-			$(wrapperDiv).children('iframe').remove();
-		});
-	}
+	return iframeNode;
 }
 
-function generateTextExpando(expandoButton) {
-	const imageLink = expandoButton.imageLink;
-	const wrapperDiv = document.createElement('div');
-	wrapperDiv.className = 'usertext';
-	imageLink.wrapperDiv = wrapperDiv;
-
-	const imgDiv = document.createElement('div');
-	imgDiv.className = 'madeVisible usertext-body';
-
-	const header = document.createElement('h3');
-	header.className = 'imgTitle';
-	$(header).safeHtml(imageLink.imageTitle);
-	imgDiv.appendChild(header);
-
-	const text = document.createElement('div');
-	text.className = 'md';
-
-	// filter out iframes, as they will not survive safeHTML
-	// TODO: make safeHTML handle iframes acceptably?
-	imageLink.src = imageLink.src.replace(/<iframe/ig, '&lt;iframe');
-
-	$(text).safeHtml(imageLink.src);
-	imgDiv.appendChild(text);
-
-	const captions = document.createElement('div');
-	captions.className = 'imgCaptions';
-	$(captions).safeHtml(imageLink.caption);
-	imgDiv.appendChild(captions);
-
-	if ('credits' in imageLink) {
-		const credits = document.createElement('div');
-		credits.className = 'imgCredits';
-		$(credits).safeHtml(imageLink.credits);
-		imgDiv.appendChild(credits);
-	}
-
-	wrapperDiv.appendChild(imgDiv);
-	if (expandoButton.classList.contains('commentImg')) {
-		$(expandoButton).after(wrapperDiv);
-	} else {
-		expandoButton.parentNode.appendChild(wrapperDiv);
-	}
-	expandoButton.expandoBox = imgDiv;
-
-	expandoButton.classList.remove('collapsed', 'collapsedExpando');
-	expandoButton.classList.add('expanded');
-
-	// TODO: Decide how to handle history for this.
-	// Selfposts already don't mark it, so either don't bother or add marking for selfposts.
+function generateText(options) {
+	return $(textTemplate(options))[0];
 }
 
-function generateVideoExpando(expandoButton, options) {
+function generateVideo(options) {
 	// Use default values for options not explicitly set
 	const filledOptions = {
 		autoplay: module.options.autoplayVideo.value,
@@ -1331,147 +1292,59 @@ function generateVideoExpando(expandoButton, options) {
 		frameRate: 24,
 		loop: false,
 		muted: true,
+		openInNewWindow: module.options.openInNewWindow.value,
 		playbackRate: 1,
 		reversable: false,
 		time: 0,
-		href: expandoButton.imageLink.href,
 		...options,
 	};
 
-	const element = videoAdvanced(filledOptions);
-
-	generateGenericExpando(expandoButton, {
-		generate: () => element,
-	});
+	return videoAdvanced(filledOptions);
 }
 
-function generateAudioExpando(expandoButton, options) {
-	const imageLink = expandoButton.imageLink;
-	const wrapperDiv = document.createElement('div');
-	wrapperDiv.className = 'usertext';
+function generateAudio(options) {
+	let {
+		autoplay,
+	} = options;
 
-	const imgDiv = document.createElement('div');
-	imgDiv.className = 'madeVisible usertext-body';
+	const audio = $(audioTemplate(options))[0];
 
-	const header = document.createElement('h3');
-	header.className = 'imgTitle';
-	$(header).safeHtml(imageLink.imageTitle);
-	imgDiv.appendChild(header);
+	audio.collapse = () => { autoplay = !audio.paused; if (!audio.paused) audio.pause(); };
+	audio.expand = () => { if (autoplay) audio.play(); };
 
-	const audio = document.createElement('audio');
-	audio.setAttribute('controls', '');
-	if (options) {
-		if (options.autoplay) {
-			audio.setAttribute('autoplay', '');
-		}
-		if (options.muted) {
-			audio.setAttribute('muted', '');
-		}
-		if (options.loop) {
-			audio.setAttribute('loop', '');
-		}
-	}
-	// TODO: add mute/unmute control, play/pause control.
-
-	const sources = $(imageLink).data('sources');
-
-	for (const source of sources) {
-		const sourceEle = document.createElement('source');
-		sourceEle.src = source.file;
-		sourceEle.type = source.type;
-		$(audio).append(sourceEle);
-	}
-
-	imgDiv.appendChild(audio);
-
-	if ('credits' in imageLink) {
-		const credits = document.createElement('div');
-		credits.className = 'imgCredits';
-		$(credits).safeHtml(imageLink.credits);
-		imgDiv.appendChild(credits);
-	}
-
-	wrapperDiv.appendChild(imgDiv);
-	if (expandoButton.classList.contains('commentImg')) {
-		$(expandoButton).after(wrapperDiv);
-	} else {
-		expandoButton.parentNode.appendChild(wrapperDiv);
-	}
-	expandoButton.expandoBox = imgDiv;
-
-	expandoButton.classList.remove('collapsed', 'collapsedExpando');
-	expandoButton.classList.add('expanded');
-
-	if (imageLink.onExpand) {
-		imageLink.onExpand(imageLink);
-	}
-
-	trackMediaLoad(imageLink, audio);
+	return audio;
 }
 
-function generateGenericExpando(expandoButton, options) {
-	const mediaLink = expandoButton.imageLink;
-	const wrapperDiv = document.createElement('div');
-	wrapperDiv.className = 'usertext';
-	mediaLink.wrapperDiv = wrapperDiv;
+function generateGeneric(options) {
+	const element = options.generate(options);
 
 	const mediaDiv = document.createElement('div');
-	mediaDiv.className = 'madeVisible usertext-body';
-
-	const element = options.generate(options);
 	mediaDiv.appendChild(element);
-	wrapperDiv.appendChild(mediaDiv);
 
-	if (expandoButton.classList.contains('commentImg')) {
-		$(expandoButton).after(wrapperDiv);
-	} else {
-		expandoButton.parentNode.appendChild(wrapperDiv);
-	}
-
-	const video = element.querySelector('video');
-
-	expandoButton.expandoBox = mediaDiv;
-	expandoButton.classList.remove('collapsed', 'collapsedExpando');
-	expandoButton.classList.add('expanded');
-	$(expandoButton).data('associatedImage', video || element);
-
-	if (video) {
-		makeMediaZoomable(video);
-		syncPlaceholder(video);
-	}
-
-	if (mediaLink.onExpand) {
-		mediaLink.onExpand(mediaLink);
-	}
-
-	trackMediaLoad(mediaLink, element);
+	return mediaDiv;
 }
 
-async function generateNoEmbedExpando(expandoButton) {
-	const imageLink = expandoButton.imageLink;
-
-	const response = await ajax({
-		url: 'https://noembed.com/embed',
-		data: { url: imageLink.src },
-		type: 'json',
-	});
-
-	const wrapperDiv = document.createElement('div');
-	wrapperDiv.className = 'usertext';
-	imageLink.wrapperDiv = wrapperDiv;
-
+// TODO Correctness not considered since it is not in use
+async function generateNoEmbed(options) {
 	const noEmbedFrame = document.createElement('iframe');
 	// not all noEmbed responses have a height and width, so if
 	// this siteMod has a width and/or height set, use them.
-	if (imageLink.siteMod.width) {
-		noEmbedFrame.setAttribute('width', imageLink.siteMod.width);
+	if (options.width) {
+		noEmbedFrame.setAttribute('width', options.width);
 	}
-	if (imageLink.siteMod.height) {
-		noEmbedFrame.setAttribute('height', imageLink.siteMod.height);
+	if (options.height) {
+		noEmbedFrame.setAttribute('height', options.height);
 	}
-	if (imageLink.siteMod.urlMod) {
-		noEmbedFrame.setAttribute('src', imageLink.siteMod.urlMod(response.url));
+	if (options.urlMod) {
+		noEmbedFrame.setAttribute('src', options.urlMod(response.url));
 	}
+
+	const response = await ajax({
+		url: 'https://noembed.com/embed',
+		data: { url: options.src },
+		type: 'json',
+	});
+
 	for (const key in response) {
 		switch (key) {
 			case 'url':
@@ -1489,19 +1362,8 @@ async function generateNoEmbedExpando(expandoButton) {
 				break;
 		}
 	}
-	noEmbedFrame.className = 'madeVisible usertext-body';
 
-	wrapperDiv.appendChild(noEmbedFrame);
-	if (expandoButton.classList.contains('commentImg')) {
-		$(expandoButton).after(wrapperDiv);
-	} else {
-		expandoButton.parentNode.appendChild(wrapperDiv);
-	}
-
-	expandoButton.expandoBox = noEmbedFrame;
-
-	expandoButton.classList.remove('collapsed', 'collapsedExpando');
-	expandoButton.classList.add('expanded');
+	return noEmbedFrame;
 }
 
 const trackVisit = batch(async links => {
@@ -1519,106 +1381,62 @@ const trackVisit = batch(async links => {
 	});
 }, { delay: 1000 });
 
-function trackMediaLoad(link, media) {
+function trackMediaLoad(link) {
 	if (module.options.markVisited.value) {
 		// also use reddit's mechanism for storing visited links if user has gold.
 		if ($('body').hasClass('gold')) {
 			trackVisit(link);
 		}
+
 		const isNSFW = $(link).closest('.thing').is('.over18');
 		const sfwMode = module.options.sfwHistory.value;
 
-		if (process.env.BUILD_TARGET === 'chrome' || process.env.BUILD_TARGET === 'firefox') {
-			onLoad();
-		} else {
-			media.addEventListener('load', onLoad, false);
-		}
-
-		function onLoad() {
-			const url = link.historyURL || link.href;
-			if (!isNSFW || sfwMode !== 'none') link.classList.add('visited');
-			if (!isNSFW || sfwMode === 'add') {
-				addURLToHistory(url);
-			}
-		}
-	}
-
-	media.addEventListener('load', e => {
-		$(e.target).data('loaded', true);
-		$(e.target).closest('a.madeVisible').removeClass('csspinner');
-	}, false);
-}
-
-const dragTargetData = {
-	// numbers just picked as sane initialization values
-	imageWidth: 100,
-	diagonal: 0, // zero to represent the state where no the mouse button is not down
-	dragging: false,
-};
-const moveTargetData = {
-	moving: false, // Whether the image should move with the mouse or not
-	mouseLastPos: [0, 0], // Last position of the mouse. Used to calculate deltaX and deltaY for our move.
-	hasMoved: false, // If true we will stop click events on the image
-};
-
-function getDragSize(e) {
-	const rc = e.target.getBoundingClientRect();
-	const p = Math.pow;
-	const dragSize = p(p(e.clientX - rc.left, 2) + p(e.clientY - rc.top, 2), 0.5);
-
-	return Math.round(dragSize);
-}
-
-function setPlaceholder(mediaTag) {
-	if (!$(mediaTag).data('imagePlaceholder')) {
-		const thisPH = document.createElement('div');
-		$(thisPH).addClass('RESImagePlaceholder');
-		$(mediaTag).data('imagePlaceholder', thisPH);
-
-		if (mediaTag.tagName === 'VIDEO') {
-			// the placeholder for videos should be sibling to .res-player
-			$(mediaTag).closest('.res-player').parent().append(thisPH);
-		} else {
-			$(mediaTag).parent().append(thisPH);
-		}
-	}
-	// we need to use a different onload event for videos...
-	if (mediaTag.tagName === 'VIDEO') {
-		mediaTag.addEventListener('loadedmetadata', handleMediaLoad);
-	} else {
-		mediaTag.addEventListener('load', handleMediaLoad);
+		const url = link.href;
+		if (!isNSFW || sfwMode !== 'none') link.classList.add('visited');
+		if (!isNSFW || sfwMode === 'add') addURLToHistory(url);
 	}
 }
 
-function setMediaControls(mediaTag) {
-	// Is bar enabled
+function setMediaControls(media, lookupUrl) {
 	if (!module.options.mediaControls.value) return;
 
-	// Generate media controls
-	const controls = document.createElement('div');
-	controls.className = `RESMediaControls ${module.options.mediaControlsPosition.value}`;
-	controls.innerHTML = mediaControlsTemplate();
+	const options = { lookupUrl, position: module.options.mediaControlsPosition.value };
 
-	const $media = $(mediaTag);
-	$media.data('media-controls', controls);
-	$media.parent().append(controls);
+	const element = $(mediaControlsTemplate(options))[0];
+	const controls = element.querySelector('.RESMediaControls');
+	media.parentElement.replaceChild(element, media);
+	element.appendChild(media);
 
-	// Hook up controls
-	$(controls).find('span').click(function(e) {
-		e.preventDefault();
-		e.stopPropagation();
+	let rotationState = 0;
+	let rotationChanged = false;
 
-		// Implement control logic
-		switch ($(this).data('action')) {
+	function hookInResizeListener() {
+		media.addEventListener('resize', () => {
+			const horizontal = rotationState % 2 === 0;
+			const height = horizontal ? media.clientHeight : media.clientWidth;
+			const width = horizontal ? media.clientWidth : media.clientHeight;
+
+			element.style.width = `${width}px`;
+			element.style.height = `${height}px`;
+
+			media.style.position = 'absolute';
+		});
+	}
+
+	controls.addEventListener('click', e => {
+		if (!rotationChanged) {
+			rotationChanged = true;
+			hookInResizeListener();
+		}
+
+		switch (e.target.dataset.action) {
 			case 'rotateLeft':
-				rotateMedia(mediaTag, ($media.data('rotation-state') || 0) - 1);
+				rotateMedia(media, --rotationState);
 				break;
 			case 'rotateRight':
-				rotateMedia(mediaTag, ($media.data('rotation-state') || 0) + 1);
+				rotateMedia(media, ++rotationState);
 				break;
 			case 'imageLookup':
-				let lookupUrl = ($media[0].tagName === 'IMG') ? $media.attr('src') : $media.parent().attr('href');
-
 				// Google doesn't like image url's without a protacol
 				lookupUrl = new URL(lookupUrl, location.href).href;
 
@@ -1631,72 +1449,16 @@ function setMediaControls(mediaTag) {
 				// do nothing if action is unknown
 				break;
 		}
-		return false;
+
+		e.stopPropagation();
+		e.preventDefault();
 	});
-}
-
-function handleMediaLoad() {
-	// don't do this twice (e.g. on image reload from cache), as we get bad height/width data.
-	if ($(this).data('loaded')) {
-		return;
-	}
-	if (!this.tagName) { // validation to fix issue #1672
-		return;
-	}
-
-	$(this).data('loaded', true);
-	if (this.tagName !== 'VIDEO') {
-		this.style.position = 'absolute';
-	}
-
-	syncPlaceholder(this);
-}
-
-function syncPlaceholder(e) {
-	// Get media item as jQuery object
-	const $ele = $(e.target || e);
-
-	const $thisPH = $($ele.data('imagePlaceholder'));
-	const rotationState = $ele.data('rotation-state');
-
-	// Is the media item currently horizontal?
-	const isHorizontal = (rotationState === 1 || rotationState === 3);
-
-	if ($ele[0].tagName !== 'VIDEO') {
-		// Flip height & width if image is horizontal
-		if (isHorizontal) {
-			$thisPH.width(`${$ele.height()}px`).height(`${$ele.width()}px`);
-		} else {
-			$thisPH.width(`${$ele.width()}px`).height(`${$ele.height()}px`);
-		}
-	} else {
-		// get the div.res-player and sync it too
-		const $resPlayer = $ele.parent().closest('.res-player');
-
-		if (isHorizontal) {
-			// Explicitly set container height & width, else videos can get cut off
-			$ele.parent().width(`${$ele.height()}px`).height(`${$ele.width()}px`);
-			$resPlayer.width(`${$ele.height()}px`);
-		} else {
-			// Unset containers height/width
-			$ele.parent().width('auto').height('auto');
-			$resPlayer.width(`${$ele.width()}px`);
-		}
-
-		// Set placeholder height to match players
-		$thisPH.height(`${$resPlayer.height()}px`);
-	}
-	updateParentHeight($ele[0]);
 }
 
 function addSiteAttribution(siteModuleID, expandoBox) {
 	const siteModule = siteModules[siteModuleID];
 	if (siteModule.attribution === false || siteModule.domains.length === 0) {
 		// Site module adds its own attribution or deliberately doesn't want it
-		return;
-	}
-
-	if (!expandoBox) {
 		return;
 	}
 
@@ -1733,43 +1495,106 @@ function setMediaClippyText(elem) {
 }
 
 function makeMediaZoomable(mediaTag) {
-	if (module.options.imageZoom.value) {
-		setPlaceholder(mediaTag);
-		setMediaControls(mediaTag);
-		setMediaClippyText(mediaTag);
+	if (!module.options.imageZoom.value) return;
+	mediaTag.classList.add('res-media-resizeable');
 
-		mediaTag.addEventListener('mousedown', mousedownMedia, false);
-		mediaTag.addEventListener('mouseup', dragMedia, false);
-		mediaTag.addEventListener('mousemove', dragMedia, false);
-		mediaTag.addEventListener('mouseout', mouseoutMedia, false);
+	let dragTargetData;
 
-		mediaTag.addEventListener('click', clickMedia, false);
+	function getDragSize(e) {
+		const rc = e.target.getBoundingClientRect();
+		const p = Math.pow;
+		const dragSize = p(p(e.clientX - rc.left, 2) + p(e.clientY - rc.top, 2), 0.5);
+
+		return Math.round(dragSize);
 	}
+
+	function dragMedia(e) {
+		if (dragTargetData) {
+			const newDiagonal = getDragSize(e);
+			const oldDiagonal = dragTargetData.diagonal;
+
+			if (newDiagonal !== oldDiagonal) {
+				dragTargetData.hasChangedWidth = true;
+
+				const imageWidth = dragTargetData.imageWidth;
+				const maxWidth = Math.max(mediaTag.minWidth, newDiagonal / oldDiagonal * imageWidth);
+
+				resizeMedia(mediaTag, maxWidth);
+			}
+		}
+	}
+
+	mediaTag.addEventListener('mousedown', e => {
+		// shiftKey is used by makeMediaMovable
+		if (e.button === 0 && !e.shiftKey) {
+			if (!e.target.minWidth) mediaTag.minWidth = Math.max(1, Math.min(mediaTag.clientWidth, 100));
+			dragTargetData = {
+				imageWidth: mediaTag.clientWidth,
+				diagonal: getDragSize(e),
+				hasChangedWidth: false,
+			};
+
+			e.preventDefault();
+		}
+	}, false);
+	mediaTag.addEventListener('mouseup', dragMedia, false);
+	mediaTag.addEventListener('mousemove', dragMedia, false);
+	mediaTag.addEventListener('mouseout', () => { dragTargetData = null; }, false);
+	mediaTag.addEventListener('click', e => {
+		if (dragTargetData && dragTargetData.hasChangedWidth) {
+			e.preventDefault();
+		}
+
+		dragTargetData = null;
+	}, false);
 }
 
 function makeMediaMovable(mediaTag) {
-	if (module.options.imageMove.value) {
-		setMediaClippyText(mediaTag);
-		// We can add duplicates safely without checking if makeMediaZoomable already added them
-		// because duplicate EventListeners are discarded
-		// See: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget.addEventListener
-		mediaTag.addEventListener('mousedown', mousedownMedia, false);
-		// The click event fires after the mouseup event, and it is the click event that triggers link following.
-		// Therefore preventing this event and not mouseup.
-		// If we haven't moved we should not prevent the default behaviour
-		mediaTag.addEventListener('click', e => {
-			if (moveTargetData.moving && moveTargetData.hasMoved) {
-				moveTargetData.moving = false;
-				e.preventDefault();
-			}
-		}, false);
-		mediaTag.addEventListener('mousemove', checkMoveMedia, false);
-		mediaTag.addEventListener('mouseout', () => {
+	if (!module.options.imageMove.value) return;
+	mediaTag.classList.add('res-media-movable');
+
+	const moveTargetData = {
+		moving: false, // Whether the image should move with the mouse or not
+		mouseLastPos: [0, 0], // Last position of the mouse. Used to calculate deltaX and deltaY for our move.
+		hasMoved: false, // If true we will stop click events on the image
+	};
+
+	mediaTag.addEventListener('mousedown', e => {
+		if (e.button === 0 && e.shiftKey) {
+			// Record where the move began, both for the cursor and the image
+			moveTargetData.moving = true;
+			moveTargetData.hasMoved = false;
+			moveTargetData.mouseLastPos = [e.clientX, e.clientY];
+		}
+
+		e.preventDefault();
+	}, false);
+
+	// The click event fires after the mouseup event, and it is the click event that triggers link following.
+	// Therefore preventing this event and not mouseup.
+	// If we haven't moved we should not prevent the default behaviour
+	mediaTag.addEventListener('click', e => {
+		if (moveTargetData.moving && moveTargetData.hasMoved) {
 			moveTargetData.moving = false;
-		}, false);
-		// Set this so the image is displayed above the "Set tag" buttons
-		mediaTag.style.zIndex = 1;
-	}
+			e.preventDefault();
+		}
+	}, false);
+	mediaTag.addEventListener('mousemove', e => {
+		if (moveTargetData.moving) {
+			const deltaX = e.clientX - moveTargetData.mouseLastPos[0];
+			const deltaY = e.clientY - moveTargetData.mouseLastPos[1];
+
+			if (deltaX || deltaY) {
+				moveMedia(mediaTag, deltaX, deltaY);
+				moveTargetData.mouseLastPos[0] = e.clientX;
+				moveTargetData.mouseLastPos[1] = e.clientY;
+				moveTargetData.hasMoved = true;
+			}
+		}
+	}, false);
+	mediaTag.addEventListener('mouseout', () => {
+		moveTargetData.moving = false;
+	}, false);
 }
 
 function videoAdvanced(options) {
@@ -1781,7 +1606,8 @@ function videoAdvanced(options) {
 	} = options;
 
 	let {
-		time,
+			autoplay,
+			time,
 	} = options;
 
 	const element = $(videoAdvancedTemplate(options))[0];
@@ -1796,15 +1622,13 @@ function videoAdvanced(options) {
 			time = vid.duration - vid.currentTime;
 
 			Array.from(vid.querySelectorAll('source')).forEach(v => {
-				const currentSrc = v.src;
-				v.src = v.dataset.reverse;
-				v.dataset.reverse = currentSrc;
+				[v.src, v.dataset.reverse] = [v.dataset.reverse, v.src];
 			});
 
 			vid.load();
 			vid.play();
 
-			ctrlReverse.innerHTML = ctrlReverse.innerText === String.fromCharCode(0xf16d) ? '&#xf169;' : '&#xf16d;';
+			element.classList.toggle('reversed');
 		}
 
 		const ctrlContainer = element.querySelector('.video-advanced-controls');
@@ -1853,14 +1677,10 @@ function videoAdvanced(options) {
 
 	function sourceErrorFallback() {
 		if (fallback) {
-			const fallbackImg = document.createElement('img');
-
-			fallbackImg.src = fallback;
-			fallbackImg.className = 'RESImage';
-
-			element.parentNode.replaceChild(fallbackImg, element);
-			makeMediaZoomable(fallbackImg);
-			makeMediaMovable(fallbackImg);
+			element.parentElement.replaceChild(generateImage({
+				...options,
+				src: fallback,
+			}), element);
 		} else {
 			msgError.hidden = false;
 		}
@@ -1876,174 +1696,72 @@ function videoAdvanced(options) {
 		setAdvancedControls();
 	}
 
+	// Ignore events which might be meant for controls
+	vid.addEventListener('mousedown', e => {
+		if (vid.hasAttribute('controls')) {
+			const rc = vid.getBoundingClientRect();
+			let controlsBottomHeight = 0;
+			if (process.env.BUILD_TARGET === 'edge') controlsBottomHeight = 0.5 * rc.height;
+			if (process.env.BUILD_TARGET === 'firefox') controlsBottomHeight = 40;
+			if ((rc.height - controlsBottomHeight) < (e.clientY - rc.top)) {
+				e.stopImmediatePropagation();
+				// FIXME (Firefox) Since anchor is parent, it will be fired on click
+			}
+		}
+	});
+
+	makeMediaZoomable(vid);
+	makeMediaMovable(element);
+	setMediaControls(vid);
+	setMediaClippyText(vid);
+
 	vid.style.maxWidth = `${module.options.maxWidth.value}px`;
 	vid.style.maxHeight = `${module.options.maxHeight.value}px`;
+
+	element.collapse = () => { autoplay = !vid.paused; if (!vid.paused) vid.pause(); };
+	element.expand = () => { if (autoplay) vid.play(); };
+
+	element.ready = Promise.race([waitForEvent(vid, 'loadeddata'), waitForEvent(lastSource, 'error')]);
+
+	vid.addEventListener('loadedmetadata', () => { element.dispatchEvent(new CustomEvent('resize', { bubbles: true })); });
 
 	return element;
 }
 
-function mousedownMedia(e) {
-	if (e.button === 0) {
-		if (!e.shiftKey) {
-			if (e.target.tagName === 'VIDEO' && e.target.hasAttribute('controls')) {
-				const rc = e.target.getBoundingClientRect();
-				// ignore drag if click is in control area (40 px from bottom of video, 50% of player size for edge.)
-				const controlsHeight = (process.env.BUILD_TARGET === 'edge') ? (0.5 * rc.height) : 40;
-				if ((rc.height - controlsHeight) < (e.clientY - rc.top)) {
-					return true;
-				}
-			}
-			if (!e.target.minWidth) e.target.minWidth = Math.max(1, Math.min($(e.target).width(), 100));
-			dragTargetData.imageWidth = $(e.target).width();
-			dragTargetData.diagonal = getDragSize(e);
-			dragTargetData.dragging = false;
-			dragTargetData.hasChangedWidth = false;
-		} else {
-			// Record where the move began, both for the cursor and the image
-			moveTargetData.moving = true;
-			moveTargetData.hasMoved = false;
-			moveTargetData.mouseLastPos = [e.clientX, e.clientY];
-		}
-		e.preventDefault();
-	}
-}
-
-function mouseoutMedia() {
-	dragTargetData.diagonal = 0;
-}
-
-function dragMedia(e) {
-	if (dragTargetData.diagonal) {
-		const newDiagonal = getDragSize(e);
-		const oldDiagonal = dragTargetData.diagonal;
-		const imageWidth = dragTargetData.imageWidth;
-		const maxWidth = Math.max(e.target.minWidth, newDiagonal / oldDiagonal * imageWidth);
-
-		if (Math.abs(newDiagonal - oldDiagonal) > 5 && e.target.tagName === 'VIDEO') {
-			e.target.preventPlayPause = true;
-		}
-
-		resizeMedia(e.target, maxWidth);
-		dragTargetData.dragging = true;
-	}
-	if (e.type === 'mouseup') {
-		dragTargetData.diagonal = 0;
-	}
-}
-
-function checkMoveMedia(e) {
-	if (moveTargetData.moving) {
-		const deltaX = e.clientX - moveTargetData.mouseLastPos[0];
-		const deltaY = e.clientY - moveTargetData.mouseLastPos[1];
-		moveMedia(e.target, deltaX, deltaY);
-
-		moveTargetData.mouseLastPos[0] = e.clientX;
-		moveTargetData.mouseLastPos[1] = e.clientY;
-		moveTargetData.hasMoved = true;
-	}
-}
-
 export function moveMedia(ele, deltaX, deltaY) {
-	$(ele).css('margin-left', parseInt($(ele).css('margin-left'), 10) + deltaX);
-	$(ele).css('margin-top', parseInt($(ele).css('margin-top'), 10) + deltaY);
-
-	if (ele.tagName !== 'VIDEO') {
-		ele.style.position = 'absolute';
-	}
-
-	syncPlaceholder(ele);
-}
-
-function clickMedia(e) {
-	dragTargetData.diagonal = 0;
-	if (dragTargetData.hasChangedWidth) {
-		dragTargetData.dragging = false;
-		// if video let video controls function
-		if (e.target.tagName === 'VIDEO' && e.target.hasAttribute('controls')) {
-			const rc = e.target.getBoundingClientRect();
-			// ignore drag if click is in control area (40 px from bottom of video)
-			if ((rc.height - 40) < (e.clientY - rc.top)) {
-				return true;
-			}
-		}
-		e.preventDefault();
-		return false;
-	}
-	dragTargetData.hasChangedWidth = false;
+	ele.style.left = `${(parseFloat(ele.style.left, 10) || 0) + deltaX}px`;
+	ele.style.top = `${(parseFloat(ele.style.top, 10) || 0) + deltaY}px`;
 }
 
 export function resizeMedia(ele, newWidth) {
-	const currWidth = $(ele).width();
-	if (newWidth !== currWidth) {
-		dragTargetData.hasChangedWidth = true;
+	ele.style.width = `${newWidth}px`;
+	ele.style.maxWidth = `${newWidth}px`;
+	ele.style.maxHeight = '';
+	ele.style.height = 'auto';
 
-		ele.style.width = `${newWidth}px`;
-		ele.style.maxWidth = `${newWidth}px`;
-		ele.style.maxHeight = '';
-		ele.style.height = 'auto';
-
-		if (ele.tagName !== 'VIDEO') {
-			ele.style.position = 'absolute';
-		}
-
-		syncPlaceholder(ele);
-	}
+	ele.dispatchEvent(new CustomEvent('resize', { bubbles: true }));
 }
 
 function rotateMedia(ele, rotationState) {
-	const $ele = $(ele);
-	// get valid rotation state
-	const newRotationState = Math.abs(rotationState % 4);
-
-	// apply data
-	$ele.css('transform-origin', 'top left');
-	$ele.data('rotation-state', newRotationState);
+	ele.style.transformOrigin = 'top left';
 
 	// apply rotation
-	switch (newRotationState) {
+	switch (((rotationState % 4) + 4) % 4) {
 		case 0:
-			$ele.css('transform', '');
+			ele.style.transform = '';
 			break;
 		case 1:
-			$ele.css('transform', 'rotate(90deg) translateY(-100%)');
+			ele.style.transform = 'rotate(90deg) translateY(-100%)';
 			break;
 		case 2:
-			$ele.css('transform', 'rotate(180deg) translate(-100%, -100%)');
+			ele.style.transform = 'rotate(180deg) translate(-100%, -100%)';
 			break;
 		case 3:
-			$ele.css('transform', 'rotate(270deg) translateX(-100%)');
+			ele.style.transform = 'rotate(270deg) translateX(-100%)';
 			break;
 		default:
-			$ele.css('transform', ''); // default on unknown value
 			break;
 	}
 
-	// re-sync container heights
-	syncPlaceholder(ele);
-}
-
-function updateParentHeight(ele) {
-	if (module.options.autoMaxHeight.value && ele) {
-		const parent = $(ele).closest('.md')[0];
-		const type = $(parent).closest('body:not(.comments-page) .expando')[0] || $(parent).closest('.thing')[0];
-		if (parent && (type.classList.contains('expando') || type.classList.contains('comment'))) {
-			const placeholders = $(parent).find('.expando-button.expanded + * .RESImagePlaceholder, .expando-button.expanded + * > *:not(p)');
-			const selfMax = parseInt(module.options.selfTextMaxHeight.value, 10);
-			const commentMax = parseInt(module.options.commentMaxHeight.value, 10);
-			let height = 0;
-
-			for (const placeholder of Array.from(placeholders)) {
-				const tempHeight = $(placeholder).height();
-				if ((tempHeight || 0) > height) {
-					height = tempHeight;
-				}
-			}
-
-			if (selfMax && type.classList.contains('expando')) {
-				parent.style.maxHeight = `${(height > selfMax) ? height : selfMax}px`;
-			} else if (commentMax && type.classList.contains('comment')) {
-				parent.style.maxHeight = `${(height > commentMax) ? height : commentMax}px`;
-			}
-		}
-	}
+	ele.dispatchEvent(new CustomEvent('resize', { bubbles: true }));
 }

--- a/lib/modules/showParent.js
+++ b/lib/modules/showParent.js
@@ -162,7 +162,7 @@ export function showCommentHover(base) {
 	I am stripping out the image viewer stuff for now.
 	Making the image viewer work here requires some changes that are for another time.
 	*/
-	$parents.find('.madeVisible, .toggleImage').remove(); // image viewer
+	$parents.find('.res-expando, .toggleImage').remove(); // image viewer
 	$parents.find('.keyNavAnnotation').remove();
 
 	const $container = $('<div class="parentCommentWrapper">');

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -99,12 +99,11 @@ module.go = function() {
 		if (tagsPerPage) {
 			const controlWrapper = document.createElement('div');
 			controlWrapper.id = 'tagPageControls';
-			controlWrapper.className = 'RESGalleryControls';
 			controlWrapper.page = 1;
 			controlWrapper.pageCount = 1;
 
 			const leftButton = document.createElement('a');
-			leftButton.className = 'previous noKeyNav';
+			leftButton.className = 'res-step noKeyNav';
 			leftButton.addEventListener('click', () => {
 				if (controlWrapper.page === 1) {
 					controlWrapper.page = controlWrapper.pageCount;
@@ -117,12 +116,12 @@ module.go = function() {
 			controlWrapper.appendChild(leftButton);
 
 			const posLabel = document.createElement('span');
-			posLabel.className = 'RESGalleryLabel';
+			posLabel.className = 'res-step-progress';
 			posLabel.textContent = '1 of 2';
 			controlWrapper.appendChild(posLabel);
 
 			const rightButton = document.createElement('a');
-			rightButton.className = 'next noKeyNav';
+			rightButton.className = 'res-step res-step-reverse noKeyNav';
 			rightButton.addEventListener('click', () => {
 				if (controlWrapper.page === controlWrapper.pageCount) {
 					controlWrapper.page = 1;
@@ -429,7 +428,7 @@ function drawUserTagTable(sortMethod, descending) {
 		page = Math.min(page, pages);
 		page = Math.max(page, 1);
 		$tagControls.prop('page', page).prop('pageCount', pages);
-		$tagControls.find('.RESGalleryLabel').text(`${page} of ${pages}`);
+		$tagControls.find('.res-step-progress').text(`${page} of ${pages}`);
 		start = tagsPerPage * (page - 1);
 		end = Math.min(count, tagsPerPage * page);
 	}

--- a/lib/templates/audio.mustache
+++ b/lib/templates/audio.mustache
@@ -1,0 +1,5 @@
+<audio controls {{#muted}}muted{{/muted}} {{#loop}}loop{{/loop}}>
+	{{#sources}}
+	<source src="{{ file }}" {{#type}}type="{{ type }}"{{/type}}>
+	{{/sources}}
+</audio>

--- a/lib/templates/expando.mustache
+++ b/lib/templates/expando.mustache
@@ -1,0 +1,3 @@
+<div class="res-expando" style="min-height: {{loadHeight}}px">
+	<div class="res-expando-media" style="width: {{textMaxWidth}}px"></div>
+</div>

--- a/lib/templates/gallery.mustache
+++ b/lib/templates/gallery.mustache
@@ -1,0 +1,27 @@
+<div class="res-gallery">
+	{{#title}}
+	<h3 class="res-gallery-title">{{title}}</h3>
+	{{/title}}
+	{{#caption}}
+	<div class="res-gallery-caption">{{{caption}}}</div>
+	{{/caption}}
+	{{#credits}}
+	<div class="res-credits">{{{credits}}}</div>
+	{{/credits}}
+	<div class="res-gallery-individual-controls">
+		<div class="res-step res-gallery-previous"></div>
+		<div class="res-step-progress">
+			<span class="res-gallery-position">1</span> of {{pieces.length}}
+		</div>
+		<div class="res-step res-gallery-next"></div>
+	</div>
+	<div class="res-gallery-pieces"></div>
+	<div class="res-gallery-below">
+		<div>
+			<div class="res-expando-siteAttribution"></div>
+			<div class="res-gallery-increase-concurrent">
+				Show in film strip mode
+			</div>
+		</div>
+	</div>
+</div>

--- a/lib/templates/gallery.mustache
+++ b/lib/templates/gallery.mustache
@@ -13,15 +13,13 @@
 		<div class="res-step-progress">
 			<span class="res-gallery-position">1</span> of {{pieces.length}}
 		</div>
-		<div class="res-step res-gallery-next"></div>
+		<div class="res-step res-step-reverse res-gallery-next"></div>
 	</div>
 	<div class="res-gallery-pieces"></div>
 	<div class="res-gallery-below">
 		<div>
 			<div class="res-expando-siteAttribution"></div>
-			<div class="res-gallery-increase-concurrent">
-				Show in film strip mode
-			</div>
+			<div class="res-gallery-increase-concurrent"></div>
 		</div>
 	</div>
 </div>

--- a/lib/templates/gallery.mustache
+++ b/lib/templates/gallery.mustache
@@ -1,9 +1,9 @@
 <div class="res-gallery">
 	{{#title}}
-	<h3 class="res-gallery-title">{{title}}</h3>
+	<h3 class="res-gallery res-gallery-title">{{title}}</h3>
 	{{/title}}
 	{{#caption}}
-	<div class="res-gallery-caption">{{{caption}}}</div>
+	<div class="res-caption res-gallery-caption">{{{caption}}}</div>
 	{{/caption}}
 	{{#credits}}
 	<div class="res-credits">{{{credits}}}</div>

--- a/lib/templates/image.mustache
+++ b/lib/templates/image.mustache
@@ -1,0 +1,14 @@
+<div class="res-image">
+	{{#title}}
+	<h4 class="res-title">{{title}}</h4>
+	{{/title}}
+	{{#caption}}
+	<div class="res-image-caption">{{caption}}</div>
+	{{/caption}}
+	<a class="noKeyNav" href="{{href}}" {{#openInNewWindow}}target="_blank" rel="noopener noreferrer"{{/openInNewWindow}}>
+		<img class="res-image-media" src="{{src}}">
+	</a>
+	{{#credits}}
+	<div class="res-credits">{{{credits}}}</div>
+	{{/credits}}
+</div>

--- a/lib/templates/image.mustache
+++ b/lib/templates/image.mustache
@@ -3,7 +3,7 @@
 	<h4 class="res-title">{{title}}</h4>
 	{{/title}}
 	{{#caption}}
-	<div class="res-image-caption">{{caption}}</div>
+	<div class="res-caption">{{caption}}</div>
 	{{/caption}}
 	<a class="noKeyNav" href="{{href}}" {{#openInNewWindow}}target="_blank" rel="noopener noreferrer"{{/openInNewWindow}}>
 		<img class="res-image-media" src="{{src}}">

--- a/lib/templates/mediaControls.mustache
+++ b/lib/templates/mediaControls.mustache
@@ -1,4 +1,10 @@
-<span class="res-icon gearIcon" title="Settings" data-action="showImageSettings"></span>
-<span class="rotateLeft res-icon" title="Rotate image counter-clockwise" data-action="rotateLeft"></span>
-<span class="rotateRight res-icon" title="Rotate image clockwise" data-action="rotateRight"></span>
-<span class="imageLookup res-icon" title="Reverse image seach" data-action="imageLookup"></span>
+<div class="res-media-rotatable">
+	<div class="RESMediaControls {{position}}">
+		<span class="res-icon gearIcon" title="Settings" data-action="showImageSettings"></span>
+		<span class="rotateLeft res-icon" title="Rotate image counter-clockwise" data-action="rotateLeft"></span>
+		<span class="rotateRight res-icon" title="Rotate image clockwise" data-action="rotateRight"></span>
+		{{#lookupUrl}}
+		<span class="imageLookup res-icon" title="Reverse image seach" data-action="imageLookup"></span>
+		{{/lookupUrl}}
+	<div>
+</div>

--- a/lib/templates/text.mustache
+++ b/lib/templates/text.mustache
@@ -1,0 +1,9 @@
+<div class="res-text usertext-body">
+	{{#title}}
+	<h3 class="res-title">{{title}}</h3>
+	{{/title}}
+	<div class="res-text-media md">{{{src}}}</div>
+	{{#credits}}
+	<div class="res-credits">{{{credits}}}</div>
+	{{/credits}}
+</div>

--- a/lib/templates/videoAdvanced.mustache
+++ b/lib/templates/videoAdvanced.mustache
@@ -25,7 +25,7 @@
 			</div>
 			<div class="video-advanced-main">
 				{{#advancedControls}}
-				<div hidden class="video-advanced-controls">
+				<div class="video-advanced-controls">
 					<div title="Toggle pause" class="res-icon video-advanced-button video-advanced-toggle-pause"></div>
 					{{#reversable}}
 					<div title="Reverse video" class="res-icon video-advanced-button video-advanced-reverse"></div>

--- a/lib/templates/videoAdvanced.mustache
+++ b/lib/templates/videoAdvanced.mustache
@@ -1,49 +1,60 @@
-<div class="res-player video video-advanced">
-	<a class="madeVisible" target="_blank" href="{{href}}">
-		<video {{#controls}}controls{{/controls}} {{#autoplay}}autoplay{{/autoplay}} {{#muted}}muted{{/muted}} {{#loop}}loop{{/loop}} poster="{{ poster }}">
+<div class="video-advanced">
+	<div class="video-advanced-container">
+		{{^controls}}
+		<a class="noKeyNav" href="{{href}}" {{#openInNewWindow}}target="_blank" rel="noopener noreferrer"{{/openInNewWindow}}>
+			<video {{#muted}}muted{{/muted}} {{#loop}}loop{{/loop}} poster="{{ poster }}">
+				{{#sources}}
+				<source src="{{ source }}" {{#type}}type="{{ type }}"{{/type}} {{#reverse}}data-reverse="{{ reverse }}"{{/reverse}}>
+				{{/sources}}
+			</video>
+		</a>
+		{{/controls}}
+		{{#controls}}
+		<video controls {{#muted}}muted{{/muted}} {{#loop}}loop{{/loop}} poster="{{ poster }}">
 			{{#sources}}
 			<source src="{{ source }}" {{#type}}type="{{ type }}"{{/type}} {{#reverse}}data-reverse="{{ reverse }}"{{/reverse}}>
 			{{/sources}}
 		</video>
-	</a>
-	<div class="video-advanced-interface {{#controls}}video-advanced-push-below{{/controls}}">
-		<div class="video-advanced-progress">
-			{{#advancedControls}}
-			<div class="video-advanced-position"></div>
-			<div class="video-advanced-position-thumb"></div>
-			{{/advancedControls}}
-		</div>
-		<div class="video-advanced-main">
-			{{#advancedControls}}
-			<div hidden class="video-advanced-controls">
-				<div title="Toggle pause" class="res-icon video-advanced-button video-advanced-toggle-pause"></div>
-				{{#reversable}}
-				<div title="Reverse video" class="res-icon video-advanced-button video-advanced-reverse"></div>
-				{{/reversable}}
-				<div class="video-advanced-controls-group video-advanced-current-time">
-					<div title="Select previous frame" class="res-icon video-advanced-button video-advanced-time-decrease"></div>
-					<div class="video-advanced-time">1.00s</div>
-					<div title="Select next frame" class="res-icon video-advanced-button video-advanced-time-increase"></div>
-				</div>
-				<div class="video-advanced-controls-group video-advanced-playback-rate">
-					<div title="Decrease speed by 10%" class="res-icon video-advanced-button video-advanced-speed-decrease"></div>
-					<div class="video-advanced-speed">1.00x</div>
-					<div title="Increase speed by 10%" class="res-icon video-advanced-button video-advanced-speed-increase"></div>
-				</div>
+		{{/controls}}
+		<div class="video-advanced-interface {{#controls}}video-advanced-push-below{{/controls}}">
+			<div class="video-advanced-progress">
+				{{#advancedControls}}
+				<div class="video-advanced-position"></div>
+				<div class="video-advanced-position-thumb"></div>
+				{{/advancedControls}}
 			</div>
-			{{/advancedControls}}
-			<div hidden class="video-advanced-error">
-				<div class="res-icon">&#xf15b</div>
-				<span>Could not load video</span>
-			</div>
-			<div class="video-advanced-info">
-				{{#source}}
-				<a class="video-advanced-link video-advanced-source" href="{{ source }}">source</a>
-				{{/source}}
-				{{#downloadurl}}
-				<a class="video-advanced-link video-advanced-download res-icon" href="{{ downloadurl }}" title="download"></a>
-				{{/downloadurl}}
-				<div class="res-expando-siteAttribution"></div>
+			<div class="video-advanced-main">
+				{{#advancedControls}}
+				<div hidden class="video-advanced-controls">
+					<div title="Toggle pause" class="res-icon video-advanced-button video-advanced-toggle-pause"></div>
+					{{#reversable}}
+					<div title="Reverse video" class="res-icon video-advanced-button video-advanced-reverse"></div>
+					{{/reversable}}
+					<div class="video-advanced-controls-group video-advanced-current-time">
+						<div title="Select previous frame" class="res-icon video-advanced-button video-advanced-time-decrease"></div>
+						<div class="video-advanced-time">1.00s</div>
+						<div title="Select next frame" class="res-icon video-advanced-button video-advanced-time-increase"></div>
+					</div>
+					<div class="video-advanced-controls-group video-advanced-playback-rate">
+						<div title="Decrease speed by 10%" class="res-icon video-advanced-button video-advanced-speed-decrease"></div>
+						<div class="video-advanced-speed">1.00x</div>
+						<div title="Increase speed by 10%" class="res-icon video-advanced-button video-advanced-speed-increase"></div>
+					</div>
+				</div>
+				{{/advancedControls}}
+				<div hidden class="video-advanced-error">
+					<div class="res-icon">&#xf15b</div>
+					<span>Could not load video</span>
+				</div>
+				<div class="video-advanced-info">
+					{{#source}}
+					<a class="video-advanced-link video-advanced-source" href="{{ source }}">source</a>
+					{{/source}}
+					{{#downloadurl}}
+					<a class="video-advanced-link video-advanced-download res-icon" href="{{ downloadurl }}" title="download"></a>
+					{{/downloadurl}}
+					<div class="res-expando-siteAttribution"></div>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/lib/vendor/index.js
+++ b/lib/vendor/index.js
@@ -54,8 +54,7 @@ require('./HTMLPasteurizer');
 const Pasteurizer = GLOBAL.Pasteurizer;
 
 $.fn.safeHtml = function(string) {
-	if (!string) return '';
 	return $(this).html(
-		Pasteurizer.safeParseHTML(string).wrapAll('<div></div>').parent().html()
+		Pasteurizer.safeParseHTML(string || '').wrapAll('<div></div>').parent().html() || ''
 	);
 };


### PR DESCRIPTION
- Separated gallery from `generateImageExpando`
- Gallery requires an array `src`, which pieces it pipes into their respective generation functions
- Gallery preloads by default 2 pieces
- `buildExpando` is abstracted from `generate*Expando`, which creates a container it can put the media which is generated from `generate*` into
 - All `generate*Expando` has been partially refactored to `generate$0`, and now only requires an options-object, and return a element
 - `generateImage`, `generateAudio`, and `generateText` is now template based
 - Methods `collapse` on `expand` allows the media to determine itself how to process these events
- The placeholder is replaced with setting the parent height
 - When a media is resized, it will emit a `resize` event
 - `rotateMedia` only hooks into the event when utilized
- `conserveMemory` is refactored to work for both expandos and galleries, and by calling the media's `restore` and `unload` functions let itself determine how to go into a low-memory state
- Some simplication of `makeMediaZoomable`, `makeMediaMovable`, and `setMediaControls`

Fixes #2918, fixes #2828, fixes #2923, fixes #2883 
Lays groundwork for #1833

Tested on Firefox 46 and Chrome 50.