### PR TITLE
linting: switch from sort-imports-es6 to import/order

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,6 @@
 		"consistent-return-legacy",
 		"prefer-bind-operator",
 		"prefer-spread",
-		"sort-imports-es6",
 		"filenames",
 		"import"
 	],
@@ -58,8 +57,6 @@
 
 		"prefer-spread/prefer-object-spread": 2,
 
-		"sort-imports-es6/sort-imports-es6": [2, { "memberSyntaxSortOrder": ["none", "single", "all", "multiple"] }],
-
 		"filenames/filenames": [2, ".*", "match-regex-and-exported"],
 
 		"import/no-unresolved": 2,
@@ -78,7 +75,7 @@
 		"import/no-duplicates": 2,
 		"import/no-namespace": 0,
 		"import/extensions": [2, { "js": "never" }],
-		"import/order": 0,
+		"import/order": 2,
 
 		"no-alert": 0,
 		"no-array-constructor": 2,
@@ -268,7 +265,7 @@
 		"semi": 2,
 		"semi-spacing": 2,
 		"sort-vars": 0,
-		"sort-imports": 0, // see sort-imports-es6/sort-imports-es6
+		"sort-imports": 0, // see import/order
 		"space-before-blocks": 2,
 		"space-before-function-paren": [2, "never"],
 		"space-in-parens": 2,

--- a/chrome/background.entry.js
+++ b/chrome/background.entry.js
@@ -30,6 +30,7 @@
 
 */
 
+import { createMessageHandler } from '../lib/environment/_helpers';
 import Cache from '../lib/utils/Cache';
 
 import cssOff from './images/css-off.png';
@@ -38,7 +39,6 @@ import cssOn from './images/css-on.png';
 import cssOnSmall from './images/css-on-small.png';
 
 import { apiToPromise } from './_helpers';
-import { createMessageHandler } from '../lib/environment/_helpers';
 
 const _sendMessage = apiToPromise(chrome.tabs.sendMessage);
 

--- a/chrome/environment.js
+++ b/chrome/environment.js
@@ -1,6 +1,6 @@
-import { apiToPromise } from './_helpers';
 import { createMessageHandler } from '../lib/environment/_helpers';
 import { extendDeep, keyedMutex, waitForEvent } from '../lib/utils';
+import { apiToPromise } from './_helpers';
 
 const _sendMessage = apiToPromise(chrome.runtime.sendMessage);
 

--- a/firefox/background.entry.js
+++ b/firefox/background.entry.js
@@ -1,4 +1,10 @@
+import mainEntry from '../lib/main.entry'; // eslint-disable-line import/default
+import resCss from '../lib/css/res.scss';
+
+import { createMessageHandler } from '../lib/environment/_helpers';
+import { nativeRequire } from '../lib/environment/_nativeRequire';
 import Cache from '../lib/utils/Cache';
+import { extendDeep } from '../lib/utils/object';
 
 import cssDisabled from './images/css-disabled.png';
 import cssDisabledSmall from './images/css-disabled-small.png';
@@ -6,13 +12,6 @@ import cssOff from './images/css-off.png';
 import cssOffSmall from './images/css-off-small.png';
 import cssOn from './images/css-on.png';
 import cssOnSmall from './images/css-on-small.png';
-import mainEntry from '../lib/main.entry'; // eslint-disable-line import/default
-import resCss from '../lib/css/res.scss';
-
-import { createMessageHandler } from '../lib/environment/_helpers';
-import { extendDeep } from '../lib/utils/object';
-
-import { nativeRequire } from '../lib/environment/_nativeRequire';
 
 const priv = nativeRequire('sdk/private-browsing');
 const ss = nativeRequire('sdk/simple-storage');

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,9 +1,9 @@
 /* eslint-disable import/no-nodejs-modules */
 
+import path from 'path';
 import globby from 'globby';
 import gulp from 'gulp';
 import merge from 'merge-stream';
