### PR TITLE
Automated beta releases (for Chrome)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,9 @@ deploy:
     on:
       tags: true
       node: 6
+  - provider: script
+    script: node build/deploy.js
+    skip_cleanup: true
+    on:
+      tags: true
+      node: 6

--- a/build/deploy.js
+++ b/build/deploy.js
@@ -1,0 +1,53 @@
+/* eslint-disable import/no-commonjs, import/no-nodejs-modules */
+
+const fs = require('fs');
+const path = require('path');
+const deploy = require('chrome-extension-deploy');
+const { version } = require('../package.json');
+const isBetaVersion = require('./isBetaVersion');
+
+if (isBetaVersion(version)) {
+	console.log(`Deploying ${version} beta release...`);
+
+	deployChromeBeta();
+} else {
+	console.log(`Deploying ${version} stable release...`);
+
+	deployChromeBeta();
+	deployChromeStable();
+}
+
+function deployChromeBeta() {
+	console.log('Deploying Chrome beta...');
+
+	deploy({
+		clientId: process.env.CHROME_CLIENT_ID,
+		clientSecret: process.env.CHROME_CLIENT_SECRET,
+		refreshToken: process.env.CHROME_REFRESH_TOKEN,
+		id: 'flhpapomijliefifkkeepedibpmibbpo',
+		zip: fs.readFileSync(path.join(__dirname, '../dist/zip/chrome.zip')),
+		to: deploy.TRUSTED_TESTERS,
+	}).then(() => {
+		console.log('Chrome beta deployment complete!');
+	}, err => {
+		console.error('Chrome beta failed:', err);
+		process.exitCode = 1;
+	});
+}
+
+function deployChromeStable() {
+	console.log('Deploying Chrome stable...');
+
+	deploy({
+		clientId: process.env.CHROME_CLIENT_ID,
+		clientSecret: process.env.CHROME_CLIENT_SECRET,
+		refreshToken: process.env.CHROME_REFRESH_TOKEN,
+		id: 'kbmfpngjjgdllneeigpgjifpgocmfgmb',
+		zip: fs.readFileSync(path.join(__dirname, '../dist/zip/chrome.zip')),
+	}).then(() => {
+		console.log('Chrome stable deployment complete!');
+	}, err => {
+		console.error('Chrome stable failed:', err);
+		process.exitCode = 1;
+	});
+}

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "babel-preset-es2015": "6.9.0",
     "babel-preset-stage-0": "6.5.0",
     "babel-traverse": "6.9.0",
+    "chrome-extension-deploy": "2.0.1",
     "coveralls": "2.11.11",
     "cross-env": "2.0.0",
     "css-loader": "0.23.1",


### PR DESCRIPTION
Resolves #2728.

This does two things:

- For tags with an ~~odd minor version number~~<sup>1</sup> (to be used as beta releases), automatically builds and publishes the Chrome version to a beta listing
- ~~For *all* version number tags, builds all targets and uploads the artifacts to a new GitHub release~~ #3181

<sup>1: Actually, we might as well release all versions to the beta channel, so beta users don't have to switch back to the main extension for normal releases.</sup>

**Todo**

- [x] [Create beta app listing in Chrome webstore](https://chrome.google.com/webstore/developer/dashboard) (use [the package from 4.7.1](https://github.com/honestbleeps/Reddit-Enhancement-Suite/releases/tag/v4.7.1) and this [beta icon](https://github.com/honestbleeps/Reddit-Enhancement-Suite/blob/master/images/beta128.png)) and private visiblity (select the google group in the dropdown and make sure you do this before first publish)
- [x] [Get Chrome webstore API OAuth tokens](https://erikdesjardins.github.io/chrome-deploy-key/) (client id, client secret, refresh token) and add as environment variables with [these names](https://github.com/honestbleeps/Reddit-Enhancement-Suite/pull/2946/files#diff-7bce112a2436361628559f89e56eae6bR23) to [Travis CI](https://travis-ci.org/honestbleeps/Reddit-Enhancement-Suite/settings)
- [x] add beta extension id to [deploy.js](https://github.com/honestbleeps/Reddit-Enhancement-Suite/pull/2946/files#diff-7bce112a2436361628559f89e56eae6bR26)
- [x] Write beta instructions / disclaimers for store listing
