### PR TITLE
[Bugfix] Fix user tagger dialog being behind expandos

### DIFF
--- a/lib/css/modules/_userTagger.scss
+++ b/lib/css/modules/_userTagger.scss
@@ -3,7 +3,7 @@
 	position: absolute;
 	width: 336px;
 	box-sizing: border-box;
-	z-index: 35;
+	z-index: $zindex-res-hover;
 
 	form > div {
 		clear: both;

--- a/lib/css/modules/_userTagger.scss
+++ b/lib/css/modules/_userTagger.scss
@@ -3,6 +3,7 @@
 	position: absolute;
 	width: 336px;
 	box-sizing: border-box;
+	z-index: 35;
 
 	form > div {
 		clear: both;


### PR DESCRIPTION
Fix z-index so user tagger dialog shows above expando images

fixes https://github.com/honestbleeps/Reddit-Enhancement-Suite/issues/3383