### PR TITLE
userTagger: remove `display: inline-block` from .userTagLink

### DIFF
--- a/lib/css/modules/_commentTools.scss
+++ b/lib/css/modules/_commentTools.scss
@@ -127,7 +127,6 @@
 
 	a.userTagLink {
 		cursor: default;
-		display: inline;
 	}
 }
 

--- a/lib/css/modules/_userTagger.scss
+++ b/lib/css/modules/_userTagger.scss
@@ -123,12 +123,8 @@ a.voteWeight {
 	color: #9BD;
 }
 
-.userTagLink {
-	display: inline-block;
-
-	&.RESUserTagImage:hover {
-		text-decoration: none;
-	}
+.userTagLink.RESUserTagImage:hover {
+	text-decoration: none;
 }
 
 .hoverHelp {
@@ -138,7 +134,6 @@ a.voteWeight {
 
 .userTagLink.hasTag,
 #userTaggerPreview {
-	display: inline-block;
 	padding: 0 4px;
 	line-height: normal;
 	border: 1px solid #c7c7c7;


### PR DESCRIPTION
...because it doesn't seem to make a difference (except in the preview, which is still inline-block), and breaks some stylesheets (like /r/Italy)

ref: https://www.reddit.com/r/RESissues/comments/4nqy5n/issue_shifting_items_on_link_bar/