### PR TITLE
showImages: Allow iframe overflow

### DIFF
--- a/lib/modules/hosts/eroshare.js
+++ b/lib/modules/hosts/eroshare.js
@@ -8,8 +8,8 @@ export default {
 		return {
 			type: 'IFRAME',
 			embed: `//eroshare.com/embed/${hash}`,
-			width: '550',
-			height: '550',
+			width: '550px',
+			height: '550px',
 		};
 	},
 };

--- a/lib/modules/hosts/graphiq.js
+++ b/lib/modules/hosts/graphiq.js
@@ -20,8 +20,8 @@ export default {
 			type: 'IFRAME',
 			muted: true,
 			embed: `https://www.graphiq.com/w/${id}`,
-			width: data.width,
-			height: data.height,
+			width: `${data.width}px`,
+			height: `${data.height}px`,
 		};
 	},
 };

--- a/lib/modules/hosts/strawpoll.js
+++ b/lib/modules/hosts/strawpoll.js
@@ -11,8 +11,7 @@ export default {
 			muted: true,
 			embed: `//strawpoll.me/embed_1/${uid}`,
 			height: '500px',
-			width: '95%',
-			maxwidth: '700px',
+			width: '700px',
 		};
 	},
 };

--- a/lib/modules/hosts/uploadly.js
+++ b/lib/modules/hosts/uploadly.js
@@ -8,8 +8,8 @@ export default {
 		return {
 			type: 'IFRAME',
 			embed: `//uploadly.com/embed/${hash}`,
-			width: '550',
-			height: '550',
+			width: '550px',
+			height: '550px',
 		};
 	},
 };

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1118,13 +1118,16 @@ function generateIframe(options) {
 	const iframeNode = document.createElement('iframe');
 	iframeNode.src = (module.options.autoplayVideo.value && options.embedAutoplay) ?
 		options.embedAutoplay : options.embed;
-	iframeNode.width = options.width || '640';
-	iframeNode.height = options.height || '360';
 	iframeNode.allowFullscreen = true;
-	iframeNode.setAttribute('frameborder', '0');
-	iframeNode.style.maxWidth = options.maxwidth || '100%';
+	iframeNode.style.border = '0';
+	iframeNode.style.height = options.height || '360px';
+	iframeNode.style.width = options.width || '640px';
+	iframeNode.style.minWidth = '480px';
+	iframeNode.style.maxWidth = 'initial';
 
 	iframeNode.expand = () => {
+		iframeNode.dispatchEvent(new CustomEvent('resize', { bubbles: true }));
+
 		if (module.options.autoplayVideo.value && options.play) {
 			// May not work reliable on first expand
 			$(iframeNode).ready(() => {


### PR DESCRIPTION
Removes the width restriction imposed on it by `.entry`, similar to videos and images.