### PR TITLE
hover: Indicate loading on async HoverInfoCard

### DIFF
--- a/lib/css/modules/_hover.scss
+++ b/lib/css/modules/_hover.scss
@@ -7,6 +7,11 @@
 	z-index: $zindex-res-hover;
 }
 
+.RESHoverLoadIndicator {
+	display: flex;
+	justify-content: center;
+}
+
 .RESHoverInfoCard {
 	&::before {
 		content: '';

--- a/lib/modules/hover.js
+++ b/lib/modules/hover.js
@@ -118,7 +118,6 @@ class Hover {
 	template = hoverDefaultTemplate;
 	_options = Hover._defaultOptions;
 	_enabled = true;
-	_loadIndicator = '<div class="RESHoverLoadIndicator"><span class="RESLoadingSpinner"></span></div>';
 
 	constructor(id) {
 		this.instanceID = id;
@@ -317,6 +316,7 @@ class Hover {
 
 class HoverInfoCard extends Hover {
 	template = hoverInfoCardTemplate;
+	_loadIndicator = '<div class="RESHoverLoadIndicator"><span class="RESLoadingSpinner"></span></div>';
 
 	_displayLoadIndicator($container) {
 		this._populate($container, null, this._loadIndicator);

--- a/lib/modules/hover.js
+++ b/lib/modules/hover.js
@@ -118,6 +118,7 @@ class Hover {
 	template = hoverDefaultTemplate;
 	_options = Hover._defaultOptions;
 	_enabled = true;
+	_loadIndicator = '<div class="RESHoverLoadIndicator"><span class="RESLoadingSpinner"></span></div>';
 
 	constructor(id) {
 		this.instanceID = id;
@@ -203,6 +204,7 @@ class Hover {
 		const $container = this.getContainer();
 
 		if (this._callback) {
+			if (this._displayLoadIndicator) this._displayLoadIndicator($container);
 			(async () => {
 				try {
 					const update = (...items) => this._populate($container, ...items);
@@ -315,6 +317,10 @@ class Hover {
 
 class HoverInfoCard extends Hover {
 	template = hoverInfoCardTemplate;
+
+	_displayLoadIndicator($container) {
+		this._populate($container, null, this._loadIndicator);
+	}
 
 	_updatePosition($container) {
 		const { top, left } = $(this._target).offset();

--- a/lib/modules/hover.js
+++ b/lib/modules/hover.js
@@ -203,7 +203,7 @@ class Hover {
 		const $container = this.getContainer();
 
 		if (this._callback) {
-			if (this._displayLoadIndicator) this._displayLoadIndicator($container);
+			this._displayLoadIndicator($container);
 			(async () => {
 				try {
 					const update = (...items) => this._populate($container, ...items);
@@ -221,6 +221,8 @@ class Hover {
 
 		$container.show().css({ opacity: 1 }); // nvm fade in, too much trouble
 	}
+
+	_displayLoadIndicator($container) {} // eslint-disable-line no-unused-vars
 
 	_populate($container, ...items) {
 		if (!this._enabled) return false;

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -111,7 +111,7 @@ function handleMouseOver(e) {
 async function showUserInfo(authorLink, context, update) {
 	const username = authorLink.href.match(UserTagger.usernameRE)[1];
 
-	update(username, '<span class="RESLoadingSpinner"></span>');
+	update(username);
 
 	let data;
 


### PR DESCRIPTION
The previous content was shown until the new one is ready, which is confusing when it takes several seconds to fetch new data. This instantaneously replaces it with a loading indicator until the new content is ready.