### PR TITLE
host : added osu.ppy.sh/ss/ expando

### DIFF
--- a/lib/modules/hosts/ppy.js
+++ b/lib/modules/hosts/ppy.js
@@ -1,0 +1,13 @@
+export default {
+	moduleID: 'ppy.sh',
+	name: 'ppy.sh',
+	domains: ['ppy.sh'],
+	logo: 'https://s.ppy.sh/favicon.ico',
+	detect: ({ href }) => (/^https?:\/\/osu.ppy.sh\/ss\/(\d+)/i).exec(href),
+	async handleLink(href, [, code]) {
+		return {
+			type: 'IMAGE',
+			src: `http://osu.ppy.sh/ss/${code}`,
+		};
+	},
+};

--- a/lib/modules/hosts/ppy.js
+++ b/lib/modules/hosts/ppy.js
@@ -1,10 +1,10 @@
 export default {
 	moduleID: 'ppy.sh',
 	name: 'ppy.sh',
-	domains: ['ppy.sh'],
+	domains: ['osu.ppy.sh'],
 	logo: 'https://s.ppy.sh/favicon.ico',
-	detect: ({ href }) => (/^https?:\/\/osu.ppy.sh\/ss\/(\d+)/i).exec(href),
-	async handleLink(href, [, code]) {
+	detect: ({ pathname }) => (/^\/ss\/(\d+)/i).exec(pathname),
+	handleLink(href, [, code]) {
 		return {
 			type: 'IMAGE',
 			src: `http://osu.ppy.sh/ss/${code}`,


### PR DESCRIPTION
Allows link with the osu.ppy.sh/ss/<id> format to be displayed with expandos.

Tested with https://www.reddit.com/domain/ppy.sh.

See [this /r/Enhancement post](https://np.reddit.com/r/Enhancement/comments/51zk40/feature_request_osuppyshss_screenshots_expandos/) for the feature request.