### PR TITLE
Fix issues with Keyboard Navigation when `fixHideLinks` is turned off.

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -776,8 +776,6 @@ function updateCommentLinkAnnotations(selected) {
 		});
 }
 
-
-
 const drawHelp = _.once(() => {
 	const keys = Object.entries(module.options)
 		.filter(([optionKey, { type }]) =>

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -852,7 +852,7 @@ function hideLink() {
 	}
 
 	if (module.options.onHideMoveDown.value) {
-		SelectedEntry.selectClosestVisible();
+		SelectedEntry.selectClosestVisible({ scrollStyle: 'none' });
 	}
 }
 

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -846,7 +846,10 @@ function hideLink() {
 	if (!selected) return;
 
 	// find the hide link and click it...
-	click(selected.entry.querySelector('.hide-button a, .unhide-button a'));
+	let hide = selected.entry.querySelector('.hide-button a, .unhide-button a')
+	if (hide){
+		click(hide);
+	}
 
 	if (module.options.onHideMoveDown.value) {
 		moveDown();

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -67,9 +67,6 @@ module.options = {
 		}, {
 			name: 'legacy',
 			value: 'legacy',
-		}, {
-			name: 'none',
-			value: 'none',
 		}],
 		value: 'directional',
 		description: `
@@ -79,7 +76,6 @@ module.options = {
 			<br>Lock to top: Always align the selected element to the top of the screen.
 			<br>In middle: Scroll just enough to bring the selected element to the middle of the viewport.
 			<br>Legacy: If the element is offscreen, lock to top.
-			<br>None: Do not scroll automatically
 		`,
 		advanced: true,
 	},
@@ -100,9 +96,6 @@ module.options = {
 		}, {
 			name: 'legacy',
 			value: 'legacy',
-		}, {
-			name: 'none',
-			value: 'none',
 		}],
 		value: 'legacy',
 		description: 'When jumping to a entry (moveUpThread/moveDownThread, moveUpSibling/moveDownSibling, moveToParent, and moveDownParentSibling), when and how should RES scroll the window?',

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -783,6 +783,8 @@ function updateCommentLinkAnnotations(selected) {
 		});
 }
 
+
+
 const drawHelp = _.once(() => {
 	const keys = Object.entries(module.options)
 		.filter(([optionKey, { type }]) =>
@@ -859,7 +861,7 @@ function hideLink() {
 	}
 
 	if (module.options.onHideMoveDown.value) {
-		moveDown();
+		SelectedEntry.selectClosestVisible();
 	}
 }
 

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -67,6 +67,9 @@ module.options = {
 		}, {
 			name: 'legacy',
 			value: 'legacy',
+		}, {
+			name: 'none',
+			value: 'none',
 		}],
 		value: 'directional',
 		description: `
@@ -76,6 +79,7 @@ module.options = {
 			<br>Lock to top: Always align the selected element to the top of the screen.
 			<br>In middle: Scroll just enough to bring the selected element to the middle of the viewport.
 			<br>Legacy: If the element is offscreen, lock to top.
+			<br>None: Do not scroll automatically
 		`,
 		advanced: true,
 	},
@@ -96,6 +100,9 @@ module.options = {
 		}, {
 			name: 'legacy',
 			value: 'legacy',
+		}, {
+			name: 'none',
+			value: 'none',
 		}],
 		value: 'legacy',
 		description: 'When jumping to a entry (moveUpThread/moveDownThread, moveUpSibling/moveDownSibling, moveToParent, and moveDownParentSibling), when and how should RES scroll the window?',

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -853,8 +853,8 @@ function hideLink() {
 	if (!selected) return;
 
 	// find the hide link and click it...
-	let hide = selected.entry.querySelector('.hide-button a, .unhide-button a')
-	if (hide){
+	const hide = selected.entry.querySelector('.hide-button a, .unhide-button a');
+	if (hide) {
 		click(hide);
 	}
 

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -144,6 +144,11 @@ export function select(thing, options) {
 	_select(thing, options);
 }
 
+export const selectClosestVisible = _.debounce(() => {
+	const target = selectedThing.getNext({ direction: 'down' }) || selectedThing.getNext({ direction: 'up' });
+	if (target) _select(target, { scrollStyle: 'none' });
+});
+
 export function unselect() {
 	const prevSelected = selectedThing;
 	_select(undefined);

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -144,10 +144,10 @@ export function select(thing, options) {
 	_select(thing, options);
 }
 
-export const selectClosestVisible = _.debounce(() => {
+export function selectClosestVisible(options) {
 	const target = selectedThing.getNext({ direction: 'down' }) || selectedThing.getNext({ direction: 'up' });
-	if (target) _select(target, { scrollStyle: 'none' });
-});
+	if (target) _select(target, options);
+}
 
 export function unselect() {
 	const prevSelected = selectedThing;


### PR DESCRIPTION
Resolves two issues around hiding links with a keyboard shortcut.

**Issue 1:** 
Null reference on pressing hide shortcut shortly after hiding or when no element is selected (this causes keyboard navigation to stop working). Quite an old issue, there was a post [here](https://www.reddit.com/r/RESissues/comments/40irwi/bug_issues_with_hide_shortcuthiding_submissions/?st=islzf9j7&sh=c3e95dd3) but it was deleted.

**Issue 2:**
Scrolling to the next item does not work nicely when hiding items, since after the item has been hidden the page content moves and the content that was previously scrolled to moves off screen. I've adapted larsjonsen's code to select the nearest item without scrolling after a hide.

https://www.reddit.com/r/RESissues/comments/4qc4xc/bug_hide_select_new_5_second_delay_hides_moves_up/?st=islz1ap4&sh=d7cffdd2 (only fixes case where `fixHideLinks` is off)