### PR TITLE
ShowImages resizer: Reduce Firefox lag

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -21,6 +21,7 @@ import {
 	addCSS,
 	batch,
 	forEachChunked,
+	frameDebounce,
 	isCurrentSubreddit,
 	isPageType,
 	objectValidator,
@@ -1481,21 +1482,21 @@ function makeMediaZoomable(mediaTag) {
 		return Math.round(dragSize);
 	}
 
-	function dragMedia(e) {
-		if (dragTargetData) {
-			const newDiagonal = getDragSize(e);
-			const oldDiagonal = dragTargetData.diagonal;
+	const dragMedia = frameDebounce(e => {
+		if (!dragTargetData) return;
 
-			if (newDiagonal !== oldDiagonal) {
-				dragTargetData.hasChangedWidth = true;
+		const newDiagonal = getDragSize(e);
+		const oldDiagonal = dragTargetData.diagonal;
 
-				const imageWidth = dragTargetData.imageWidth;
-				const maxWidth = Math.max(mediaTag.minWidth, newDiagonal / oldDiagonal * imageWidth);
+		if (newDiagonal !== oldDiagonal) {
+			dragTargetData.hasChangedWidth = true;
 
-				resizeMedia(mediaTag, maxWidth);
-			}
+			const imageWidth = dragTargetData.imageWidth;
+			const maxWidth = Math.max(mediaTag.minWidth, newDiagonal / oldDiagonal * imageWidth);
+
+			resizeMedia(mediaTag, maxWidth);
 		}
-	}
+	});
 
 	mediaTag.addEventListener('mousedown', e => {
 		// shiftKey is used by makeMediaMovable


### PR DESCRIPTION
Limits `dragMedia` to at most one execution per frame.