### PR TITLE
Firefox: show alert when db cannot be created

### DIFF
--- a/firefox/background.entry.js
+++ b/firefox/background.entry.js
@@ -138,7 +138,19 @@ let db;
 	}
 }
 
-addListener('storage', ([operation, key, value]) => {
+function storageFailureAlert(worker) {
+	sendMessage('alert', `
+		<p><b>An error occurred while creating the IndexedDB database.</b></p>
+		<p>Reddit Enhancement Suite will not function.</p>
+		<p>Your Firefox profile may be corrupted (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=944918">Bug 944918</a>).</p>
+		<br>
+		<p>Please report this to the relevant beta thread or /r/RESissues.</p>
+	`, worker);
+}
+
+addListener('storage', ([operation, key, value], worker) => {
+	if (!db) storageFailureAlert(worker);
+
 	switch (operation) {
 		case 'get':
 			return new Promise((resolve, reject) => {

--- a/lib/environment/alert.js
+++ b/lib/environment/alert.js
@@ -1,0 +1,4 @@
+import { Alert } from '../utils';
+import { addListener } from 'browserEnvironment';
+
+addListener('alert', text => { Alert.open(text); });

--- a/lib/environment/index.js
+++ b/lib/environment/index.js
@@ -1,3 +1,5 @@
+import './alert';
+
 export { addURLToHistory, isURLVisited } from './history';
 export { ajax } from './ajax';
 export { deleteCookies } from './cookies';


### PR DESCRIPTION
This should give us an idea if #3194 is common or not (in the beta); hopefully we don't have to fall back to simple-storage and its horrible instability :cold_sweat:.

![image](https://cloud.githubusercontent.com/assets/7673145/17120843/02e060bc-529d-11e6-86cd-a6090f7e16db.png)