### PR TITLE
Fix scrollStyle 'top': Pad bottom when necessary

### DIFF
--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -113,6 +113,24 @@ export function getPercentageVisibleYAxis(obj) {
 	return Math.max(0, (bottom - top) / rect.height);
 }
 
+let $bottomPaddingElement;
+
+function padBottom(scrollTop, viewportHeight) {
+	const currentPadding = $bottomPaddingElement ? $bottomPaddingElement.height() : 0;
+	const extraPadding = 50; // In case the body's height reduces
+	const paddingRequired = extraPadding +
+		-(document.documentElement.scrollHeight - scrollTop - viewportHeight - currentPadding);
+	if (paddingRequired > 0) {
+		if (!$bottomPaddingElement) {
+			$bottomPaddingElement = $('<div style="clear: both">').appendTo(document.body);
+		}
+
+		$bottomPaddingElement.height(paddingRequired).show();
+	} else if ($bottomPaddingElement) {
+		$bottomPaddingElement.hide();
+	}
+}
+
 export function scrollToElement(element, options) {
 	options = $.extend(true, {
 		topOffset: 5,
@@ -131,7 +149,8 @@ export function scrollToElement(element, options) {
 	if (options.scrollStyle === 'none') {
 		return;
 	} else if (options.scrollStyle === 'top') {
-		// Always scroll element to top of page
+		// Always scroll element to top of page; pad bottom if necessary
+		padBottom(top, viewport.height);
 		scrollTo(0, top);
 	} else if (target.top >= 0 && target.bottom <= viewport.height) {
 		// Element is already completely inside viewport


### PR DESCRIPTION
Adds a padding at the bottom of the page before scrolling when the page otherwise is not long enough to have the element at the top of the viewport. Useful for keyboard navigation in linklists.