### PR TITLE
showImages video: conserveMemory & defer play until visible

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -47,6 +47,7 @@ import {
 	isPageType,
 	waitForEvent,
 	watchForElement,
+	getPercentageVisibleYAxis,
 } from '../utils';
 import { addURLToHistory, ajax, isPrivateBrowsing, openNewTab, Permissions } from '../environment';
 import * as Options from '../core/options';
@@ -346,6 +347,18 @@ module.options = {
 		value: true,
 		description: 'Autoplay inline videos',
 	},
+	onlyPlayMutedWhenVisible: {
+		dependsOn: 'autoplayVideo',
+		type: 'boolean',
+		value: true,
+		description: 'Auto-pause muted videos when they are not visible.',
+	},
+	maxSimultaneousPlaying: {
+		dependsOn: 'autoplayVideo',
+		type: 'text',
+		value: '0',
+		description: 'Auto-play at most this many muted videos simultaneously. (0 for no limit)',
+	},
 };
 module.exclude = [
 	/^\/ads\/[\-\w\._\?=]*/i,
@@ -513,42 +526,46 @@ export const thingExpandoBuildListeners: * = $.Callbacks('unique');
  * @returns {void}
  */
 function enableConserveMemory() {
-	const refresh = _.debounce(() => {
+	const refresh = _.throttle(frameThrottle(() => {
 		const activeExpandos = Array.from(primaryExpandos.values());
+		const openExpandos = [];
 
 		// Empty collapsed when beyond buffer
 		for (const expando of activeExpandos) {
 			if (!expando.isAttached()) expando.destroy();
-			else if (!expando.open && !isWithinBuffer(expando.button)) expando.empty();
+			else if (expando.open) openExpandos.push(expando);
+			else if (!isWithinBuffer(expando.button)) expando.empty();
 		}
 
 		// Unload expanded when beyond buffer
 		flow(
-			filterMap(v => {
-				if (v.isAttached() && v.open && v.media) {
-					return [{ media: v.media, data: v.media }];
-				}
+			filterMap(expando => {
+				if (expando.media) return [{ media: expando.media, data: expando.media }];
 			}),
 			lazyUnload(isWithinBuffer)
-		)(activeExpandos);
-	}, 150);
+		)(openExpandos);
+	}), 150);
 
 	window.addEventListener('scroll', refresh);
 	// not using element-resize-detector because it sets the target to `position: relative`, breaking some stylesheets (/r/nba)
 	window.addEventListener('resize', refresh);
 }
 
-const lazyUnload = _.curryRight(/*:: <T> */(expandos: Array<{ media: ?ExpandoMediaElement, data: T }>, testKeepLoaded: (data: T) => boolean) => {
-	for (const { media, data } of expandos) {
+const lazyUnload = _.curryRight(/*:: <T> */(pieces: Array<{ media: ?ExpandoMediaElement, data: T }>, testKeepLoaded: (data: T) => boolean) => {
+	const actions: Array<() => void> = [];
+
+	for (const { media, data } of pieces) {
 		if (!media || !media.unload || !media.restore) continue;
 
 		const keepLoaded = testKeepLoaded(data);
-		if (keepLoaded && media.state === mediaStates.UNLOADED && media.restore) {
-			media.restore();
-		} else if (!keepLoaded && media.state === mediaStates.LOADED && media.unload) {
-			media.unload();
+		if (/*:: media.restore && */ keepLoaded && media.state === mediaStates.UNLOADED) {
+			actions.push(media.restore);
+		} else if (/*:: media.unload && */ !keepLoaded && media.state !== mediaStates.UNLOADED) {
+			actions.push(media.unload);
 		}
 	}
+
+	for (const action of actions) action();
 });
 
 let viewImagesButton;
@@ -1756,6 +1773,55 @@ function makeMediaIndependentOnResize(media, element) {
 	};
 }
 
+
+// When videos is added, this will pause or play them individually depending on their visibility
+const mutedVideoManager = _.once(() => {
+	const maxSimultaneousPlaying = parseInt(module.options.maxSimultaneousPlaying.value, 10) || Infinity;
+	const videos: HTMLVideoElement[] = [];
+
+	const updatePlay = frameThrottle(() => {
+		const all = videos.map(video => {
+			const thing = Thing.from(video);
+			return {
+				video,
+				visibility: getPercentageVisibleYAxis(video),
+				top: video.getBoundingClientRect().top,
+				selected: Number(thing && thing.isSelected()),
+			};
+		});
+
+		const notVisible = all.filter(({ visibility }) => visibility === 0);
+		for (const { video } of notVisible) if (!video.paused) video.pause();
+
+		_.without(all, ...notVisible)
+			.sort((a, b) => b.selected - a.selected || b.visibility - a.visibility || a.top - b.top)
+			.forEach(({ video, visibility }, index) => {
+				const play = index < maxSimultaneousPlaying && visibility > 0;
+				if (play === video.paused) {
+					if (play) video.play();
+					else video.pause();
+				}
+			});
+	});
+
+	let intervalId = null;
+
+	return {
+		observe(video) {
+			videos.push(video);
+			updatePlay();
+			if (intervalId === null) intervalId = setInterval(updatePlay, 100);
+		},
+		unobserve(video) {
+			_.pull(videos, video);
+			if (!videos.length && intervalId) {
+				clearInterval(intervalId);
+				intervalId = null;
+			}
+		},
+	};
+});
+
 function videoAdvanced(options) {
 	const {
 		fallback,
@@ -1824,7 +1890,13 @@ function videoAdvanced(options) {
 		const msgSpeed = ctrlContainer.querySelector('.video-advanced-speed');
 		const msgTime = ctrlContainer.querySelector('.video-advanced-time');
 
-		ctrlTogglePause.addEventListener('click', () => { if (vid.paused) vid.play(); else vid.pause(); });
+		ctrlTogglePause.addEventListener('click', () => {
+			if (vid.paused) vid.play(); else vid.pause();
+			if (module.options.onlyPlayMutedWhenVisible.value && options.muted) {
+				autoplay = false; // Stop automatic control
+				mutedVideoManager().unobserve(vid);
+			}
+		});
 		if (ctrlReverse) ctrlReverse.addEventListener('click', reverse);
 
 		ctrlSpeedDecrease.addEventListener('click', () => { vid.playbackRate /= 1.1; });
@@ -1895,24 +1967,54 @@ function videoAdvanced(options) {
 		}
 	});
 
-	element.collapse = () => {
+	function unload() {
 		// Video is auto-paused when detached from DOM
 		if (!document.body.contains(vid)) return;
 
-		autoplay = !vid.paused;
 		if (!vid.paused) vid.pause();
 
 		time = vid.currentTime;
 		vid.setAttribute('src', ''); // vid.src has precedence over any child source element
 		vid.load();
-	};
-	element.expand = () => {
+
+		if (module.options.onlyPlayMutedWhenVisible.value && options.muted) mutedVideoManager().unobserve(vid);
+	}
+
+	function restore() {
 		if (vid.hasAttribute('src')) {
 			vid.removeAttribute('src');
 			vid.load();
 		}
 
-		if (autoplay) vid.play();
+		if (autoplay) {
+			if (module.options.onlyPlayMutedWhenVisible.value && options.muted) mutedVideoManager().observe(vid);
+			else vid.play();
+		}
+	}
+
+	element.collapse = unload;
+	element.expand = restore;
+
+	element.state = mediaStates.LOADED;
+
+	element.unload = () => {
+		if (element.state === mediaStates.UNLOADED) return;
+
+		// If video has audio, it may be in use even if it is not visible
+		if (!options.muted && !vid.paused) return;
+
+		unload();
+		element.state = mediaStates.UNLOADED;
+	};
+	element.restore = () => {
+		if (element.state === mediaStates.LOADED) return;
+
+		restore();
+		element.state = mediaStates.LOADED;
+	};
+
+	element.emitResizeEvent = () => {
+		if (element.state !== mediaStates.UNLOADED) vid.dispatchEvent(new CustomEvent('mediaResize', { bubbles: true }));
 	};
 
 	element.ready = Promise.race([waitForEvent(vid, 'suspend'), waitForEvent(lastSource, 'error')]);

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -467,4 +467,8 @@ export default class Thing {
 			!this.getClosest(function() { return this.thing.classList.contains('collapsed'); })
 		);
 	}
+
+	isSelected() {
+		return this.thing.classList.contains('RES-keyNav-activeThing');
+	}
 }


### PR DESCRIPTION
- Unload video when outside of `bufferScreens`
- Start playing video when at least `visibleThreshold` (%) of it is visible
  - It will only check while it is within `bufferScreens`
- `maxSimultaneousPlaying` can be set to only have to have a given number playing at any time.
 - Prioritized by: 1. Thing is selected. 2. Visibility.  3. Nearest top.