### PR TITLE
keyboardNav commentLink: Create option for whether to toggle expando instead of opening link

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -120,7 +120,14 @@ module.options = {
 		description: 'Which side commentsLinkNumbers are displayed',
 		advanced: true,
 	},
+	commentsLinkToggleExpando: {
+		dependsOn: 'commentsLinkNumbers',
+		type: 'boolean',
+		value: true,
+		description: 'When a link has an expando, toggle it instead of opening the link.',
+	},
 	commentsLinkNewTab: {
+		dependsOn: 'commentsLinkNumbers',
 		type: 'boolean',
 		value: true,
 		description: 'Open number key links in a new tab',
@@ -1253,7 +1260,7 @@ function commentLink(index) {
 	if (!link) return;
 
 	const expando = ShowImages.getLinkExpando(link);
-	if (expando) {
+	if (module.options.commentsLinkToggleExpando.value && expando) {
 		click(expando.button);
 	} else if (module.options.commentsLinkNewTab.value) {
 		openNewTab(link.href, module.options.followLinkNewTabFocus.value);


### PR DESCRIPTION
By request, since a lot of people became accustomed to it being broken (it always opened the link).

Future feature: Create alt-mode for links, perhaps so it can be opened or toggled depending on `shift` is pressed.

https://www.reddit.com/r/RESAnnouncements/comments/50qer8/announcement_res_v500_release/d79m058