### PR TITLE
Partially revert "userTagger: remove `display: inline-block` from .userTagLink"

### DIFF
--- a/lib/css/modules/_userTagger.scss
+++ b/lib/css/modules/_userTagger.scss
@@ -134,6 +134,7 @@ a.voteWeight {
 
 .userTagLink.hasTag,
 #userTaggerPreview {
+	display: inline-block;
 	padding: 0 4px;
 	line-height: normal;
 	border: 1px solid #c7c7c7;


### PR DESCRIPTION
(partially) Reverts honestbleeps/Reddit-Enhancement-Suite#3067

Turns out that this _is_ important (top border is cut off):

![image](https://cloud.githubusercontent.com/assets/7673145/17465868/51e3cde8-5ccf-11e6-9aed-3fa28beb839a.png)