### PR TITLE
showImages: ensure we set `display: inline-block` on `.commentImg`

### DIFF
--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -42,6 +42,7 @@ img {
 	&.commentImg {
 		vertical-align: middle !important;
 		float: none;
+		display: inline-block;
 		margin: 0 4px;
 
 		+ .res-expando-box {


### PR DESCRIPTION
re #3269

Otherwise we lose expando icons in comments with the native types (selftext, video):

![image](https://cloud.githubusercontent.com/assets/7673145/17645702/345dd312-617b-11e6-9882-103f2fcae989.png)

And for `.comment > .parent > &.linkImg`:

![image](https://cloud.githubusercontent.com/assets/7673145/17645712/8b3b69ba-617b-11e6-9a68-2c57aa844cc8.png)