### PR TITLE
neverEndingReddit: Fix auto load option not always being acknowledged

### DIFF
--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -32,23 +32,18 @@ module.options = {
 		value: true,
 		description: 'Automatically load new page on scroll (if off, you click to load)',
 	},
+	pauseAfterEvery: {
+		dependsOn: 'autoLoad',
+		type: 'text',
+		value: 0,
+		description: 'After auto-loading a certain number of pages, pause the auto-loader<br><br>0 or a negative number means Never-Ending Reddit will only pause when you click the play/pause button in the top right corner.',
+	},
 	reversePauseIcon: {
+		dependsOn: 'autoLoad',
 		type: 'boolean',
 		value: false,
 		description: 'Show "paused" bars icon when auto-load is paused and "play" wedge icon when active',
 		advanced: true,
-	},
-	showServerInfo: {
-		type: 'boolean',
-		value: false,
-		description: 'Show the π server / debug details next to the floating Never-Ending Reddit tools',
-		advanced: true,
-		bodyClass: true,
-	},
-	pauseAfterEvery: {
-		type: 'text',
-		value: 0,
-		description: 'After auto-loading a certain number of pages, pause the auto-loader<br><br>0 or a negative number means Never-Ending Reddit will only pause when you click the play/pause button in the top right corner.',
 	},
 	hideDupes: {
 		type: 'enum',
@@ -64,6 +59,13 @@ module.options = {
 			value: 'none',
 		}],
 		description: 'Fade or completely hide duplicate posts already showing on the page.',
+		bodyClass: true,
+	},
+	showServerInfo: {
+		type: 'boolean',
+		value: false,
+		description: 'Show the π server / debug details next to the floating Never-Ending Reddit tools',
+		advanced: true,
 		bodyClass: true,
 	},
 };
@@ -101,11 +103,11 @@ module.go = () => {
 
 	if (nextPrevLinks && nextPrevLinks.next) {
 		nextPageURL = nextPrevLinks.next.getAttribute('href');
-		initiate(nextPrevLinks.next);
+		initiate();
 	}
 };
 
-function initiate(nextLink) {
+function initiate() {
 	siteTable.classList.add('res-ner-listing');
 
 	// modified from a contribution by Peter Siewert, thanks Peter!
@@ -116,10 +118,10 @@ function initiate(nextLink) {
 	}
 
 	attachLoaderWidget();
-	addPauseControls();
 
-	// watch for the user scrolling to the bottom of the page.  If they do it, load a new page.
-	if (module.options.autoLoad.value && nextLink) {
+	if (module.options.autoLoad.value) {
+		addPauseControls();
+		// watch for the user scrolling to the bottom of the page.  If they do it, load a new page.
 		window.addEventListener('scroll', _.debounce(handleScroll, 300));
 	}
 }


### PR DESCRIPTION
The `handleScroll` function was invoked via `togglePause`.

This also hides the toggle pause floater if `autoLoad` is disabled, and fixes option dependencies.