### PR TITLE
showImages: Default image max size fixed migration

### DIFF
--- a/lib/core/migrate.js
+++ b/lib/core/migrate.js
@@ -233,12 +233,6 @@ const migrations = [
 				.map(key => Storage.delete(key));
 		},
 	}, {
-		versionNumber: '4.7.0-changeDefaultImageMaxSize',
-		async go() {
-			await migrators.generic.updateOption('showImages', 'maxWidth', 640, '100%');
-			await migrators.generic.updateOption('showImages', 'maxHeight', 480, '80%');
-		},
-	}, {
 		versionNumber: '4.7.0-voteWeight',
 		async go() {
 			await migrators.generic.moveOption('userTagger', 'colorUser', 'userTagger', 'trackVoteWeight');
@@ -309,6 +303,14 @@ const migrations = [
 			await migrators.generic.moveOption('showImages', 'display Oddshot', 'showImages', 'display_oddshot');
 			await migrators.generic.moveOption('showImages', 'display Miiverse', 'showImages', 'display_miiverse');
 			await migrators.generic.moveOption('showImages', 'display swirl', 'showImages', 'display_swirl');
+		},
+	}, {
+		versionNumber: '4.7.1-changeDefaultImageMaxSizeRetry',
+		async go() {
+			await migrators.generic.updateOption('showImages', 'maxWidth', 640, '100%');
+			await migrators.generic.updateOption('showImages', 'maxHeight', 480, '80%');
+			await migrators.generic.updateOption('showImages', 'maxWidth', '640', '100%');
+			await migrators.generic.updateOption('showImages', 'maxHeight', '480', '80%');
 		},
 	},
 ];


### PR DESCRIPTION
I noticed that Edge didn't migrate max size (`maxWidth` and `maxHeight`), perhaps because it came directly from 4.5 and still had the settings saved as strings. This should make it work either way.