### PR TITLE
Fixed spacing between est. upvote count and label

### DIFF
--- a/lib/modules/voteEnhancements.js
+++ b/lib/modules/voteEnhancements.js
@@ -179,14 +179,14 @@ function estimatePostScoreVotes() {
 			const downvotes = upvotes - points;
 			if (module.options.estimatePostScore.value) {
 				$linkinfoScore.after(`
-					<span class="upvotes"><span class="number">${commaDelimitedNumber(upvotes)}</span><span class="word">${upvotes === 1 ? 'upvote' : 'upvotes'}</span></span>
-					<span class="downvotes"><span class="number">${commaDelimitedNumber(downvotes)}</span><span class="word">${downvotes === 1 ? 'downvote' : 'downvotes'}</span></span>
+					<span class="upvotes"><span class="number">${commaDelimitedNumber(upvotes)}</span> <span class="word">${upvotes === 1 ? 'upvote' : 'upvotes'}</span></span>
+					<span class="downvotes"><span class="number">${commaDelimitedNumber(downvotes)}</span> <span class="word">${downvotes === 1 ? 'downvote' : 'downvotes'}</span></span>
 				`);
 			}
 			if (module.options.estimatePostVotes.value) {
 				const totalVotes = upvotes + downvotes;
 				$linkinfoScore.after(`
-					<span class="totalvotes"><span class="number">${commaDelimitedNumber(totalVotes)}</span><span class="word">${totalVotes === 1 ? 'vote' : 'votes'}</span></span>
+					<span class="totalvotes"><span class="number">${commaDelimitedNumber(totalVotes)}</span> <span class="word">${totalVotes === 1 ? 'vote' : 'votes'}</span></span>
 				`);
 			}
 		}


### PR DESCRIPTION
The estimated vote count didn't have a space between the value and the label. This fixes it.