### PR TITLE
Fix media controls showing when not hovered

### DIFF
--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -210,8 +210,7 @@ body:not(.res-showImages-displayImageCaptions) {
 	}
 }
 
-a.madeVisible,
-div.madeVisible {
+div.madeVisible a.madeVisible {
 	position: relative;
 
 	.RESMediaControls {


### PR DESCRIPTION
Fixes https://github.com/honestbleeps/Reddit-Enhancement-Suite/issues/2923

Selector was previously targeting `div.madeVisible` & `a.madeVisible`, rather than the a (which wraps the dragged-able element) itself..