### PR TITLE
Travis: mark GitHub releases as prereleases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ deploy:
   - provider: releases
     api_key:
       secure: F0CNYZBoZbLiZDm+KkIpX/FjWhwUKMQs4O+bg6EUT32GOb17ed1HBS1Dw9DCTClyydEkhtCMZTFHQUbfNhlU7xkZxy8J/Ac9UykngVmjJBz3+ZKmbGsokjwCm8r08VCMzB0AJrvIodRwegzg9J5muXvMGNBzKxi7Q7XiNsxLNDc=
+    prerelease: true
     file:
       - dist/zip/chrome.zip
       - dist/zip/edge.zip


### PR DESCRIPTION
This is [undocumented](https://docs.travis-ci.com/user/deployment/releases), but it should work because you can [pass through options](https://github.com/travis-ci/dpl#github-releases) to Octokit, which [supports prereleases](https://github.com/octokit/octokit.rb/blob/f58728da197c6810b9187d4aa87606dd030d65c8/lib/octokit/client/releases.rb#L51).