### PR TITLE
selectedEntry: Use getBoundingClientRect instead of offsetTop to compare position

### DIFF
--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -167,9 +167,11 @@ function _select(thingOrEntry, options = {}) {
 	const newSelected = newThing;
 	const oldSelected = selectedThing;
 
-	if (listeners) {
-		listeners.fire(newSelected, oldSelected, options);
-	}
+	const direction = newThing && newThing.isVisible() && oldSelected && oldSelected.isVisible() ?
+		(newThing.entry.getBoundingClientRect().top > oldSelected.entry.getBoundingClientRect().top ? 'down' : 'up') :
+		null;
+
+	listeners.fire(newSelected, oldSelected, { direction, ...options });
 
 	selectedThing = newSelected;
 	selectedContainer = newSelected && $(newSelected.thing).parent().closest('.thing');
@@ -196,12 +198,7 @@ function onNewComments(entry) {
 
 function scrollTo(selected, last, options) {
 	if (!selected) return;
-	options = {
-		makeVisible: selected.entry,
-		direction: selected.thing.offsetTop > (last && last.thing.offsetTop) ? 'down' : 'up',
-		...options,
-	};
-	scrollToElement(selected.thing, options);
+	scrollToElement(selected.entry, options);
 }
 
 // this is run immediately for a reason, but I don't know/remember why

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -341,4 +341,8 @@ export default class Thing {
 	toggleFilter(value) {
 		this.thing.classList.toggle('RESFiltered', value);
 	}
+
+	isVisible() {
+		return this.thing && this.thing.offsetParent;
+	}
 }

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -131,9 +131,9 @@ function padBottom(scrollTop, viewportHeight) {
 	}
 }
 
-export function scrollToElement(element, { scrollStyle, makeVisible = null, direction }) {
+export function scrollToElement(element, { scrollStyle, direction }) {
 	const viewport = getViewportDimensions();
-	const target = _.assignIn({}, (makeVisible || element).getBoundingClientRect()); // top, right, bottom, left are relative to viewport
+	const target = _.assignIn({}, element.getBoundingClientRect()); // top, right, bottom, left are relative to viewport
 	target.top -= viewport.yOffset;
 	target.bottom -= viewport.yOffset;
 


### PR DESCRIPTION
This makes `scrollStyle: 'middle'` compatible with more custom stylesheets.