### PR TITLE
Fix reloading after restoring a backup in Edge

### DIFF
--- a/lib/modules/backupAndRestore.js
+++ b/lib/modules/backupAndRestore.js
@@ -74,7 +74,7 @@ function restoreFromFile(e) {
 
 		Alert.open('Your RES settings have been imported. Reloading reddit.');
 		location.hash = '';
-		setTimeout(::location.reload, 500);
+		setTimeout(() => location.reload(), 500);
 	};
 
 	reader.readAsText(file);


### PR DESCRIPTION
It seems that Edge doesn't like binding to `location`