### PR TITLE
Don't track visits incognito

### DIFF
--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -14,7 +14,7 @@ import {
 	regexes,
 	watchForElement,
 } from '../utils';
-import { Storage } from '../environment';
+import { Storage, isPrivateBrowsing } from '../environment';
 import * as Dashboard from './dashboard';
 import * as Notifications from './notifications';
 
@@ -39,6 +39,19 @@ module.options = {
 		type: 'boolean',
 		value: true,
 		description: 'Show the Subscribe button?',
+	},
+	monitorPostsVisited: {
+		type: 'boolean',
+		value: true,
+		description: 'Monitor the number of comments on posts you have visited.',
+		advanced: true,
+	},
+	monitorPostsVisitedIncognito: {
+		dependsOn: 'monitorPostsVisited',
+		type: 'boolean',
+		value: false,
+		description: 'Monitor the number of comments on posts you have visited while browsing in incognito/private mode.',
+		advanced: true,
 	},
 };
 
@@ -300,7 +313,10 @@ let currentCommentID;
  * @param {int} newCommentCount - new number of comments to save
  * @returns {bool}
  */
-function saveCommentCount(commentID, newCommentCount) {
+async function saveCommentCount(commentID, newCommentCount) {
+	if (!module.options.monitorPostsVisited.value) return;
+	if (!module.options.monitorPostsVisitedIncognito.value && await isPrivateBrowsing()) return;
+
 	commentCounts[commentID] = commentCounts[commentID] || {};
 
 	const patch = {

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -314,8 +314,8 @@ let currentCommentID;
  * @returns {bool}
  */
 async function saveCommentCount(commentID, newCommentCount) {
-	if (!module.options.monitorPostsVisited.value) return;
-	if (!module.options.monitorPostsVisitedIncognito.value && await isPrivateBrowsing()) return;
+	if (!module.options.monitorPostsVisited.value) return false;
+	if (!module.options.monitorPostsVisitedIncognito.value && await isPrivateBrowsing()) return false;
 
 	commentCounts[commentID] = commentCounts[commentID] || {};
 

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -12,7 +12,7 @@ import {
 	string,
 	watchForElement,
 } from '../utils';
-import { Session, Storage, ajax } from '../environment';
+import { Session, Storage, ajax, isPrivateBrowsing } from '../environment';
 import * as Notifications from './notifications';
 import * as SettingsNavigation from './settingsNavigation';
 
@@ -114,6 +114,19 @@ module.options = {
 		type: 'boolean',
 		value: true,
 		description: 'Show last update information on the front page (work only if you have at least 50/100 subscription, see <a href="/r/help/wiki/faq#wiki_some_of_my_subreddits_keep_disappearing.__why.3F">here</a> for more info).',
+	},
+	trackVisitedSubreddit: {
+		type: 'boolean',
+		value: true,
+		description: 'Mark subreddits visited when you visit a post listing, comments page, wiki, etc.',
+		advanced: true,
+	},
+	trackVisitedSubredditIncognito: {
+		dependsOn: 'trackVisitedSubreddit',
+		type: 'boolean',
+		value: false,
+		description: 'Mark subreddits visited when browsing in incognito/private mode.',
+		advanced: true,
 	},
 	/*		sortingField: {
 		type: 'enum',
@@ -1338,6 +1351,9 @@ async function removeSubredditShortcut(subreddit) {
 }
 
 async function setLastViewtime() {
+	if (!module.options.trackVisitedSubreddit.value) return;
+	if (!module.options.trackVisitedSubredditIncognito.value && await isPrivateBrowsing()) return;
+
 	const storageKey = `RESmodules.subredditManager.subredditsLastViewed.${loggedInUser()}`;
 	subredditsLastViewed = await Storage.get(storageKey) || {};
 

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -115,17 +115,17 @@ module.options = {
 		value: true,
 		description: 'Show last update information on the front page (work only if you have at least 50/100 subscription, see <a href="/r/help/wiki/faq#wiki_some_of_my_subreddits_keep_disappearing.__why.3F">here</a> for more info).',
 	},
-	trackVisitedSubreddit: {
+	storeSubredditVisit: {
 		type: 'boolean',
 		value: true,
-		description: 'Mark subreddits visited when you visit a post listing, comments page, wiki, etc.',
+		description: 'Store the last time you visited a subreddit.',
 		advanced: true,
 	},
-	trackVisitedSubredditIncognito: {
-		dependsOn: 'trackVisitedSubreddit',
+	storeSubredditVisitIncognito: {
+		dependsOn: 'storeSubredditVisit',
 		type: 'boolean',
 		value: false,
-		description: 'Mark subreddits visited when browsing in incognito/private mode.',
+		description: 'Store the last time you visited a subreddit in incognito/private mode.',
 		advanced: true,
 	},
 	/*		sortingField: {
@@ -1351,8 +1351,8 @@ async function removeSubredditShortcut(subreddit) {
 }
 
 async function setLastViewtime() {
-	if (!module.options.trackVisitedSubreddit.value) return;
-	if (!module.options.trackVisitedSubredditIncognito.value && await isPrivateBrowsing()) return;
+	if (!module.options.storeSubredditVisit.value) return;
+	if (!module.options.storeSubredditVisitIncognito.value && await isPrivateBrowsing()) return;
 
 	const storageKey = `RESmodules.subredditManager.subredditsLastViewed.${loggedInUser()}`;
 	subredditsLastViewed = await Storage.get(storageKey) || {};


### PR DESCRIPTION
Fixes #3405 

 - [x] Subreddit Manager optionally won't track visits to subreddits normally (do track by default) or incognito (don't track by default)
 - [x] New Comment Count optionally won't track visits to comments pages (do track by default) incognito (don't track by default) ... and maybe incognito shouldn't show "new comment" notifications at all?