### PR TITLE
Switch soundcloud to less bloated player, no ajax

### DIFF
--- a/lib/modules/hosts/soundcloud.js
+++ b/lib/modules/hosts/soundcloud.js
@@ -6,12 +6,11 @@ export default {
 	domains: ['soundcloud.com'],
 	logo: 'https://a-v2.sndcdn.com/assets/images/sc-icons/favicon-2cadd14b.ico',
 	detect: () => true,
-	async handleLink(href) {
-		const src = string.encode`https://w.soundcloud.com/player/?url=${href}`;
+	handleLink(href) {
 		return {
 			type: 'IFRAME',
-			embed: src,
-			height: '124px',
+			embed: string.encode`https://w.soundcloud.com/player/?url=${href}`,
+			height: '166px',
 			pause: '{"method":"pause"}',
 			play: '{"method":"play"}',
 		};

--- a/lib/modules/hosts/soundcloud.js
+++ b/lib/modules/hosts/soundcloud.js
@@ -11,6 +11,7 @@ export default {
 			type: 'IFRAME',
 			embed: string.encode`https://w.soundcloud.com/player/?url=${href}`,
 			height: '166px',
+			width: '100%',
 			pause: '{"method":"pause"}',
 			play: '{"method":"play"}',
 		};

--- a/lib/modules/hosts/soundcloud.js
+++ b/lib/modules/hosts/soundcloud.js
@@ -1,5 +1,3 @@
-import { $ } from '../../vendor';
-import { ajax } from '../../environment';
 import { string } from '../../utils';
 
 export default {
@@ -9,7 +7,7 @@ export default {
 	logo: 'https://a-v2.sndcdn.com/assets/images/sc-icons/favicon-2cadd14b.ico',
 	detect: () => true,
 	async handleLink(href) {
-		const src = string.encode`https://w.soundcloud.com/player/?url=${href}`;		
+		const src = string.encode`https://w.soundcloud.com/player/?url=${href}`;
 		return {
 			type: 'IFRAME',
 			embed: src,

--- a/lib/modules/hosts/soundcloud.js
+++ b/lib/modules/hosts/soundcloud.js
@@ -1,5 +1,6 @@
 import { $ } from '../../vendor';
 import { ajax } from '../../environment';
+import { string } from '../../utils';
 
 export default {
 	moduleID: 'soundcloud',
@@ -8,21 +9,11 @@ export default {
 	logo: 'https://a-v2.sndcdn.com/assets/images/sc-icons/favicon-2cadd14b.ico',
 	detect: () => true,
 	async handleLink(href) {
-		const { html } = await ajax({
-			url: 'https://soundcloud.com/oembed',
-			data: {
-				url: href,
-				format: 'json',
-				iframe: 'true',
-			},
-			type: 'json',
-		});
-
-		// Get src from iframe html returned
-		const src = $(html).attr('src');
+		const src = string.encode`https://w.soundcloud.com/player/?url=${href}`;		
 		return {
 			type: 'IFRAME',
 			embed: src,
+			height: '124px',
 			pause: '{"method":"pause"}',
 			play: '{"method":"play"}',
 		};


### PR DESCRIPTION
This uses a different player that is similar, smaller, and does the same stuff. It also allows for a method to create the embeded player using a far simpler method.