### PR TITLE
Tell user to reload when score has been revealed

### DIFF
--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -175,7 +175,11 @@ module.go = function() {
 					const scoreHiddenDuration = parseInt(this.getAttribute('title').match(/[0-9]+/)[0], 10);
 					const postTime = new Date(timeNode.getAttribute('datetime')).getTime();
 					const minutesLeft = Math.ceil((postTime + scoreHiddenDuration * 60000 - new Date().getTime()) / 60000);
-					this.setAttribute('title', `score will be revealed in ${minutesLeft} minute${minutesLeft > 1 ? 's' : ''}`);
+					if (minutesLeft >= 1) {
+						this.setAttribute('title', `score will be revealed in ${minutesLeft} minute${minutesLeft === 1 ? 's' : ''}`);
+					} else {
+						this.setAttribute('title', 'reload page to reveal score');
+					}
 				}
 			}
 		});


### PR DESCRIPTION
Instead of giving them a negative amount of time with incorrect pluralization.