### PR TITLE
KeyboardNav: Allow navigation when activeElement is 'a' or 'button'

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -780,8 +780,20 @@ function getCommandsForKeyEvent(keyEvent) {
 
 function handleKeyPress(e) {
 	const konamitest = !EasterEgg.konamiActive();
+	let callbacks;
+
+	// Allow navigation on other elements when input has no (apparent) default behavior
+	if (['A', 'BUTTON'].includes(document.activeElement.tagName)) {
+		const hasDefaultBehavior = [/* tab */9, /* enter */13, /* space */32].includes(e.which);
+		callbacks = getCommandsForKeyEvent(e);
+
+		if (!hasDefaultBehavior && callbacks) {
+			document.activeElement.blur();
+		}
+	}
+
 	if ((document.activeElement.tagName === 'BODY') && (konamitest)) {
-		const callbacks = getCommandsForKeyEvent(e);
+		callbacks = callbacks || getCommandsForKeyEvent(e);
 		if (callbacks) {
 			callbacks.fire(e);
 			return true;


### PR DESCRIPTION
Fixes #2976 