### PR TITLE
Removed extra / from <iframe> URL

### DIFF
--- a/lib/modules/hosts/raddit.js
+++ b/lib/modules/hosts/raddit.js
@@ -63,7 +63,7 @@ export default {
 		} else { // otherwise, create it.
 			const width = window.getComputedStyle(sb).width;
 
-			const src = `//radd.it/${path}${path.includes('?') ? '&' : '?'}embed`;
+			const src = `//radd.it${path}${path.includes('?') ? '&' : '?'}embed`;
 
 			listr = document.createElement('iframe');
 			listr.className = 'RES-raddit';


### PR DESCRIPTION
URL was pointing at (for example) https://radd.it//r/listentous/music?embed which is breaking some of the embedded playlisters.

Many thanks to whomever restructured all of this embed code.  Certainly not the code I remember!