### PR TITLE
Shortened repetitive descriptions for ease of read

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -157,7 +157,7 @@ const commands = {
 	moveDown: {
 		include: ['linklist', 'modqueue', 'profile', 'search'],
 		value: [74, false, false, false], // j
-		description: 'Move down to the next link or comment in flat lists',
+		description: '… to next link',
 	},
 	moveUpComment: {
 		include: ['comments', 'inbox'],
@@ -167,7 +167,7 @@ const commands = {
 	moveDownComment: {
 		include: ['comments', 'inbox'],
 		value: [74, false, false, false], // j
-		description: 'Move down to the next comment on threaded comment pages',
+		description: '… to next comment',
 	},
 	moveTop: {
 		include: ['linklist', 'modqueue', 'profile', 'inbox', 'search'],
@@ -177,7 +177,7 @@ const commands = {
 	moveBottom: {
 		include: ['linklist', 'modqueue', 'profile', 'inbox', 'search'],
 		value: [74, false, false, true], // shift-j
-		description: 'Move to bottom of list (on link pages)',
+		description: '… to bottom of list',
 	},
 	moveUpSibling: {
 		include: ['comments'],
@@ -187,7 +187,7 @@ const commands = {
 	moveDownSibling: {
 		include: ['comments'],
 		value: [74, false, false, true], // shift-j
-		description: 'Move to next sibling (in comments) - skips to next sibling at the same depth.',
+		description: '… to next sibling',
 	},
 	moveUpThread: {
 		include: ['comments'],
@@ -197,12 +197,12 @@ const commands = {
 	moveDownThread: {
 		include: ['comments'],
 		value: [74, true, false, true], // shift-alt-j
-		description: 'Move to the topmost comment of the next thread (in comments).',
+		description: '… of the next thread',
 	},
 	moveToTopComment: {
 		include: ['comments'],
 		value: [84, false, false, false], // t
-		description: 'Move to the topmost comment of the current thread (in comments).',
+		description: '… of the current thread',
 	},
 	moveToParent: {
 		include: ['comments'],
@@ -222,7 +222,7 @@ const commands = {
 	followLinkNewTab: {
 		include: ['linklist', 'modqueue', 'profile', 'comments', 'search'],
 		value: [13, false, false, true], // shift-enter
-		description: 'Follow link in new tab (link pages only)',
+		description: '… in new tab',
 		callback() {
 			module.followLink(true);
 		},
@@ -244,16 +244,16 @@ const commands = {
 	},
 	imageSizeDown: {
 		value: [189, false, false, false], // - -- 173 in firefox
-		description: 'Decrease the size of image(s) in the highlighted post area',
+		description: '… decrease the size of image(s)',
 	},
 	imageSizeUpFine: {
 		value: [187, false, false, true], // shift-=
-		description: 'Increase the size of image(s) in the highlighted post area (finer control)',
+		description: '… (finer control) increase',
 		callback() { module.imageSizeUp(true); },
 	},
 	imageSizeDownFine: {
 		value: [189, false, false, true], // shift--
-		description: 'Decrease the size of image(s) in the highlighted post area (finer control)',
+		description: '… (finer control) decrease',
 		callback() { module.imageSizeDown(true); },
 	},
 	imageMoveUp: {
@@ -262,15 +262,15 @@ const commands = {
 	},
 	imageMoveDown: {
 		value: [40, false, true, false], // ctrl-down
-		description: 'Move the image(s) in the highlighted post area down',
+		description: '… down',
 	},
 	imageMoveLeft: {
 		value: [37, false, true, false], // ctrl-left
-		description: 'Move the image(s) in the highlighted post area left',
+		description: '… left',
 	},
 	imageMoveRight: {
 		value: [39, false, true, false], // ctrl-right
-		description: 'Move the image(s) in the highlighted post area right',
+		description: '… right',
 	},
 	previousGalleryImage: {
 		value: [219, false, false, false], // [
@@ -278,7 +278,7 @@ const commands = {
 	},
 	nextGalleryImage: {
 		value: [221, false, false, false], // ]
-		description: 'View the next image of an inline gallery.',
+		description: '… next image',
 	},
 	toggleViewImages: {
 		value: [88, false, false, true], // shift-x
@@ -292,12 +292,12 @@ const commands = {
 	followComments: {
 		include: ['linklist', 'modqueue', 'profile', 'search'],
 		value: [67, false, false, false], // c
-		description: 'View comments for link (shift opens them in a new tab)',
+		description: 'View comments for link',
 	},
 	followCommentsNewTab: {
 		include: ['linklist', 'modqueue', 'profile', 'search'],
 		value: [67, false, false, true], // shift-c
-		description: 'View comments for link in a new tab',
+		description: '… in a new tab',
 		callback() { module.followComments(true); },
 	},
 	followLinkAndCommentsNewTab: {
@@ -309,7 +309,7 @@ const commands = {
 	followLinkAndCommentsNewTabBG: {
 		include: ['linklist', 'modqueue', 'profile'],
 		value: [76, false, false, true], // shift-l
-		description: 'View link and comments in new background tabs',
+		description: '… in new background tabs',
 		callback() { followLinkAndComments(true); },
 	},
 	upVote: {
@@ -320,7 +320,7 @@ const commands = {
 	downVote: {
 		include: ['linklist', 'modqueue', 'profile', 'comments', 'inbox', 'search'],
 		value: [90, false, false, false], // z
-		description: 'Downvote selected link or comment (or remove the downvote)',
+		description: '… downvote (or remove)',
 	},
 	upVoteWithoutToggling: {
 		include: ['linklist', 'modqueue', 'profile', 'comments', 'inbox', 'search'],
@@ -331,7 +331,7 @@ const commands = {
 	downVoteWithoutToggling: {
 		include: ['linklist', 'modqueue', 'profile', 'comments', 'inbox', 'search'],
 		value: [90, false, false, true], // z
-		description: 'Downvote selected link or comment (but don\'t remove the downvote)',
+		description: '… downvote (but don\'t removeh)',
 		callback() { module.downVote(true); },
 	},
 	savePost: {
@@ -343,7 +343,7 @@ const commands = {
 	saveComment: {
 		include: ['comments'],
 		value: [83, false, false, true], // shift-s
-		description: 'Save the current comment to your reddit account. This is accessible from anywhere that you\'re logged in, but does not preserve the original text if it\'s edited or deleted.',
+		description: '… the current comment',
 	},
 	saveRES: {
 		include: ['comments', 'profile'],
@@ -364,7 +364,7 @@ const commands = {
 	followPermalinkNewTab: {
 		include: ['comments', 'inbox'],
 		value: [89, false, false, true], // shift-y
-		description: 'Open the current comment\'s permalink in a new tab (comment pages only)',
+		description: '… in a new tab',
 		callback() { module.followPermalink(true); },
 	},
 	followSubreddit: {
@@ -375,7 +375,7 @@ const commands = {
 	followSubredditNewTab: {
 		include: ['linklist', 'modqueue', 'profile', 'search'],
 		value: [82, false, false, true], // shift-r
-		description: 'Go to subreddit of selected link in a new tab (link pages only)',
+		description: '… in a new tab',
 		callback() { module.followSubreddit(true); },
 	},
 	inbox: {
@@ -385,7 +385,7 @@ const commands = {
 	},
 	inboxNewTab: {
 		value: [73, false, false, true], // shift+i
-		description: 'Go to inbox in a new tab',
+		description: '… in a new tab',
 		dependsOn: 'goMode',
 		callback() { module.inbox(true); },
 	},
@@ -396,7 +396,7 @@ const commands = {
 	},
 	modmailNewTab: {
 		value: [77, false, false, true], // shift+m
-		description: 'Go to modmail in a new tab',
+		description: '… in a new tab',
 		dependsOn: 'goMode',
 		callback() { module.modmail(true); },
 	},
@@ -407,7 +407,7 @@ const commands = {
 	},
 	profileNewTab: {
 		value: [85, false, false, true], // shift+u
-		description: 'Go to profile in a new tab',
+		description: '… in a new tab',
 		dependsOn: 'goMode',
 		callback() { module.profile(true); },
 	},
@@ -436,7 +436,7 @@ const commands = {
 	prevPage: {
 		include: ['linklist', 'modqueue', 'profile', 'inbox'],
 		value: [80, false, false, false], // p
-		description: 'Go to prev page (link list pages only)',
+		description: '… prev page',
 		dependsOn: 'goMode',
 	},
 	link1: {
@@ -447,55 +447,55 @@ const commands = {
 	},
 	link2: {
 		value: [50, false, false, false], // 2
-		description: 'Open link #2 within comment.',
+		description: '… link #2',
 		noconfig: true,
 		callback() { commentLink(1); },
 	},
 	link3: {
 		value: [51, false, false, false], // 3
-		description: 'Open link #3 within comment.',
+		description: '… link #3',
 		noconfig: true,
 		callback() { commentLink(2); },
 	},
 	link4: {
 		value: [52, false, false, false], // 4
-		description: 'Open link #4 within comment.',
+		description: '… link #4',
 		noconfig: true,
 		callback() { commentLink(3); },
 	},
 	link5: {
 		value: [53, false, false, false], // 5
-		description: 'Open link #5 within comment.',
+		description: '… link #5',
 		noconfig: true,
 		callback() { commentLink(4); },
 	},
 	link6: {
 		value: [54, false, false, false], // 6
-		description: 'Open link #6 within comment.',
+		description: '… link #6',
 		noconfig: true,
 		callback() { commentLink(5); },
 	},
 	link7: {
 		value: [55, false, false, false], // 7
-		description: 'Open link #7 within comment.',
+		description: '… link #7',
 		noconfig: true,
 		callback() { commentLink(6); },
 	},
 	link8: {
 		value: [56, false, false, false], // 8
-		description: 'Open link #8 within comment.',
+		description: '… link #8',
 		noconfig: true,
 		callback() { commentLink(7); },
 	},
 	link9: {
 		value: [57, false, false, false], // 9
-		description: 'Open link #9 within comment.',
+		description: '… link #9',
 		noconfig: true,
 		callback() { commentLink(8); },
 	},
 	link10: {
 		value: [48, false, false, false], // 0
-		description: 'Open link #10 within comment.',
+		description: '… link #10',
 		noconfig: true,
 		callback() { commentLink(9); },
 	},
@@ -507,55 +507,55 @@ const commands = {
 	},
 	link2NumPad: {
 		value: [98, false, false, false], // 2
-		description: 'Open link #2 within comment.',
+		description: '… link #2',
 		noconfig: true,
 		callback() { commentLink(1); },
 	},
 	link3NumPad: {
 		value: [99, false, false, false], // 3
-		description: 'Open link #3 within comment.',
+		description: '… link #3',
 		noconfig: true,
 		callback() { commentLink(2); },
 	},
 	link4NumPad: {
 		value: [100, false, false, false], // 4
-		description: 'Open link #4 within comment.',
+		description: '… link #4',
 		noconfig: true,
 		callback() { commentLink(3); },
 	},
 	link5NumPad: {
 		value: [101, false, false, false], // 5
-		description: 'Open link #5 within comment.',
+		description: '… link #5',
 		noconfig: true,
 		callback() { commentLink(4); },
 	},
 	link6NumPad: {
 		value: [102, false, false, false], // 6
-		description: 'Open link #6 within comment.',
+		description: '… link #6',
 		noconfig: true,
 		callback() { commentLink(5); },
 	},
 	link7NumPad: {
 		value: [103, false, false, false], // 7
-		description: 'Open link #7 within comment.',
+		description: '… link #7',
 		noconfig: true,
 		callback() { commentLink(6); },
 	},
 	link8NumPad: {
 		value: [104, false, false, false], // 8
-		description: 'Open link #8 within comment.',
+		description: '… link #8',
 		noconfig: true,
 		callback() { commentLink(7); },
 	},
 	link9NumPad: {
 		value: [105, false, false, false], // 9
-		description: 'Open link #9 within comment.',
+		description: '… link #9',
 		noconfig: true,
 		callback() { commentLink(8); },
 	},
 	link10NumPad: {
 		value: [96, false, false, false], // 0
-		description: 'Open link #10 within comment.',
+		description: '… link #10',
 		noconfig: true,
 		callback() { commentLink(9); },
 	},
@@ -578,7 +578,7 @@ const commands = {
 	commentNavigatorMoveDown: {
 		include: 'comments',
 		value: [40, false, false, true], // shift+down arrow
-		description: 'Move down using Comment Navigator',
+		description: '… move down',
 		callback() { CommentNavigator.moveDown(); },
 	},
 };


### PR DESCRIPTION
Current help menu is hard to read at a glance because it is tl;dr. I've trimmed descriptions of things that are just variants of their preceding item.

Another thing that needs to be done is to make the help menu obey night mode, but I'm not sure how to do that.