### PR TITLE
Setting link that can be relatively linked (backwards compatible)

### DIFF
--- a/lib/modules/search.js
+++ b/lib/modules/search.js
@@ -311,14 +311,12 @@ function onSearchResultCopy(result) {
 }
 
 function makeOptionSearchResultLink(result) {
-	const baseUrl = location.pathname;
-
 	const context = $.extend(true, {}, result);
 	$.extend(context, {
-		url: baseUrl + SettingsNavigation.makeUrlHash(result.moduleID, result.optionKey),
-		settingsUrl: baseUrl + SettingsNavigation.makeUrlHash(),
-		moduleUrl: baseUrl + SettingsNavigation.makeUrlHash(result.moduleID),
-		optionUrl: baseUrl + SettingsNavigation.makeUrlHash(result.moduleID, result.optionKey),
+		url: SettingsNavigation.makeUrlHash(result.moduleID, result.optionKey),
+		settingsUrl: SettingsNavigation.makeUrlHash(),
+		moduleUrl: SettingsNavigation.makeUrlHash(result.moduleID),
+		optionUrl: SettingsNavigation.makeUrlHash(result.moduleID, result.optionKey),
 	});
 
 	return `${optionLinkTemplate(context).trim()}\n\n\n`;

--- a/lib/modules/settingsNavigation.js
+++ b/lib/modules/settingsNavigation.js
@@ -61,7 +61,7 @@ export function makeUrlHashLink(moduleID, optionKey, displayText, cssClass) {
 }
 
 export function makeUrlHash(moduleID, optionKey) {
-	const hashComponents = ['#res/settings'];
+	const hashComponents = ['#res:settings'];
 
 	if (moduleID) {
 		hashComponents.push(moduleID);
@@ -101,7 +101,7 @@ export function resetUrlHash() {
 
 function onHashChange() {
 	const hash = location.hash;
-	if (!hash.startsWith('#!settings') && !hash.startsWith('#res/settings')) return;
+	if (!hash.startsWith('#!settings') && !hash.startsWith('#res:settings')) return;
 
 	const params = hash.match(/\/(?:\w|\s|%20)+/g);
 	let moduleID;
@@ -118,7 +118,7 @@ function onHashChange() {
 
 function onPopState(event) {
 	const state = typeof event.state === 'string' && event.state.split('/');
-	if (!state || state[0] !== '#!settings' || state[0] !== '#res/settings') {
+	if (!state || state[0] !== '#!settings' || state[0] !== '#res:settings') {
 		if (SettingsConsole.isOpen) {
 			// Avoid adding a duplicate page to the browser history
 			SettingsConsole.close({ resetUrl: false });

--- a/lib/modules/settingsNavigation.js
+++ b/lib/modules/settingsNavigation.js
@@ -101,7 +101,7 @@ export function resetUrlHash() {
 
 function onHashChange() {
 	const hash = location.hash;
-	if (hash.substring(0, 10) !== '#!settings' && hash.substring(0, 13) !== '#res/settings') return;
+	if (!hash.startsWith('#!settings') && !hash.startsWith('#res/settings')) return;
 
 	const params = hash.match(/\/(?:\w|\s|%20)+/g);
 	let moduleID;

--- a/lib/modules/settingsNavigation.js
+++ b/lib/modules/settingsNavigation.js
@@ -61,7 +61,7 @@ export function makeUrlHashLink(moduleID, optionKey, displayText, cssClass) {
 }
 
 export function makeUrlHash(moduleID, optionKey) {
-	const hashComponents = ['#!settings'];
+	const hashComponents = ['#res/settings'];
 
 	if (moduleID) {
 		hashComponents.push(moduleID);
@@ -101,7 +101,7 @@ export function resetUrlHash() {
 
 function onHashChange() {
 	const hash = location.hash;
-	if (hash.substring(0, 10) !== '#!settings') return;
+	if (hash.substring(0, 10) !== '#!settings' && hash.substring(0, 13) !== '#res/settings') return;
 
 	const params = hash.match(/\/(?:\w|\s|%20)+/g);
 	let moduleID;
@@ -118,7 +118,7 @@ function onHashChange() {
 
 function onPopState(event) {
 	const state = typeof event.state === 'string' && event.state.split('/');
-	if (!state || state[0] !== '#!settings') {
+	if (!state || state[0] !== '#!settings' || state[0] !== '#res/settings') {
 		if (SettingsConsole.isOpen) {
 			// Avoid adding a duplicate page to the browser history
 			SettingsConsole.close({ resetUrl: false });


### PR DESCRIPTION
Currently, since the current links (`#!settings`) begin with an exclamation mark `!` after the `#`, they cannot be relatively linked since reddit requires 'domains' to start with an alphanumeric character. 

So this is an invalid link:

`[RES Settings](#!settings)`

So I'm proposing changing to a valid link syntax:

`[RES Settings](#res/settings)`

So people on reddit can more easily link to reddit settings that work no matter what page (or page context level) you are viewing them from. 

This change is backwards compatible as well, so previous links will still work and be converted to the new format. The `hashComponents` doesn't have to be changed for this to work, but if it doesn't, it would greatly hinder the features discoverability.