### PR TITLE
Create mediaHost blacklist & add dropbox to it

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -292,6 +292,9 @@ module.exclude = [
 	/^https?:\/\/(?:[\-\w\.]+\.)?reddit\.com\/[\-\w\.\/]*\/submit\/?$/i,
 	/^https?:\/\/(?:[\-\w\.]+\.)?reddit\.com\/subreddits/i,
 ];
+module.mediaHostBlackList = [
+	"dropbox.com"
+];
 
 module.loadDynamicOptions = () => {
 	// Augment the options with available image modules
@@ -681,6 +684,13 @@ async function resolveMediaUrl(element, thing) {
 }
 
 function getMediaInfo(element, mediaUrl) {
+	// Check host is not blacklisted
+	for (var blackListedHost of module.mediaHostBlackList) {
+		if(mediaUrl.hostname.indexOf(module.mediaHostBlackList) !== -1){
+			return false;
+		}
+	}
+
 	const matchingHosts = [
 		...modulesForHostname(mediaUrl.hostname),
 		siteModules.default,

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -293,7 +293,7 @@ module.exclude = [
 	/^https?:\/\/(?:[\-\w\.]+\.)?reddit\.com\/subreddits/i,
 ];
 module.mediaHostBlackList = [
-	"dropbox.com"
+	'dropbox.com',
 ];
 
 module.loadDynamicOptions = () => {
@@ -685,8 +685,8 @@ async function resolveMediaUrl(element, thing) {
 
 function getMediaInfo(element, mediaUrl) {
 	// Check host is not blacklisted
-	for (var blackListedHost of module.mediaHostBlackList) {
-		if(mediaUrl.hostname.indexOf(module.mediaHostBlackList) !== -1){
+	for (const blackListedHost of module.mediaHostBlackList) {
+		if (mediaUrl.hostname.indexOf(blackListedHost) !== -1) {
 			return false;
 		}
 	}


### PR DESCRIPTION
Edit: Depending on the outcome of discussions in https://github.com/honestbleeps/Reddit-Enhancement-Suite/issues/2604 it may be better to go with a working mediahost & close this for now (assuming we don't have anything else we want to blacklist?)

-----

Provides an initial fix to https://github.com/honestbleeps/Reddit-Enhancement-Suite/issues/2604 by blacklisting the dropbox domain from the image expando system.

As a bonus, it also means reddit's own dropbox expando's (which seem to work by using a reddit held copy of the image) will work on the index pages 