-import path from 'path';
 import zip from 'gulp-zip';
 
 gulp.task('zip', () =>

--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -1,8 +1,11 @@
 import _ from 'lodash';
+import { $ } from '../vendor';
 import * as Metadata from './metadata';
 import * as Modules from './modules';
-import { $ } from '../vendor';
-import {
+import { _loadModuleOptions } from './options/options';
+import { _loadModulePrefs } from './modules/modules';
+import { migrate } from './migrate';
+import { // eslint-disable-line import/order
 	Alert,
 	BodyClasses,
 	filter,
@@ -15,9 +18,6 @@ import {
 	waitForChild,
 	waitForEvent,
 } from '../utils';
-import { _loadModuleOptions } from './options/options';
-import { _loadModulePrefs } from './modules/modules';
-import { migrate } from './migrate';
 
 const _resolve = {};
 

--- a/lib/core/migrate.js
+++ b/lib/core/migrate.js
@@ -1,9 +1,9 @@
 import * as Notifications from '../modules/notifications';
-import * as Options from './options';
 import * as SettingsNavigation from '../modules/settingsNavigation';
 import * as Stylesheet from '../modules/stylesheet';
 import { Storage } from '../environment';
 import { range, seq } from '../utils';
+import * as Options from './options';
 
 const migrations = [
 	{

--- a/lib/core/modules/modules.js
+++ b/lib/core/modules/modules.js
@@ -1,3 +1,4 @@
+import { flow, forEach, isEmpty, keyBy, filter as ldFilter, map, negate, tap } from 'lodash/fp';
 import { Storage } from '../../environment';
 import {
 	collect,
@@ -5,7 +6,6 @@ import {
 	matchesPageLocation,
 	objectValidator,
 } from '../../utils';
-import { flow, forEach, isEmpty, keyBy, filter as ldFilter, map, negate, tap } from 'lodash/fp';
 
 const moduleContext = require.context('../../modules', false, /\.js$/);
 

--- a/lib/environment/ajax.js
+++ b/lib/environment/ajax.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
-import { XhrCache } from './';
 import { loggedInUserHash, string } from '../utils';
+import { XhrCache } from './';
 import { sendMessage } from 'browserEnvironment';
 
 /**

--- a/lib/environment/multicast.js
+++ b/lib/environment/multicast.js
@@ -1,5 +1,5 @@
-import { addListener, sendMessage } from 'browserEnvironment';
 import { cloneDeep } from 'lodash/fp';
+import { addListener, sendMessage } from 'browserEnvironment';
 
 const callbacks = new Map();
 

--- a/lib/environment/pageAction.js
+++ b/lib/environment/pageAction.js
@@ -1,5 +1,5 @@
-import { addListener, sendMessage } from 'browserEnvironment';
 import { invokeAll } from '../utils';
+import { addListener, sendMessage } from 'browserEnvironment';
 
 const clickListeners = [];
 

--- a/lib/modules/RESTips.js
+++ b/lib/modules/RESTips.js
@@ -1,12 +1,12 @@
 import _ from 'lodash';
-import * as KeyboardNav from './keyboardNav';
-import * as Menu from './menu';
+import { $, guiders } from '../vendor';
 import * as Modules from '../core/modules';
 import * as Options from '../core/options';
-import * as SettingsNavigation from './settingsNavigation';
-import { $, guiders } from '../vendor';
 import { CreateElement, range } from '../utils';
 import { Storage } from '../environment';
+import * as KeyboardNav from './keyboardNav';
+import * as Menu from './menu';
+import * as SettingsNavigation from './settingsNavigation';
 
 export const module = {};
 

--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -1,11 +1,11 @@
 import _ from 'lodash';
+import { $ } from '../vendor';
+import { Alert, getUserInfo, loggedInUser, niceDateDiff } from '../utils';
+import { ajax, deleteCookies, multicast } from '../environment';
 import * as BetteReddit from './betteReddit';
 import * as CommandLine from './commandLine';
 import * as Notifications from './notifications';
 import * as SettingsNavigation from './settingsNavigation';
-import { $ } from '../vendor';
-import { Alert, getUserInfo, loggedInUser, niceDateDiff } from '../utils';
-import { ajax, deleteCookies, multicast } from '../environment';
 
 export const module = {};
 

--- a/lib/modules/announcements.js
+++ b/lib/modules/announcements.js
@@ -1,9 +1,9 @@
 // import announcementsNotificationTemplate from '../templates/announcementsNotification.mustache';
-import * as Menu from './menu';
-import * as Metadata from '../core/metadata';
 import { $ } from '../vendor';
+import * as Metadata from '../core/metadata';
 import { DAY, HOUR, isCurrentSubreddit } from '../utils';
 import { Storage, ajax } from '../environment';
+import * as Menu from './menu';
 
 export const module = {};
 

--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -1,8 +1,6 @@
 import _ from 'lodash';
-import * as AccountSwitcher from './accountSwitcher';
-import * as Modules from '../core/modules';
-import * as SubredditManager from './subredditManager';
 import { $ } from '../vendor';
+import * as Modules from '../core/modules';
 import {
 	Alert,
 	DAY,
@@ -17,6 +15,8 @@ import {
 	watchForElement,
 } from '../utils';
 import { ajax } from '../environment';
+import * as AccountSwitcher from './accountSwitcher';
+import * as SubredditManager from './subredditManager';
 
 export const module = {};
 

--- a/lib/modules/commandLine.js
+++ b/lib/modules/commandLine.js
@@ -1,7 +1,6 @@
 import commandLineTemplate from '../templates/commandLine.mustache';
-import * as Menu from './menu';
-import * as Modules from '../core/modules';
 import { $ } from '../vendor';
+import * as Modules from '../core/modules';
 import {
 	Alert,
 	currentMultireddit,
@@ -12,6 +11,7 @@ import {
 	string,
 } from '../utils';
 import { Storage, XhrCache, ajax, openNewTab } from '../environment';
+import * as Menu from './menu';
 
 export const module = {};
 

--- a/lib/modules/commentNavigator.js
+++ b/lib/modules/commentNavigator.js
@@ -1,10 +1,10 @@
 import _ from 'lodash';
 import commentNavigatorTemplate from '../templates/commentNavigator.mustache';
+import { $ } from '../vendor';
+import { loggedInUser, scrollTo } from '../utils';
 import * as BetteReddit from './betteReddit';
 import * as Floater from './floater';
 import * as UserInfo from './userInfo';
-import { $ } from '../vendor';
-import { loggedInUser, scrollTo } from '../utils';
 
 export const module = {};
 

--- a/lib/modules/commentPreview.js
+++ b/lib/modules/commentPreview.js
@@ -1,10 +1,8 @@
 import _ from 'lodash';
-import * as CommentTools from './commentTools';
-import * as KeyboardNav from './keyboardNav';
-import * as Modules from '../core/modules';
-import * as SettingsNavigation from './settingsNavigation';
+import { markdown, markdownWiki } from 'snudown-js';
 import { $ } from '../vendor';
 import { ajax } from '../environment';
+import * as Modules from '../core/modules';
 import {
 	checkKeysForEvent,
 	currentSubreddit,
@@ -13,7 +11,9 @@ import {
 	isPageType,
 	watchForElement,
 } from '../utils';
-import { markdown, markdownWiki } from 'snudown-js';
+import * as CommentTools from './commentTools';
+import * as KeyboardNav from './keyboardNav';
+import * as SettingsNavigation from './settingsNavigation';
 
 export const module = {};
 

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -1,9 +1,6 @@
 import _ from 'lodash';
-import * as AccountSwitcher from './accountSwitcher';
-import * as Modules from '../core/modules';
-import * as SettingsNavigation from './settingsNavigation';
-import * as UserTagger from './userTagger';
 import { $ } from '../vendor';
+import * as Modules from '../core/modules';
 import {
 	Alert,
 	Thing,
@@ -18,6 +15,9 @@ import {
 	regexes,
 } from '../utils';
 import { Storage } from '../environment';
+import * as AccountSwitcher from './accountSwitcher';
+import * as SettingsNavigation from './settingsNavigation';
+import * as UserTagger from './userTagger';
 
 export const module = {};
 

--- a/lib/modules/contribute.js
+++ b/lib/modules/contribute.js
@@ -1,6 +1,6 @@
 import contributeTemplate from '../templates/contributePanel.mustache';
-import * as Menu from './menu';
 import { openNewTab } from '../environment';
+import * as Menu from './menu';
 
 export const module = {};
 

--- a/lib/modules/customToggles.js
+++ b/lib/modules/customToggles.js
@@ -1,10 +1,10 @@
 import _ from 'lodash';
-import * as Menu from './menu';
+import { $ } from '../vendor';
 import * as Modules from '../core/modules';
 import * as Options from '../core/options';
-import * as SettingsConsole from './settingsConsole';
-import { $ } from '../vendor';
 import { CreateElement, indexOptionTable } from '../utils';
+import * as Menu from './menu';
+import * as SettingsConsole from './settingsConsole';
 
 export const module = {};
 

--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -1,5 +1,3 @@
-import * as Menu from './menu';
-import * as Notifications from './notifications';
 import { $ } from '../vendor';
 import {
 	Alert,
@@ -11,6 +9,8 @@ import {
 	watchers,
 } from '../utils';
 import { Storage } from '../environment';
+import * as Menu from './menu';
+import * as Notifications from './notifications';
 
 export const module = {};
 

--- a/lib/modules/easterEgg.js
+++ b/lib/modules/easterEgg.js
@@ -1,6 +1,6 @@
 import Konami from 'konami';
-import * as Notifications from './notifications';
 import { $ } from '../vendor';
+import * as Notifications from './notifications';
 
 export const module = {};
 

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -1,10 +1,5 @@
-import * as CommandLine from './commandLine';
-import * as CustomToggles from './customToggles';
-import * as Menu from './menu';
-import * as Notifications from './notifications';
-import * as Options from '../core/options';
-import * as SettingsNavigation from './settingsNavigation';
 import { $ } from '../vendor';
+import * as Options from '../core/options';
 import {
 	BodyClasses,
 	Thing,
@@ -20,6 +15,11 @@ import {
 	string,
 	watchForElement,
 } from '../utils';
+import * as CommandLine from './commandLine';
+import * as CustomToggles from './customToggles';
+import * as Menu from './menu';
+import * as Notifications from './notifications';
+import * as SettingsNavigation from './settingsNavigation';
 
 export const module = {};
 

--- a/lib/modules/hosts/github.js
+++ b/lib/modules/hosts/github.js
@@ -1,6 +1,6 @@
+import { markdown } from 'snudown-js';
 import { DAY, string } from '../../utils';
 import { ajax } from '../../environment';
-import { markdown } from 'snudown-js';
 
 export default {
 	moduleID: 'github',

--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -1,8 +1,8 @@
+import { flow, memoize } from 'lodash/fp';
 import * as ShowImages from '../showImages';
 import { $ } from '../../vendor';
 import { ajax } from '../../environment';
 import { batch, string } from '../../utils';
-import { flow, memoize } from 'lodash/fp';
 
 const imgur = {
 	moduleID: 'imgur',

--- a/lib/modules/hosts/tumblr.js
+++ b/lib/modules/hosts/tumblr.js
@@ -1,5 +1,5 @@
-import { Permissions, ajax } from '../../environment';
 import { markdown } from 'snudown-js';
+import { Permissions, ajax } from '../../environment';
 
 export default {
 	moduleID: 'tumblr',

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1,16 +1,6 @@
 import _ from 'lodash';
-import * as CommandLine from './commandLine';
-import * as CommentNavigator from './commentNavigator';
-import * as EasterEgg from './easterEgg';
-import * as Hover from './hover';
-import * as Modules from '../core/modules';
-import * as NeverEndingReddit from './neverEndingReddit';
-import * as NoParticipation from './noParticipation';
-import * as SaveComments from './saveComments';
-import * as SelectedEntry from './selectedEntry';
-import * as ShowImages from './showImages';
-import * as ShowParent from './showParent';
 import { $ } from '../vendor';
+import * as Modules from '../core/modules';
 import {
 	Thing,
 	click,
@@ -31,6 +21,16 @@ import {
 	scrollToElement,
 } from '../utils';
 import { openNewTab } from '../environment';
+import * as CommandLine from './commandLine';
+import * as CommentNavigator from './commentNavigator';
+import * as EasterEgg from './easterEgg';
+import * as Hover from './hover';
+import * as NeverEndingReddit from './neverEndingReddit';
+import * as NoParticipation from './noParticipation';
+import * as SaveComments from './saveComments';
+import * as SelectedEntry from './selectedEntry';
+import * as ShowImages from './showImages';
+import * as ShowParent from './showParent';
 
 export const module = {};
 

--- a/lib/modules/menu.js
+++ b/lib/modules/menu.js
@@ -1,6 +1,6 @@
+import { $ } from '../vendor';
 import * as Hover from './hover';
 import * as StyleTweaks from './styleTweaks';
-import { $ } from '../vendor';
 
 export const module = {};
 

--- a/lib/modules/messageMenu.js
+++ b/lib/modules/messageMenu.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
+import { $ } from '../vendor';
 import * as Hover from './hover';
 import * as QuickMessage from './quickMessage';
 import * as SettingsNavigation from './settingsNavigation';
-import { $ } from '../vendor';
 
 export const module = {};
 

--- a/lib/modules/modhelper.js
+++ b/lib/modules/modhelper.js
@@ -1,6 +1,6 @@
+import { markdown } from 'snudown-js';
 import { $ } from '../vendor';
 import { currentSubreddit, isPageType } from '../utils';
-import { markdown } from 'snudown-js';
 
 export const module = {};
 

--- a/lib/modules/multiredditNavbar.js
+++ b/lib/modules/multiredditNavbar.js
@@ -1,7 +1,7 @@
-import * as Hover from './hover';
-import * as SettingsNavigation from './settingsNavigation';
 import { $ } from '../vendor';
 import { regexes } from '../utils';
+import * as Hover from './hover';
+import * as SettingsNavigation from './settingsNavigation';
 
 export const module = {};
 

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -1,10 +1,4 @@
 import _ from 'lodash';
-import * as Floater from './floater';
-import * as Notifications from './notifications';
-import * as Orangered from './orangered';
-import * as SettingsConsole from './settingsConsole';
-import * as SettingsNavigation from './settingsNavigation';
-import * as SubredditManager from './subredditManager';
 import { $ } from '../vendor';
 import { Session, Storage, ajax } from '../environment';
 import {
@@ -15,6 +9,12 @@ import {
 	pageType,
 	scrollTo,
 } from '../utils';
+import * as Floater from './floater';
+import * as Notifications from './notifications';
+import * as Orangered from './orangered';
+import * as SettingsConsole from './settingsConsole';
+import * as SettingsNavigation from './settingsNavigation';
+import * as SubredditManager from './subredditManager';
 
 export const module = {};
 

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -1,6 +1,4 @@
 import _ from 'lodash';
-import * as Dashboard from './dashboard';
-import * as Notifications from './notifications';
 import { $ } from '../vendor';
 import {
 	Alert,
@@ -16,6 +14,8 @@ import {
 	watchForElement,
 } from '../utils';
 import { Storage, ajax } from '../environment';
+import * as Dashboard from './dashboard';
+import * as Notifications from './notifications';
 
 export const module = {};
 

--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -1,12 +1,12 @@
-import * as CommandLine from './commandLine';
-import * as Menu from './menu';
+import { $ } from '../vendor';
 import * as Modules from '../core/modules';
 import * as Options from '../core/options';
-import * as SettingsConsole from './settingsConsole';
-import * as StyleTweaks from './styleTweaks';
-import { $ } from '../vendor';
 import { BodyClasses, CreateElement, currentSubreddit } from '../utils';
 import { Storage, multicast } from '../environment';
+import * as CommandLine from './commandLine';
+import * as Menu from './menu';
+import * as SettingsConsole from './settingsConsole';
+import * as StyleTweaks from './styleTweaks';
 
 export const module = {};
 

--- a/lib/modules/noParticipation.js
+++ b/lib/modules/noParticipation.js
@@ -1,6 +1,4 @@
 import _ from 'lodash';
-import * as CommentTools from './commentTools';
-import * as Notifications from './notifications';
 import { $ } from '../vendor';
 import {
 	BodyClasses,
@@ -9,6 +7,8 @@ import {
 	loggedInUser,
 	watchForElement,
 } from '../utils';
+import * as CommentTools from './commentTools';
+import * as Notifications from './notifications';
 
 export const module = {};
 

--- a/lib/modules/notifications.js
+++ b/lib/modules/notifications.js
@@ -1,11 +1,11 @@
-import * as CommandLine from './commandLine';
+import { $ } from '../vendor';
 import * as Init from '../core/init';
 import * as Modules from '../core/modules';
 import * as Options from '../core/options';
-import * as SettingsNavigation from './settingsNavigation';
-import { $ } from '../vendor';
 import { Storage } from '../environment';
 import { fadeElementIn, fadeElementOut, firstValid, hashCode } from '../utils';
+import * as CommandLine from './commandLine';
+import * as SettingsNavigation from './settingsNavigation';
 
 export const module = {};
 

--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -1,9 +1,9 @@
 import Favico from 'favico.js';
-import * as BetteReddit from './betteReddit';
-import * as Floater from './floater';
 import { $ } from '../vendor';
 import { loggedInUser } from '../utils';
 import { multicast } from '../environment';
+import * as BetteReddit from './betteReddit';
+import * as Floater from './floater';
 
 export const module = {};
 

--- a/lib/modules/pageNavigator.js
+++ b/lib/modules/pageNavigator.js
@@ -1,6 +1,6 @@
-import * as Floater from './floater';
 import { $ } from '../vendor';
 import { scrollTo } from '../utils';
+import * as Floater from './floater';
 
 export const module = {};
 

--- a/lib/modules/presets.js
+++ b/lib/modules/presets.js
@@ -1,8 +1,8 @@
 import * as Modules from '../core/modules';
-import * as Notifications from './notifications';
 import * as Options from '../core/options';
-import * as Troubleshooter from './troubleshooter';
 import { collect, map } from '../utils';
+import * as Notifications from './notifications';
+import * as Troubleshooter from './troubleshooter';
 
 export const module = {};
 

--- a/lib/modules/quickMessage.js
+++ b/lib/modules/quickMessage.js
@@ -1,10 +1,5 @@
 import _ from 'lodash';
 import quickMessageTemplate from '../templates/quickMessage.mustache';
-import * as CommandLine from './commandLine';
-import * as CommentTools from './commentTools';
-import * as Modules from '../core/modules';
-import * as Notifications from './notifications';
-import * as UsernameHider from './usernameHider';
 import { $ } from '../vendor';
 import {
 	HOUR,
@@ -18,7 +13,12 @@ import {
 	regexes,
 	string,
 } from '../utils';
+import * as Modules from '../core/modules';
 import { Storage, ajax } from '../environment';
+import * as CommandLine from './commandLine';
+import * as CommentTools from './commentTools';
+import * as Notifications from './notifications';
+import * as UsernameHider from './usernameHider';
 
 export const module = {};
 

--- a/lib/modules/saveComments.js
+++ b/lib/modules/saveComments.js
@@ -1,7 +1,3 @@
-import * as KeyboardNav from './keyboardNav';
-import * as Notifications from './notifications';
-import * as SelectedEntry from './selectedEntry';
-import * as SettingsNavigation from './settingsNavigation';
 import { $ } from '../vendor';
 import {
 	Alert,
@@ -12,6 +8,10 @@ import {
 	watchForElement,
 } from '../utils';
 import { Storage } from '../environment';
+import * as KeyboardNav from './keyboardNav';
+import * as Notifications from './notifications';
+import * as SelectedEntry from './selectedEntry';
+import * as SettingsNavigation from './settingsNavigation';
 
 export const module = {};
 

--- a/lib/modules/search.js
+++ b/lib/modules/search.js
@@ -3,13 +3,13 @@ import optionLinkTemplate from '../templates/optionLinkSnudown.mustache';
 import searchFormTemplate from '../templates/settingsConsoleSearch.mustache';
 import searchPanelTemplate from '../templates/searchPanel.mustache';
 import searchResultTemplate from '../templates/searchResultOption.mustache';
+import { $ } from '../vendor';
+import * as Modules from '../core/modules';
+import { Alert } from '../utils';
 import * as CommandLine from './commandLine';
 import * as Menu from './menu';
-import * as Modules from '../core/modules';
 import * as SettingsConsole from './settingsConsole';
 import * as SettingsNavigation from './settingsNavigation';
-import { $ } from '../vendor';
-import { Alert } from '../utils';
 
 export const module = {};
 

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -1,6 +1,4 @@
 import _ from 'lodash';
-import * as Hover from './hover';
-import * as KeyboardNav from './keyboardNav';
 import { $ } from '../vendor';
 import { Session } from '../environment';
 import {
@@ -12,6 +10,8 @@ import {
 	scrollToElement,
 	watchForElement,
 } from '../utils';
+import * as Hover from './hover';
+import * as KeyboardNav from './keyboardNav';
 
 export const module = {};
 

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -1,12 +1,9 @@
 import _ from 'lodash';
 import consoleContainerTemplate from '../templates/settingsConsole.mustache';
 import moduleSelectorTemplate from '../templates/settingsConsoleModuleSelector.mustache';
-import * as Menu from './menu';
 import * as Metadata from '../core/metadata';
 import * as Modules from '../core/modules';
 import * as Options from '../core/options';
-import * as Search from './search';
-import * as SettingsNavigation from './settingsNavigation';
 import { $ } from '../vendor';
 import {
 	Alert,
@@ -16,6 +13,9 @@ import {
 	niceKeyCode,
 } from '../utils';
 import { Storage } from '../environment';
+import * as Menu from './menu';
+import * as Search from './search';
+import * as SettingsNavigation from './settingsNavigation';
 
 export const module = {};
 

--- a/lib/modules/settingsNavigation.js
+++ b/lib/modules/settingsNavigation.js
@@ -1,9 +1,9 @@
+import { $ } from '../vendor';
 import * as Modules from '../core/modules';
 import * as Options from '../core/options';
+import { Alert } from '../utils';
 import * as Search from './search';
 import * as SettingsConsole from './settingsConsole';
-import { $ } from '../vendor';
-import { Alert } from '../utils';
 
 export const module = {};
 

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -4,13 +4,11 @@
 */
 
 import _ from 'lodash';
-import gfycat from './hosts/gfycat';
+import { flow, forEach, keyBy, map, tap } from 'lodash/fp';
 import mediaControlsTemplate from '../templates/mediaControls.mustache';
 import siteAttributionTemplate from '../templates/siteAttribution.mustache';
 import videoAdvancedTemplate from '../templates/videoAdvanced.mustache';
 import * as Modules from '../core/modules';
-import * as SelectedEntry from './selectedEntry';
-import * as SettingsNavigation from './settingsNavigation';
 import { $ } from '../vendor';
 import {
 	DAY,
@@ -27,7 +25,9 @@ import {
 	watchForElement,
 } from '../utils';
 import { addURLToHistory, ajax, isPrivateBrowsing, openNewTab } from '../environment';
-import { flow, forEach, keyBy, map, tap } from 'lodash/fp';
+import * as SelectedEntry from './selectedEntry';
+import * as SettingsNavigation from './settingsNavigation';
+import gfycat from './hosts/gfycat';
 
 const hostsContext = require.context('./hosts', false, /\.js$/);
 const siteModules = flow(

--- a/lib/modules/showParent.js
+++ b/lib/modules/showParent.js
@@ -1,5 +1,5 @@
-import * as Hover from './hover';
 import { $ } from '../vendor';
+import * as Hover from './hover';
 
 export const module = {};
 

--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -1,7 +1,4 @@
 import _ from 'lodash';
-import * as CommandLine from './commandLine';
-import * as NightMode from './nightMode';
-import * as Notifications from './notifications';
 import { $ } from '../vendor';
 import { PageAction, Storage } from '../environment';
 import {
@@ -10,6 +7,9 @@ import {
 	elementInViewport,
 	isPageType,
 } from '../utils';
+import * as CommandLine from './commandLine';
+import * as NightMode from './nightMode';
+import * as Notifications from './notifications';
 
 export const module = {};
 

--- a/lib/modules/stylesheet.js
+++ b/lib/modules/stylesheet.js
@@ -1,4 +1,3 @@
-import * as CustomToggles from './customToggles';
 import * as Init from '../core/init';
 import { $ } from '../vendor';
 import {
@@ -8,6 +7,7 @@ import {
 	currentUserProfile,
 	loggedInUser,
 } from '../utils';
+import * as CustomToggles from './customToggles';
 
 export const module = {};
 

--- a/lib/modules/submitIssue.js
+++ b/lib/modules/submitIssue.js
@@ -1,10 +1,10 @@
 import submitIssueDefaultBodyTemplate from '../templates/submitIssueDefaultBody.mustache';
 import submitWizardTemplate from '../templates/submitWizard.mustache';
 import * as Metadata from '../core/metadata';
-import * as NightMode from './nightMode';
 import { $, guiders } from '../vendor';
 import { BrowserDetect } from '../utils';
 import { ajax } from '../environment';
+import * as NightMode from './nightMode';
 
 export const module = {};
 

--- a/lib/modules/subredditInfo.js
+++ b/lib/modules/subredditInfo.js
@@ -1,9 +1,5 @@
-import * as Dashboard from './dashboard';
-import * as FilteReddit from './filteReddit';
-import * as Hover from './hover';
-import * as Modules from '../core/modules';
-import * as SubredditManager from './subredditManager';
 import { $ } from '../vendor';
+import * as Modules from '../core/modules';
 import {
 	HOUR,
 	commaDelimitedNumber,
@@ -14,6 +10,10 @@ import {
 	string,
 } from '../utils';
 import { ajax } from '../environment';
+import * as Dashboard from './dashboard';
+import * as FilteReddit from './filteReddit';
+import * as Hover from './hover';
+import * as SubredditManager from './subredditManager';
 
 export const module = {};
 

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -1,5 +1,3 @@
-import * as Notifications from './notifications';
-import * as SettingsNavigation from './settingsNavigation';
 import { $ } from '../vendor';
 import {
 	Alert,
@@ -13,6 +11,8 @@ import {
 	string,
 } from '../utils';
 import { Session, Storage, ajax } from '../environment';
+import * as Notifications from './notifications';
+import * as SettingsNavigation from './settingsNavigation';
 
 export const module = {};
 

--- a/lib/modules/troubleshooter.js
+++ b/lib/modules/troubleshooter.js
@@ -1,6 +1,6 @@
 import testTemplate from '../templates/test.mustache';
-import * as Notifications from './notifications';
 import { Session, Storage, XhrCache } from '../environment';
+import * as Notifications from './notifications';
 
 export const module = {};
 

--- a/lib/modules/userHighlight.js
+++ b/lib/modules/userHighlight.js
@@ -1,5 +1,3 @@
-import * as SettingsConsole from './settingsConsole';
-import * as UserInfo from './userInfo';
 import { $ } from '../vendor';
 import {
 	Alert,
@@ -8,6 +6,8 @@ import {
 	hashCode,
 	watchForElement,
 } from '../utils';
+import * as SettingsConsole from './settingsConsole';
+import * as UserInfo from './userInfo';
 
 export const module = {};
 

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -1,11 +1,6 @@
-import * as CommentNavigator from './commentNavigator';
-import * as Hover from './hover';
-import * as Modules from '../core/modules';
-import * as QuickMessage from './quickMessage';
-import * as UserHighlight from './userHighlight';
-import * as UserTagger from './userTagger';
 import { $ } from '../vendor';
 import { ajax } from '../environment';
+import * as Modules from '../core/modules';
 import {
 	click,
 	commaDelimitedNumber,
@@ -16,6 +11,11 @@ import {
 	niceDateDiff,
 	string,
 } from '../utils';
+import * as CommentNavigator from './commentNavigator';
+import * as Hover from './hover';
+import * as QuickMessage from './quickMessage';
+import * as UserHighlight from './userHighlight';
+import * as UserTagger from './userTagger';
 
 export const module = {};
 

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -1,12 +1,6 @@
 import _ from 'lodash';
-import * as CommandLine from './commandLine';
-import * as Dashboard from './dashboard';
-import * as KeyboardNav from './keyboardNav';
-import * as Modules from '../core/modules';
-import * as NightMode from './nightMode';
-import * as SelectedEntry from './selectedEntry';
-import * as SettingsNavigation from './settingsNavigation';
 import { $ } from '../vendor';
+import * as Modules from '../core/modules';
 import {
 	Alert,
 	CreateElement,
@@ -20,6 +14,12 @@ import {
 	watchForElement,
 } from '../utils';
 import { Storage, openNewTabs } from '../environment';
+import * as CommandLine from './commandLine';
+import * as Dashboard from './dashboard';
+import * as KeyboardNav from './keyboardNav';
+import * as NightMode from './nightMode';
+import * as SelectedEntry from './selectedEntry';
+import * as SettingsNavigation from './settingsNavigation';
 
 export const module = {};
 

--- a/lib/modules/userbarHider.js
+++ b/lib/modules/userbarHider.js
@@ -1,7 +1,7 @@
+import { $ } from '../vendor';
+import * as Options from '../core/options';
 import * as AccountSwitcher from './accountSwitcher';
 import * as Notifications from './notifications';
-import * as Options from '../core/options';
-import { $ } from '../vendor';
 
 export const module = {};
 

--- a/lib/modules/usernameHider.js
+++ b/lib/modules/usernameHider.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
-import * as AccountSwitcher from './accountSwitcher';
 import { $ } from '../vendor';
 import { addCSS, loggedInUser, regexes } from '../utils';
+import * as AccountSwitcher from './accountSwitcher';
 
 export const module = {};
 

--- a/lib/utils/user.js
+++ b/lib/utils/user.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
-import { HOUR, MINUTE, string } from './';
 import { ajax } from '../environment';
+import { HOUR, MINUTE, string } from './';
 
 export const loggedInUser = _.once(() => {
 	const userLink = document.querySelector('#header-bottom-right > span.user > a');

--- a/lib/vendor/index.js
+++ b/lib/vendor/index.js
@@ -5,7 +5,7 @@
  * `require` is used to ensure ordering (ES6 imports are hoisted - or at least Babel does it)
  */
 
-/* eslint-disable import/imports-first, import/no-commonjs, sort-imports-es6/sort-imports-es6 */
+/* eslint-disable import/imports-first, import/no-commonjs */
 
 import jQuery from 'jquery'; // eslint-disable-line no-restricted-imports
 

--- a/node/loader.entry.js
+++ b/node/loader.entry.js
@@ -1,12 +1,12 @@
 import './mocks';
 
+import * as Init from '../lib/core/init';
+import { nativeRequire } from '../lib/environment/_nativeRequire';
+import { _mockStorage } from './environment';
+
 import expected from 'json!./storage/andytuba-4.5.4-6dffad39.json';
 import ignoredKeys from 'json!./storage/_ignore-4.5.4-6dffad39.json';
 import storage from 'json!./storage/andytuba-4.5.4.json';
-
-import * as Init from '../lib/core/init';
-import { _mockStorage } from './environment';
-import { nativeRequire } from '../lib/environment/_nativeRequire';
 
 const _yargs = nativeRequire('yargs');
 const equals = nativeRequire('deep-equal');

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "eslint-plugin-no-useless-assign": "1.0.2",
     "eslint-plugin-prefer-bind-operator": "0.0.4",
     "eslint-plugin-prefer-spread": "1.0.3",
-    "eslint-plugin-sort-imports-es6": "0.0.3",
     "extricate-loader": "0.0.2",
     "file-loader": "0.8.5",
     "globby": "4.0.0",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,12 +1,14 @@
 /* eslint-disable import/no-nodejs-modules */
 
+import { basename, join } from 'path';
+
 import InertEntryPlugin from 'inert-entry-webpack-plugin';
 import ProgressBarPlugin from 'progress-bar-webpack-plugin';
 import autoprefixer from 'autoprefixer';
-import babelrc from './.babelrc.json';
 import webpack from 'webpack';
 import yargs from 'yargs';
-import { basename, join } from 'path';
+
+import babelrc from './.babelrc.json';
 
 const browserConfig = {
 	chrome: {


### PR DESCRIPTION
Fixes #2934.

Imports now must be ordered in the following groups:

- node builtins (`path`)
- npm modules (`snudown-js`)
- relative imports from parent dirs (`../utils`)
- relative imports from the current dir (`./quickMessage`)
- the index of the current dir (`./`)

Within the groups, they may be ordered arbitrarily.