### PR TITLE
ShowImages: Style fixes

### DIFF
--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -200,10 +200,9 @@ img {
 	}
 
 	.res-expando-media {
-		display: inline-block;
+		width: inherit;
 
-		.usertext-body &,
-		.selftext.expanded ~ * & {
+		> * {
 			max-width: 100%;
 		}
 	}
@@ -239,6 +238,15 @@ img {
 }
 
 .res-gallery {
+	&,
+	.res-gallery-pieces {
+		width: 100%;
+	}
+
+	.res-gallery-piece-block > * {
+		max-width: 100%;
+	}
+
 	.res-gallery-title {
 		margin: 3px;
 		font-size: 15px;
@@ -289,11 +297,11 @@ img {
 
 .res-image {
 	a {
-		display: inline-block;
+		// Limits width to that of child elements
+		display: table;
 	}
 
 	.res-image-media {
-		display: block !important;
 		user-select: none;
 
 		@at-root .res-media-load-error#{&} {

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -923,7 +923,7 @@ function buildExpandoBox(expandoButton) {
 	const imageLink = expandoButton.imageLink;
 	const options = {
 		loadHeight: 20, // gives an indication that the expando is opened
-		textMaxWidth: imageLink.parentElement.getBoundingClientRect().width,
+		width: imageLink.parentElement.getBoundingClientRect().width,
 	};
 
 	const expando = expandoButton.expandoBox = $(expandoTemplate(options))[0];
@@ -1001,7 +1001,12 @@ function generateGallery(options) {
 
 		piece.media = piece.media || generateMedia(piece.options);
 		piece.media.hidden = false;
-		if (!piece.media.parentElement) piecesContainer.appendChild(piece.media);
+		if (!piece.media.parentElement) {
+			const block = document.createElement('div');
+			block.classList.add('res-gallery-piece-block');
+			block.appendChild(piece.media);
+			piecesContainer.appendChild(block);
+		}
 		if (piece.media.expand) piece.media.expand();
 		piecesContainer.dispatchEvent(new CustomEvent('resize', { bubbles: true }));
 	}

--- a/lib/templates/expando.mustache
+++ b/lib/templates/expando.mustache
@@ -1,3 +1,3 @@
 <div class="res-expando" style="min-height: {{loadHeight}}px">
-	<div class="res-expando-media" style="width: {{textMaxWidth}}px"></div>
+	<div class="res-expando-media" style="width: {{width}}px"></div>
 </div>

--- a/lib/templates/gallery.mustache
+++ b/lib/templates/gallery.mustache
@@ -1,6 +1,6 @@
 <div class="res-gallery">
 	{{#title}}
-	<h3 class="res-gallery res-gallery-title">{{title}}</h3>
+	<h3 class="res-title res-gallery-title">{{title}}</h3>
 	{{/title}}
 	{{#caption}}
 	<div class="res-caption res-gallery-caption">{{{caption}}}</div>


### PR DESCRIPTION
Propagates the width of the expando-parent into the expandobox, so that text won't horizontally overflow.