### PR TITLE
Profile navigator

### DIFF
--- a/lib/modules/profileNavigator.js
+++ b/lib/modules/profileNavigator.js
@@ -1,0 +1,110 @@
+import * as Hover from './hover';
+import * as SettingsNavigation from './settingsNavigation';
+import { $ } from '../vendor';
+import { loggedInUser } from '../utils';
+
+export const module = {};
+
+module.moduleID = 'profileNavigator';
+module.moduleName = 'Profile Navigator';
+module.description = 'Enhance getting to various parts of your user page';
+module.category = 'My account';
+
+
+module.options = {
+	sectionMenu: {
+		type: 'boolean',
+		value: true,
+		description: 'Show a menu linking to various sections of the current user\'s profile when hovering your mouse over the username link in the top right corner.'
+	},
+	sectionLinks: {
+		dependsOn: 'sectionMenu',
+		type: 'table',
+		addRowText: '+add profile section shortcut',
+		fields: [{
+			name: 'label',
+			type: 'text'
+		}, {
+			name: 'url',
+			type: 'text'
+		}],
+		value: [
+			['comments', './comments'],
+			['submitted', './submitted'],
+			['gilded', './gilded'],
+			['upvoted', './upvoted'],
+			['downvoted', './downvoted'],
+			['saved', './saved']
+		]
+	},
+	hoverDelay: {
+		dependsOn: 'sectionMenu',
+		type: 'text',
+		value: 1000,
+		description: 'Delay, in milliseconds, before hover tooltip loads. Default is 1000.',
+		advanced: true
+	},
+	fadeDelay: {
+		dependsOn: 'sectionMenu',
+		type: 'text',
+		value: 200,
+		description: 'Delay, in milliseconds, before hover tooltip fades away. Default is 200.',
+		advanced: true
+	},
+	fadeSpeed: {
+		dependsOn: 'sectionMenu',
+		type: 'text',
+		value: 0.7,
+		description: 'Fade animation\'s speed (in seconds). Default is 0.7.',
+		advanced: true
+	}
+};
+
+module.go = function() {
+	if (module.options.sectionMenu.value) {
+		$('#header .user a').on('mouseover', onMouseoverProfileLink);
+	}
+};
+
+function onMouseoverProfileLink(e) {
+	Hover.dropdownList(module.moduleID)
+		.target(e.currentTarget)
+		.options({
+			openDelay: module.options.hoverDelay.value,
+			fadeDelay: module.options.fadeDelay.value,
+			fadeSpeed: module.options.fadeSpeed.value,
+			pin: Hover.pin.below
+		})
+		.populateWith(() => populateSectionMenu(loggedInUser()))
+		.begin();
+}
+
+const populateSectionMenu = (username) => [
+	module.options.sectionLinks.value
+		.map(link => populateSectionItem(username, link))
+		.reduce((prev, curr) => (curr ? prev.add(curr) : prev), $())
+		.add(populateSectionItem('.', [
+			`<i>${module.moduleName}</i>`,
+			SettingsNavigation.makeUrlHash(module.moduleID, 'sectionMenu')
+		]))
+];
+
+function populateSectionItem(username, link) {
+	if (!(link && link.length >= 2)) {
+		return false;
+	}
+
+	const label = link[0] || '';
+	const url = link[1] || '';
+	const $link = $('<a />')
+		.safeHtml(label)
+		.attr('href', `/user/${username}/${url}`);
+
+	if (url.indexOf('#!settings') !== -1) {
+		$link.append('<span class="RESMenuItemButton gearIcon" />');
+	}
+
+	$link.on('click', () => Hover.dropdownList(module.moduleID).close());
+
+	return $('<li />').append($link);
+}

--- a/lib/modules/profileNavigator.js
+++ b/lib/modules/profileNavigator.js
@@ -1,97 +1,101 @@
+/* @flow */
+
+import { $ } from '../vendor';
+import { Module } from '../core/module';
+import { loggedInUser } from '../utils';
+import { i18n } from '../environment';
 import * as Hover from './hover';
 import * as SettingsNavigation from './settingsNavigation';
-import { $ } from '../vendor';
-import { loggedInUser } from '../utils';
 
-export const module = {};
+export const module: Module<*> = new Module('profileNavigator');
 
