### PR TITLE
showImages: Create option for which media types to auto expand

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -385,7 +385,7 @@ const commands = {
 	},
 	toggleViewImages: {
 		value: [88, false, false, true], // shift-x
-		description: 'Toggle "view images" button',
+		description: 'Toggle "show images" button',
 		callback: ShowImages.toggleViewImages,
 	},
 	toggleChildren: {

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -322,7 +322,7 @@ const commands = {
 	},
 	toggleExpando: {
 		value: [88, false, false, false], // x
-		description: 'Toggle expando (image/text/video) (link pages only)',
+		description: 'Toggle expando (image/text/video)',
 		callback() {
 			const thing = SelectedEntry.selectedThing();
 			if (thing) ShowImages.toggleThingExpandos(thing, module.options.scrollOnExpando.value);

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -25,6 +25,7 @@ import {
 	batch,
 	click,
 	CreateElement,
+	elementInViewport,
 	scrollToElement,
 	forEachChunked,
 	forEachSeq,
@@ -126,11 +127,6 @@ module.options = {
 		value: true,
 		description: 'Add special styling to expando buttons for images marked NSFW.',
 		bodyClass: true,
-	},
-	autoExpandSelfText: {
-		type: 'boolean',
-		value: true,
-		description: 'When loading selftext from an Aa+ expando, auto expand images, videos, and embeds.',
 	},
 	imageZoom: {
 		type: 'boolean',
@@ -260,6 +256,35 @@ module.options = {
 		type: 'boolean',
 		value: true,
 		description: 'Show a \'view images\' tab at the top of each subreddit, to easily toggle showing all images at once.',
+	},
+	autoExpandTypes: {
+		type: 'enum',
+		value: 'any',
+		values: [{
+			name: 'Images (but occasionally also .gif)',
+			value: 'image',
+		}, {
+			name: 'Images, text',
+			value: 'image text',
+		}, {
+			name: 'Images, text, galleries, and muted videos',
+			value: 'image text gallery video',
+		}, {
+			name: 'All muted expandos (includes iframes)',
+			value: 'any',
+		}],
+		description: 'Media types to be automatically expanded when using "view images" or autoExpandSelfText.',
+	},
+	autoExpandSelfText: {
+		type: 'boolean',
+		value: true,
+		description: 'When loading selftext from an Aa+ expando, auto expand enclosed expandos.',
+	},
+	autoExpandFirstVisibleNonMuted: {
+		dependsOn: 'autoExpandSelfText',
+		type: 'boolean',
+		value: true,
+		description: 'Expand the first visible potentially non-muted expando on autoExpandSelfText.',
 	},
 	showSiteAttribution: {
 		type: 'boolean',
@@ -562,8 +587,9 @@ export function toggleThingExpandos(thing, scrollOnExpando) {
 		if (scrollOnExpando) scrollToElement(thing.entry, { scrollStyle: 'directional' });
 	} else {
 		for (const expando of expandos) {
-			if (!(expando instanceof Expando) ||
-				expando::isExpandWanted({ thing, autoExpand: true, ignoreDuplicates: false, explicitOpen: true })
+			if (
+				!(expando instanceof Expando) ||
+				expando::isExpandWanted({ thing, autoExpandFirstVisibleNonMutedInThing: true, autoExpand: true, autoExpandTypes: ['any'], ignoreDuplicatesScope: thing.element })
 			) {
 				expando.expand();
 			}
@@ -592,24 +618,34 @@ function mediaBrowse(selected, unselected, options) {
 	}
 }
 
+function hasEntryAnyExpandedNonMuted(thing) {
+	return thing.getTextExpandos().some(expando =>
+		expando.getTypes().includes('non-muted') && (expando.open || expando.expandWanted)
+	);
+}
+
 function isExpandWanted({
 		thing = null,
-		explicitOpen = false,
-		autoExpand = autoExpandActive || explicitOpen,
+		autoExpand = autoExpandActive,
+		autoExpandTypes = module.options.autoExpandTypes.value.split(' '),
 		ignoreDuplicates = true,
+		ignoreDuplicatesScope = null,
+		onlyExpandMuted = true,
+		autoExpandFirstVisibleNonMutedInThing = false,
 	} = {}) {
-	if (ignoreDuplicates && !this.isPrimary()) return false;
+	if (
+		ignoreDuplicates && !this.isPrimary() &&
+		(!ignoreDuplicatesScope || ignoreDuplicatesScope.contains(this.getPrimary().button))
+	) return false;
 
-	if (this.inText && thing && (autoExpand ||
-		module.options.autoExpandSelfText.value && thing.isSelfPost() && !isPageType('comments')
-	)) {
-		// Expand all muted expandos and the first non-muted expando
-		return (this.mediaOptions && this.mediaOptions.muted) ||
-			!thing.getTextExpandos()
-				.find(v => (v.open || v.expandWanted) && (v.mediaOptions && !v.mediaOptions.muted));
-	} else {
-		return explicitOpen || (autoExpand && (this.mediaOptions && this.mediaOptions.muted));
-	}
+	const expandoTypes = this.getTypes();
+	const expandoIsNonMuted = expandoTypes.includes('non-muted');
+
+	const typeCriteriaOK = autoExpandTypes.includes('any') || _.intersection(expandoTypes, autoExpandTypes).length;
+	const muteCriteriaOK = !(onlyExpandMuted && expandoIsNonMuted) ||
+		(autoExpandFirstVisibleNonMutedInThing && elementInViewport(this.button) && !hasEntryAnyExpandedNonMuted(thing));
+
+	return autoExpand && muteCriteriaOK && typeCriteriaOK;
 }
 
 function findAllImages(elem, isSelfText) {
@@ -818,7 +854,17 @@ async function completeExpando(expando, thing, mediaInfo) {
 		thing.entry.addEventListener('mediaResize', updateParentHeight);
 	}
 
-	if (!expando.expandWanted) expando.expandWanted = expando::isExpandWanted({ thing });
+	if (!expando.expandWanted) {
+		let autoExpand;
+		let autoExpandFirstVisibleNonMutedInThing;
+
+		if (module.options.autoExpandSelfText.value && expando.inText && thing.isSelfPost() && !isPageType('comments')) {
+			autoExpand = true;
+			autoExpandFirstVisibleNonMutedInThing = module.options.autoExpandFirstVisibleNonMuted.value;
+		}
+
+		expando.expandWanted = expando::isExpandWanted({ thing, autoExpand, autoExpandFirstVisibleNonMutedInThing });
+	}
 
 	expando.initialize();
 

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -280,11 +280,17 @@ module.options = {
 		value: true,
 		description: 'When loading selftext from an Aa+ expando, auto expand enclosed expandos.',
 	},
-	autoExpandFirstVisibleNonMuted: {
+	autoExpandSelfTextFirstVisibleNonMuted: {
 		dependsOn: 'autoExpandSelfText',
 		type: 'boolean',
 		value: true,
-		description: 'Expand the first visible potentially non-muted expando on autoExpandSelfText.',
+		description: 'In selftexts, expand the first visible potentially non-muted expando.',
+	},
+	autoExpandSelfTextNSFW: {
+		dependsOn: 'autoExpandSelfText',
+		type: 'boolean',
+		value: true,
+		description: 'Also expand expandos in selftexts which are marked NSFW.',
 	},
 	showSiteAttribution: {
 		type: 'boolean',
@@ -859,8 +865,9 @@ async function completeExpando(expando, thing, mediaInfo) {
 		let autoExpandFirstVisibleNonMutedInThing;
 
 		if (module.options.autoExpandSelfText.value && expando.inText && thing.isSelfPost() && !isPageType('comments')) {
-			autoExpand = true;
-			autoExpandFirstVisibleNonMutedInThing = module.options.autoExpandFirstVisibleNonMuted.value;
+			const dontAutoExpandNSFW = !module.options.autoExpandSelfTextNSFW.value && thing.isNSFW();
+			autoExpand = !dontAutoExpandNSFW;
+			autoExpandFirstVisibleNonMutedInThing = module.options.autoExpandSelfTextFirstVisibleNonMuted.value;
 		}
 
 		expando.expandWanted = expando::isExpandWanted({ thing, autoExpand, autoExpandFirstVisibleNonMutedInThing });

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -255,7 +255,7 @@ module.options = {
 	showViewImagesTab: {
 		type: 'boolean',
 		value: true,
-		description: 'Show a \'view images\' tab at the top of each subreddit, to easily toggle showing all images at once.',
+		description: 'Show a \'show images\' tab at the top of each subreddit, to easily toggle showing all images at once.',
 	},
 	autoExpandTypes: {
 		type: 'enum',
@@ -273,7 +273,7 @@ module.options = {
 			name: 'All muted expandos (includes iframes)',
 			value: 'any',
 		}],
-		description: 'Media types to be automatically expanded when using "view images" or autoExpandSelfText.',
+		description: 'Media types to be automatically expanded when using "show images" or autoExpandSelfText.',
 	},
 	autoExpandSelfText: {
 		type: 'boolean',

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -289,7 +289,7 @@ module.options = {
 	autoExpandSelfTextNSFW: {
 		dependsOn: 'autoExpandSelfText',
 		type: 'boolean',
-		value: true,
+		value: false,
 		description: 'Also expand expandos in selftexts which are marked NSFW.',
 	},
 	showSiteAttribution: {

--- a/lib/utils/expando.js
+++ b/lib/utils/expando.js
@@ -28,6 +28,20 @@ export class Expando {
 		this.expandCallbacks.push(callback);
 	}
 
+	getTypes() {
+		const types = [];
+
+		if (this.mediaOptions) {
+			types.push(
+				this.mediaOptions.type.toLowerCase(),
+				this.mediaOptions.muted ? 'muted' : 'non-muted',
+				...((this.mediaOptions.expandoClass || '').toLowerCase().split(' ')).filter(v => v)
+			);
+		}
+
+		return types;
+	}
+
 	updateButton() {
 		let mediaClass, title;
 


### PR DESCRIPTION
Also adds an option for whether to auto-expand the first **visible** non-muted (video, etc) expando in self-text posts.

Using `image text gallery video` instead of `any` as default value may be desirable.

Lays groundwork for #2540 

Fixes #3422
Resolves #3508 