### PR TITLE
Cache the npm cache on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: false
 language: node_js
 node_js:
   - 6
+cache:
+  directories:
+    - $HOME/.npm
 script:
   - npm run eslint
   - npm run sass-lint

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 environment:
   matrix:
     - nodejs_version: '6'
+cache:
+  - '%APPDATA%\npm-cache'
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install -g npm@latest || (timeout 30 && npm install -g npm@latest)


### PR DESCRIPTION
https://docs.npmjs.com/cli/cache
https://docs.travis-ci.com/user/caching/
https://www.appveyor.com/docs/build-cache

This should hopefully speed up builds without any risk of caching outdated deps in `node_modules`.