### PR TITLE
showImages: Use fallback mechanism to update placeholder

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1007,10 +1007,6 @@ function generateImage(options) {
 	element.ready = waitForEvent(image, 'load', 'error');
 
 	element.emitResizeEvent = () => { image.dispatchEvent(new CustomEvent('mediaResize', { bubbles: true })); };
-	// Loading of images is often slow, and it takes a while for the load event to be emitted
-	// so have the placeholder mostly synchroized, send a resize event often
-	elementResizeDetector.listenTo(anchor, element.emitResizeEvent);
-	element.ready.then(() => { elementResizeDetector.removeListener(anchor, element.emitResizeEvent); });
 
 	setMediaMaxSize(image);
 	makeMediaZoomable(image);
@@ -1469,10 +1465,23 @@ function makeMediaIndependentOnResize(media, element) {
 		}
 	}, true);
 
+	let lastHeight = 0;
+
 	media.addEventListener('mediaResize', () => {
-		wrapper.style.height = `${element.clientHeight}px`;
+		const height = element.clientHeight;
+		if (lastHeight !== height) {
+			lastHeight = height;
+			wrapper.style.height = `${height}px`;
+		}
+
 		independent.classList.add('res-media-independent');
 		window.addEventListener('resize', debouncedResize);
+	});
+
+	// This is a slower method to listen to resizes, as it waits till the frame after the size is se to updatet.
+	// Using this is however necessary when it's not possible to determine size from media events.
+	elementResizeDetector.listenTo(element, () => {
+		if (element.clientHeight !== lastHeight) media.emitResizeEvent();
 	});
 
 	const prevExpand = media.expand;


### PR DESCRIPTION
In Firefox the video bounding rect is not updated before the `loadedmetadata` event is emitted. This PR implmenets a fallback mechanism.

Fixes #3158 