### PR TITLE
Fix strawpoll expando's

### DIFF
--- a/lib/modules/hosts/strawpoll.js
+++ b/lib/modules/hosts/strawpoll.js
@@ -9,7 +9,7 @@ export default {
 			type: 'IFRAME',
 			expandoClass: 'selftext',
 			muted: true,
-			embed: `//strawpoll.me/embed_1/${uid}`,
+			embed: `//www.strawpoll.me/embed_1/${uid}`,
 			height: '500px',
 			width: '700px',
 		};


### PR DESCRIPTION
Strawpoll seems to redirect https://strawpoll.me to http://www.strawpoll.me breaking the embed on https. Updating link to www to avoid the redirect.