### PR TITLE
Update account switcher cookie removal for Firefox 48

### DIFF
--- a/firefox/package.json
+++ b/firefox/package.json
@@ -9,7 +9,7 @@
 	"version": "{{to-string!./getVersion}}",
 	"main": "{{./background.entry.js}}",
 	"engines": {
-		"firefox": ">=46.0a1"
+		"firefox": ">=48.0a1"
 	},
 	"permissions": {
 		"private-browsing": true


### PR DESCRIPTION
...now that it is stable.

Fixes #3052.