### PR TITLE
TEMP: try to prevent babel-traverse from updating past 6.9.0 and causing issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "babel-plugin-transform-runtime": "6.9.0",
     "babel-preset-es2015": "6.9.0",
     "babel-preset-stage-0": "6.5.0",
+    "babel-traverse": "6.9.0",
     "coveralls": "2.11.9",
     "cross-env": "1.0.8",
     "css-loader": "0.23.1",


### PR DESCRIPTION
Until https://github.com/babel/babel/pull/3557 is merged and released.

This works for fresh installs, but it may not work if you've already installed a version of babel-traverse with the issue.

`npm-shrinkwrap` would guarantee this, but hopefully it'll be fixed soon and we won't need to resort to that.