### PR TITLE
ShowImages: Hide MediaControls when resizing

### DIFF
--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -186,6 +186,7 @@ img {
 		transition: opacity 300ms;
 	}
 
+	body.res-media-resizing &,
 	.res-media-load-error & {
 		display: none !important;
 	}

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1470,6 +1470,7 @@ function setMediaClippyText(elem) {
 
 function makeMediaZoomable(mediaTag) {
 	if (!module.options.imageZoom.value) return;
+
 	mediaTag.classList.add('res-media-resizable');
 
 	let dragTargetData;
@@ -1497,9 +1498,16 @@ function makeMediaZoomable(mediaTag) {
 		}
 	}
 
+	function endDrag() {
+		document.body.classList.remove('res-media-resizing');
+		dragTargetData = null;
+	}
+
 	mediaTag.addEventListener('mousedown', e => {
 		// shiftKey is used by makeMediaMovable
 		if (e.button === 0 && !e.shiftKey) {
+			document.body.classList.add('res-media-resizing');
+
 			if (!e.target.minWidth) mediaTag.minWidth = Math.max(1, Math.min(mediaTag.clientWidth, 100));
 			dragTargetData = {
 				imageWidth: mediaTag.clientWidth,
@@ -1512,13 +1520,13 @@ function makeMediaZoomable(mediaTag) {
 	}, false);
 	mediaTag.addEventListener('mouseup', dragMedia, false);
 	mediaTag.addEventListener('mousemove', dragMedia, false);
-	mediaTag.addEventListener('mouseout', () => { dragTargetData = null; }, false);
+	mediaTag.addEventListener('mouseout', endDrag, false);
 	mediaTag.addEventListener('click', e => {
 		if (dragTargetData && dragTargetData.hasChangedWidth) {
 			e.preventDefault();
 		}
 
-		dragTargetData = null;
+		endDrag();
 	}, false);
 }
 


### PR DESCRIPTION
MediaControls can interfere with resizing (by triggering a `mouseout` event on hover).