### PR TITLE
Revert "Cache the npm cache on CI"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ sudo: false
 language: node_js
 node_js:
   - 6
-cache:
-  directories:
-    - $HOME/.npm
 script:
   - npm run eslint
   - npm run sass-lint

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,6 @@
 environment:
   matrix:
     - nodejs_version: '6'
-cache:
-  - '%APPDATA%\npm-cache'
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install -g npm@latest || (timeout 30 && npm install -g npm@latest)


### PR DESCRIPTION
Reverts honestbleeps/Reddit-Enhancement-Suite#3278

There have been about 20 builds each on Travis and Appveyor, and there's no noticeable difference in build time. Still ~5:30 on Travis and ~4:30 on Appveyor. The install phase specifically is also still ~90s in Travis.

Closes #3282