### PR TITLE
showImages addDragListener: Safari compatibility

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1403,11 +1403,11 @@ function addDragListener({ media, atShiftKey, onStart, onMove }) {
 	let isActive, hasMoved, lastX, lastY;
 
 	const handleMove = frameDebounce(e => {
-		if (!e.movementX && !e.movementY) {
+		const movementX = e.clientX - lastX;
+		const movementY = e.clientY - lastY;
+
+		if (!movementX && !movementY) {
 			// Mousemove may be triggered even without movement
-			return;
-		} else if (e.buttons !== 1) {
-			stop();
 			return;
 		} else if (atShiftKey !== e.shiftKey) {
 			isActive = false;
@@ -1422,25 +1422,24 @@ function addDragListener({ media, atShiftKey, onStart, onMove }) {
 			document.body.classList.add('res-media-dragging');
 		}
 
-		onMove(e.clientX, e.clientY, e.clientX - lastX, e.clientY - lastY);
+		onMove(e.clientX, e.clientY, movementX, movementY);
 		({ clientX: lastX, clientY: lastY } = e);
 	});
 
 	function handleClick(e) {
 		if (hasMoved) e.preventDefault();
 		document.removeEventListener('click', handleClick);
-
-		stop();
 	}
 
 	function stop() {
 		document.body.classList.remove('res-media-dragging');
 
 		document.removeEventListener('mousemove', handleMove);
+		document.removeEventListener('mouseup', stop);
 	}
 
 	function initiate(e) {
-		if (e.buttons !== 1) return;
+		if (e.button !== 0) return;
 
 		({ clientX: lastX, clientY: lastY } = e);
 
@@ -1448,6 +1447,7 @@ function addDragListener({ media, atShiftKey, onStart, onMove }) {
 		isActive = false;
 
 		document.addEventListener('mousemove', handleMove);
+		document.addEventListener('mouseup', stop);
 		document.addEventListener('click', handleClick);
 
 		e.preventDefault();

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1462,9 +1462,9 @@ function makeMediaZoomable(media) {
 	media.classList.add('res-media-zoomable');
 
 	let initialWidth, initialDiagonal, minWidth;
-	const { left, top } = media.getBoundingClientRect();
 
 	function getDiagonal(x, y) {
+		const { left, top } = media.getBoundingClientRect();
 		const w = Math.max(1, x - left);
 		const h = Math.max(1, y - top);
 		return Math.round(Math.hypot(w, h));


### PR DESCRIPTION
Safari does not expose `MouseEvent.movementX`, `MouseEvent.movementY`, and `MouseEvent.buttons`, which my implementation required. This provides a workaround in order to make `addDragListener` Safari compatible.

Please note that I have not had the opportunity to test this on Safari yet.

Fixes #3209 