### PR TITLE
dashboard: fix tabs

### DIFF
--- a/lib/css/modules/_dashboard.scss
+++ b/lib/css/modules/_dashboard.scss
@@ -374,3 +374,21 @@ ul.widgetStateButtons {
 #userTaggerTable tr:hover .deleteIcon {
 	color: #369;
 }
+
+.res-r-dashboard {
+	.tabmenu li:not(.res-tabmenu-button),
+	.pagename {
+		display: none;
+	}
+
+	.tabmenu.res-dashboard-tabmenu-ready { display: inline-block; }
+
+	.res-dashboard-tab {
+		font-variant: small-caps;
+		font-size: 1.2em;
+		vertical-align: bottom;
+
+		// We want the tabs to act as a radio, i.e. don't allow deselect the currently selected
+		&.selected { pointer-events: none; }
+	}
+}

--- a/lib/css/modules/_dashboard.scss
+++ b/lib/css/modules/_dashboard.scss
@@ -375,7 +375,7 @@ ul.widgetStateButtons {
 	color: #369;
 }
 
-.res-r-dashboard {
+.res-dashboard {
 	.tabmenu li:not(.res-tabmenu-button),
 	.pagename {
 		display: none;

--- a/lib/css/res.scss
+++ b/lib/css/res.scss
@@ -1829,16 +1829,12 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 	user-select: none;
 	display: inline-block;
 
-	label {
+	a {
 		cursor: pointer;
 
 		&::after {
 			content: attr(aftercontent);
 		}
-	}
-
-	input {
-		display: none;
 	}
 }
 

--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -483,7 +483,7 @@ function pinCommonElements(sm) {
 function restoreSavedTab() {
 	CreateElement.tabMenuItem({
 		text: 'saved',
-	}).label.addEventListener('click', () => { location.href = `/user/${loggedInUser()}/saved/`; });
+	}).addEventListener('change', () => { location.href = `/user/${loggedInUser()}/saved/`; });
 }
 
 function applyNoCtrlF(searchIn) {

--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -21,6 +21,7 @@ module.moduleID = 'dashboard';
 module.moduleName = 'RES Dashboard';
 module.category = 'Productivity';
 module.description = 'The RES Dashboard is home to a number of features including widgets and other useful tools';
+module.bodyClass = true;
 module.options = {
 	menuItem: {
 		type: 'boolean',

--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -1,6 +1,7 @@
 import { $ } from '../vendor';
 import {
 	Alert,
+	CreateElement,
 	currentSubreddit,
 	formatDateTime,
 	invokeAll,
@@ -10,6 +11,7 @@ import {
 	watchers,
 } from '../utils';
 import { Storage } from '../environment';
+import * as Modules from '../core/modules';
 import * as Menu from './menu';
 import * as Notifications from './notifications';
 
@@ -19,7 +21,6 @@ module.moduleID = 'dashboard';
 module.moduleName = 'RES Dashboard';
 module.category = 'Productivity';
 module.description = 'The RES Dashboard is home to a number of features including widgets and other useful tools';
-module.alwaysEnabled = true;
 module.options = {
 	menuItem: {
 		type: 'boolean',
@@ -65,45 +66,63 @@ module.options = {
 		advanced: true,
 	},
 };
+module.shouldRun = () => isCurrentSubreddit('dashboard');
 
-export let widgets = [];
+module.always = () => {
+	if (Modules.isEnabled(module)) {
+		if (module.options.menuItem.value) Menu.addMenuItem('<div id="DashboardLink"><a href="/r/Dashboard">my dashboard</a></div>', null, true);
+		if (module.options.dashboardShortcut.value && currentSubreddit()) addDashboardShortcuts();
+	}
+};
 
 module.go = async () => {
 	await getLatestWidgets();
 
-	if (module.options.menuItem.value) {
-		Menu.addMenuItem('<div id="DashboardLink"><a href="/r/Dashboard">my dashboard</a></div>', null, true);
-	}
-	if (currentSubreddit()) {
-		if (module.options.dashboardShortcut.value) addDashboardShortcuts();
-	}
+	drawDashboard();
+
+	document.querySelector('#header-bottom-left .tabmenu').classList.add('res-dashboard-tabmenu-ready');
 };
 
-module.afterLoad = () => {
-	// needs to be done in afterLoad so other modules have a chance to add pages
-	if (isCurrentSubreddit('dashboard')) {
-		$('#noresults, #header-bottom-left .tabmenu:not(".viewimages")').hide();
-		$('#header-bottom-left .redditname a:first').text('My Dashboard');
-		drawDashboard();
-	}
-};
+const initialTabID = location.hash.replace('#', '') || 'dashboardContents';
+let selectedTabMenuItem;
+
+export function addTab(tabID, tabName) {
+	const $tabPage = $('<div class="dashboardPane">').appendTo('#siteTable.linklisting').hide();
+
+	const tabMenuItem = CreateElement.tabMenuItem({
+		text: tabName,
+		className: 'res-dashboard-tab',
+		prepend: true,
+	});
+	tabMenuItem.addEventListener('change', ({ detail: active }) => {
+		if (active) {
+			$tabPage.show();
+			if (selectedTabMenuItem) selectedTabMenuItem.click();
+			selectedTabMenuItem = tabMenuItem;
+			location.hash = tabID;
+		} else {
+			$tabPage.hide();
+		}
+	});
+
+	if (tabID === initialTabID) tabMenuItem.click();
+
+	return $tabPage;
+}
 
 const MAX_ROWS = 100;
+
+export let widgets = [];
 
 async function getLatestWidgets() {
 	widgets = await Storage.get(`RESmodules.dashboard.${loggedInUser()}`) || [];
 }
 
 function drawDashboard() {
-	const $dbLinks = $('span.redditname a');
-	if ($dbLinks.length > 1) {
-		$($dbLinks[0]).addClass('active');
-	}
-
 	// add each subreddit widget...
 	// add the "add widget" form...
-	attachContainer();
-	attachAddComponent();
+	const $tabPage = addTab('dashboardContents', 'My dashboard', true);
+	attachAddComponent($tabPage);
 	attachEditComponent();
 	initUpdateQueue();
 }
@@ -190,27 +209,6 @@ function saveOrder() {
 	}
 	widgets = newOrder;
 	Storage.set(`RESmodules.dashboard.${loggedInUser()}`, widgets);
-}
-
-function attachContainer() {
-	$('#siteTable.linklisting').append('<div id="dashboardContents" class="dashboardPane" />');
-	if ((location.hash !== '') && (location.hash !== '#dashboardContents')) {
-		$('span.redditname a').removeClass('active');
-		const activeTabID = location.hash.replace('#', '#tab-');
-		$(activeTabID).addClass('active');
-		$('.dashboardPane').hide();
-		$(location.hash).show();
-	} else {
-		$('#userTaggerContents').hide();
-	}
-	$('span.redditname a:first').click(function(e) {
-		e.preventDefault();
-		location.hash = 'dashboardContents';
-		$('span.redditname a').removeClass('active');
-		$(this).addClass('active');
-		$('.dashboardPane').hide();
-		$('#dashboardContents').show();
-	});
 }
 
 let widgetBeingEdited;
@@ -364,7 +362,7 @@ function showEditForm() {
 
 let $dashboardUL;
 
-function attachAddComponent() {
+function attachAddComponent($tabPage) {
 	const $dashboardAddComponent = $('<div id="RESDashboardAddComponent" class="RESDashboardComponent" />');
 	$dashboardAddComponent.html(`
 		<div class="addNewWidget">Add a new widget</div>
@@ -525,10 +523,8 @@ function attachAddComponent() {
 		$('#addSearch').val('').blur();
 		$('#addSearchFormContainer').fadeOut(() => $('#addWidgetButtons').fadeIn());
 	});
-	const $dashboardContents = $('#dashboardContents');
-	$dashboardContents.append($dashboardAddComponent);
 	$dashboardUL = $('<ul id="RESDashboard"></ul>');
-	$dashboardContents.append($dashboardUL);
+	$tabPage.append($dashboardAddComponent, $dashboardUL);
 }
 
 function addWidget(optionsObject, isNew) {
@@ -866,16 +862,4 @@ export function toggleDashboard(e) {
 		});
 		e.target.classList.add('remove');
 	}
-}
-
-export function addTab(tabID, tabName) {
-	$('#siteTable.linklisting').append(`<div id="${tabID}" class="dashboardPane" />`);
-	$('span.redditname').append(`<a id="tab-${tabID}" class="dashboardTab" title="${tabName}">${tabName}</a>`);
-	$(`#tab-${tabID}`).click(function() {
-		location.hash = tabID;
-		$('span.redditname a').removeClass('active');
-		$(this).addClass('active');
-		$('.dashboardPane').hide();
-		$(`#${tabID}`).show();
-	});
 }

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -772,8 +772,8 @@ module.go = () => {
 			CreateElement.tabMenuItem({
 				text: 'filter visited links',
 				className: 'res-filter-visited-links',
-			}).checkbox.addEventListener('change', e => {
-				removeVisitedLinksActive = e.target.checked;
+			}).addEventListener('change', e => {
+				removeVisitedLinksActive = e.detail;
 				scanEntries();
 			});
 		}

--- a/lib/modules/hosts/raddit.js
+++ b/lib/modules/hosts/raddit.js
@@ -50,7 +50,7 @@ export default {
 			title: `show/hide radd.it${path} playlist in the sidebar`,
 			text: 'playlister',
 			checked: ShowImages.module.options['always show sidebar playlister'].value,
-		}).checkbox.addEventListener('change', () => { this.toggleSidebarPlaylist(path); });
+		}).addEventListener('change', () => { this.toggleSidebarPlaylist(path); });
 	},
 	toggleSidebarPlaylist(path) {
 		const sb = document.querySelector('.side');

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -60,7 +60,7 @@ module.go = () => {
 	} else if (isCurrentSubreddit('dashboard')) {
 		// If we're on the dashboard, add a tab to it...
 		// add tab to dashboard
-		Dashboard.addTab('newCommentsContents', 'My Subscriptions');
+		const $tabPage = Dashboard.addTab('newCommentsContents', 'My Subscriptions');
 		// populate the contents of the tab
 		const $openOnReddit = $('<a href="#" id="openOnReddit">as reddit link listing</a>');
 		$openOnReddit.click(event => {
@@ -72,10 +72,10 @@ module.go = () => {
 			url += concatIds;
 			location.href = `/by_id/${url}`;
 		});
-		$('#newCommentsContents').append($openOnReddit);
+		$tabPage.append($openOnReddit);
 		const $thisTable = $('<table id="newCommentsTable" />');
 		$thisTable.append('<thead><tr><th sort="" class="active">Submission</th><th sort="subreddit">Subreddit</th><th sort="updateTime">Last viewed</th><th sort="subscriptionDate">Expires in</th><th class="actions">Actions</th></tr></thead><tbody></tbody>');
-		$('#newCommentsContents').append($thisTable);
+		$tabPage.append($thisTable);
 		$('#newCommentsTable thead th').click(function(e) {
 			e.preventDefault();
 			if ($(this).hasClass('actions')) {

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -30,7 +30,6 @@ import {
 	forEachSeq,
 	filter,
 	frameDebounce,
-	isCurrentSubreddit,
 	isPageType,
 	objectValidator,
 	waitForEvent,
@@ -498,30 +497,19 @@ let autoExpandActive = false;
 let mediaBrowseModeActive = false;
 
 export function toggleViewImages() {
-	viewImagesButton.checkbox.checked = !viewImagesButton.checkbox.checked;
-	viewImagesButton.checkbox.dispatchEvent(new Event('change'));
+	viewImagesButton.click();
 }
 
 function createImageButtons() {
-	let $mainMenuUL = $('#header-bottom-left ul.tabmenu');
-	// Create new tabmenu on these pages, regardless if one already exists.
-	if (isPageType('search', 'modqueue') || isCurrentSubreddit('dashboard')) {
-		$mainMenuUL = $('<ul>', { class: 'tabmenu viewimages' });
-		$mainMenuUL.appendTo('#header-bottom-left');
-		$mainMenuUL.css('display', 'inline-block'); // Override dashboard's subreddit style.
-	}
-
 	if (module.options.showViewImagesTab.value) {
 		viewImagesButton = CreateElement.tabMenuItem({
 			text: 'show images',
 			className: 'res-show-images',
+			aftercontent: ' (0)', // initial count…
 		});
 
-		// Always show a count
-		viewImagesButton.label.setAttribute('aftercontent', ' (0)');
-
-		viewImagesButton.checkbox.addEventListener('change', e => {
-			autoExpandActive = e.target.checked;
+		viewImagesButton.addEventListener('change', e => {
+			autoExpandActive = e.detail;
 			// When activated, open the new ones in addition to the ones already open
 			// When deactivated, close all which are open
 			updateRevealedImages({ onlyOpen: autoExpandActive });
@@ -537,7 +525,7 @@ const updateAutoExpandCount = _.debounce(() => {
 			expando::isExpandWanted({ autoExpand: true }))
 		.length;
 
-	viewImagesButton.label.setAttribute('aftercontent', ` (${count})`);
+	viewImagesButton.setAttribute('aftercontent', ` (${count})`);
 }, 200);
 
 const updateRevealedImages = _.debounce(({ onlyOpen = false } = {}) => {

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -89,12 +89,12 @@ module.go = () => {
 	// If we're on the dashboard, add a tab to it...
 	if (isCurrentSubreddit('dashboard')) {
 		// add tab to dashboard
-		Dashboard.addTab('userTaggerContents', 'My User Tags');
+		const $tabPage = Dashboard.addTab('userTaggerContents', 'My User Tags');
 		// populate the contents of the tab
 		const $showDiv = $('<div class="show">Show </div>');
 		const $tagFilter = $('<select id="tagFilter"><option>tagged users</option><option>all users</option></select>');
 		$($showDiv).append($tagFilter);
-		$('#userTaggerContents').append($showDiv);
+		$tabPage.append($showDiv);
 		$('#tagFilter').change(() => drawUserTagTable());
 
 		const tagsPerPage = parseInt(Dashboard.module.options.tagsPerPage.value, 10);
@@ -134,7 +134,7 @@ module.go = () => {
 			});
 			controlWrapper.appendChild(rightButton);
 
-			$('#userTaggerContents').append(controlWrapper);
+			$tabPage.append(controlWrapper);
 		}
 		const $thisTable = $(`
 			<table id="userTaggerTable">
@@ -151,7 +151,7 @@ module.go = () => {
 			</table>
 		`);
 
-		$('#userTaggerContents').append($thisTable);
+		$tabPage.append($thisTable);
 		$('#userTaggerTable thead th').click(function(e) {
 			e.preventDefault();
 			const $this = $(this);

--- a/lib/templates/tabMenuLink.mustache
+++ b/lib/templates/tabMenuLink.mustache
@@ -1,8 +1,3 @@
-<li class="res-tabmenu-button">
-	<a class="{{ className }}" {{#title}}title="{{ title }}"{{/title}}>
-	<label>
-		<input type="checkbox" {{checked}}>
-		{{text}}
-	</label>
-	</a>
+<li class="res-tabmenu-button {{#checked}}selected{{/checked}} {{ className }}">
+	<a {{#title}}title="{{ title }}"{{/title}} {{#aftercontent}}aftercontent="{{aftercontent}}"{{/aftercontent}}>{{text}}</a>
 </li>

--- a/lib/utils/createElement.js
+++ b/lib/utils/createElement.js
@@ -1,5 +1,6 @@
 import { $ } from '../vendor';
 import tabMenuLinkTemplate from '../templates/tabMenuLink.mustache';
+import { isPageType } from './';
 
 export function toggleButton(onClick = () => {}, fieldID, enabled = false, onText = 'on', offText = 'off', isTable = false) {
 	const $thisToggle = $('<div>', {
@@ -83,28 +84,30 @@ export function table(items, callback) {
 }
 
 export function tabMenuItem(options) {
-	const menu = document.querySelector('#header-bottom-left ul.tabmenu');
+	let menu = document.querySelector('#header-bottom-left ul.tabmenu');
+
+	// Build missing menu if on some of the sites that doesn't have one
+	if (!menu && isPageType('search', 'modqueue')) {
+		menu = $('<ul>', { class: 'tabmenu' })
+			.appendTo('#header-bottom-left')
+			.get(0);
+	} else if (!menu) {
+		console.error('Could not find tab menu');
+		return document.createElement('a');
+	}
 
 	const element = $(tabMenuLinkTemplate(options))[0];
 
-	try {
-		menu.appendChild(element);
-	} catch (e) {
-		console.error('Could not find tab menu');
-		return {
-			label: document.createElement('div'),
-			checkbox: document.createElement('input'),
-		};
-	}
+	if (options.prepend) $(menu).prepend(element);
+	else menu.appendChild(element);
 
-	const checkbox = element.querySelector('input');
-	checkbox.addEventListener('change', e => {
-		e.stopPropagation();
-		element.classList.toggle('selected', checkbox.checked);
+	let checked = options.checked;
+	const a = element.querySelector('a');
+	a.addEventListener('click', () => {
+		checked = !checked;
+		element.classList.toggle('selected', checked);
+		a.dispatchEvent(new CustomEvent('change', { detail: checked }));
 	});
 
-	return {
-		label: element.querySelector('label'),
-		checkbox,
-	};
+	return a;
 }


### PR DESCRIPTION
- Adds  `filter visited links` and `show images` buttons back to the dashboard.
- Limits running the dashboard module to when visiting `/r/dashboard`
- It also changes of the tab menu buttons a little, as they were too structurally different from the native ones to always work as intended.
 - Clicking on the padding didn't trigger a `change` event 

Side effects:
- In the gear menu, `my dashboard` is below `RES console settings` (this is IMO preferable)
- In the dashboard, the tab items are a little reordered and has different styles (as the style is defined in the subreddit stylesheet).