### PR TITLE
Don't generate dialogs until they're used

### DIFF
--- a/lib/modules/commandLine.js
+++ b/lib/modules/commandLine.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import commandLineTemplate from '../templates/commandLine.mustache';
 import { $ } from '../vendor';
 import * as Modules from '../core/modules';
@@ -46,8 +47,6 @@ module.go = () => {
 	if (module.options.launchFromMenuButton.value) {
 		addMenuButtonHandler();
 	}
-
-	attachCommandLineWidget();
 };
 
 function addMenuItem() {
@@ -69,27 +68,25 @@ function _onClickMenu() {
 	toggleCmdLine(true);
 }
 
-let commandLineWidget, commandLineInput, commandLineInputTip, commandLineInputError;
-
-function attachCommandLineWidget() {
+const commandLine = _.once(() => {
 	const $widget = $(commandLineTemplate());
+	const widget = $widget[0];
 
-	commandLineWidget = $widget[0];
+	widget.style.display = 'none';
 
-	commandLineWidget.style.display = 'none';
+	const input = $widget.find('#keyCommandInput')[0];
 
-	commandLineInput = $widget.find('#keyCommandInput')[0];
+	input.setAttribute('autocomplete', 'off');
 
-	commandLineInput.setAttribute('autocomplete', 'off');
-
-	commandLineInput.addEventListener('blur', () => {
-		if (!commandLineInput.value.length) {
+	input.addEventListener('blur', () => {
+		if (!input.value.length) {
 			toggleCmdLine(false);
 		} else {
 			cmdLineShowError('click into the text input and press escape to close the command line');
 		}
 	});
-	commandLineInput.addEventListener('keyup', e => {
+
+	input.addEventListener('keyup', e => {
 		if (e.keyCode === 27) {
 			// close prompt.
 			toggleCmdLine(false);
@@ -98,8 +95,9 @@ function attachCommandLineWidget() {
 			cmdLineHelper(e.target.value);
 		}
 	});
-	commandLineInputTip = $widget.find('#keyCommandInputTip')[0];
-	commandLineInputError = $widget.find('#keyCommandInputError')[0];
+
+	const $tip = $widget.find('#keyCommandInputTip');
+	const $error = $widget.find('#keyCommandInputError');
 
 	const commandLineForm = $widget.find('#keyCommandForm')[0];
 	commandLineForm.addEventListener('keydown', e => {
@@ -108,39 +106,41 @@ function attachCommandLineWidget() {
 		}
 	});
 
-	document.body.appendChild(commandLineWidget);
-}
+	$widget.appendTo(document.body);
+
+	return { widget, input, $tip, $error };
+});
 
 function cmdLineShowTip(str) {
 	if (str === false) {
-		$(commandLineInputTip).empty();
+		commandLine().$tip.empty();
 	} else {
-		$(commandLineInputTip).safeHtml(str);
+		commandLine().$tip.safeHtml(str);
 	}
 }
 
 function cmdLineShowError(str) {
 	if (str === false) {
-		$(commandLineInputError).empty();
+		commandLine().$error.empty();
 	} else {
-		$(commandLineInputError).safeHtml(str);
+		commandLine().$error.safeHtml(str);
 	}
 }
 
 export function toggleCmdLine(force = true) {
 	if (!Modules.isRunning(module)) return;
 
-	const open = force && commandLineWidget.style.display !== 'block';
+	const open = force && commandLine().widget.style.display !== 'block';
 
 	if (open) {
 		cmdLineShowError(false);
 		cmdLineShowTip(false);
-		commandLineWidget.style.display = 'block';
-		setTimeout(() => commandLineInput.focus(), 20);
-		commandLineInput.value = '';
+		commandLine().widget.style.display = 'block';
+		setTimeout(() => commandLine().input.focus(), 20);
+		commandLine().input.value = '';
 	} else {
-		commandLineInput.blur();
-		commandLineWidget.style.display = 'none';
+		commandLine().input.blur();
+		commandLine().widget.style.display = 'none';
 	}
 }
 
@@ -163,7 +163,7 @@ function cmdLineSubmit(e) {
 	e.preventDefault();
 	cmdLineShowError(false);
 
-	const splitWords = commandLineInput.value.split(' ');
+	const splitWords = commandLine().input.value.split(' ');
 	const command = splitWords[0];
 	const val = splitWords.slice(1).join(' ');
 

--- a/lib/modules/quickMessage.js
+++ b/lib/modules/quickMessage.js
@@ -71,21 +71,6 @@ module.options = {
 	},
 };
 
-const quickMessageFields = {};
-let $quickMessageDialog;
-
-module.beforeLoad = () => {
-	$quickMessageDialog = $('<div>', {
-		id: 'quickMessage',
-		html: quickMessageTemplate({ settingsUrl: SettingsNavigation.makeUrlHash(module.moduleID) }),
-	});
-
-	quickMessageFields.from = $quickMessageDialog.find('#quickMessageDialogFrom').get(0);
-	quickMessageFields.to = $quickMessageDialog.find('#quickMessageDialogTo').get(0);
-	quickMessageFields.subject = $quickMessageDialog.find('#quickMessageDialogSubject').get(0);
-	quickMessageFields.body = $quickMessageDialog.find('#quickMessageDialogBody').get(0);
-};
-
 module.go = () => {
 	CommandLine.registerCommand(
 		(cmd, val) => cmd === 'qm' && (/^(?:([^\s]+)(?:\s(.*))?)?$/).exec(val),
@@ -103,19 +88,7 @@ module.go = () => {
 		}
 	);
 
-	$quickMessageDialog.appendTo(document.body);
-
-	attachEventListeners();
-};
-
-function updateModeratorIcon(state) {
-	$quickMessageDialog
-		.find('label[for=quickMessageDialogFrom]')
-		.toggleClass('moderator', state);
-}
-
-function attachEventListeners() {
-	// keyboard shortcut
+	// global keyboard shortcut
 	window.addEventListener('keydown', e => {
 		if (checkKeysForEvent(e, module.options.openQuickMessage.value)) {
 			e.preventDefault();
@@ -123,8 +96,27 @@ function attachEventListeners() {
 		}
 	}, true);
 
+	if (module.options.handleContentLinks.value) {
+		$('div.content[role="main"]').on('click', 'a[href*="/message/compose"]', messageLinkEventHandler);
+	}
+	if (module.options.handleSideLinks.value) {
+		$('div.side').on('click', 'a[href*="/message/compose"]', messageLinkEventHandler);
+	}
+};
+
+const quickMessageDialog = _.once(() => {
+	const $dialog = $('<div>', {
+		id: 'quickMessage',
+		html: quickMessageTemplate({ settingsUrl: SettingsNavigation.makeUrlHash(module.moduleID) }),
+	});
+
+	const from = $dialog.find('#quickMessageDialogFrom').get(0);
+	const to = $dialog.find('#quickMessageDialogTo').get(0);
+	const subject = $dialog.find('#quickMessageDialogSubject').get(0);
+	const body = $dialog.find('#quickMessageDialogBody').get(0);
+
 	// close dialog with "x" button
-	$quickMessageDialog
+	$dialog
 		.find('#quickMessageDialogClose')
 		.on('click', e => {
 			e.preventDefault();
@@ -132,7 +124,7 @@ function attachEventListeners() {
 		});
 
 	// close dialog with escape key
-	$quickMessageDialog
+	$dialog
 		.get(0)
 		.addEventListener('keydown', e => {
 			if (e.keyCode === CommentTools.KEYS.ESCAPE) {
@@ -141,8 +133,8 @@ function attachEventListeners() {
 			}
 		}, true);
 
-	// send with "send message" button (we would use a 'submit' event listener, but then the user could accidentally send the message by pressing enter)
-	$quickMessageDialog
+	// send with "send message" button
+	$dialog
 		.find('#quickMessageDialogSend')
 		.get(0)
 		.addEventListener('click', e => {
@@ -154,31 +146,33 @@ function attachEventListeners() {
 	CommentTools.onCtrlEnter('#quickMessageDialog', sendMessage);
 
 	// open full message form
-	const updateUrl = e => (e.target.href = getFullMessageFormUrl());
-	$quickMessageDialog
+	$dialog
 		.find('a.fullMessageForm')
-		.on('mousedown', updateUrl)
-		.on('focus', updateUrl) // mousedown isn't fired if you tab over to the button
+		// mousedown isn't fired if you tab over to the button
+		.on('mousedown focus', e => { e.target.href = getFullMessageFormUrl(); })
 		.on('click', closeQuickMessageDialog);
 
-	$quickMessageDialog.find('a').on('keypress', e => {
+	$dialog.find('a').on('keypress', e => {
 		if ((e.keyCode || e.which) === 13) {
 			$(e.target).trigger('click');
 		}
 	});
 
 	// show moderator shield when sending from subreddit and store the user's selection
-	quickMessageFields.from.addEventListener('change', ({ target }) => {
+	from.addEventListener('change', ({ target }) => {
 		updateModeratorIcon(target.value.startsWith('/r/'));
 		Storage.set(`RESmodules.quickMessage.lastSentAs.${loggedInUser()}`, target.value);
 	});
 
-	if (module.options.handleContentLinks.value) {
-		$('div.content[role="main"]').on('click', 'a[href*="/message/compose"]', messageLinkEventHandler);
-	}
-	if (module.options.handleSideLinks.value) {
-		$('div.side').on('click', 'a[href*="/message/compose"]', messageLinkEventHandler);
-	}
+	$dialog.appendTo(document.body);
+
+	return { $dialog, from, to, subject, body };
+});
+
+function updateModeratorIcon(state) {
+	quickMessageDialog().$dialog
+		.find('label[for=quickMessageDialogFrom]')
+		.toggleClass('moderator', state);
 }
 
 function messageLinkEventHandler(e) {
@@ -245,19 +239,19 @@ const setUpSendFromDropdown = _.once(async () => {
 		const currentOption = document.createElement('option');
 		currentOption.value = name;
 		currentOption.text = displayText || name;
-		quickMessageFields.from.add(currentOption);
+		quickMessageDialog().from.add(currentOption);
 	}
-	quickMessageFields.from.disabled = (senders.length < 2);
+	quickMessageDialog().from.disabled = (senders.length < 2);
 });
 
 function focusFirstEmpty() {
-	Array.from($quickMessageDialog.find('input, textarea'))
+	Array.from(quickMessageDialog().$dialog.find('input, textarea'))
 		.find((ele, i, { length }) => !ele.value || i === length - 1)
 		.focus();
 }
 
 async function updateSelectedSender(desiredUser = '') {
-	const sendAsOptions = Array.from(quickMessageFields.from.options).map(ele => ele.textContent.toLowerCase());
+	const sendAsOptions = Array.from(quickMessageDialog().from.options).map(ele => ele.textContent.toLowerCase());
 	let indexToSelect = sendAsOptions.indexOf(desiredUser.toLowerCase());
 
 	if (indexToSelect === -1) {
@@ -273,7 +267,7 @@ async function updateSelectedSender(desiredUser = '') {
 				}
 				break;
 			case 'temporary':
-				indexToSelect = quickMessageFields.from.selectedIndex;
+				indexToSelect = quickMessageDialog().from.selectedIndex;
 				break;
 			// case 'user':
 			default:
@@ -282,8 +276,8 @@ async function updateSelectedSender(desiredUser = '') {
 		}
 	}
 
-	quickMessageFields.from.selectedIndex = (indexToSelect !== -1 ? indexToSelect : 0);
-	updateModeratorIcon(quickMessageFields.from.value.startsWith('/r/'));
+	quickMessageDialog().from.selectedIndex = (indexToSelect !== -1 ? indexToSelect : 0);
+	updateModeratorIcon(quickMessageDialog().from.value.startsWith('/r/'));
 }
 
 export async function openQuickMessageDialog({ from = '', to = '', subject = module.options.defaultSubject.value, body = module.options.linkToCurrentPage.value ? location.href : '' } = {}) {
@@ -301,28 +295,28 @@ export async function openQuickMessageDialog({ from = '', to = '', subject = mod
 	await setUpSendFromDropdown();
 
 	await updateSelectedSender(from);
-	quickMessageFields.to.value = to;
-	quickMessageFields.subject.value = subject;
-	quickMessageFields.body.value = body;
+	quickMessageDialog().to.value = to;
+	quickMessageDialog().subject.value = subject;
+	quickMessageDialog().body.value = body;
 
-	$quickMessageDialog.fadeIn(300);
+	quickMessageDialog().$dialog.fadeIn(300);
 
 	focusFirstEmpty();
 }
 
 function closeQuickMessageDialog() {
-	$quickMessageDialog.fadeOut(300);
+	quickMessageDialog().$dialog.fadeOut(300);
 
 	// remove focus from any input fields
-	for (const ele of $quickMessageDialog.find('input, textarea, button')) {
+	for (const ele of quickMessageDialog().$dialog.find('input, textarea, button')) {
 		ele.blur();
 	}
 }
 
 function getFullMessageFormUrl() {
-	const subreddit = quickMessageFields.from.value.startsWith('/r/') ? quickMessageFields.from.value : '';
+	const subreddit = quickMessageDialog().from.value.startsWith('/r/') ? quickMessageDialog().from.value : '';
 	return subreddit +
-		string.encode`/message/compose?to=${quickMessageFields.to.value}&subject=${quickMessageFields.subject.value}&message=${quickMessageFields.body.value}`;
+		string.encode`/message/compose?to=${quickMessageDialog().to.value}&subject=${quickMessageDialog().subject.value}&message=${quickMessageDialog().body.value}`;
 }
 
 const presetSendErrors = {
@@ -334,7 +328,7 @@ const presetSendErrors = {
 };
 
 async function sendMessage() {
-	const from = quickMessageFields.from.value;
+	const from = quickMessageDialog().from.value;
 
 	try {
 		const { json: { errors } } = await ajax({
@@ -343,9 +337,9 @@ async function sendMessage() {
 			data: {
 				api_type: 'json',
 				from_sr: from.includes('/r/') ? from.slice(3) : '',
-				subject: quickMessageFields.subject.value,
-				text: quickMessageFields.body.value,
-				to: quickMessageFields.to.value,
+				subject: quickMessageDialog().subject.value,
+				text: quickMessageDialog().body.value,
+				to: quickMessageDialog().to.value,
 			},
 			type: 'json',
 		});


### PR DESCRIPTION
These aren't opened on the vast majority of pageloads, so creating them up front is mildly wasteful.

Bonus: quickMessage now has no (visible) global state.