### PR TITLE
Firefox: append `beta` to beta version numbers

### DIFF
--- a/build/isBetaVersion.js
+++ b/build/isBetaVersion.js
@@ -1,0 +1,5 @@
+/* eslint-disable import/no-commonjs */
+
+const semver = require('semver');
+
+module.exports = version => (semver.minor(version) % 2 === 1);

--- a/firefox/getVersion.js
+++ b/firefox/getVersion.js
@@ -1,0 +1,6 @@
+/* eslint-disable import/no-commonjs */
+
+const isBetaVersion = require('../build/isBetaVersion');
+const { version } = require('../package.json');
+
+module.exports = (isBetaVersion(version) ? `${version}beta` : version);

--- a/firefox/package.json
+++ b/firefox/package.json
@@ -6,7 +6,7 @@
 	"author": "honestbleeps",
 	"homepage": "http://redditenhancementsuite.com/",
 	"license": "GPL-3.0",
-	"version": "{{prop?version!../package.json}}",
+	"version": "{{to-string!./getVersion}}",
 	"main": "{{./background.entry.js}}",
 	"permissions": {
 		"private-browsing": true

--- a/package.json
+++ b/package.json
@@ -112,7 +112,9 @@
     "rimraf": "2.5.3",
     "sass-lint": "1.8.2",
     "sass-loader": "4.0.0",
+    "semver": "5.3.0",
     "spawn-loader": "0.1.0",
+    "to-string-loader": "1.1.4",
     "url-loader": "0.5.7",
     "webpack": "1.13.1",
     "yargs": "4.8.0"


### PR DESCRIPTION
For future release automation: since they'll be deployed to the same listing as stable RES, they need the suffix.