### PR TITLE
selectedEntry: Selecting on mousedown may disrupt click handlers; use mouseup instead

### DIFF
--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -107,7 +107,7 @@ module.go = () => {
 		window.addEventListener('scroll', _.debounce(autoSelect, 300));
 	}
 	if (module.options.selectOnClick.value) {
-		$(document.body).on('mousedown', Thing.bodyThingSelector, handleClick);
+		$(document.body).on('mouseup', Thing.bodyThingSelector, handleClick);
 	}
 
 	if (module.options.addFocusBGColor.value) {


### PR DESCRIPTION
Fixes https://www.reddit.com/r/RESissues/comments/51aphm/bug_problematic_interaction_of_comment_expandos

Selecting something sometimes causes elements to move around, so that the user-click won't register on the element as intended. 

Regression caused by #3364