### PR TITLE
Youtube: More link formats & parameter options features

### DIFF
--- a/lib/modules/hosts/youtube.js
+++ b/lib/modules/hosts/youtube.js
@@ -8,7 +8,7 @@ export default {
 	domains: ['youtube.com', 'youtu.be'],
 	detect(href, elem) {
 		return !elem.classList.contains('title') &&
-			(/^https?:\/\/(?:youtu\.be|(?:www\.|m\.)?youtube\.com)\/?(?:watch|embed)?(?:.*?v=|v\/|\/)([\w-_]+)/i).exec(href);
+			(/^https?:\/\/(?:youtu\.be|(?:www\.|m\.)?youtube\.com)\/?(?:watch|embed)?(?:.*?v=|v\/|\/)([\w-]+)/i).exec(href);
 	},
 	handleLink(elem, [, hash]) {
 		// Check url for timecode e.g t=1h23m15s

--- a/lib/modules/hosts/youtube.js
+++ b/lib/modules/hosts/youtube.js
@@ -12,16 +12,15 @@ export default {
 	},
 	handleLink(elem, [, hash]) {
 		// Check url for timecode e.g t=1h23m15s
-		const starttimeRe = /[\&\?](?:t=|start=)([0-9hms]+)/i;
+		const starttimeRe = /[&\?](?:t=|start=)([0-9hms]+)/i;
 		const starttimeResult = starttimeRe.exec(elem.href);
-		
 		// End time is always in integer format, no need to parse
-		const endtimeRe = /[\&\?]end=([0-9]+)/i;
+		const endtimeRe = /[&\?]end=([0-9]+)/i;
 		const endtimeResult = endtimeRe.exec(elem.href);
-		
-		const playlistRe = /[\&\?]list=([\w\-_]+)/i;
+		// Finds playlist id if included
+		const playlistRe = /[&\?]list=([\w\-_]+)/i;
 		const playlistResult = playlistRe.exec(elem.href);
-		
+
 		let starttime = 0;
 		if (starttimeResult) {
 			const timeBlocks = { h: 3600, m: 60, s: 1 };
@@ -45,15 +44,15 @@ export default {
 
 		let src = `https://www.youtube.com/embed/${hash}?enablejsapi=1&enablecastapi=1&start=${starttime}`;
 		
-		if(endtimeResult) {
+		if (endtimeResult) {
 			// `&version=3` seems to be required for end time to work
 			src += `&end=${endtimeResult[1]}&version=3`;
 		}
-		if(playlistResult) {
+
+		if (playlistResult) {
 			// appends playlist id if found
 			src += `&list=${playlistResult[1]}`;
 		}
-		
 
 		if (ShowImages.module.options.autoplayVideo.value) {
 			// Avoid auto playing more than 1 item

--- a/lib/modules/hosts/youtube.js
+++ b/lib/modules/hosts/youtube.js
@@ -43,7 +43,7 @@ export default {
 		}
 
 		let src = `https://www.youtube.com/embed/${hash}?enablejsapi=1&enablecastapi=1&start=${starttime}`;
-		
+
 		if (endtimeResult) {
 			// `&version=3` seems to be required for end time to work
 			src += `&end=${endtimeResult[1]}&version=3`;

--- a/lib/modules/hosts/youtube.js
+++ b/lib/modules/hosts/youtube.js
@@ -8,19 +8,26 @@ export default {
 	domains: ['youtube.com', 'youtu.be'],
 	detect(href, elem) {
 		return !elem.classList.contains('title') &&
-			((/^https?:\/\/(?:www\.|m\.)?youtube\.com\/watch.*?[?&]v=([\w\-]+)/i).exec(href) || (/^https?:\/\/(?:www\.)?youtu\.be\/([\w\-]+)/i).exec(href));
+			(/^https?:\/\/(?:youtu\.be|(?:www\.|m\.)?youtube\.com)\/?(?:watch|embed)?(?:.*?v=|v\/|\/)([\w-_]+)/i).exec(href);
 	},
 	handleLink(elem, [, hash]) {
 		// Check url for timecode e.g t=1h23m15s
-		const timecodeRe = /t=(.*?)(?:$|&)/i;
-		const timecodeResult = timecodeRe.exec(elem.href);
+		const starttimeRe = /[\&\?](?:t=|start=)([0-9hms]+)/i;
+		const starttimeResult = starttimeRe.exec(elem.href);
+		
+		// End time is always in integer format, no need to parse
+		const endtimeRe = /[\&\?]end=([0-9]+)/i;
+		const endtimeResult = endtimeRe.exec(elem.href);
+		
+		const playlistRe = /[\&\?]list=([\w\-_]+)/i;
+		const playlistResult = playlistRe.exec(elem.href);
+		
 		let starttime = 0;
-
-		if (timecodeResult) {
+		if (starttimeResult) {
 			const timeBlocks = { h: 3600, m: 60, s: 1 };
 			const timeRe = /[0-9]+[hms]/ig;
 			// Get each segment e.g. 8m and calculate its value in seconds
-			const timeMatch = timecodeResult[0].match(timeRe);
+			const timeMatch = starttimeResult[1].match(timeRe);
 
 			if (timeMatch) {
 				timeMatch.forEach(ts => {
@@ -31,12 +38,22 @@ export default {
 				});
 			} else {
 				// support direct timestamp e.g. t=200
-				starttime = parseInt(timecodeResult[0].replace('t=', ''), 10);
+				starttime = parseInt(starttimeResult[1], 10);
 				if (isNaN(starttime)) starttime = 0;
 			}
 		}
 
 		let src = `https://www.youtube.com/embed/${hash}?enablejsapi=1&enablecastapi=1&start=${starttime}`;
+		
+		if(endtimeResult) {
+			// `&version=3` seems to be required for end time to work
+			src += `&end=${endtimeResult[1]}&version=3`;
+		}
+		if(playlistResult) {
+			// appends playlist id if found
+			src += `&list=${playlistResult[1]}`;
+		}
+		
 
 		if (ShowImages.module.options.autoplayVideo.value) {
 			// Avoid auto playing more than 1 item


### PR DESCRIPTION
Catches significantly more types of link formats without any performance hit, allowing for most variations of Youtube links to be found. 

Also allows options to have a start / end time for the video. Previously only caught '&t=', but not '&start=' ? '&end=', now it catches all of them.

Also properly includes playlists by including the '&list=' parameter.