### PR TITLE
keyboardNav: Only resize the most visible

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -962,9 +962,11 @@ function imageResize({ factor = 1, removeHeightRestriction }) {
 	const selected = SelectedEntry.selectedThing();
 	if (!selected) return;
 
-	for (const image of selected.entry.querySelectorAll('.res-media-zoomable')) {
-		if (removeHeightRestriction) image.style.maxHeight = '';
-		ShowImages.resizeMedia(image, image.clientWidth * factor);
+	const images = selected.entry.querySelectorAll('.res-media-zoomable');
+	const mostVisible = _.maxBy(images, media => getPercentageVisibleYAxis(media));
+	if (mostVisible) {
+		if (removeHeightRestriction) mostVisible.style.maxHeight = '';
+		ShowImages.resizeMedia(mostVisible, mostVisible.clientWidth * factor);
 	}
 }
 


### PR DESCRIPTION
Similar to `imageMove`. The previous implementation also resized other pieces in the gallery.