### PR TITLE
YouTube: Stop instead of pause video on collapse

### DIFF
--- a/lib/modules/hosts/youtube.js
+++ b/lib/modules/hosts/youtube.js
@@ -44,7 +44,7 @@ export default {
 			type: 'IFRAME',
 			embed: src,
 			embedAutoplay: `${src}&autoplay=1`,
-			pause: '{"event":"command","func":"pauseVideo","args":""}',
+			pause: '{"event":"command","func":"stopVideo","args":""}',
 			play: '{"event":"command","func":"playVideo","args":""}',
 		};
 	},


### PR DESCRIPTION
Stopping will stop further loading / buffering, and also cancel autoplay of playlist.

Appears to fix
https://www.reddit.com/r/Enhancement/comments/50qnyj/announcement_res_v500_release/d78js0p
https://www.reddit.com/r/RESissues/comments/50xux9/bugproblem_with_youtube_playlists_in_expandos/