### PR TITLE
keyboardNav: Generate commentsLinkNumbers dynamically

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -124,7 +124,7 @@ module.options = {
 		dependsOn: 'commentsLinkNumbers',
 		type: 'boolean',
 		value: true,
-		description: 'When a link has an expando, toggle it instead of opening the link. Holding shift inverts this action.',
+		description: 'When a link has an expando, toggle it instead of opening the link. Holding alt inverts this action.',
 	},
 	commentsLinkNewTab: {
 		dependsOn: 'commentsLinkNumbers',
@@ -588,7 +588,7 @@ const commands = {
 		description: 'Move down using Comment Navigator',
 		callback() { CommentNavigator.moveDown(); },
 	},
-	// numbers and numkeys are used by commentLinks (see getCommentsLinkKeyArrays)
+	// numbers and numpad numbers are used by commentsLink (see getCommentsLinkKeys)
 };
 
 module.loadDynamicOptions = () => {
@@ -683,32 +683,32 @@ const drawHelp = _.once(() => {
 	return $(keyHelpTemplate({ keys })).appendTo(document.body);
 });
 
-function getCommentsLinkKeyArrays() {
-	const keyArrays = [];
+function getCommentsLinkKeys() {
+	const keys = [];
 
-	function addArray(key, index) {
-		keyArrays.push({
+	function addKey(key, index) {
+		keys.push({
 			type: 'keycode',
 			value: [key, false, false, false], // number
 			callback() { commentLink(index); },
 		}, {
 			type: 'keycode',
-			value: [key, true, false, false], // shift-number
+			value: [key, true, false, false], // alt-number
 			callback() { commentLink(index, true); },
 		});
 	}
 
 	if (module.options.commentsLinkNumbers.value && isPageType('comments')) {
-		[49, 50, 51, 52, 53, 54, 55, 56, 57, 48].forEach(addArray);
-		[97, 98, 99, 100, 101, 102, 103, 104, 105, 96].forEach(addArray);
+		[49, 50, 51, 52, 53, 54, 55, 56, 57, 48].forEach(addKey); // numbers 1 2 3 4 5 6 7 8 9 0
+		[97, 98, 99, 100, 101, 102, 103, 104, 105, 96].forEach(addKey); // numpad 1 2 3 4 5 6 7 8 9 0
 	}
 
-	return keyArrays;
+	return keys;
 }
 
 const _commandLookup = _.once(() => {
 	const lookup = {};
-	for (const option of [...Object.values(module.options), ...getCommentsLinkKeyArrays()]) {
+	for (const option of [...Object.values(module.options), ...getCommentsLinkKeys()]) {
 		if (option.type !== 'keycode') continue;
 		if (!option.callback) continue;
 		if (!matchesPageLocation(option.include, option.exclude)) continue;

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -124,7 +124,7 @@ module.options = {
 		dependsOn: 'commentsLinkNumbers',
 		type: 'boolean',
 		value: true,
-		description: 'When a link has an expando, toggle it instead of opening the link.',
+		description: 'When a link has an expando, toggle it instead of opening the link. Holding shift inverts this action.',
 	},
 	commentsLinkNewTab: {
 		dependsOn: 'commentsLinkNumbers',
@@ -566,126 +566,6 @@ const commands = {
 		callback: prevPage,
 		goMode: true,
 	},
-	link1: {
-		value: [49, false, false, false], // 1
-		description: 'Open first link within comment.',
-		noconfig: true,
-		callback() { commentLink(0); },
-	},
-	link2: {
-		value: [50, false, false, false], // 2
-		description: 'Open link #2 within comment.',
-		noconfig: true,
-		callback() { commentLink(1); },
-	},
-	link3: {
-		value: [51, false, false, false], // 3
-		description: 'Open link #3 within comment.',
-		noconfig: true,
-		callback() { commentLink(2); },
-	},
-	link4: {
-		value: [52, false, false, false], // 4
-		description: 'Open link #4 within comment.',
-		noconfig: true,
-		callback() { commentLink(3); },
-	},
-	link5: {
-		value: [53, false, false, false], // 5
-		description: 'Open link #5 within comment.',
-		noconfig: true,
-		callback() { commentLink(4); },
-	},
-	link6: {
-		value: [54, false, false, false], // 6
-		description: 'Open link #6 within comment.',
-		noconfig: true,
-		callback() { commentLink(5); },
-	},
-	link7: {
-		value: [55, false, false, false], // 7
-		description: 'Open link #7 within comment.',
-		noconfig: true,
-		callback() { commentLink(6); },
-	},
-	link8: {
-		value: [56, false, false, false], // 8
-		description: 'Open link #8 within comment.',
-		noconfig: true,
-		callback() { commentLink(7); },
-	},
-	link9: {
-		value: [57, false, false, false], // 9
-		description: 'Open link #9 within comment.',
-		noconfig: true,
-		callback() { commentLink(8); },
-	},
-	link10: {
-		value: [48, false, false, false], // 0
-		description: 'Open link #10 within comment.',
-		noconfig: true,
-		callback() { commentLink(9); },
-	},
-	link1NumPad: {
-		value: [97, false, false, false], // 1
-		description: 'Open first link within comment.',
-		noconfig: true,
-		callback() { commentLink(0); },
-	},
-	link2NumPad: {
-		value: [98, false, false, false], // 2
-		description: 'Open link #2 within comment.',
-		noconfig: true,
-		callback() { commentLink(1); },
-	},
-	link3NumPad: {
-		value: [99, false, false, false], // 3
-		description: 'Open link #3 within comment.',
-		noconfig: true,
-		callback() { commentLink(2); },
-	},
-	link4NumPad: {
-		value: [100, false, false, false], // 4
-		description: 'Open link #4 within comment.',
-		noconfig: true,
-		callback() { commentLink(3); },
-	},
-	link5NumPad: {
-		value: [101, false, false, false], // 5
-		description: 'Open link #5 within comment.',
-		noconfig: true,
-		callback() { commentLink(4); },
-	},
-	link6NumPad: {
-		value: [102, false, false, false], // 6
-		description: 'Open link #6 within comment.',
-		noconfig: true,
-		callback() { commentLink(5); },
-	},
-	link7NumPad: {
-		value: [103, false, false, false], // 7
-		description: 'Open link #7 within comment.',
-		noconfig: true,
-		callback() { commentLink(6); },
-	},
-	link8NumPad: {
-		value: [104, false, false, false], // 8
-		description: 'Open link #8 within comment.',
-		noconfig: true,
-		callback() { commentLink(7); },
-	},
-	link9NumPad: {
-		value: [105, false, false, false], // 9
-		description: 'Open link #9 within comment.',
-		noconfig: true,
-		callback() { commentLink(8); },
-	},
-	link10NumPad: {
-		value: [96, false, false, false], // 0
-		description: 'Open link #10 within comment.',
-		noconfig: true,
-		callback() { commentLink(9); },
-	},
 	toggleCommentNavigator: {
 		include: 'comments',
 		value: [78, false, false, false], // N
@@ -708,6 +588,7 @@ const commands = {
 		description: 'Move down using Comment Navigator',
 		callback() { CommentNavigator.moveDown(); },
 	},
+	// numbers and numkeys are used by commentLinks (see getCommentsLinkKeyArrays)
 };
 
 module.loadDynamicOptions = () => {
@@ -802,9 +683,32 @@ const drawHelp = _.once(() => {
 	return $(keyHelpTemplate({ keys })).appendTo(document.body);
 });
 
+function getCommentsLinkKeyArrays() {
+	const keyArrays = [];
+
+	function addArray(key, index) {
+		keyArrays.push({
+			type: 'keycode',
+			value: [key, false, false, false], // number
+			callback() { commentLink(index); },
+		}, {
+			type: 'keycode',
+			value: [key, true, false, false], // shift-number
+			callback() { commentLink(index, true); },
+		});
+	}
+
+	if (module.options.commentsLinkNumbers.value && isPageType('comments')) {
+		[49, 50, 51, 52, 53, 54, 55, 56, 57, 48].forEach(addArray);
+		[97, 98, 99, 100, 101, 102, 103, 104, 105, 96].forEach(addArray);
+	}
+
+	return keyArrays;
+}
+
 const _commandLookup = _.once(() => {
 	const lookup = {};
-	for (const option of Object.values(module.options)) {
+	for (const option of [...Object.values(module.options), ...getCommentsLinkKeyArrays()]) {
 		if (option.type !== 'keycode') continue;
 		if (!option.callback) continue;
 		if (!matchesPageLocation(option.include, option.exclude)) continue;
@@ -1255,12 +1159,12 @@ function prevPage() {
 	}
 }
 
-function commentLink(index) {
+function commentLink(index, altMode = false) {
 	const link = linkAnnotations[index] && linkAnnotations[index].link;
 	if (!link) return;
 
 	const expando = ShowImages.getLinkExpando(link);
-	if (module.options.commentsLinkToggleExpando.value && expando) {
+	if (expando && (module.options.commentsLinkToggleExpando.value !== altMode)) {
 		click(expando.button);
 	} else if (module.options.commentsLinkNewTab.value) {
 		openNewTab(link.href, module.options.followLinkNewTabFocus.value);


### PR DESCRIPTION
- So that `Event.preventDefault` won't be invoked when `commentsLinkNumbers` is disabled
- Provide alternative mode to invert `commentsLinkToggleExpando` action (toggle expando vs open in new tab)

Fixes https://www.reddit.com/r/RESissues/comments/518czp/bug_commentslinknumbers_interferes_with_single/