### PR TITLE
Allow hiding children of nested comments

### DIFF
--- a/lib/modules/hideChildComments.js
+++ b/lib/modules/hideChildComments.js
@@ -32,11 +32,7 @@ module.go = () => {
 	toggleAllLink.setAttribute('title', 'Show only replies to original poster.');
 	toggleAllLink.addEventListener('click', function(e) {
 		e.preventDefault();
-		if (module.options.noNested.value) {
-			toggleComments(false, this.getAttribute('action'));
-		} else {
-			toggleComments(true, this.getAttribute('action'));
-		}
+		toggleComments(this.getAttribute('action'), module.options.noNested.value);
 		if (this.getAttribute('action') === 'hide') {
 			this.setAttribute('action', 'show');
 			this.setAttribute('title', 'Show all comments.');
@@ -51,7 +47,7 @@ module.go = () => {
 	const commentMenu = document.querySelector('ul.buttons');
 	if (commentMenu) {
 		commentMenu.appendChild(toggleButton);
-		const rootComments = document.querySelectorAll('div.commentarea > div.sitetable > div.thing > div.child > div.listing');
+		const rootComments = document.querySelectorAll('div.commentarea > div.sitetable > div.thing > div.child > div.listing, div.listing div.listing');
 		rootComments::forEachChunked(comment => {
 			const toggleButton = document.createElement('li');
 			const toggleLink = document.createElement('a');
@@ -62,27 +58,7 @@ module.go = () => {
 			// toggleLink.setAttribute('title','Hide child comments.');
 			toggleLink.addEventListener('click', function(e) {
 				e.preventDefault();
-				toggleComments(true, this.getAttribute('action'), this);
-			}, true);
-			toggleButton.appendChild(toggleLink);
-			const sib = comment.parentNode.previousSibling;
-			if (sib) {
-				const sibMenu = sib.querySelector('ul.buttons');
-				if (sibMenu) sibMenu.appendChild(toggleButton);
-			}
-		});
-		const secondaryComments = document.querySelectorAll('div.listing div.listing');
-		secondaryComments::forEachChunked(comment => {
-			const toggleButton = document.createElement('li');
-			const toggleLink = document.createElement('a');
-			toggleLink.setAttribute('data-text', 'hide child comments');
-			toggleLink.setAttribute('action', 'hide');
-			toggleLink.setAttribute('href', '#');
-			toggleLink.setAttribute('class', 'toggleChildren noCtrlF');
-			// toggleLink.setAttribute('title','Hide child comments.');
-			toggleLink.addEventListener('click', function(e) {
-				e.preventDefault();
-				toggleComments(true, this.getAttribute('action'), this);
+				toggleComments(this.getAttribute('action'), this);
 			}, true);
 			toggleButton.appendChild(toggleLink);
 			const sib = comment.parentNode.previousSibling;
@@ -101,14 +77,14 @@ module.go = () => {
 	}
 };
 
-function toggleComments(nested, action, obj) {
+function toggleComments(action, obj) {
 	let commentContainers;
-	if (obj) { // toggle a single comment tree
-		commentContainers = $(obj).closest('.thing');
-	} else if (nested) { // toggle all comments
-		commentContainers = document.querySelectorAll('div.commentarea div.sitetable div.thing');
-	} else { // toggle all top level comments
+	if (obj === true) { // toggle only top level comments
 		commentContainers = document.querySelectorAll('div.commentarea > div.sitetable > div.thing');
+	} else if (obj === false) { // toggle all comments
+		commentContainers = document.querySelectorAll('div.commentarea div.sitetable div.thing');
+	} else if (obj) { // toggle all top level comments
+		commentContainers = $(obj).closest('.thing');
 	}
 	commentContainers::forEachChunked(container => {
 		const thisChildren = container.querySelector('div.child > div.sitetable');

--- a/lib/modules/hideChildComments.js
+++ b/lib/modules/hideChildComments.js
@@ -16,8 +16,8 @@ module.options = {
 	noNested: {
 		type: 'boolean',
 		value: true,
-		description: 'Do not hide children for nested comments when above option is enabled or if "hide all child comments" is clicked.'
-	}
+		description: 'Do not hide children for nested comments when above option is enabled or if "hide all child comments" is clicked.',
+	},
 };
 module.include = [
 	'comments',
@@ -105,7 +105,7 @@ function toggleComments(nested, action, obj) {
 	let commentContainers;
 	if (obj) { // toggle a single comment tree
 		commentContainers = $(obj).closest('.thing');
-	} else if (nested)  { // toggle all comments
+	} else if (nested) { // toggle all comments
 		commentContainers = document.querySelectorAll('div.commentarea div.sitetable div.thing');
 	} else { // toggle all top level comments
 		commentContainers = document.querySelectorAll('div.commentarea > div.sitetable > div.thing');

--- a/lib/modules/hideChildComments.js
+++ b/lib/modules/hideChildComments.js
@@ -6,13 +6,18 @@ export const module = {};
 module.moduleID = 'hideChildComments';
 module.moduleName = 'Hide All Child Comments';
 module.category = 'Comments';
-module.description = 'Allows you to hide all comments except for replies to the OP for easier reading.';
+module.description = 'Allows you to hide child comments.';
 module.options = {
 	automatic: {
 		type: 'boolean',
 		value: false,
-		description: 'Automatically hide all but parent comments, or provide a link to hide them all?',
+		description: 'Hide children for all comments by default.',
 	},
+	noNested: {
+		type: 'boolean',
+		value: true,
+		description: 'Do not hide children for nested comments when above option is enabled or if "hide all child comments" is clicked.'
+	}
 };
 module.include = [
 	'comments',
@@ -27,7 +32,11 @@ module.go = () => {
 	toggleAllLink.setAttribute('title', 'Show only replies to original poster.');
 	toggleAllLink.addEventListener('click', function(e) {
 		e.preventDefault();
-		toggleComments(this.getAttribute('action'));
+		if (module.options.noNested.value) {
+			toggleComments(false, this.getAttribute('action'));
+		} else {
+			toggleComments(true, this.getAttribute('action'));
+		}
 		if (this.getAttribute('action') === 'hide') {
 			this.setAttribute('action', 'show');
 			this.setAttribute('title', 'Show all comments.');
@@ -53,7 +62,27 @@ module.go = () => {
 			// toggleLink.setAttribute('title','Hide child comments.');
 			toggleLink.addEventListener('click', function(e) {
 				e.preventDefault();
-				toggleComments(this.getAttribute('action'), this);
+				toggleComments(true, this.getAttribute('action'), this);
+			}, true);
+			toggleButton.appendChild(toggleLink);
+			const sib = comment.parentNode.previousSibling;
+			if (sib) {
+				const sibMenu = sib.querySelector('ul.buttons');
+				if (sibMenu) sibMenu.appendChild(toggleButton);
+			}
+		});
+		const secondaryComments = document.querySelectorAll('div.listing div.listing');
+		secondaryComments::forEachChunked(comment => {
+			const toggleButton = document.createElement('li');
+			const toggleLink = document.createElement('a');
+			toggleLink.setAttribute('data-text', 'hide child comments');
+			toggleLink.setAttribute('action', 'hide');
+			toggleLink.setAttribute('href', '#');
+			toggleLink.setAttribute('class', 'toggleChildren noCtrlF');
+			// toggleLink.setAttribute('title','Hide child comments.');
+			toggleLink.addEventListener('click', function(e) {
+				e.preventDefault();
+				toggleComments(true, this.getAttribute('action'), this);
 			}, true);
 			toggleButton.appendChild(toggleLink);
 			const sib = comment.parentNode.previousSibling;
@@ -72,11 +101,13 @@ module.go = () => {
 	}
 };
 
-function toggleComments(action, obj) {
+function toggleComments(nested, action, obj) {
 	let commentContainers;
 	if (obj) { // toggle a single comment tree
 		commentContainers = $(obj).closest('.thing');
-	} else { // toggle all comments
+	} else if (nested)  { // toggle all comments
+		commentContainers = document.querySelectorAll('div.commentarea div.sitetable div.thing');
+	} else { // toggle all top level comments
 		commentContainers = document.querySelectorAll('div.commentarea > div.sitetable > div.thing');
 	}
 	commentContainers::forEachChunked(container => {


### PR DESCRIPTION
Fixes issue #3207.

A link to hide child comments has been added to all comments that have children. This functionality was previously only for top level comments.

I added a new option to the module called noNested. This is enabled by default so as to preserve the current behaviour. When disabled, clicking "hide all child comments" or enabling the automatic option will collapse children of nested comments as well.

Previous wording felt a bit awkward, so I've slightly changed that too.

<img width="1017" alt="screen shot 2016-08-10 at 23 47 31" src="https://cloud.githubusercontent.com/assets/5273804/17573826/dc5924f0-5f54-11e6-98a5-c49629ed7fca.png">
<img width="1002" alt="screen shot 2016-08-10 at 23 47 09" src="https://cloud.githubusercontent.com/assets/5273804/17573825/dc3939b0-5f54-11e6-8575-eb4f9f0d7087.png">
