### PR TITLE
Firefox: remove `unsafe-content-script` permission

### DIFF
--- a/firefox/package.json
+++ b/firefox/package.json
@@ -9,7 +9,6 @@
 	"version": "{{prop?version!../package.json}}",
 	"main": "{{./background.entry.js}}",
 	"permissions": {
-		"private-browsing": true,
-		"unsafe-content-script": true
+		"private-browsing": true
 	}
 }


### PR DESCRIPTION
We don't use unsafeWindow anymore.

Closes #1744.