### PR TITLE
showImages: Media max size (maxHeight, maxWidth) as percentage of viewport

### DIFF
--- a/lib/core/migrate.js
+++ b/lib/core/migrate.js
@@ -235,9 +235,10 @@ const migrations = [
 				.map(key => Storage.delete(key));
 		},
 	}, {
-		versionNumber: '4.7.0-changeDefaultImageMaxHeight',
+		versionNumber: '4.7.0-changeDefaultImageMaxSize',
 		async go() {
-			await migrators.generic.updateOption('showImages', 'maxHeight', 480, 0);
+			await migrators.generic.updateOption('showImages', 'maxWidth', 640, '100%');
+			await migrators.generic.updateOption('showImages', 'maxHeight', 480, '80%');
 		},
 	}, {
 		versionNumber: '4.7.0-voteWeight',

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -378,8 +378,9 @@ const mediaStates = {
 };
 
 const resizeSources = {
-	MANUAL: 0,
-	OTHER: 1,
+	KEEP_VISIBLE: 0,
+	MANUAL: 1,
+	OTHER: 2,
 };
 
 function isWithinBuffer(ele) {
@@ -1260,7 +1261,7 @@ function keepMediaVisible(media) {
 	media.classList.add('res-media-keep-visible');
 
 	const adjustAlignment = frameDebounce(e => {
-		if (!media.offsetParent) return;
+		if (e.detail === resizeSources.KEEP_VISIBLE || !media.offsetParent) return;
 
 		// Realignment on manual resizing may be non-intutive
 		if (isManuallyMoved || e.detail === resizeSources.MANUAL) {
@@ -1275,12 +1276,12 @@ function keepMediaVisible(media) {
 		const mediaLeft = media.getBoundingClientRect().left;
 		const mediaRight = mediaLeft + mediaWidth;
 
-		if (mediaWidth > width) {
-			moveMedia(media, -mediaLeft, 0, resizeSources.OTHER);
-		} else if (mediaRight - media.offsetLeft > width) {
-			moveMedia(media, width - mediaRight, 0, resizeSources.OTHER);
-		} else if (media.offsetLeft) {
-			moveMedia(media, -media.offsetLeft, 0, resizeSources.OTHER);
+		if (mediaWidth > width) { // Left align
+			moveMedia(media, -mediaLeft, 0, resizeSources.KEEP_VISIBLE);
+		} else if (mediaRight - media.offsetLeft > width) { // Right align
+			moveMedia(media, width - mediaRight, 0, resizeSources.KEEP_VISIBLE);
+		} else if (media.offsetLeft) { // Reset
+			moveMedia(media, -media.offsetLeft, 0, resizeSources.KEEP_VISIBLE);
 		}
 	});
 

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -73,13 +73,13 @@ module.options = {
 	maxWidth: {
 		type: 'text',
 		value: '640',
-		description: 'Max width of image displayed onscreen (enter zero for unlimited).',
+		description: 'Max width of media (in pixels, enter zero for unlimited). Percentage of window width may also be used (e.g. "100%").',
 		advanced: true,
 	},
 	maxHeight: {
 		type: 'text',
 		value: '0',
-		description: 'Max height of image displayed onscreen (enter zero for unlimited).',
+		description: 'Max height of media (in pixels, enter zero for unlimited). Percentage of window height may also be used (e.g. "100%").',
 		advanced: true,
 	},
 	displayOriginalResolution: {
@@ -960,11 +960,6 @@ function generateImage(options) {
 		}
 	});
 
-	const maxWidth = parseInt(module.options.maxWidth.value, 10);
-	if (maxWidth > 0) image.style.maxWidth = `${maxWidth}px`;
-	const maxHeight = parseInt(module.options.maxHeight.value, 10);
-	if (maxHeight > 0) image.style.maxHeight = `${maxHeight}px`;
-
 	element.unload = () => {
 		element.state = mediaStates.UNLOADED;
 
@@ -990,6 +985,7 @@ function generateImage(options) {
 	const resizeWhileLoading = setInterval(element.emitResizeEvent, 50);
 	element.ready.then(() => { clearInterval(resizeWhileLoading); });
 
+	setMediaMaxSize(image);
 	makeMediaZoomable(image);
 	setMediaClippyText(image);
 	const wrapper = setMediaControls(anchor, options.src);
@@ -1309,6 +1305,28 @@ function setMediaClippyText(elem) {
 	elem.setAttribute('title', title);
 }
 
+function setMediaMaxSize(media) {
+	let value = module.options.maxWidth.value;
+	let maxWidth = parseInt(value, 10);
+	if (maxWidth > 0) {
+		if (_.isString(value) && value.endsWith('%')) {
+			const viewportWidth = document.documentElement.clientWidth;
+			maxWidth *= viewportWidth / 100;
+		}
+		media.style.maxWidth = `${maxWidth}px`;
+	}
+
+	value = module.options.maxHeight.value;
+	let maxHeight = parseInt(value, 10);
+	if (maxHeight > 0) {
+		if (_.isString(value) && value.endsWith('%')) {
+			const viewportHeight = document.documentElement.clientHeight;
+			maxHeight *= viewportHeight / 100;
+		}
+		media.style.maxHeight = `${maxHeight}px`;
+	}
+}
+
 function addDragListener({ media, atShiftKey, onStart, onMove }) {
 	let isActive, hasMoved, lastX, lastY;
 
@@ -1522,11 +1540,7 @@ function videoAdvanced(options) {
 		}
 	});
 
-	const maxWidth = parseInt(module.options.maxWidth.value, 10);
-	if (maxWidth > 0) vid.style.maxWidth = `${maxWidth}px`;
-	const maxHeight = parseInt(module.options.maxHeight.value, 10);
-	if (maxHeight > 0) vid.style.maxHeight = `${maxHeight}px`;
-
+	setMediaMaxSize(vid);
 	makeMediaZoomable(vid);
 	setMediaClippyText(vid);
 	setMediaControls(vid);

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -78,7 +78,7 @@ module.options = {
 	},
 	maxHeight: {
 		type: 'text',
-		value: '0',
+		value: '80%',
 		description: 'Max height of media (in pixels, enter zero for unlimited). Percentage of window height may also be used (e.g. "100%").',
 		advanced: true,
 	},

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -72,7 +72,7 @@ module.options = {
 	},
 	maxWidth: {
 		type: 'text',
-		value: '640',
+		value: '100%',
 		description: 'Max width of media (in pixels, enter zero for unlimited). Percentage of window width may also be used (e.g. "100%").',
 		advanced: true,
 	},


### PR DESCRIPTION
Also sets default max-width to 100% of viewport, since it works fine with `keepMediaVisible`. In addition it sets default max-height to 95% of viewport, as most media otherwise would require scrolling.