### PR TITLE
New feature: Safari extension now supports Safari web browser

### DIFF
--- a/safari/background.entry.js
+++ b/safari/background.entry.js
@@ -8,10 +8,10 @@ const {
 	_handleMessage,
 	sendMessage,
 	addListener,
-} = createMessageHandler((type, obj, page) => page.dispatchMessage(type, obj));
+} = createMessageHandler((type, obj, tab) => tab.page.dispatchMessage(type, obj));
 
 safari.application.addEventListener('message', ({ name: type, message: obj, target: tab }) => {
-	_handleMessage(type, obj, tab.page);
+	_handleMessage(type, obj, tab);
 });
 
 // Listeners
@@ -125,6 +125,6 @@ addListener('multicast', async (request, senderTab) =>
 			.map(w => Array.from(w.tabs))
 			.reduce((acc, tabs) => acc.concat(tabs), [])
 			.filter(tab => tab !== senderTab && tab.private === senderTab.private && tab.page)
-			.map(({ page }) => sendMessage('multicast', request, page))
+			.map(tab => sendMessage('multicast', request, tab))
 	)
 );


### PR DESCRIPTION
There is a fatal bug that causes the RES Safari extension to not work at all. Specifically, the extension would crash if it ever tried to open a non-Reddit URL in a new tab. The extension was guaranteed to do this 100% of the time thanks to the `onboarding` module, which automatically tries to open http://redditenhancementsuite.com/... in a new tab when RES starts up. Normally it only does this on first install, but since the extension would crash before it could record it had been run, it would try to do this every single time the extension tried to run, leading to a crash every single time.

The root cause of the crash was in the global page's 'openNewTabs` handler. It assumed that it was being passed a browser tab object when it was called by the global page message event handler function, but it was actually being passed a web page object. This led to the openNewTabs handler trying to call a non-existent function on that object, which created an unhandled exception that crashed the global page, breaking the extension entirely.

This commit fixes the bug by having the message event handler pass the browser tab object to handlers it calls, rather than web page objects. This object is much more useful, and is necessary for functions like openNewTabs to work. I also had to make a corresponding change to the `multicast` handler, so that it knew to expect a tab, not a web page, when dealing with message events.

I suspect the bug was introduced in fc17a0738aa, but I haven't done a bisect to verify that theory.