### PR TITLE
chrome minimum version bump

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -2,7 +2,7 @@
 	"name": "{{prop?title!../package.json}}",
 	"version": "{{prop?version!../package.json}}",
 	"manifest_version": 2,
-	"minimum_chrome_version": "49",
+	"minimum_chrome_version": "53",
 	"description": "{{prop?description!../package.json}}",
 	"background": {
 		"scripts": [


### PR DESCRIPTION
chrome 49 can't `for (const foo in bar)`