### PR TITLE
Move mediaBrowse logic to showImages

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -185,7 +185,7 @@ const commands = {
 		value: [75, false, false, false], // k
 		description: 'Move up to the previous link or comment in flat lists',
 		callback() {
-			move(thing => thing.getNext({ direction: 'up' }), getLinearLinklistMoveOptions());
+			move(thing => thing.getNext({ direction: 'up' }), getLinearListMoveOptions());
 		},
 	},
 	moveDown: {
@@ -193,7 +193,7 @@ const commands = {
 		value: [74, false, false, false], // j
 		description: 'Move down to the next link or comment in flat lists',
 		callback() {
-			move(thing => thing.getNext({ direction: 'down' }), getLinearLinklistMoveOptions());
+			move(thing => thing.getNext({ direction: 'down' }), getLinearListMoveOptions());
 		},
 	},
 	moveUpComment: {
@@ -783,16 +783,11 @@ function followSubreddit(newWindow) {
 	}
 }
 
-function getLinearLinklistMoveOptions() {
-	return {
-		mediaBrowse: module.options.mediaBrowseMode.value,
-		get scrollStyle() {
-			return module.options.scrollOnExpando.value && this.didAutoExpand ?
-				'top' :
-				module.options.linearScrollStyle.value;
-		},
-	};
-}
+const getLinearListMoveOptions = () => ({
+	mediaBrowse: module.options.mediaBrowseMode.value,
+	scrollStyle: module.options.linearScrollStyle.value,
+	mediaBrowseScrollStyle: module.options.scrollOnExpando.value ? 'top' : undefined,
+});
 
 export let recentKeyMove = false;
 const refreshKeyMoveTimer = _.debounce(() => { recentKeyMove = false; }, 1000);

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -12,7 +12,6 @@ import {
 	hashKeyArray,
 	hashKeyEvent,
 	isCommentCode,
-	isCurrentSubreddit,
 	isEmptyLink,
 	isPageType,
 	loggedInUser,
@@ -186,17 +185,16 @@ const commands = {
 		value: [75, false, false, false], // k
 		description: 'Move up to the previous link or comment in flat lists',
 		callback() {
-			move(
-				thing => thing.getNext({ direction: 'up' }),
-				{ scrollStyle: module.options.linearScrollStyle.value, tryMediaBrowse: true }
-			);
+			move(thing => thing.getNext({ direction: 'up' }), getLinearLinklistMoveOptions());
 		},
 	},
 	moveDown: {
 		include: ['linklist', 'modqueue', 'profile', 'search'],
 		value: [74, false, false, false], // j
 		description: 'Move down to the next link or comment in flat lists',
-		callback: moveDown,
+		callback() {
+			move(thing => thing.getNext({ direction: 'down' }), getLinearLinklistMoveOptions());
+		},
 	},
 	moveUpComment: {
 		include: ['comments', 'inbox'],
@@ -763,7 +761,7 @@ function hideLink() {
 	}
 
 	if (module.options.onHideMoveDown.value) {
-		SelectedEntry.selectClosestVisible({ scrollStyle: 'none' });
+		SelectedEntry.selectClosestVisible({ scrollStyle: 'none', mediaBrowse: module.options.mediaBrowseMode.value });
 	}
 }
 
@@ -785,10 +783,21 @@ function followSubreddit(newWindow) {
 	}
 }
 
+function getLinearLinklistMoveOptions() {
+	return {
+		mediaBrowse: module.options.mediaBrowseMode.value,
+		get scrollStyle() {
+			return module.options.scrollOnExpando.value && this.didAutoExpand ?
+				'top' :
+				module.options.linearScrollStyle.value;
+		},
+	};
+}
+
 export let recentKeyMove = false;
 const refreshKeyMoveTimer = _.debounce(() => { recentKeyMove = false; }, 1000);
 
-function move(target, { scrollStyle = 'legacy', tryMediaBrowse = false } = {}) {
+function move(target, options) {
 	const selected = SelectedEntry.selectedThing();
 
 	if (typeof target === 'function') {
@@ -801,38 +810,12 @@ function move(target, { scrollStyle = 'legacy', tryMediaBrowse = false } = {}) {
 
 	if (!target) return null;
 
-	if (module.options.mediaBrowseMode.value && tryMediaBrowse && selected) {
-		const didExpand = ShowImages.mediaBrowseMode(selected, target);
-		if (didExpand && module.options.scrollOnExpando.value) scrollStyle = 'top';
-	}
-
-	SelectedEntry.select(target, { scrollStyle });
+	SelectedEntry.select(target, options);
 
 	recentKeyMove = true;
 	refreshKeyMoveTimer();
 
 	return target;
-}
-
-function moveDown() {
-	const target = move(
-		thing => thing.getNext({ direction: 'down' }),
-		{ scrollStyle: module.options.linearScrollStyle.value, tryMediaBrowse: true }
-	);
-
-	if (
-		target &&
-		!isCurrentSubreddit('dashboard') &&
-		isPageType('linklist', 'modqueue') &&
-		Modules.isRunning(NeverEndingReddit) &&
-		NeverEndingReddit.module.options.autoLoad.value
-	) {
-		const things = Thing.visibleThingElements();
-		if (things.indexOf(target.element) + 2 > things.length) {
-			// nearing the bottom of the list, so initiate load of next page
-			nextPage();
-		}
-	}
 }
 
 function showParents() {
@@ -993,7 +976,7 @@ function upVote(preventToggle) {
 
 	const link = isPageType('linklist', 'modqueue', 'profile');
 	if (link && module.options.onVoteMoveDown.value || !link && module.options.onVoteCommentMoveDown.value) {
-		moveDown();
+		module.options.moveDown.callback();
 	}
 }
 
@@ -1017,7 +1000,7 @@ function downVote(preventToggle) {
 
 	const link = isPageType('linklist', 'modqueue', 'profile');
 	if (link && module.options.onVoteMoveDown.value || !link && module.options.onVoteCommentMoveDown.value) {
-		moveDown();
+		module.options.moveDown.callback();
 	}
 }
 

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -123,6 +123,16 @@ function initiate() {
 		addPauseControls();
 		// watch for the user scrolling to the bottom of the page.  If they do it, load a new page.
 		window.addEventListener('scroll', _.debounce(handleScroll, 300));
+
+		SelectedEntry.addListener(selected => {
+			if (!selected) return;
+
+			const things = Thing.visibleThingElements();
+			if (things.indexOf(selected.element) + 2 > things.length) {
+				// nearing the bottom of the list, so initiate load of next page
+				loadNewPage();
+			}
+		});
 	}
 }
 

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -117,7 +117,14 @@ module.go = () => {
 		addFocusBorder();
 	}
 
-	setTimeout(selectInitial, 100);
+	addListener((selected, unselected) => unselected && Hover.infocard('showParent').close(false));
+	addListener(updateActiveElement);
+	addListener(updateLastSelectedCache);
+};
+
+module.afterLoad = () => {
+	// Do not re-select if user has already selected something
+	if (!selectedThing) selectInitial();
 };
 
 const onClick = _.throttle(e => {
@@ -173,11 +180,14 @@ function _select(thingOrEntry, options = {}) {
 	const newSelected = newThing;
 	const oldSelected = selectedThing;
 
-	const direction = newThing && newThing.isVisible() && oldSelected && oldSelected.isVisible() ?
+	options.direction = newThing && newThing.isVisible() && oldSelected && oldSelected.isVisible() ?
 		(newThing.entry.getBoundingClientRect().top > oldSelected.entry.getBoundingClientRect().top ? 'down' : 'up') :
 		null;
 
-	listeners.fire(newSelected, oldSelected, { direction, ...options });
+	listeners.fire(newSelected, oldSelected, options);
+
+	// options.scrollStyle may be dynamic and depend on whether options was mutated, so scroll after all callbacks are completed
+	scrollToElement(newThing.entry, options);
 
 	selectedThing = newSelected;
 	selectedContainer = newSelected && $(newSelected.thing).parent().closest('.thing');
@@ -201,19 +211,6 @@ function onNewComments(entry) {
 		}
 	}
 }
-
-function scrollTo(selected, last, options) {
-	if (!selected) return;
-	scrollToElement(selected.entry, options);
-}
-
-// this is run immediately for a reason, but I don't know/remember why
-(function addSelectListeners() {
-	addListener((selected, unselected) => unselected && Hover.infocard('showParent').close(false));
-	addListener(updateActiveElement);
-	addListener(scrollTo);
-	addListener(updateLastSelectedCache);
-})();
 
 function updateActiveElement(selected, last) {
 	if (selected) {

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -186,7 +186,7 @@ function _select(thingOrEntry, options = {}) {
 
 	listeners.fire(newSelected, oldSelected, options);
 
-	// options.scrollStyle may be dynamic and depend on whether options was mutated, so scroll after all callbacks are completed
+	// options.scrollStyle may be changed by listeners, so have this run last
 	scrollToElement(newThing.entry, options);
 
 	selectedThing = newSelected;

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -38,6 +38,7 @@ import {
 } from '../utils';
 import { addURLToHistory, ajax, isPrivateBrowsing, openNewTab, Permissions } from '../environment';
 import * as Options from '../core/options';
+import * as SelectedEntry from './selectedEntry';
 import * as SettingsNavigation from './settingsNavigation';
 
 const hostsContext = require.context('./hosts', false, /\.js$/);
@@ -364,16 +365,18 @@ module.go = () => {
 	findAllImages(document.body);
 	document.addEventListener('dragstart', () => false);
 
+	SelectedEntry.addListener(mediaBrowse);
+
 	// Handle spotlight next/prev hiding open expando's
 	const spotlight = document.querySelector('#siteTable_organic');
 	if (spotlight) {
 		const nextprev = spotlight.querySelector('.nextprev');
-		if (!nextprev) return;
-
-		nextprev.addEventListener('click', () => {
-			const open = spotlight.querySelector('.expando-button.expanded');
-			if (open) open.click();
-		});
+		if (nextprev) {
+			nextprev.addEventListener('click', () => {
+				const open = spotlight.querySelector('.expando-button.expanded');
+				if (open) open.click();
+			});
+		}
 	}
 };
 
@@ -571,11 +574,11 @@ export function toggleThingExpandos(thing, scrollOnExpando) {
 	}
 }
 
-export function mediaBrowseMode(oldThing, newThing) {
-	if (autoExpandActive) return false;
+function mediaBrowse(selected, unselected, options) {
+	if (!selected || !options.mediaBrowse || autoExpandActive) return;
 
-	const oldExpando = oldThing && oldThing.getEntryExpando();
-	const newExpando = newThing && newThing.getEntryExpando();
+	const oldExpando = unselected && unselected.getEntryExpando();
+	const newExpando = selected && selected.getEntryExpando();
 
 	if (oldExpando) {
 		mediaBrowseModeActive = oldExpando.expandWanted || oldExpando.open;
@@ -583,10 +586,12 @@ export function mediaBrowseMode(oldThing, newThing) {
 
 	if (mediaBrowseModeActive) {
 		if (oldExpando) oldExpando.collapse();
-		if (newExpando) newExpando.expand();
-	}
 
-	return newExpando && mediaBrowseModeActive;
+		if (newExpando) {
+			newExpando.expand();
+			options.didAutoExpand = true;
+		}
+	}
 }
 
 function isExpandWanted({

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -586,10 +586,9 @@ function mediaBrowse(selected, unselected, options) {
 
 	if (mediaBrowseModeActive) {
 		if (oldExpando) oldExpando.collapse();
-
 		if (newExpando) {
 			newExpando.expand();
-			options.didAutoExpand = true;
+			if (options.mediaBrowseScrollStyle) options.scrollStyle = options.mediaBrowseScrollStyle;
 		}
 	}
 }


### PR DESCRIPTION
By removing the mediaBrowse logic from the `move` function, it can easier by invoked by other select functions.

Fixes https://www.reddit.com/r/RESissues/comments/51nu5e/bug_images_not_autoexpanding_next_post_after/?ref=search_posts