### PR TITLE
ignore spotlight box when initializing NER

### DIFF
--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -102,8 +102,8 @@ module.go = function() {
 	siteTable.classList.add('res-ner-listing');
 
 	// modified from a contribution by Peter Siewert, thanks Peter!
-	// use div#siteTable in selector to avoid marking duplicates found in spotlight box
-	const entries = document.body.querySelectorAll('div#siteTable a.comments');
+	// use #siteTable in selector to avoid marking duplicates found in spotlight box
+	const entries = document.body.querySelectorAll('#siteTable a.comments');
 	for (const { href } of Array.from(entries)) {
 		dupeHash[href] = 1;
 	}

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -102,7 +102,8 @@ module.go = function() {
 	siteTable.classList.add('res-ner-listing');
 
 	// modified from a contribution by Peter Siewert, thanks Peter!
-	const entries = document.body.querySelectorAll('a.comments');
+	// use div#siteTable in selector to avoid marking duplicates found in spotlight box
+	const entries = document.body.querySelectorAll('div#siteTable a.comments');
 	for (const { href } of Array.from(entries)) {
 		dupeHash[href] = 1;
 	}


### PR DESCRIPTION
Uses div#siteTable in selector when finding post links on init of dupeHash.
 
This way links in div#siteTable_organic are ignored when marking duplicates.

See commentary at https://redd.it/4bsvpw