### PR TITLE
Added support for r/ and u/ prefixes for auto completion

### DIFF
--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -1167,7 +1167,7 @@ function autoCompleteInsert(inputValue) {
 	const caretPos = textarea.selectionStart;
 	let left = textarea.value.substr(0, caretPos);
 	const right = textarea.value.substr(caretPos);
-	left = left.replace(/\/?([ru])\/(\w*)\s?$/, `/$1/${inputValue} `);
+	left = left.replace(/\/?([ru])\/(\w*)\s?$/, (left[0] === '/') ? `/$1/${inputValue} ` : `$1/${inputValue} `);
 	textarea.value = left + right;
 	textarea.selectionStart = textarea.selectionEnd = left.length;
 	textarea.focus();

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -1167,7 +1167,7 @@ function autoCompleteInsert(inputValue) {
 	const caretPos = textarea.selectionStart;
 	let left = textarea.value.substr(0, caretPos);
 	const right = textarea.value.substr(caretPos);
-	left = left.replace(/\/?([ru])\/(\w*)\s?$/, (left[0] === '/') ? `/$1/${inputValue} ` : `$1/${inputValue} `);
+	left = left.replace(/(\/?[ru])\/(\w*)\s?$/, `$1/${inputValue} `);
 	textarea.value = left + right;
 	textarea.selectionStart = textarea.selectionEnd = left.length;
 	textarea.focus();


### PR DESCRIPTION
When using auto-completion for subreddits and users, RES would automatically add a leading slash (/r/, /u/). This change enables support for new subreddit and user linking. Auto complete will now respect whatever the user types initially, so /r/ and /u/ are still supported.

I'm pretty sure no one has already opened an issue or PR for this.

I have verified this works in Firefox, for both comments and text posts, for users and subreddits. Since it's a very minor, one-line change, it should work the same in all other browsers.

It also looks like snudown has been updated to support missing leading slashes in comment/post previews, but hasn't made its way into release.