### PR TITLE
keyboardNav: New shortcut: Move to parent's next sibling

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -311,7 +311,12 @@ const commands = {
 		include: ['comments'],
 		value: [80, false, false, false], // p
 		description: 'Move to parent (in comments).',
-		callback() { move(thing => thing.getParent()); },
+		callback() {
+			move(
+				thing => thing.getParent(),
+				{ scrollStyle: module.options.threadScrollStyle.value }
+			);
+		},
 	},
 	showParents: {
 		include: ['comments'],

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -79,7 +79,7 @@ module.options = {
 		`,
 		advanced: true,
 	},
-	siblingScrollStyle: {
+	nonLinearScrollStyle: {
 		type: 'enum',
 		values: [{
 			name: 'directional',
@@ -98,29 +98,7 @@ module.options = {
 			value: 'legacy',
 		}],
 		value: 'legacy',
-		description: 'When moving between siblings with moveUpSibling/moveDownSibling, when and how should RES scroll the window?',
-		advanced: true,
-	},
-	threadScrollStyle: {
-		type: 'enum',
-		values: [{
-			name: 'directional',
-			value: 'directional',
-		}, {
-			name: 'page up/down',
-			value: 'page',
-		}, {
-			name: 'lock to top',
-			value: 'top',
-		}, {
-			name: 'in middle',
-			value: 'middle',
-		}, {
-			name: 'legacy',
-			value: 'legacy',
-		}],
-		value: 'legacy',
-		description: 'When moving between threads with moveUpThread/moveDownThread, when and how should RES scroll the window?',
+		description: 'When jumping to a entry (moveUpThread/moveDownThread, moveUpSibling/moveDownSibling, moveToParent, and moveDownParentSibling), when and how should RES scroll the window?',
 		advanced: true,
 	},
 	commentsLinkNumbers: {
@@ -253,7 +231,7 @@ const commands = {
 		callback() {
 			move(
 				thing => thing.getNextSibling({ direction: 'up' }) || thing.getParent(),
-				{ scrollStyle: module.options.siblingScrollStyle.value }
+				{ scrollStyle: module.options.nonLinearScrollStyle.value }
 			);
 		},
 	},
@@ -264,7 +242,7 @@ const commands = {
 		callback() {
 			move(
 				thing => thing.getClosest(thing.getNextSibling, { direction: 'down' }),
-				{ scrollStyle: module.options.siblingScrollStyle.value }
+				{ scrollStyle: module.options.nonLinearScrollStyle.value }
 			);
 		},
 	},
@@ -275,7 +253,7 @@ const commands = {
 		callback() {
 			move(
 				thing => (thing.getParent() || thing).getClosest(thing.getNextSibling, { direction: 'down' }),
-				{ scrollStyle: module.options.threadScrollStyle.value }
+				{ scrollStyle: module.options.nonLinearScrollStyle.value }
 			);
 		},
 	},
@@ -286,7 +264,7 @@ const commands = {
 		callback() {
 			move(
 				thing => thing.getThreadTop().getNextSibling({ direction: 'up' }) || thing.getThreadTop(),
-				{ scrollStyle: module.options.threadScrollStyle.value }
+				{ scrollStyle: module.options.nonLinearScrollStyle.value }
 			);
 		},
 	},
@@ -297,7 +275,7 @@ const commands = {
 		callback() {
 			move(
 				thing => thing.getThreadTop().getNextSibling({ direction: 'down' }),
-				{ scrollStyle: module.options.threadScrollStyle.value }
+				{ scrollStyle: module.options.nonLinearScrollStyle.value }
 			);
 		},
 	},
@@ -314,7 +292,7 @@ const commands = {
 		callback() {
 			move(
 				thing => thing.getParent(),
-				{ scrollStyle: module.options.threadScrollStyle.value }
+				{ scrollStyle: module.options.nonLinearScrollStyle.value }
 			);
 		},
 	},

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -268,6 +268,17 @@ const commands = {
 			);
 		},
 	},
+	moveDownParentSibling: {
+		include: ['comments'],
+		value: [74, true, false, false], // alt-j
+		description: 'Move to parent\' next sibling (in comments).',
+		callback() {
+			move(
+				thing => (thing.getParent() || thing).getClosest(thing.getNextSibling, { direction: 'down' }),
+				{ scrollStyle: module.options.threadScrollStyle.value }
+			);
+		},
+	},
 	moveUpThread: {
 		include: ['comments'],
 		value: [75, true, false, true], // shift-alt-k


### PR DESCRIPTION
Combines `moveToParent` and then `moveDownSibling`.

I don't think `moveUpParentSibling` is necessary, as it would be the same as `moveToParent`. An symmetrical shortcut (`alt+k`) would be nice but I couldn't think of any good way to implement alternative shortcuts.

This reuses the `threadScrollStyle` option, as the action is similar. The option should probably also be used on `moveToParent`.