### PR TITLE
Move large assets to separate repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.eps filter=lfs diff=lfs merge=lfs -text

--- a/assets/RESbeta.eps
+++ b/assets/RESbeta.eps
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2dfd70d6e84bb7670ae19971937ef400fbac4c63ea47648b0678735b777e109d
-size 6942158

--- a/assets/RESpromo.eps
+++ b/assets/RESpromo.eps
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:847ab0416c4eab60b3588e9bd5f59f8b4e2a25b698fad7aededbbc8216fdc3b5
-size 11027150

--- a/assets/RESuppercase.eps
+++ b/assets/RESuppercase.eps
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a04a1414e35ce29e4d176d3fcda76e8f8d6ca998d509e5fbe8cabe7c1d6316cc
-size 6990418


### PR DESCRIPTION
https://github.com/Reddit-Enhancement-Suite/assets/pull/1

We're running out of Git LFS bandwidth...which apparently includes forks, CI checkouts, etc.

![image](https://cloud.githubusercontent.com/assets/7673145/17125222/a097ae60-52bf-11e6-9cc2-2b3dfa3b276e.png) (via email to honestbleeps)

<sup>Git LFS is probably the worst thing I've ever inflicted on this repo :sweat:</sup>