### PR TITLE
Update #2906: Captions position

### DIFF
--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -205,10 +205,6 @@ img {
 		.selftext.expanded ~ * & {
 			max-width: 100%;
 		}
-
-		> * {
-			display: inline-block;
-		}
 	}
 
 	.res-expando-independent {
@@ -310,6 +306,8 @@ img {
 }
 
 .video-advanced {
+	display: inline-block;
+
 	.video-advanced-container {
 		overflow: hidden;
 		position: relative;
@@ -484,5 +482,43 @@ img {
 		color: rgb(221, 221, 221);
 		border-color: rgb(102, 102, 102);
 		background: none;
+	}
+}
+
+.res-showImages-captionsPosition {
+	@at-root {
+		.res-image,
+		.res-gallery {
+			display: inline-flex;
+			flex-direction: column;
+		}
+
+		// Keep these below any captions
+		.res-gallery-below,
+		.res-expando-siteAttribution,
+		.res-gallery-increase-concurrent {
+			order: 2;
+		}
+	}
+
+	&-creditsBelow {
+		.res-credits {
+			order: 1;
+		}
+	}
+
+	&-titleAbove {
+		.res-caption,
+		.res-credits {
+			order: 1;
+		}
+	}
+
+	&-allBelow {
+		.res-title,
+		.res-caption,
+		.res-credits {
+			order: 1;
+		}
 	}
 }

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -159,6 +159,33 @@ module.options = {
 		}],
 		description: 'Set position of media controls',
 	},
+	displayImageCaptions: {
+		type: 'boolean',
+		value: true,
+		description: 'Retrieve image captions/attribution information.',
+		advanced: true,
+	},
+	captionsPosition: {
+		dependsOn: 'displayImageCaptions',
+		type: 'enum',
+		value: 'titleAbove',
+		values: [{
+			name: 'Display all captions above image.',
+			value: 'allAbove',
+		}, {
+			name: 'Display title and caption above image, credits below.',
+			value: 'creditsBelow',
+		}, {
+			name: 'Display title above image, caption and credits below.',
+			value: 'titleAbove',
+		}, {
+			name: 'Display all captions below image.',
+			value: 'allBelow',
+		}],
+		description: 'Where to display captions around an image.',
+		advanced: true,
+		bodyClass: true,
+	},
 	clippy: {
 		type: 'boolean',
 		value: true,
@@ -195,32 +222,6 @@ module.options = {
 		type: 'boolean',
 		value: true,
 		description: 'Do not create expandos for images that appear multiple times in a page.',
-	},
-	displayImageCaptions: {
-		type: 'boolean',
-		value: true,
-		description: 'Retrieve image captions/attribution information.',
-		advanced: true,
-	},
-	captionsPosition: {
-		dependsOn: 'displayImageCaptions',
-		type: 'enum',
-		value: 'titleAbove',
-		values: [{
-			name: 'Display all captions above image.',
-			value: 'allAbove',
-		}, {
-			name: 'Display title and caption above image, credits below.',
-			value: 'creditsBelow',
-		}, {
-			name: 'Display title above image, caption and credits below.',
-			value: 'titleAbove',
-		}, {
-			name: 'Display all captions below image.',
-			value: 'allBelow',
-		}],
-		description: 'Where to display captions around an image.',
-		advanced: true,
 	},
 	loadAllInAlbum: {
 		type: 'boolean',

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -202,6 +202,26 @@ module.options = {
 		description: 'Retrieve image captions/attribution information.',
 		advanced: true,
 	},
+	captionsPosition: {
+		dependsOn: 'displayImageCaptions',
+		type: 'enum',
+		value: 'titleAbove',
+		values: [{
+			name: 'Display all captions above image.',
+			value: 'allAbove',
+		}, {
+			name: 'Display title and caption above image, credits below.',
+			value: 'creditsBelow',
+		}, {
+			name: 'Display title above image, caption and credits below.',
+			value: 'titleAbove',
+		}, {
+			name: 'Display all captions below image.',
+			value: 'allBelow',
+		}],
+		description: 'Where to display captions around an image.',
+		advanced: true,
+	},
 	loadAllInAlbum: {
 		type: 'boolean',
 		value: false,

--- a/lib/templates/image.mustache
+++ b/lib/templates/image.mustache
@@ -5,10 +5,10 @@
 	{{#caption}}
 	<div class="res-caption">{{caption}}</div>
 	{{/caption}}
-	<a class="noKeyNav" href="{{href}}" {{#openInNewWindow}}target="_blank" rel="noopener noreferrer"{{/openInNewWindow}}>
-		<img class="res-image-media" src="{{src}}">
-	</a>
 	{{#credits}}
 	<div class="res-credits">{{{credits}}}</div>
 	{{/credits}}
+	<a class="noKeyNav" href="{{href}}" {{#openInNewWindow}}target="_blank" rel="noopener noreferrer"{{/openInNewWindow}}>
+		<img class="res-image-media" src="{{src}}">
+	</a>
 </div>


### PR DESCRIPTION
Closes #2906.

Implemented with flexbox order, since there isn't a simple way to reorder elements in a moustache template (AFAIK).

~~Changed the default to `allAbove`, since the status quo is king (people hate change), and the problem it solves is very niche.~~
[after discussion in IRC] Keeps `titleAbove`; moves the option down next to `mediaControls` for discoverability. Hopefully that'll be good enough.