### PR TITLE
NER: Clean-up and returnToPrev refactor

### DIFF
--- a/lib/css/modules/_hover.scss
+++ b/lib/css/modules/_hover.scss
@@ -7,11 +7,6 @@
 	z-index: $zindex-res-hover;
 }
 
-.RESHoverLoadIndicator {
-	display: flex;
-	justify-content: center;
-}
-
 .RESHoverInfoCard {
 	&::before {
 		content: '';

--- a/lib/css/modules/_neverEndingReddit.scss
+++ b/lib/css/modules/_neverEndingReddit.scss
@@ -16,7 +16,8 @@
 	top: 40px;
 	z-index: $zindex-ner-content;
 	width: 570px;
-	left: calc(50% - 285px);
+	left: 50%;
+	transform: translateX(-50%);
 	background-color: #FFF;
 	color: #000;
 	padding: 10px;
@@ -32,7 +33,6 @@
 
 #NERFail {
 	min-height: 30px;
-	width: 95%;
 	font-size: 14px;
 	border: 1px solid #999;
 	border-radius: 10px;

--- a/lib/css/modules/_neverEndingReddit.scss
+++ b/lib/css/modules/_neverEndingReddit.scss
@@ -1,7 +1,6 @@
 @import '../zindex';
 
 #NERModal {
-	display: none;
 	z-index: $zindex-ner-content - 1;
 	position: fixed;
 	top: 0;
@@ -13,21 +12,22 @@
 }
 
 #NERContent {
-	display: none;
 	position: fixed;
 	top: 40px;
 	z-index: $zindex-ner-content;
-	width: 720px;
+	width: 570px;
+	left: calc(50% - 285px);
 	background-color: #FFF;
 	color: #000;
 	padding: 10px;
 	font-size: 12px;
+
+	.RESCenteredLoadIndicator { margin-top: 20px; }
 }
 
 #NERModalClose {
-	position: absolute;
-	top: 3px;
-	right: 3px;
+	float: right;
+	position: static;
 }
 
 #NERFail {

--- a/lib/css/res.scss
+++ b/lib/css/res.scss
@@ -1753,6 +1753,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 	}
 }
 
+.RESCenteredLoadIndicator {
+	display: flex;
+	justify-content: center;
+}
+
 #RESStyleSheetTipPane {
 	display: none;
 	position: relative;

