### PR TITLE
[Resub] Add options in showImages to display captions above or below images.

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -909,20 +909,20 @@ addModule('showImages', (module, moduleID) => {
 			imgDiv.sources[0] = singleImage;
 		}
 
-		let header;
 		// Pre-generate elements to be added based on caption ordering option
+		let header, captions, credits;
 		if ('imageTitle' in imageLink) {
 			header = document.createElement('h3');
 			header.classList.add('imgTitle');
 			$(header).safeHtml(imageLink.imageTitle);
 		}
 		if ('caption' in imageLink) {
-			const captions = document.createElement('div');
+			captions = document.createElement('div');
 			captions.className = 'imgCaptions';
 			$(captions).safeHtml(imageLink.caption);
 		}
 		if ('credits' in imageLink) {
-			const credits = document.createElement('div');
+			credits = document.createElement('div');
 			credits.className = 'imgCredits';
 			$(credits).safeHtml(imageLink.credits);
 		}
@@ -1037,13 +1037,14 @@ addModule('showImages', (module, moduleID) => {
 			}
 
 			// Pre-generate elements to be added based on caption ordering option
+			let imageTitle, imageCaptions;
 			if ('title' in sourceImage) {
-				const imageTitle = document.createElement('h4');
+				imageTitle = document.createElement('h4');
 				imageTitle.className = 'imgCaptions';
 				$(imageTitle).safeHtml(sourceImage.title);
 			}
 			if ('caption' in sourceImage) {
-				const imageCaptions = document.createElement('div');
+				imageCaptions = document.createElement('div');
 				imageCaptions.className = 'imgCaptions';
 				$(imageCaptions).safeHtml(sourceImage.caption);
 			}

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -160,6 +160,26 @@ addModule('showImages', (module, moduleID) => {
 			advanced: true,
 			bodyClass: true
 		},
+		captionsPosition: {
+			dependsOn: 'displayImageCaptions',
+			type: 'enum',
+			value: 'titleAbove',
+			values: [{
+				name: 'Display all captions above image.',
+				value: 'allAbove'
+			}, {
+				name: 'Display title and caption above image, credits below.',
+				value: 'creditsBelow'
+			}, {
+				name: 'Display title above image, caption and credits below.',
+				value: 'titleAbove'
+			}, {
+				name: 'Display all captions below image.',
+				value: 'allBelow'
+			}],
+			description: 'Where to display captions around an image.',
+			advanced: true
+		},
 		loadAllInAlbum: {
 			type: 'boolean',
 			value: false,
@@ -890,26 +910,31 @@ addModule('showImages', (module, moduleID) => {
 		}
 
 		let header;
+		// Pre-generate elements to be added based on caption ordering option
 		if ('imageTitle' in imageLink) {
 			header = document.createElement('h3');
 			header.classList.add('imgTitle');
 			$(header).safeHtml(imageLink.imageTitle);
-			imgDiv.appendChild(header);
 		}
-
 		if ('caption' in imageLink) {
 			const captions = document.createElement('div');
 			captions.className = 'imgCaptions';
 			$(captions).safeHtml(imageLink.caption);
-			imgDiv.appendChild(captions);
 		}
-
 		if ('credits' in imageLink) {
 			const credits = document.createElement('div');
 			credits.className = 'imgCredits';
 			$(credits).safeHtml(imageLink.credits);
-			imgDiv.appendChild(credits);
 		}
+
+		const captionsAboveBelow = modules['showImages'].options.captionsPosition.value;
+		if (header && captionsAboveBelow !== 'allBelow') imgDiv.appendChild(header);
+		if (captions && (captionsAboveBelow === 'allAbove' || captionsAboveBelow === 'creditsBelow')) imgDiv.appendChild(captions);
+		if (credits && captionsAboveBelow === 'allAbove') imgDiv.appendChild(credits);
+
+		// Create paragraph to hold image captions, if necessary
+		let imgCapPar;
+		if (captionsAboveBelow === 'allBelow') imgCapPar = document.createElement('p');
 
 		let leftButton, rightButton;
 
@@ -987,33 +1012,45 @@ addModule('showImages', (module, moduleID) => {
 				}
 				/* falls through */
 			case 'IMAGE':
-				addImage(imgDiv, which, this);
+				addImage(imgDiv, which, imgCapPar);
 				break;
 			default:
 				throw new Error(`Invalid image expando type: ${imageLink.type}`);
 		}
 
-		function addImage(container, sourceNumber) {
+		if (captionsAboveBelow === 'allBelow') {
+			if (header) imgDiv.appendChild(header);
+			if (imgCapPar) imgDiv.appendChild(imgCapPar);
+		}
+		if (captions && (captionsAboveBelow === 'allBelow' || captionsAboveBelow === 'titleAbove')) imgDiv.appendChild(captions);
+		if (credits && captionsAboveBelow !== 'allAbove') imgDiv.appendChild(credits);
+
+		function addImage(container, sourceNumber, captionContainer) {
 			const sourceImage = container.sources[sourceNumber];
 
-			const paragraph = document.createElement('p');
+			if (!captionContainer) {
+				captionContainer = document.createElement('p');
+			}
 
 			if (!sourceImage) {
 				return;
 			}
+
+			// Pre-generate elements to be added based on caption ordering option
 			if ('title' in sourceImage) {
 				const imageTitle = document.createElement('h4');
 				imageTitle.className = 'imgCaptions';
 				$(imageTitle).safeHtml(sourceImage.title);
-				paragraph.appendChild(imageTitle);
 			}
-
 			if ('caption' in sourceImage) {
 				const imageCaptions = document.createElement('div');
 				imageCaptions.className = 'imgCaptions';
 				$(imageCaptions).safeHtml(sourceImage.caption);
-				paragraph.appendChild(imageCaptions);
 			}
+
+			const captionsAboveBelow = modules['showImages'].options.captionsPosition.value;
+			if (imageTitle && captionsAboveBelow !== 'allBelow') captionContainer.appendChild(imageTitle);
+			if (imageCaptions && (captionsAboveBelow === 'allAbove' || captionsAboveBelow === 'creditsBelow')) captionContainer.appendChild(imageCaptions);
 
 			const imageAnchor = document.createElement('a');
 			imageAnchor.classList.add('madeVisible');
@@ -1029,9 +1066,12 @@ addModule('showImages', (module, moduleID) => {
 			module.makeMediaZoomable(media);
 			module.makeMediaMovable(media);
 			trackMediaLoad(imageLink, media);
-			paragraph.appendChild(imageAnchor);
+			captionContainer.appendChild(imageAnchor);
 
-			container.appendChild(paragraph);
+			if (imageTitle && captionsAboveBelow === 'allBelow') captionContainer.appendChild(imageTitle);
+			if (imageCaptions && (captionsAboveBelow === 'allBelow' || captionsAboveBelow === 'titleAbove')) captionContainer.appendChild(imageCaptions);
+
+			container.appendChild(captionContainer);
 		}
 
 		function generateImage(sourceImage) {


### PR DESCRIPTION
Updating my repository closed the **[OLD PULL REQUEST](https://github.com/honestbleeps/Reddit-Enhancement-Suite/pull/2685)**.

Currently, when you expando an image, all captions (titles, "caption" captions, and credits) are displayed above it. This is generally not the desired style, since captions are most commonly displayed under the image. More specifically, this destroys the ordering of Tumblr galleries that continue into the description.

I have made a few simple additions that give users four options:
* **(Current)** Display all captions above the image
* Display the title and caption above the image, and the credits below it
* **(New Default)** Display the title above the image, and the caption and credits below it
* Display all captions below the image