### PR TITLE
moveMedia: Use parseInt instead of parseFloat

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1759,8 +1759,8 @@ function videoAdvanced(options) {
 }
 
 export function moveMedia(ele, deltaX, deltaY, source = resizeSources.OTHER) {
-	ele.style.marginLeft = `${(parseFloat(ele.style.marginLeft, 10) || 0) + deltaX}px`;
-	ele.style.marginTop = `${(parseFloat(ele.style.marginTop, 10) || 0) + deltaY}px`;
+	ele.style.marginLeft = `${(parseInt(ele.style.marginLeft, 10) || 0) + deltaX}px`;
+	ele.style.marginTop = `${(parseInt(ele.style.marginTop, 10) || 0) + deltaY}px`;
 
 	ele.dispatchEvent(new CustomEvent('mediaResize', { bubbles: true, detail: source }));
 }


### PR DESCRIPTION
Using parseFloat sometimes resulted in values such as 0.0113E-6px, which CSS doesn't support.