### PR TITLE
ShowImages: ConserveMemory fixes

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -403,7 +403,7 @@ function enableConserveMemory() {
 		// Unload expanded when beyond buffer
 		Array.from(activeImageList)
 			.filter(v => v.classList.contains('expanded'))
-			.map(v => ({ media: v.mediaElement, data: v }))
+			.map(v => ({ media: v.mediaElement, data: v.mediaElement }))
 			::lazyUnload(isWithinBuffer);
 	}, 300), false);
 }

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -405,7 +405,7 @@ function enableConserveMemory() {
 			.filter(v => v.classList.contains('expanded'))
 			.map(v => ({ media: v.mediaElement, data: v.mediaElement }))
 			::lazyUnload(isWithinBuffer);
-	}, 300), false);
+	}, 150), false);
 }
 
 function lazyDestroy(testKeepLoaded) {


### PR DESCRIPTION
The `conserveMemory` operation has become cheaper, so we may as well have it run more often so that expandos reload quicker.