### PR TITLE
Imgur video: remove webm source

### DIFF
--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -239,9 +239,6 @@ const imgur = {
 			loop: true,
 			muted: true,
 			sources: [{
-				source: info.webm,
-				type: 'video/webm',
-			}, {
 				source: info.mp4,
 				type: 'video/mp4',
 			}],


### PR DESCRIPTION
https://api.imgur.com/changelog: `Imgur no longer generates webm. Removed the webm response from the Gallery Image and Image models.`