### PR TITLE
Init: pipe return values through each lifecycle method

### DIFF
--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -71,7 +71,7 @@ export const contentLoaded = typeof window !== 'undefined' ?
 sourceLoaded.then(() => migrate());
 
 export const loadDynamicOptions = sourceLoaded
-	.then(() => allModules('loadDynamicOptions'));
+	.then(() => allModules('loadDynamicOptions', { skipEnabledCheck: true, withContext: true }));
 
 export const loadOptions = loadDynamicOptions
 	.then(() => Promise.all([
@@ -83,33 +83,39 @@ export const addModuleBodyClasses = loadOptions
 	.then(() => _addModuleBodyClasses());
 
 export const always = Promise.all([loadOptions, headReady])
-	.then(() => allModules('always'));
+	.then(() => allModules('always', { skipEnabledCheck: true }));
 
 export const beforeLoad = Promise.all([loadOptions, headReady])
-	.then(() => allModules('beforeLoad', true));
+	.then(() => allModules('beforeLoad', { withContext: true }));
 
 export const go = Promise.all([beforeLoad, bodyReady])
-	.then(() => allModules('go', true));
+	.then(() => allModules('go', { withContext: true }));
 
 export const afterLoad = Promise.all([go, contentLoaded])
-	.then(() => allModules('afterLoad', true));
+	.then(() => allModules('afterLoad', { withContext: true }));
 
-const errored = new Set();
+const ERRORED_KEY = Symbol('errored');
+const CONTEXT_KEY = Symbol('context');
 
-function allModules(key, checkShouldRun = false) {
+function allModules(key, { skipEnabledCheck = false, withContext = false } = {}) {
 	return Promise.all(
 		Modules.all()
-			::filter(({ moduleID: id }) => !errored.has(id))
+			::filter(module => (
+				module[key] &&
+				!module[ERRORED_KEY] &&
+				(skipEnabledCheck || Modules.isRunning(module))
+			))
 			::map(async module => {
 				try {
-					if (!module[key]) return;
-					if (checkShouldRun && !Modules.isRunning(module)) return;
-					await module[key]();
+					if (withContext) {
+						module[CONTEXT_KEY] = await module[key](module[CONTEXT_KEY]);
+					} else {
+						await module[key]();
+					}
 				} catch (e) {
-					const id = module.moduleID;
-					console.error('Error in module:', id, 'during:', key);
+					module[ERRORED_KEY] = true;
+					console.error('Error in module:', module.moduleID, 'during:', key);
 					console.error(e);
-					errored.add(id);
 				}
 			})
 	);


### PR DESCRIPTION
...to facilitate loading things in `beforeLoad` and using them in `go` without needing a global

e.g. before
```js
let foo, bar;
module.beforeLoad = async () => {
    foo = await something();
    bar = somethingElse();
};
module.go = () => {
    doSomething(foo);
    doSomethingElse(bar);
};
```
after
```js
module.beforeLoad = async () => {
    const foo = await something();
    const bar = somethingElse();
    return { foo, bar };  
};
module.go = ({ foo, bar }) => {
    doSomething(foo);
    doSomethingElse(bar);
};
```