### PR TITLE
newCommentCount: remove the option to show all tracked threads

### DIFF
--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -62,9 +62,6 @@ module.go = () => {
 		// add tab to dashboard
 		Dashboard.addTab('newCommentsContents', 'My Subscriptions');
 		// populate the contents of the tab
-		const $showDiv = $('<div class="show">Show </div>');
-		const $subscriptionFilter = $('<select id="subscriptionFilter"><option>subscribed threads</option><option>all threads</option></select>');
-		$showDiv.append($subscriptionFilter);
 		const $openOnReddit = $('<a href="#" id="openOnReddit">as reddit link listing</a>');
 		$openOnReddit.click(event => {
 			event.preventDefault();
@@ -75,9 +72,7 @@ module.go = () => {
 			url += concatIds;
 			location.href = `/by_id/${url}`;
 		});
-		$showDiv.append(' ').append($openOnReddit);
-		$('#newCommentsContents').append($showDiv);
-		$('#subscriptionFilter').change(() => drawSubscriptionsTable());
+		$('#newCommentsContents').append($openOnReddit);
 		const $thisTable = $('<table id="newCommentsTable" />');
 		$thisTable.append('<thead><tr><th sort="" class="active">Submission</th><th sort="subreddit">Subreddit</th><th sort="updateTime">Last viewed</th><th sort="subscriptionDate">Expires in</th><th class="actions">Actions</th></tr></thead><tbody></tbody>');
 		$('#newCommentsContents').append($thisTable);
@@ -111,7 +106,6 @@ module.go = () => {
 let currentSortMethod, isDescending;
 
 function drawSubscriptionsTable(sortMethod, descending) {
-	const filterType = $('#subscriptionFilter').val();
 	currentSortMethod = sortMethod || currentSortMethod;
 	isDescending = (descending === undefined) ? isDescending : !!descending;
 	const thisCounts = [];
@@ -154,7 +148,7 @@ function drawSubscriptionsTable(sortMethod, descending) {
 	let rows = 0;
 	for (const { subscriptionDate, updateTime, id, url, title, subreddit } of thisCounts) {
 		const isSubscribed = typeof subscriptionDate !== 'undefined';
-		if ((filterType === 'all threads') || ((filterType === 'subscribed threads') && (isSubscribed))) {
+		if (isSubscribed) {
 			const thisUpdateTime = new Date(updateTime);
 			const now = new Date();
 
@@ -197,11 +191,7 @@ function drawSubscriptionsTable(sortMethod, descending) {
 		}
 	}
 	if (rows === 0) {
-		if (filterType === 'subscribed threads') {
-			$('#newCommentsTable tbody').append('<td colspan="5">You are currently not subscribed to any threads. To subscribe to a thread, click the "subscribe" button found near the top of the comments page.</td>');
-		} else {
-			$('#newCommentsTable tbody').append('<td colspan="5">No threads found</td>');
-		}
+		$('#newCommentsTable tbody').append('<td colspan="5">You are currently not subscribed to any threads. To subscribe to a thread, click the "subscribe" button found near the top of the comments page.</td>');
 		$('#openOnReddit').hide();
 	} else {
 		$('#openOnReddit').show();


### PR DESCRIPTION
...and only show threads that have been explicitly subscribed to.

https://www.reddit.com/r/Enhancement/comments/4ym1di/

This is effectively an implementation detail, so I'm not sure why this was visible in the first place. I suppose you could stop tracking new comments for a thread, but it's not like the `(x new)` text is very intrusive ¯\\\_(ツ)_/¯

Related to but not an implementation of #1330