--- a/lib/modules/hover.js
+++ b/lib/modules/hover.js
@@ -318,7 +318,7 @@ class Hover {
 
 class HoverInfoCard extends Hover {
 	template = hoverInfoCardTemplate;
-	_loadIndicator = '<div class="RESHoverLoadIndicator"><span class="RESLoadingSpinner"></span></div>';
+	_loadIndicator = '<div class="RESCenteredLoadIndicator"><span class="RESLoadingSpinner"></span></div>';
 
 	_displayLoadIndicator($container) {
 		this._populate($container, null, this._loadIndicator);

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -1,17 +1,16 @@
 import _ from 'lodash';
 import { $ } from '../vendor';
-import { Session, Storage, ajax } from '../environment';
+import { go } from '../core/init';
+import { Storage, ajax } from '../environment';
 import {
 	Thing,
 	addCSS,
-	currentSubreddit,
 	elementInViewport,
-	pageType,
-	scrollTo,
 } from '../utils';
 import * as Floater from './floater';
 import * as Notifications from './notifications';
 import * as Orangered from './orangered';
+import * as SelectedEntry from './selectedEntry';
 import * as SettingsConsole from './settingsConsole';
 import * as SettingsNavigation from './settingsNavigation';
 import * as SubredditManager from './subredditManager';
@@ -75,15 +74,19 @@ module.exclude = [
 
 const dupeSet = new Set();
 let currPage = 1;
-let siteTable, $NREPause, isPaused, pauseReason, isLoading, fromBackButton, nextPageURL;
+let siteTable, $NREPause, isPaused, pauseReason, nextPageURL;
+let failMarker, pageMarker;
 
 export let progressIndicator;
+export let loadPromise;
 
 module.beforeLoad = async () => {
 	[isPaused, pauseReason] = await Promise.all([
 		Storage.get('RESmodules.neverEndingReddit.isPaused'),
 		Storage.get('RESmodules.neverEndingReddit.pauseReason'),
 	]);
+
+	if (module.options.returnToPrevPage.value) initiateReturnToPrevPage();
 };
 
 module.go = () => {
@@ -93,16 +96,15 @@ module.go = () => {
 
 	// store access to the siteTable div since that's where we'll append new data...
 	siteTable = Thing.thingsContainer();
+	const nextPrevLinks = siteTable && getNextPrevLinks(siteTable);
 
-	if (!siteTable) {
-		// Couldn't find anything to work with, abandon ship
-		return;
+	if (nextPrevLinks && nextPrevLinks.next) {
+		nextPageURL = nextPrevLinks.next.getAttribute('href');
+		initiate(nextPrevLinks.next);
 	}
+};
 
-	// get the first link to the next page of reddit...
-	const nextPrevLinks = getNextPrevLinks(siteTable);
-	if (!nextPrevLinks) return;
-
+function initiate(nextLink) {
 	siteTable.classList.add('res-ner-listing');
 
 	// modified from a contribution by Peter Siewert, thanks Peter!
@@ -112,22 +114,16 @@ module.go = () => {
 		dupeSet.add(href);
 	}
 
-	const nextLink = nextPrevLinks.next;
-	if (nextLink) {
-		nextPageURL = nextLink.getAttribute('href');
-
-		attachLoaderWidget();
-	}
-
-	if (module.options.returnToPrevPage.value) {
-		returnToPrevPageCheck(location.hash);
-	}
+	attachLoaderWidget();
+	addPauseControls();
 
 	// watch for the user scrolling to the bottom of the page.  If they do it, load a new page.
 	if (module.options.autoLoad.value && nextLink) {
 		window.addEventListener('scroll', _.debounce(handleScroll, 300));
 	}
+}
 
+function addPauseControls() {
 	$NREPause = $('<div>', {
 		id: 'NREPause',
 		title: 'Pause / Restart Never Ending Reddit',
@@ -136,13 +132,10 @@ module.go = () => {
 
 	if (module.options.reversePauseIcon.value) $NREPause.addClass('reversePause');
 
+	Floater.addElement($NREPause);
 	// set up initial state of NER bar
 	togglePause(isPaused, pauseReason);
-
-	Floater.addElement($NREPause);
-};
-
-const pageMarkers = [];
+}
 
 function togglePause(pause, source) {
 	isPaused = pause;
@@ -173,82 +166,65 @@ function togglePause(pause, source) {
 	setWidgetActionText();
 }
 
-function returnToPrevPageCheck(hash) {
-	const pageRE = /page=(\d+)/;
-	const match = pageRE.exec(hash);
-	// Set the current page to page 1...
-	currPage = 1;
-	if (match) {
-		const backButtonPageNumber = match[1] || 1;
-		if (backButtonPageNumber > 1) {
-			attachModalWidget();
-			currPage = parseInt(backButtonPageNumber, 10) || 1;
-			loadNewPage(true);
-		}
+function initiateReturnToPrevPage() {
+	if (history.state && history.state.resRestorePage && history.state.resRestoreURL) {
+		({ resRestorePage: currPage, resRestoreURL: nextPageURL } = history.state);
+		returnToPrevPage();
 	}
+
+	SelectedEntry.addListener(selected => {
+		if (!selected) return;
+
+		let resRestorePage = null;
+		let resRestoreURL = null;
+
+		const pageMarker = $(selected.$thing).closest('.sitetable').prev('.NERPageMarker').get(0);
+		if (pageMarker) {
+			// Do not have the browser auto-scroll when returning to this page
+			history.scrollRestoration = 'manual';
+
+			({ currPage: resRestorePage, nextPageURL: resRestoreURL } = pageMarker);
+		}
+
+		history.replaceState(
+			{ resRestorePage, resRestoreURL },
+			`${document.title}${resRestorePage ? `- page ${resRestorePage}` : ''}`
+		);
+	});
+}
+
+async function returnToPrevPage() {
+	attachModalWidget();
+
+	$modalWidget.show();
+	$modalContent.show();
+
+	loadNewPage();
+
+	try {
+		await loadPromise;
+		pageMarker.scrollIntoView();
+	} catch (e) { /* empty */ }
+
+	$modalWidget.hide();
+	$modalContent.hide();
 }
 
 function handleScroll() {
-	if (SettingsConsole.isOpen) { // avoid console to close when scrolling
-		return;
-	}
-	const thisPageType = `${pageType()}.${currentSubreddit()}`;
-	let thisPageNum = 1;
-
-	for (const pageMarker of pageMarkers) {
-		const { top } = $(pageMarker).offset();
-		if (top < window.pageYOffset) {
-			thisPageNum = pageMarker.getAttribute('id').replace('page-', '');
-			currPage = parseInt(thisPageNum, 10) || 1;
-			if (pageMarker) {
-				Session.set(`RESmodules.neverEndingReddit.lastPage.${thisPageType}`, pageMarker.getAttribute('url'));
-			}
-		} else {
-			break;
-		}
-	}
-	if (thisPageNum !== sessionStorage.NERpage) {
-		if (thisPageNum > 1) {
-			// sessionStorage.NERpageURL = location.href;
-			sessionStorage.NERpage = thisPageNum;
-			location.hash = `page=${thisPageNum}`;
-		} else {
-			if (location.hash.includes('page=')) {
-				location.hash = `page=${thisPageNum}`;
-			}
-			delete sessionStorage.NERpage;
-		}
-	}
-	if (!fromBackButton && module.options.returnToPrevPage.value) {
-		for (const link of Thing.$things()) {
-			if (elementInViewport(link)) {
-				const thisClassString = link.getAttribute('class');
-				const thisClass = thisClassString.match(/id-t[\d]_[\w]+/);
-
-				if (thisClass) {
-					const thisID = thisClass[0];
-					Session.set(`RESmodules.neverEndingReddit.lastVisibleIndex.${thisPageType}`, thisID);
-					break;
-				}
-			}
-		}
-	}
-	if (elementInViewport(progressIndicator) && !fromBackButton) {
-		if (!isPaused) {
-			loadNewPage();
-			pauseAfter(thisPageNum);
-		}
+	if (
+		!loadPromise &&
+		!isPaused &&
+		!SettingsConsole.isOpen && // avoid console to close when scrolling
+		elementInViewport(progressIndicator)
+	) {
+		loadNewPage();
 	}
 }
 
-let pauseAfterPages = null;
+function pauseAfter() {
+	const pauseAfterPages = parseInt(module.options.pauseAfterEvery.value, 10);
 
-function pauseAfter(currPageNum) {
-	if (pauseAfterPages === null) {
-		pauseAfterPages = parseInt(module.options.pauseAfterEvery.value, 10);
-	}
-
-	if ((pauseAfterPages > 0) && (currPageNum % pauseAfterPages === 0)) {
+	if ((pauseAfterPages > 0) && (currPage % pauseAfterPages === 0)) {
 		togglePause(true, 'pauseAfterEvery');
 		Notifications.showNotification({
 			moduleID: module.moduleID,
@@ -287,9 +263,8 @@ function attachModalWidget() {
 		id: 'NERContent',
 		html: `
 			<div id="NERModalClose" class="RESCloseButton">&times;</div>
-			Never Ending Reddit has detected that you are returning from a page that it loaded. Please give us a moment while we reload that content and return you to where you left off
-			<br>
-			<span class="RESLoadingSpinner"></span>
+			Never Ending Reddit has detected that you are returning from a page that it loaded. Please give us a moment while we reload that content and return you to where you left off.
+			<div class="RESCenteredLoadIndicator"><span class="RESLoadingSpinner"></span></div>
 		`,
 	}).appendTo(document.body);
 
@@ -360,149 +335,106 @@ function setWidgetActionText() {
 		.appendTo(progressIndicator);
 }
 
-async function loadNewPage(fromBackButton) {
-	const storageKey = `RESmodules.neverEndingReddit.lastPage.${pageType()}.${currentSubreddit()}`;
-	if (!isLoading) {
-		isLoading = true;
-		if (fromBackButton) {
-			fromBackButton = true;
-			const savePageURL = nextPageURL;
-			nextPageURL = await Session.get(storageKey);
-			if (!nextPageURL) {
-				// something went wrong, probably someone hit refresh. Just revert to the first page...
-				fromBackButton = false;
-				nextPageURL = savePageURL;
-				currPage = 1;
-				isLoading = false;
-				return false;
-			}
-			const leftCentered = Math.floor((window.innerWidth - 720) / 2);
-			$modalWidget.show();
-			$modalContent.show();
-			$modalContent.css('left', `${leftCentered}px`);
-			// remove the progress indicator early, as we don't want the user to scroll past it on accident, loading more content.
-			progressIndicator.remove();
-		} else {
-			fromBackButton = false;
-		}
+async function loadNewPage() {
+	if (loadPromise) return;
 
-
+	if (progressIndicator) {
 		progressIndicator.removeEventListener('click', loadNewPage);
 		$(progressIndicator).html('<span class="RESLoadingSpinner"></span>');
-		// as a sanity check, which should NEVER register true, we'll make sure nextPageURL is on the same domain we're browsing...
-		if (nextPageURL && !nextPageURL.includes(location.hostname)) {
-			console.log('Next page URL mismatch. Something strange may be afoot.');
-			isLoading = false;
-			return false;
-		}
-
-		let thisHTML;
-
-		try {
-			thisHTML = await ajax({ url: nextPageURL });
-		} catch (e) {
-			NERFail();
-			throw e;
-		}
-
-		progressIndicator.remove();
-
-		// drop the HTML we got back into a div...
-		const tempDiv = document.createElement('div');
-		// clear out any javascript so we don't render it again...
-		$(tempDiv).html(thisHTML.replace(/<script(.|\s)*?\/script>/g, ''));
-		// grab the siteTable out of there...
-		const newHTML = Thing.thingsContainer(tempDiv);
-		// did we find anything?
-		if (newHTML) {
-			newHTML.setAttribute('ID', `siteTable-${currPage + 1}`);
-			const firstLen = $('body').find('.link:last .rank').text().length;
-			let lastLen = $(newHTML).find('.link:last .rank').text().length;
-			if (lastLen > firstLen) {
-				lastLen = (lastLen * 1.1).toFixed(1);
-				addCSS(`body.res > .content .link .rank { width: ${lastLen}ex; }`);
-			}
-			duplicateCheck(newHTML);
-			// check for new mail
-			Orangered.updateFromPage(tempDiv);
-			// get the new nextLink value for the next page...
-			const nextPrevLinks = getNextPrevLinks(tempDiv);
-			if (nextPrevLinks) {
-				if (isNaN(currPage)) currPage = 1;
-
-				currPage++;
-
-				if (!fromBackButton && module.options.returnToPrevPage.value) {
-					Session.set(storageKey, nextPageURL);
-				}
-
-				const pageMarker = $('<div>', { id: `page-${currPage}`, class: 'NERPageMarker', text: `Page ${currPage}` })
-					.append(SettingsNavigation.makeUrlHashLink(module.moduleID, null, ' ', 'gearIcon'))
-					.get(0);
-
-				siteTable.appendChild(pageMarker);
-				pageMarkers.push(pageMarker);
-				siteTable.appendChild(newHTML);
-				isLoading = false;
-
-				const nextLink = nextPrevLinks.next;
-				if (nextLink) {
-					// console.log(nextLink);
-					pageMarker.setAttribute('url', nextPageURL);
-					if (nextLink.getAttribute('rel').includes('prev')) {
-						// remove the progress indicator from the DOM, it needs to go away.
-						progressIndicator.style.display = 'none';
-						$('<div>', {
-							id: 'endOfReddit',
-							text: 'You\'ve reached the last page available.  There are no more pages to load.',
-						}).appendTo(siteTable);
-						window.removeEventListener('scroll', handleScroll);
-					} else {
-						// console.log('not over yet');
-						nextPageURL = nextLink.getAttribute('href');
-						attachLoaderWidget();
-					}
-				}
-
-				if ((fromBackButton) && (module.options.returnToPrevPage.value)) {
-					// TODO: it'd be great to figure out a better way than a timeout, but this
-					// has considerably helped the accuracy of RES's ability to return you to where
-					// you left off.
-					setTimeout(scrollToLastElement, 4000, newHTML);
-				}
-
-				// If we're on the reddit-browsing page (/reddits or /subreddits), add +shortcut and -shortcut buttons...
-				if (/^https?:\/\/www\.reddit\.com\/(?:sub)?reddits\/?(?:\?[\w=&]+)*/.test(location.href)) {
-					SubredditManager.browsingReddits();
-				}
-			}
-
-			if (!(nextPrevLinks && nextPrevLinks.next)) {
-				const noresults = tempDiv.querySelector('#noresults');
-				const noresultsfound = !!noresults;
-				NERFail(noresultsfound);
-			}
-
-			window.dispatchEvent(new Event('neverEndingLoad', { bubbles: true, cancelable: true }));
-		}
 	}
+
+	// as a sanity check, which should NEVER register true, we'll make sure nextPageURL is on the same domain we're browsing...
+	if (nextPageURL && !nextPageURL.includes(location.hostname)) {
+		console.log('Next page URL mismatch. Something strange may be afoot.');
+		return;
+	}
+
+	loadPromise = Promise.all([ajax({ url: nextPageURL }), go]);
+
+	try {
+		appendPage((await loadPromise)[0]);
+	} catch (e) {
+		NERFail();
+		console.error(e);
+	}
+
+	loadPromise = null;
 }
 
-async function scrollToLastElement(newHTML) {
-	$modalWidget.hide();
-	$modalContent.hide();
-	const thisPageType = `${pageType()}.${currentSubreddit()}`;
-	const lastTopScrolledID = await Session.get(`RESmodules.neverEndingReddit.lastVisibleIndex.${thisPageType}`);
-	const lastTopScrolledEle = document.body.querySelector(`.${lastTopScrolledID}`) || Thing.$things(newHTML);
-	const { top } = $(lastTopScrolledEle).offset();
-	scrollTo(0, top);
-	fromBackButton = false;
+function appendPage(thisHTML) {
+	// drop the HTML we got back into a div...
+	const tempDiv = document.createElement('div');
+	// clear out any javascript so we don't render it again...
+	$(tempDiv).html(thisHTML.replace(/<script(.|\s)*?\/script>/g, ''));
+	// grab the siteTable out of there...
+	const newHTML = Thing.thingsContainer(tempDiv);
+	// did we find anything?
+	if (newHTML) {
+		progressIndicator.remove();
+	} else {
+		throw Error('Could not find any things');
+	}
+
+	const firstLen = $(document.body).find('.link:last .rank').text().length;
+	let lastLen = $(newHTML).find('.link:last .rank').text().length;
+	if (lastLen > firstLen) {
+		lastLen = (lastLen * 1.1).toFixed(1);
+		addCSS(`body.res > .content .link .rank { width: ${lastLen}ex; }`);
+	}
+	duplicateCheck(newHTML);
+	// check for new mail
+	Orangered.updateFromPage(tempDiv);
+	// get the new nextLink value for the next page...
+	const nextPrevLinks = getNextPrevLinks(tempDiv);
+	if (nextPrevLinks) {
+		if (isNaN(currPage)) currPage = 1;
+
+		pageMarker = $('<div>', { class: 'NERPageMarker', text: `Page ${currPage + 1}` })
+			.append(SettingsNavigation.makeUrlHashLink(module.moduleID, null, ' ', 'gearIcon'))
+			.get(0);
+		Object.assign(pageMarker, { currPage, nextPageURL });
+
+		currPage++;
+		pauseAfter();
+
+		siteTable.appendChild(pageMarker);
+		siteTable.appendChild(newHTML);
+
+		const nextLink = nextPrevLinks.next;
+		if (nextLink) {
+			if (nextLink.getAttribute('rel').includes('prev')) {
+				// remove the progress indicator from the DOM, it needs to go away.
+				progressIndicator.style.display = 'none';
+				$('<div>', {
+					id: 'endOfReddit',
+					text: 'You\'ve reached the last page available.  There are no more pages to load.',
+				}).appendTo(siteTable);
+				window.removeEventListener('scroll', handleScroll);
+			} else {
+				nextPageURL = nextLink.getAttribute('href');
+				attachLoaderWidget();
+			}
+		}
+
+			// If we're on the reddit-browsing page (/reddits or /subreddits), add +shortcut and -shortcut buttons...
+		if (/^https?:\/\/www\.reddit\.com\/(?:sub)?reddits\/?(?:\?[\w=&]+)*/.test(location.href)) {
+			SubredditManager.browsingReddits();
+		}
+	}
+
+	if (!(nextPrevLinks && nextPrevLinks.next)) {
+		const noresults = tempDiv.querySelector('#noresults');
+		const noresultsfound = !!noresults;
+		NERFail(noresultsfound);
+	}
+
+	window.dispatchEvent(new Event('neverEndingLoad', { bubbles: true, cancelable: true }));
+
+	if (failMarker) failMarker.remove();
 }
 
 function NERFail(noresults) {
-	isLoading = false;
-
-	$('<div>', {
+	failMarker = $('<div>', {
 		id: 'NERFail',
 		html: `
 			<h3>

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -14,7 +14,6 @@ import * as Orangered from './orangered';
 import * as SelectedEntry from './selectedEntry';
 import * as SettingsConsole from './settingsConsole';
 import * as SettingsNavigation from './settingsNavigation';
-import * as SubredditManager from './subredditManager';
 
 export const module = {};
 
@@ -412,11 +411,6 @@ function appendPage(tempDiv) {
 				text: 'You\'ve reached the last page available.  There are no more pages to load.',
 			}).appendTo(siteTable);
 			window.removeEventListener('scroll', handleScroll);
-		}
-
-		// If we're on the reddit-browsing page (/reddits or /subreddits), add +shortcut and -shortcut buttons...
-		if (/^https?:\/\/www\.reddit\.com\/(?:sub)?reddits\/?(?:\?[\w=&]+)*/.test(location.href)) {
-			SubredditManager.browsingReddits();
 		}
 	} else {
 		if (tempDiv.querySelector('#noresults')) throw Error('No results');

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -6,6 +6,7 @@ import {
 	Thing,
 	addCSS,
 	elementInViewport,
+	scrollToElement,
 } from '../utils';
 import * as Floater from './floater';
 import * as Notifications from './notifications';
@@ -75,7 +76,7 @@ module.exclude = [
 const dupeSet = new Set();
 let currPage = 1;
 let siteTable, $NREPause, isPaused, pauseReason, nextPageURL;
-let failMarker, pageMarker;
+let failMarker, lastPageMarker;
 
 export let progressIndicator;
 export let loadPromise;
@@ -167,7 +168,11 @@ function togglePause(pause, source) {
 }
 
 function initiateReturnToPrevPage() {
-	if (history.state && history.state.resRestorePage && history.state.resRestoreURL) {
+	if (
+		history.state &&
+		Number.isInteger(history.state.resRestorePage) &&
+		(history.state.resRestoreURL || '').includes(location.hostname)
+	) {
 		({ resRestorePage: currPage, resRestoreURL: nextPageURL } = history.state);
 		returnToPrevPage();
 	}
@@ -181,6 +186,7 @@ function initiateReturnToPrevPage() {
 		const pageMarker = $(selected.$thing).closest('.sitetable').prev('.NERPageMarker').get(0);
 		if (pageMarker) {
 			// Do not have the browser auto-scroll when returning to this page
+			// returnToPrevPage will scroll to the pagemarker when ready
 			history.scrollRestoration = 'manual';
 
 			({ currPage: resRestorePage, nextPageURL: resRestoreURL } = pageMarker);
@@ -203,7 +209,7 @@ async function returnToPrevPage() {
 
 	try {
 		await loadPromise;
-		pageMarker.scrollIntoView();
+		scrollToElement(lastPageMarker, { scrollStyle: 'top' });
 	} catch (e) { /* empty */ }
 
 	$modalWidget.hide();
@@ -221,7 +227,7 @@ function handleScroll() {
 	}
 }
 
-function pauseAfter() {
+function refreshPauseAfter() {
 	const pauseAfterPages = parseInt(module.options.pauseAfterEvery.value, 10);
 
 	if ((pauseAfterPages > 0) && (currPage % pauseAfterPages === 0)) {
@@ -250,7 +256,6 @@ function duplicateCheck(newHTML) {
 			dupeSet.add(thisCommentLink);
 		}
 	}
-	return newHTML;
 }
 
 let $modalWidget, $modalContent;
@@ -290,8 +295,8 @@ function attachLoaderWidget() {
 	$(siteTable).after(progressIndicator);
 }
 
-export function getNextPrevLinks(ele) {
-	const $ele = $(ele || document.body);
+export function getNextPrevLinks(ele = document.body) {
+	const $ele = $(ele);
 	// `~ .nextprev a[rel~=next]` for /about/log, because they aren't in the siteTable.
 	// It wouldn't be reddit if it were consistent, would it?
 	const links = {
@@ -299,9 +304,7 @@ export function getNextPrevLinks(ele) {
 		prev: $ele.find('.nextprev a[rel~=prev], ~ .nextprev a[rel~=prev]')[0],
 	};
 
-	if (!(links.next || links.prev)) return false;
-
-	return links;
+	return (links.next || links.prev) ? links : null;
 }
 
 function setWidgetActionText() {
@@ -338,107 +341,97 @@ function setWidgetActionText() {
 async function loadNewPage() {
 	if (loadPromise) return;
 
+	if (failMarker) failMarker.remove();
+
+	loadPromise = Promise.all([ajax({ url: nextPageURL }), go]);
+
 	if (progressIndicator) {
 		progressIndicator.removeEventListener('click', loadNewPage);
 		$(progressIndicator).html('<span class="RESLoadingSpinner"></span>');
 	}
 
-	// as a sanity check, which should NEVER register true, we'll make sure nextPageURL is on the same domain we're browsing...
-	if (nextPageURL && !nextPageURL.includes(location.hostname)) {
-		console.log('Next page URL mismatch. Something strange may be afoot.');
-		return;
-	}
-
-	loadPromise = Promise.all([ajax({ url: nextPageURL }), go]);
+	const removeProgressIndicator = () => { if (progressIndicator) progressIndicator.remove(); };
+	loadPromise.then(removeProgressIndicator, removeProgressIndicator);
 
 	try {
-		appendPage((await loadPromise)[0]);
+		const html = (await loadPromise)[0];
+
+		// drop the HTML we got back into a div...
+		const tempDiv = document.createElement('div');
+		// clear out any javascript so we don't render it again...
+		$(tempDiv).html(html.replace(/<script(.|\s)*?\/script>/g, ''));
+
+		// check for new mail
+		Orangered.updateFromPage(tempDiv);
+
+		appendPage(tempDiv);
 	} catch (e) {
-		NERFail();
+		NERFail(`Could not load the next page: ${e.message}`);
 		console.error(e);
 	}
 
 	loadPromise = null;
+	if (nextPageURL) attachLoaderWidget();
 }
 
-function appendPage(thisHTML) {
-	// drop the HTML we got back into a div...
-	const tempDiv = document.createElement('div');
-	// clear out any javascript so we don't render it again...
-	$(tempDiv).html(thisHTML.replace(/<script(.|\s)*?\/script>/g, ''));
+function appendPage(tempDiv) {
 	// grab the siteTable out of there...
 	const newHTML = Thing.thingsContainer(tempDiv);
-	// did we find anything?
-	if (newHTML) {
-		progressIndicator.remove();
-	} else {
+	if (!newHTML) {
 		throw Error('Could not find any things');
 	}
 
 	const firstLen = $(document.body).find('.link:last .rank').text().length;
-	let lastLen = $(newHTML).find('.link:last .rank').text().length;
+	let lastLen = $(siteTable).find('.link:last .rank').text().length;
 	if (lastLen > firstLen) {
 		lastLen = (lastLen * 1.1).toFixed(1);
 		addCSS(`body.res > .content .link .rank { width: ${lastLen}ex; }`);
 	}
-	duplicateCheck(newHTML);
-	// check for new mail
-	Orangered.updateFromPage(tempDiv);
+
 	// get the new nextLink value for the next page...
 	const nextPrevLinks = getNextPrevLinks(tempDiv);
 	if (nextPrevLinks) {
-		if (isNaN(currPage)) currPage = 1;
+		duplicateCheck(newHTML);
 
-		pageMarker = $('<div>', { class: 'NERPageMarker', text: `Page ${currPage + 1}` })
+		lastPageMarker = $('<div>', { class: 'NERPageMarker', text: `Page ${currPage + 1}` })
 			.append(SettingsNavigation.makeUrlHashLink(module.moduleID, null, ' ', 'gearIcon'))
 			.get(0);
-		Object.assign(pageMarker, { currPage, nextPageURL });
+		Object.assign(lastPageMarker, { currPage, nextPageURL });
 
-		currPage++;
-		pauseAfter();
-
-		siteTable.appendChild(pageMarker);
+		siteTable.appendChild(lastPageMarker);
 		siteTable.appendChild(newHTML);
 
-		const nextLink = nextPrevLinks.next;
-		if (nextLink) {
-			if (nextLink.getAttribute('rel').includes('prev')) {
-				// remove the progress indicator from the DOM, it needs to go away.
-				progressIndicator.style.display = 'none';
-				$('<div>', {
-					id: 'endOfReddit',
-					text: 'You\'ve reached the last page available.  There are no more pages to load.',
-				}).appendTo(siteTable);
-				window.removeEventListener('scroll', handleScroll);
-			} else {
-				nextPageURL = nextLink.getAttribute('href');
-				attachLoaderWidget();
-			}
+		currPage++;
+		nextPageURL = nextPrevLinks.next && nextPrevLinks.next.getAttribute('href');
+
+		refreshPauseAfter();
+
+		if (!nextPageURL) {
+			$('<div>', {
+				id: 'endOfReddit',
+				text: 'You\'ve reached the last page available.  There are no more pages to load.',
+			}).appendTo(siteTable);
+			window.removeEventListener('scroll', handleScroll);
 		}
 
-			// If we're on the reddit-browsing page (/reddits or /subreddits), add +shortcut and -shortcut buttons...
+		// If we're on the reddit-browsing page (/reddits or /subreddits), add +shortcut and -shortcut buttons...
 		if (/^https?:\/\/www\.reddit\.com\/(?:sub)?reddits\/?(?:\?[\w=&]+)*/.test(location.href)) {
 			SubredditManager.browsingReddits();
 		}
-	}
-
-	if (!(nextPrevLinks && nextPrevLinks.next)) {
-		const noresults = tempDiv.querySelector('#noresults');
-		const noresultsfound = !!noresults;
-		NERFail(noresultsfound);
+	} else {
+		if (tempDiv.querySelector('#noresults')) throw Error('No results');
+		else throw Error('Could not continue');
 	}
 
 	window.dispatchEvent(new Event('neverEndingLoad', { bubbles: true, cancelable: true }));
-
-	if (failMarker) failMarker.remove();
 }
 
-function NERFail(noresults) {
+function NERFail(message) {
 	failMarker = $('<div>', {
 		id: 'NERFail',
 		html: `
 			<h3>
-				${noresults ? 'There doesn\'t seem to be anything here!' : 'Couldn\'t load any more posts'}
+				${message}
 				<a target="_blank" href="/r/Enhancement/comments/s72xt/never_ending_reddit_and_reddit_barfing_explained/">(Why not?)</a>
 			</h3>
 			<p class="nextprev">

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -12,6 +12,7 @@ import {
 } from '../utils';
 import * as Hover from './hover';
 import * as KeyboardNav from './keyboardNav';
+import * as NeverEndingReddit from './neverEndingReddit';
 
 export const module = {};
 
@@ -103,7 +104,7 @@ module.beforeLoad = () => {
 
 module.go = () => {
 	if (module.options.autoSelectOnScroll.value) {
-		window.addEventListener('scroll', _.debounce(onScroll, 300));
+		window.addEventListener('scroll', _.debounce(autoSelect, 300));
 	}
 	if (module.options.selectOnClick.value) {
 		$(document.body).on('click', Thing.bodyThingSelector, handleClick);
@@ -221,7 +222,7 @@ function updateActiveElement(selected, last) {
 	}
 }
 
-function onScroll() {
+function autoSelect() {
 	if (KeyboardNav.recentKeyMove) return;
 	if (selectedThing && elementInViewport(selectedThing.element)) return;
 
@@ -264,7 +265,6 @@ function urlForSelectedCache() {
 	return url;
 }
 
-
 function updateLastSelectedCache(selected) {
 	if (!lastSelectedCache || !isPageType('linklist', 'modqueue', 'profile')) return;
 
@@ -283,13 +283,19 @@ async function selectInitial() {
 		return;
 	}
 
+	// NER may restore a page which contains the last selected thing
+	if (NeverEndingReddit.loadPromise) await NeverEndingReddit.loadPromise;
+
 	let target = await findLastSelectedThing();
-	if (!(target && target.length)) {
-		target = Thing.visibleThings()[0];
+	const rememberedTarget = !!target;
+
+	if (!target) {
+		const things = Thing.visibleThingElements();
+		target = things.find(v => elementInViewport(v)) || things[0];
 	}
 
 	_select(target, {
-		scrollStyle: module.options.scrollToSelectedThingOnLoad.value ? 'legacy' : 'none',
+		scrollStyle: rememberedTarget && module.options.scrollToSelectedThingOnLoad.value ? 'legacy' : 'none',
 	});
 }
 

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -10,6 +10,7 @@ import {
 	isModeratorAnywhere,
 	loggedInUser,
 	string,
+	watchForElement,
 } from '../utils';
 import { Session, Storage, ajax } from '../environment';
 import * as Notifications from './notifications';
@@ -234,10 +235,11 @@ function manageSubreddits() {
 	// If we're on the reddit-browsing page (/reddits or /subreddits), add +shortcut and -shortcut buttons...
 	if (/^https?:\/\/www\.reddit\.com\/(?:sub)?reddits\/?(?:\?[\w=&]+)*/.test(location.href)) {
 		browsingReddits();
+		watchForElement('siteTable', browsingReddits);
 	}
 }
 
-export function browsingReddits() {
+function browsingReddits() {
 	$('.subreddit').each(function() {
 		// Skip subreddit links that already have a shortcut button
 		if ($(this).data('hasShortcutButton')) {

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -70,7 +70,7 @@ export function mousedown(obj, button = 0) {
 }
 
 export function elementInViewport(ele) {
-	if (!ele) return false;
+	if (!ele || !ele.offsetParent) return false;
 
 	const { top, left, bottom, right } = ele.getBoundingClientRect();
 	const $window = $(window);


### PR DESCRIPTION
- Stores page restoration data in `window.history` state, and as such does not rely on `location.hash`
- Starts loading restored page in `beforeLoad`
- Uses `loadPromise` instead of boolean `isLoading`
- Uses `SelectedEntry.selectInitial` to select last element, which awaits `loadPromise` and new entries
- `handleScroll` now only checks if current scroll position will trigger new page load

Fixes https://www.reddit.com/r/RESissues/comments/4vyhsc/bug_never_ending_reddit_reloads_last_page_if_user/

Closes #3112  [edit 2016-08-24 --andytuba ]
Closes: @allthefoxes bug.. did it not get filed? https://www.allthefoxes.me/img/08/19-a16e.gif