### PR TITLE
Added image viewer for host sli.mg

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -108,6 +108,7 @@
 				"modules/modhelper.js",
 				"modules/quickMessage.js",
 				"modules/hosts/imgur.js",
+				"modules/hosts/slimg.js",
 				"modules/hosts/reddituploads.js",
 				"modules/hosts/derpibooru.js",
 				"modules/hosts/wikipedia.js",

--- a/firefox/index.js
+++ b/firefox/index.js
@@ -562,6 +562,7 @@ PageMod({
 		self.data.url('modules/modhelper.js'),
 		self.data.url('modules/quickMessage.js'),
 		self.data.url('modules/hosts/imgur.js'),
+		self.data.url('modules/hosts/slimg.js'),
 		self.data.url('modules/hosts/reddituploads.js'),
 		self.data.url('modules/hosts/derpibooru.js'),
 		self.data.url('modules/hosts/wikipedia.js'),

--- a/lib/modules/hosts/slimg.js
+++ b/lib/modules/hosts/slimg.js
@@ -1,0 +1,32 @@
+addLibrary('mediaHosts', 'slimg', {
+	domains: ['sli.mg', 'ioimg.com'], 
+	logo: '//sli.mg/favicon.ico',
+	detect: href => (/^https?:\/\/(?:i\.|www\.)?(sli\.mg|ioimg\.com)\/([a-z0-9]+)\.?(png|jpe?g|gif|gifv)?$/i).exec(href),
+	handleLink(elem, [, domain, id, extension]) {
+
+		if (!extension || extension == undefined) {
+			extension = 'jpg';
+		}
+		
+		if (extension == 'gifv') {
+			elem.type = 'VIDEO';
+			elem.expandoOptions = {
+				autoplay: true,
+				controls: false,
+				fallback: `https://i.${domain}/${id}.gif`,
+				loop: true,
+				muted: true,
+				sources: [{
+					source: `https://i.${domain}/${id}.webm`,
+					type: 'video/webm'
+				}, {
+					source: `https://i.${domain}/${id}.mp4`,
+					type: 'video/mp4'
+				}]
+			};
+		} else {
+			elem.type = 'IMAGE';
+			elem.src = `https://i.${domain}/${id}.${extension}`;
+		}
+	}
+});

--- a/node/files.json
+++ b/node/files.json
@@ -80,6 +80,7 @@
 	],
 	"libraries": [
 		"modules/hosts/imgur.js",
+		"modules/hosts/slimg.js",
 		"modules/hosts/reddituploads.js",
 		"modules/hosts/derpibooru.js",
 		"modules/hosts/wikipedia.js",

--- a/safari/Info.plist
+++ b/safari/Info.plist
@@ -115,6 +115,7 @@
 				<string>modules/modhelper.js</string>
 				<string>modules/quickMessage.js</string>
 				<string>modules/hosts/imgur.js</string>
+				<string>modules/hosts/slimg.js</string>
 				<string>modules/hosts/reddituploads.js</string>
 				<string>modules/hosts/derpibooru.js</string>
 				<string>modules/hosts/wikipedia.js</string>


### PR DESCRIPTION
Added support for sli.mg and ioimg.com non direct images.

Tested in Firefox and Chrome.