### PR TITLE
showImages video: Fix sourceErrorFallback replacing the wrong element

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1743,7 +1743,7 @@ function videoAdvanced(options) {
 
 	function sourceErrorFallback() {
 		if (fallback) {
-			$(element).replaceWith(generateImage({
+			$(player).replaceWith(generateImage({
 				...options,
 				src: fallback,
 			}));


### PR DESCRIPTION
When replacing `element` instead of `player` with the fallback, the expando will recognize the box as empty since `element` now is parentless.

Fixes https://www.reddit.com/r/RESissues/comments/5162cs/bug_duplicatingstacking_gif_when_opening_more/