### PR TITLE
Fix: Expando box not clearing .entry .flat-list

### DIFF
--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -159,6 +159,7 @@ img {
 
 .res-expando {
 	display: block;
+	clear: both; // Necessary on some custom stylesheets where .entry .flat-list has no height
 
 	.usertext-body {
 		user-select: text; // Allow selection if is a text expando


### PR DESCRIPTION
Issue occurs on custom stylesheets where `.entry .flat-list` has no height.