### PR TITLE
If element is not inside a thing, fallback to first visible thing

### DIFF
--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -716,10 +716,10 @@ function fillPlaceholders(box, macroText, selectedText) {
 			let value;
 			try {
 				value = getMagicPlaceholderValue(placeholderInnerText, macroText, selectedText, box);
-			 } catch (e) {
+			} catch (e) {
 				console.error('Error getting magic placeholder value', placeholderInnerText);
 				console.error(e);
-			 }
+			}
 			if (value === undefined) {
 				value = promptForPlaceholderValue(placeholder, macroText);
 			}

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -713,7 +713,13 @@ function fillPlaceholders(box, macroText, selectedText) {
 			completedPlaceholders[placeholder] = true;
 
 			const placeholderInnerText = placeholder.substring(2, placeholder.length - 2).toLowerCase();
-			let value = getMagicPlaceholderValue(placeholderInnerText, macroText, selectedText, box);
+			let value;
+			try {
+				value = getMagicPlaceholderValue(placeholderInnerText, macroText, selectedText, box);
+			 } catch (e) {
+				console.error('Error getting magic placeholder value', placeholderInnerText);
+				console.error(e);
+			 }
 			if (value === undefined) {
 				value = promptForPlaceholderValue(placeholder, macroText);
 			}

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -32,12 +32,17 @@ export default class Thing {
 		return Thing.visibleThingElements().map(ele => new Thing(ele));
 	}
 
+	static elementFor(element) {
+		return $(element).closest(Thing.thingSelector).get(0) || Thing.visibleThingElements()[0];
+	}
+
 	constructor(element) {
 		if (element instanceof Thing) return element;
 		if (things.has(element)) return things.get(element);
 
-		this.$thing = $(element).closest(Thing.thingSelector);
-		this.element = this.thing = this.$thing[0];
+		const thingElement = Thing.elementFor(element);
+		this.$thing = $(thingElement);
+		this.element = this.thing = thingElement;
 
 		if (!this.element) return this;
 

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -134,7 +134,7 @@ export default class Thing {
 	}
 
 	isComment() {
-		return this.thing.classList.contains('comment');
+		return this.thing.classList.contains('comment') || this.thing.classList.contains('was-comment');
 	}
 
 	getTitle() {
@@ -195,8 +195,8 @@ export default class Thing {
 		if (this.isPost()) {
 			return this.entry.querySelector('.tagline a.subreddit, a.search-subreddit-link');
 		} else if (this.isComment()) {
-			// TODO: does this work?
-			return this.entry.querySelector('.parent a.subreddit');
+			// TODO: does .parent a.subreddit work?
+			return this.entry.querySelector('.parent a.subreddit, .tagline .subreddit a');
 		}
 	}
 


### PR DESCRIPTION
Fixes #3426: if the reference element (e.g. "add a comment" text area on top-level comment) isn't inside a thing, use the first visible thing and assume it's the main thing, e.g. on a comments page, the original post.  May need refining later.

also some incidental fixups