-module.moduleID = 'profileNavigator';
-module.moduleName = 'Profile Navigator';
-module.description = 'Enhance getting to various parts of your user page';
-module.category = 'My account';
-
+module.moduleName = 'profileNavigatorName';
+module.description = 'profileNavigatorDesc';
+module.category = 'myAccountCategory';
 
 module.options = {
 	sectionMenu: {
 		type: 'boolean',
 		value: true,
-		description: 'Show a menu linking to various sections of the current user\'s profile when hovering your mouse over the username link in the top right corner.'
+		description: 'profileNavigatorSectionMenuDesc',
 	},
 	sectionLinks: {
 		dependsOn: 'sectionMenu',
+		description: 'profileNavigatorSectionLinksDesc',
 		type: 'table',
 		addRowText: '+add profile section shortcut',
 		fields: [{
 			name: 'label',
-			type: 'text'
+			type: 'text',
 		}, {
 			name: 'url',
-			type: 'text'
+			type: 'text',
 		}],
 		value: [
+			['saved', './saved'],
 			['comments', './comments'],
 			['submitted', './submitted'],
 			['gilded', './gilded'],
 			['upvoted', './upvoted'],
 			['downvoted', './downvoted'],
-			['saved', './saved']
-		]
+		],
 	},
 	hoverDelay: {
 		dependsOn: 'sectionMenu',
 		type: 'text',
-		value: 1000,
-		description: 'Delay, in milliseconds, before hover tooltip loads. Default is 1000.',
-		advanced: true
+		value: '1000',
+		description: 'profileNavigatorHoverDelayDesc',
+		advanced: true,
 	},
 	fadeDelay: {
 		dependsOn: 'sectionMenu',
 		type: 'text',
-		value: 200,
-		description: 'Delay, in milliseconds, before hover tooltip fades away. Default is 200.',
-		advanced: true
+		value: '200',
+		description: 'profileNavigatorFadeDelayDesc',
+		advanced: true,
 	},
 	fadeSpeed: {
 		dependsOn: 'sectionMenu',
 		type: 'text',
-		value: 0.7,
-		description: 'Fade animation\'s speed (in seconds). Default is 0.7.',
-		advanced: true
+		value: '0.7',
+		description: 'profileNavigatorFadeSpeedDesc',
+		advanced: true,
+	},
+};
+
+module.go = () => {
+	const username = loggedInUser();
+	if (module.options.sectionMenu.value && username) {
+		$('#header .user a').on('mouseover', (e: Event) => onMouseoverProfileLink(username, e));
 	}
 };
 
-module.go = function() {
-	if (module.options.sectionMenu.value) {
-		$('#header .user a').on('mouseover', onMouseoverProfileLink);
-	}
-};
-
-function onMouseoverProfileLink(e) {
+function onMouseoverProfileLink(user, e) {
 	Hover.dropdownList(module.moduleID)
-		.target(e.currentTarget)
+		.target(e.target)
 		.options({
 			openDelay: module.options.hoverDelay.value,
 			fadeDelay: module.options.fadeDelay.value,
 			fadeSpeed: module.options.fadeSpeed.value,
-			pin: Hover.pin.below
+			pin: Hover.pin.bottom,
 		})
-		.populateWith(() => populateSectionMenu(loggedInUser()))
+		.populateWith(() => populateSectionMenu(user))
 		.begin();
 }
 
-const populateSectionMenu = (username) => [
+const populateSectionMenu = username => [
 	module.options.sectionLinks.value
 		.map(link => populateSectionItem(username, link))
-		.reduce((prev, curr) => (curr ? prev.add(curr) : prev), $())
-		.add(populateSectionItem('.', [
-			`<i>${module.moduleName}</i>`,
-			SettingsNavigation.makeUrlHash(module.moduleID, 'sectionMenu')
-		]))
+		.reduce((prev, curr) => prev.add(curr), $())
+		.add(populateSectionItem('..', [
+			`<i>${i18n(module.moduleName)}</i>`,
+			SettingsNavigation.makeUrlHash(module.moduleID, 'sectionMenu'),
+		])),
 ];
 
 function populateSectionItem(username, link) {
 	if (!(link && link.length >= 2)) {
-		return false;
+		return $();
 	}
 
 	const label = link[0] || '';
@@ -100,7 +104,7 @@ function populateSectionItem(username, link) {
 		.safeHtml(label)
 		.attr('href', `/user/${username}/${url}`);
 
-	if (url.indexOf('#!settings') !== -1) {
+	if (SettingsNavigation.isSettingsUrl(url)) {
 		$link.append('<span class="RESMenuItemButton gearIcon" />');
 	}
 

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -606,6 +606,33 @@
 
     "xPostLinksDesc": {
         "message": "Create links to x-posted subreddits in post taglines."
-    }
+    },
 
+    "profileNavigatorName": {
+      "message": "Profile Navigator"
+    },
+
+    "profileNavigatorDesc": {
+      "message": "Enhance getting to various parts of your user page."
+    },
+
+    "profileNavigatorSectionMenuDesc": {
+      "message": "Show a menu linking to various sections of the current user's profile when hovering your mouse over the username link in the top right corner."
+    },
+
+    "profileNavigatorSectionLinksDesc": {
+      "message": "Links to display in the profile hover menu."
+    },
+
+    "profileNavigatorHoverDelayDesc": {
+      "message": "Delay, in milliseconds, before hover tooltip loads."
+    },
+
+    "profileNavigatorFadeDelayDesc": {
+      "message": "Delay, in milliseconds, before hover tooltip fades away."
+    },
+
+    "profileNavigatorFadeSpeedDesc": {
+      "message": "Fade animation's speed (in seconds)."
+    }
 }


### PR DESCRIPTION
Relies on #2916 ([diff](https://github.com/erikdesjardins/Reddit-Enhancement-Suite/compare/webpack...andytuba:profileNavigator))

<img width="262" alt="screen shot 2016-05-01 at 9 03 18 am" src="https://cloud.githubusercontent.com/assets/455632/14942761/93c9a5ee-0f7b-11e6-820b-34a961509bee.png">

Ignore the 🔍 button, it's only half-implemented and stashed
