### PR TITLE
Fix oddshot.tv expando to work with new URLs

### DIFF
--- a/lib/modules/hosts/oddshot.js
+++ b/lib/modules/hosts/oddshot.js
@@ -3,7 +3,7 @@ export default {
 	domains: ['oddshot.tv'],
 	logo: '//oddshot.tv/favicon.ico',
 	name: 'Oddshot',
-	detect: ({ href }) => (/^https?:\/\/(?:www\.)?oddshot.tv\/shot\/([a-z0-9_-]+)/i).exec(href),
+	detect: ({ href }) => (/^https?:\/\/(?:www\.)?oddshot.tv\/shot\/([a-z0-9_-]+(?:\/[a-z0-9_-]+)?)/i).exec(href),
 	handleLink(href, [, hash]) {
 		const	embed = `//oddshot.tv/shot/${hash}/embed`;
 


### PR DESCRIPTION
Oddshot changed URL scheme to something like "shot/streamer/hash". Changed regex to match new and old URLs.