### PR TITLE
imgur: allow exactly 5 or 7 char ids (not 6), and an [a-z] suffix

### DIFF
--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -31,8 +31,8 @@ addLibrary('mediaHosts', 'imgur', {
 	// was too greedy a search...
 	// the hashRe below was provided directly by MrGrim (well, everything after the domain was), using that now.
 	// in addition to the above, the album index was moved out of the first capture group.
-	hashRe: /^https?:\/\/(?:i\.|m\.|edge\.|www\.)*imgur\.com\/(?:r\/\w+\/)*(?!gallery)(?!removalrequest)(?!random)(?!memegen)(\w{5,7}(?:[&,]\w{5,7})*)(?:#\d+)?[sbtmlh]?(\.(?:jpe?g|gif|png|gifv))?(\?.*)?$/i,
-	hostedHashRe: /^https?:(\/\/i\.\w+\.*imgur\.com\/)(\w{5,7}(?:[&,]\w{5,7})*)(?:#\d+)?[sbtmlh]?(\.(?:jpe?g|gif|png))?(\?.*)?$/i,
+	hashRe: /^https?:\/\/(?:i\.|m\.|edge\.|www\.)*imgur\.com\/(?:r\/\w+\/)*(?!gallery)(?!removalrequest)(?!random)(?!memegen)(\w{5}(?:\w{2})?(?:[&,]\w{5}(?:\w{2})?)*)(?:#\d+)?[a-z]?(\.(?:jpe?g|gif|png|gifv))?(\?.*)?$/i,
+	hostedHashRe: /^https?:(\/\/i\.\w+\.*imgur\.com\/)(\w{5}(?:\w{2})?(?:[&,]\w{5}(?:\w{2})?)*)(?:#\d+)?[a-z]?(\.(?:jpe?g|gif|png))?(\?.*)?$/i,
 	galleryHashRe: /^https?:\/\/(?:m\.|www\.)?imgur\.com\/gallery\/(\w+)(?:[/#]|$)/i,
 	albumHashRe: /^https?:\/\/(?:m\.|www\.)?imgur\.com\/a\/(\w+)(?:[/#]|$)/i,
 	detect: (href, elem) => (


### PR DESCRIPTION
Fixes #2911.

This has the added benefit of ignoring size suffixes on 5-char ids.