### PR TITLE
showImages: generateGallery: Move attaching next/more listeners

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1007,16 +1007,14 @@ function generateGallery(options) {
 		preloadAhead();
 	}
 
-	ctrlPrev.addEventListener('click', () => { changeSlideshowPiece(-1); });
-	ctrlNext.addEventListener('click', () => { changeSlideshowPiece(1); });
-
-	ctrlConcurrentIncrease.addEventListener('click', expandFilmstrip);
-
 	if (filmstripActive || pieces.length === 1) {
 		expandFilmstrip();
+		ctrlConcurrentIncrease.addEventListener('click', expandFilmstrip);
 	} else {
 		element.classList.add('res-gallery-slideshow');
 		changeSlideshowPiece(0);
+		ctrlPrev.addEventListener('click', () => { changeSlideshowPiece(-1); });
+		ctrlNext.addEventListener('click', () => { changeSlideshowPiece(1); });
 	}
 
 	return element;


### PR DESCRIPTION
next/prev is accessible via keyboardNav, and using them when filmstrip mode is active breaks the gallery