### PR TITLE
Simplify makeMediaMovable and makeMediaZoomable

### DIFF
--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -151,7 +151,7 @@ img {
 		opacity: .8;
 	}
 
-	body.res-media-resizing &,
+	.res-media-dragging &,
 	.res-media-load-error & {
 		display: none !important;
 	}

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1120,7 +1120,7 @@ function imageResize(factor) {
 	const selected = SelectedEntry.selectedThing();
 	if (!selected) return;
 
-	const images = $(selected.entry).find('.res-media-resizable');
+	const images = $(selected.entry).find('.res-media-zoomable');
 
 	for (const image of Array.from(images)) {
 		const thisWidth = $(image).width();

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1369,119 +1369,99 @@ function setMediaClippyText(elem) {
 	elem.setAttribute('title', title);
 }
 
-function makeMediaZoomable(mediaTag) {
-	if (!module.options.imageZoom.value) return;
+function addDragListener({ media, atShiftKey, onStart, onMove }) {
+	let hasStarted, hasMoved, lastX, lastY;
 
-	mediaTag.classList.add('res-media-resizable');
-
-	let hasChangedWidth, initialWidth, initialDiagonal, minWidth;
-
-	function getDragSize(e) {
-		const { left, top } = mediaTag.getBoundingClientRect();
-		const dragSize = Math.hypot(e.clientX - left, e.clientY - top);
-
-		return Math.round(dragSize);
-	}
-
-	const dragMedia = frameDebounce(e => {
-		const newDiagonal = getDragSize(e);
-
-		if (newDiagonal !== initialDiagonal) {
-			const newWidth = Math.max(minWidth, newDiagonal / initialDiagonal * initialWidth);
-			hasChangedWidth = true;
-
-			resizeMedia(mediaTag, newWidth);
-		}
-	});
-
-	function endDrag(e) {
-		document.body.classList.remove('res-media-resizing');
-		if (!hasChangedWidth) return;
-
-		// If the target is within mediaTag, we need to wait for the click event
-		// so that we can prevent it (potentially) opening the link
-		if (!(e.type === 'mouseup' && e.path.slice(0, e.path.indexOf(mediaTag) + 1).includes(e.target))) {
-			hasChangedWidth = false;
-		}
-
-		document.removeEventListener('mousemove', dragMedia);
-		document.removeEventListener('mouseup', endDrag);
-
-		e.preventDefault();
-	}
-
-	function startDrag(e) {
-		// only resize while left mouse button is pressed
-		// shiftKey is used by makeMediaMovable
-		if (e.button !== 0 || e.shiftKey) return;
-
-		document.body.classList.add('res-media-resizing');
-
-		document.addEventListener('mousemove', dragMedia);
-		document.addEventListener('mouseup', endDrag);
-
-		hasChangedWidth = false;
-		initialWidth = mediaTag.clientWidth;
-		initialDiagonal = getDragSize(e);
-		minWidth = Math.max(1, Math.min(mediaTag.clientWidth, 100));
-
-		e.preventDefault();
-	}
-
-	mediaTag.addEventListener('mousedown', startDrag);
-	mediaTag.addEventListener('click', endDrag);
-}
-
-function makeMediaMovable(mediaTag) {
-	if (!module.options.imageMove.value) return;
-
-	mediaTag.classList.add('res-media-movable');
-
-	let hasMoved, lastX, lastY;
-
-	const dragMedia = frameDebounce(e => {
-		const deltaX = e.clientX - lastX;
-		const deltaY = e.clientY - lastY;
-
-		if (deltaX || deltaY) {
+	const handleMove = frameDebounce(e => {
+		if (e.buttons !== 1) {
+			stop();
+			return;
+		} else if (atShiftKey !== e.shiftKey) {
+			hasStarted = false;
 			({ clientX: lastX, clientY: lastY } = e);
-			hasMoved = true;
-
-			moveMedia(mediaTag, deltaX, deltaY);
+			return;
 		}
+
+		if (!hasStarted) {
+			if (onStart) onStart(lastX, lastY);
+			hasStarted = true;
+			hasMoved = true;
+			document.body.classList.add('res-media-dragging');
+		}
+
+		onMove(e.clientX, e.clientY, e.clientX - lastX, e.clientY - lastY);
+		({ clientX: lastX, clientY: lastY } = e);
 	});
 
-	function endDrag(e) {
-		if (!hasMoved) return;
+	function handleClick(e) {
+		if (hasMoved) e.preventDefault();
+		document.removeEventListener('click', handleClick);
 
-		// If the target is within mediaTag, we need to wait for the click event
-		// so that we can prevent it (potentially) opening the link
-		if (!(e.type === 'mouseup' && e.path.slice(0, e.path.indexOf(mediaTag) + 1).includes(e.target))) {
-			hasMoved = false;
-		}
-
-		document.removeEventListener('mousemove', dragMedia);
-		document.removeEventListener('mouseup', endDrag);
-
-		e.preventDefault();
+		stop();
 	}
 
-	function startDrag(e) {
-		// only move while left mouse button is pressed
-		// requires that shiftKey is pressed
-		if (e.button !== 0 || !e.shiftKey) return;
+	function stop() {
+		document.body.classList.remove('res-media-dragging');
 
-		document.addEventListener('mousemove', dragMedia);
-		document.addEventListener('mouseup', endDrag);
+		document.removeEventListener('mousemove', handleMove);
+	}
 
-		hasMoved = false;
+	function initiate(e) {
+		if (e.buttons !== 1) return;
+
 		({ clientX: lastX, clientY: lastY } = e);
 
+		hasMoved = false;
+		hasStarted = false;
+
+		document.addEventListener('mousemove', handleMove);
+		document.addEventListener('click', handleClick);
+
 		e.preventDefault();
 	}
 
-	mediaTag.addEventListener('mousedown', startDrag);
-	mediaTag.addEventListener('click', endDrag);
+	media.addEventListener('mousedown', initiate);
+}
+
+function makeMediaZoomable(media) {
+	if (!module.options.imageZoom.value) return;
+
+	media.classList.add('res-media-zoomable');
+
+	let initialWidth, initialDiagonal, minWidth;
+
+	function getDiagonal(x, y) {
+		const { left, top } = media.getBoundingClientRect();
+		const w = Math.max(1, x - left);
+		const h = Math.max(1, y - top);
+		return Math.round(Math.hypot(w, h));
+	}
+
+	addDragListener({
+		media,
+		atShiftKey: false,
+		onStart(x, y) {
+			initialDiagonal = getDiagonal(x, y);
+			initialWidth = media.clientWidth;
+			minWidth = Math.max(1, Math.min(media.clientWidth, 100));
+		},
+		onMove(x, y) {
+			const newWidth = Math.max(minWidth, getDiagonal(x, y) / initialDiagonal * initialWidth);
+			resizeMedia(media, newWidth);
+		},
+	});
+}
+
+function makeMediaMovable(media) {
+	if (!module.options.imageMove.value) return;
+
+	media.classList.add('res-media-movable');
+
+	addDragListener({
+		media,
+		atShiftKey: true,
+		onMove(x, y, deltaX, deltaY) { moveMedia(media, deltaX, deltaY); },
+	});
 }
 
 function videoAdvanced(options) {


### PR DESCRIPTION
Last implementation utilized Event.path, which Edge has not implemented yet. Also, relying only on `mouseup` and `click` for ending dragging is unreliable.

The new implementation allows both moving and zooming interchangeably without having to release the mouse button.