### PR TITLE
giphy: support urls with "tags" inline

### DIFF
--- a/lib/modules/hosts/giphy.js
+++ b/lib/modules/hosts/giphy.js
@@ -3,7 +3,7 @@ export default {
 	name: 'giphy',
 	domains: ['giphy.com'],
 	logo: '//giphy.com/static/img/favicon.png',
-	detect: ({ pathname }) => (/^\/gifs\/(.*?)(\/html5)?$/i).exec(pathname),
+	detect: ({ pathname }) => (/^\/gifs\/(?:\w+-)*(.*?)(\/html5)?$/i).exec(pathname),
 	handleLink(href, [, id, isHtml5]) {
 		if (isHtml5) {
 			return {


### PR DESCRIPTION
e.g. http://giphy.com/gifs/hot-heat-overheating-5xtDarIN81U0KvlnzKo