### PR TITLE
filteReddit: only add the quick toggle when the module is enabled and running

### DIFF
--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -718,7 +718,7 @@ module.beforeLoad = () => {
 const $nsfwSwitch = _.once(() => $(CreateElement.toggleButton(undefined, 'nsfwSwitchToggle', module.options.NSFWfilter.value)));
 let removeVisitedLinksActive = false;
 
-module.always = () => {
+module.go = () => {
 	if (module.options.NSFWQuickToggle.value) {
 		Menu.addMenuItem($('<div>', {
 			text: 'nsfw filter',
@@ -726,9 +726,7 @@ module.always = () => {
 			append: $nsfwSwitch(),
 		}), toggleNsfwFilter);
 	}
-};
 
-module.go = () => {
 	scanEntries();
 	watchForElement('siteTable', scanEntries);
 


### PR DESCRIPTION
Fixes #3285.

Previously, the toggle was added in `always()` to preserve legacy behaviour, where the toggle showed up everywhere, even on pages where filteReddit doesn't run. But this doesn't make much sense, because you're unlikely to want to toggle the NSFW filter while browsing a wiki page or something.