### PR TITLE
Rebase #2424: visitedStyle changes

### DIFF
--- a/lib/css/modules/_nightMode.scss
+++ b/lib/css/modules/_nightMode.scss
@@ -996,25 +996,20 @@
 	}
 
 	// Ordering of user colors is important.
-	.tagline .friend,
-	.tagline .friend:visited {
+	.tagline .friend {
 		color: rgb(210, 90, 50);
 	}
 
-	.tagline .submitter,
-	.tagline .submitter:visited {
+	.tagline .submitter {
 		color: hsl(200, 100%, 50%);
 	}
 
-	.tagline .moderator,
-	.tagline .moderator:visited {
+	.tagline .moderator {
 		color: rgb(34, 136, 34);
 	}
 
 	.tagline .admin,
-	.tagline .admin:visited,
-	.user-distinction .admin,
-	.user-distinction .admin:visited {
+	.user-distinction .admin {
 		color: rgb(200, 20, 20);
 	}
 

--- a/lib/css/modules/_styleTweaks.scss
+++ b/lib/css/modules/_styleTweaks.scss
@@ -13,7 +13,6 @@ blockquote.twitter-tweet {
 
 // wow, Reddit only adds a visited style for submission titles!
 // let's add visited styles to user-editable content (.md) if the user wants to.
-// else we still want visited styles on inline images.
 .res-styleTweaks-visitedStyle {
 	.md a:visited {
 		color: #551a8b; // same color as submission titles.
@@ -23,16 +22,6 @@ blockquote.twitter-tweet {
 		}
 
 		.res-nightmode.res-nightMode-coloredLinks & {
-			color: hsl(270, 50%, 65%);
-		}
-	}
-}
-
-body:not(.res-styleTweaks-visitedStyle) {
-	.md a[name^='img']:visited {
-		color: #551a8b;
-
-		.res-nightmode & {
 			color: hsl(270, 50%, 65%);
 		}
 	}

--- a/lib/css/modules/_styleTweaks.scss
+++ b/lib/css/modules/_styleTweaks.scss
@@ -11,29 +11,25 @@ blockquote.twitter-tweet {
 	}
 }
 
-// wow, Reddit doesn't define a visited class for any links on comments pages...
-// let's put that back if users want it back.
-// If not, we still need a visited class for links in comments, like imgur photos for example, or inline image viewer can't make them look different when expanded!
+// wow, Reddit only adds a visited style for submission titles!
+// let's add visited styles to user-editable content (.md) if the user wants to.
+// else we still want visited styles on inline images.
 .res-styleTweaks-visitedStyle {
-	.comment .parent,
-	.comment .tagline,
-	.comment .usertext {
-		a:visited {
-			color: #551a8b;
+	.md a:visited {
+		color: #551a8b; // same color as submission titles.
 
-			.res-nightmode & {
-				color: hsl(0, 0%, 65%);
-			}
+		.res-nightmode & {
+			color: hsl(0, 0%, 65%);
+		}
 
-			.res-nightmode.res-nightMode-coloredLinks & {
-				color: hsl(270, 50%, 65%);
-			}
+		.res-nightmode.res-nightMode-coloredLinks & {
+			color: hsl(270, 50%, 65%);
 		}
 	}
 }
 
 body:not(.res-styleTweaks-visitedStyle) {
-	.comment .md p > a:visited {
+	.md a[name^='img']:visited {
 		color: #551a8b;
 
 		.res-nightmode & {

--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -62,8 +62,7 @@ addModule('styleTweaks', (module, moduleID) => {
 		visitedStyle: {
 			type: 'boolean',
 			value: false,
-			description: 'Reddit makes it so no links on comment pages appear as "visited" - including user profiles. This option undoes that.',
-			advanced: true,
+			description: 'Change the color of links you\'ve visited to purple. (By default Reddit only does this for submission titles.)',
 			bodyClass: true
 		},
 		showExpandos: {


### PR DESCRIPTION
Closes #2424. Fixes #2654.

Addressing this comment https://github.com/honestbleeps/Reddit-Enhancement-Suite/issues/2654#issuecomment-172432168:
I'm not worried about the sidebar -- visitedStyle is disabled by default, so I don't think many people who enable it will mind.
I removed the `[name^="img"]` fallback style, so disabling visitedStyle disables it completely.