### PR TITLE
Source maps

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -48,6 +48,7 @@ const configs = browsers.map(browser => {
 			path: join(__dirname, 'dist', browserConfig[browser].output),
 			filename: basename(browserConfig[browser].entry),
 		},
+		devtool: '#cheap-module-source-map',
 		resolve: {
 			alias: {
 				browserEnvironment$: join(__dirname, browserConfig[browser].environment),


### PR DESCRIPTION
https://webpack.github.io/docs/configuration.html#devtool

Chrome seems to have issues with mapping filenames to the correct module or host when you browse through the files manually, but the error line numbers are translated correctly, which is the most important part.

i.e. showImages.js shows up as clyp.js:
![image](https://cloud.githubusercontent.com/assets/7673145/15087024/3b25d732-13b3-11e6-9881-2a9e9504cd4c.png)
But this line number is still correct:
![image](https://cloud.githubusercontent.com/assets/7673145/15087032/4dbf88ca-13b3-11e6-8ff9-0cdc3b23b06c.png)