### PR TITLE
subredditManager: Avoid overflow when zoomed in

### DIFF
--- a/lib/css/modules/_subredditManager.scss
+++ b/lib/css/modules/_subredditManager.scss
@@ -224,6 +224,7 @@
 #RESShortcutsEditContainer {
 	width: 69px;
 	position: absolute;
+	overflow: hidden;
 	right: 0;
 	top: 0;
 	z-index: 999;


### PR DESCRIPTION
The elements in `#RESShortcutsEditContainer` may overflow when the browser is zoomed in, causing a horizontal window-scrollbar to appear.

Fixes issue mentioned in https://www.reddit.com/r/RESissues/comments/4wl5k2/bug_horizontal_scrollbar_appearing_in_firefox/