### PR TITLE
replace `Element.prototype.matches` with `jQuery.fn.is`

### DIFF
--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -261,13 +261,13 @@ RESUtils.dom.observe = (ele, options, callback) => {
 
 RESUtils.dom.waitForChild = (ele, selector, { initialCheck = true } = {}) =>
 	new Promise(resolve => {
-		if (initialCheck && Array.from(ele.children).some(child => child.matches(selector))) {
+		if (initialCheck && Array.from(ele.children).some(child => $(child).is(selector))) {
 			resolve();
 			return;
 		}
 
 		const observer = RESUtils.dom.observe(ele, { childList: true }, mutation => {
-			if (Array.from(mutation.addedNodes).some(node => node.nodeType === Node.ELEMENT_NODE && node.matches(selector))) {
+			if (Array.from(mutation.addedNodes).some(node => node.nodeType === Node.ELEMENT_NODE && $(node).is(selector))) {
 				observer.disconnect();
 				resolve();
 				return true;

--- a/lib/modules/noParticipation.js
+++ b/lib/modules/noParticipation.js
@@ -76,7 +76,7 @@ addModule('noParticipation', (module, moduleID) => {
 	function removeNpFromLink(event) {
 		const elem = event.target;
 		if (elem.tagName !== 'A') return;
-		if (elem.matches('.md a')) return;
+		if ($(elem).is('.md a')) return;
 		const href = elem.getAttribute('href');
 		let hrefSansNp;
 		if (href[0] === '/') {


### PR DESCRIPTION
for Edge compatibility. See #2880.

jQuery defers to `Element.prototype.matches` for [single-element](https://github.com/jquery/jquery/blob/055cb7534e2dcf7ee8ad145be83cb2d74b5331c7/src/traversing/findFilter.js#L47-L48) `$.fn.is` [where supported](https://github.com/jquery/jquery/blob/055cb7534e2dcf7ee8ad145be83cb2d74b5331c7/external/sizzle/dist/sizzle.js#L933-L939), so this should be effectively the same for the other browsers.