### PR TITLE
showImages: Advanced option to mark selftext links visited

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -203,7 +203,14 @@ module.options = {
 	markVisited: {
 		type: 'boolean',
 		value: true,
-		description: 'Mark links visited when you view images.',
+		description: 'Mark non-selftext links visited when opening the expando.',
+		advanced: true,
+	},
+	markSelftextVisited: {
+		dependsOn: 'markVisited',
+		type: 'boolean',
+		value: false,
+		description: 'Mark selftext links visited when opening the expando.',
 		advanced: true,
 	},
 	sfwHistory: {
@@ -887,8 +894,7 @@ function updateParentHeight(e) {
 }
 
 function trackNativeExpando(expando, element) {
-	// only track media
-	if (expando.button.classList.contains('selftext')) return;
+	if (!module.options.markSelftextVisited.value && expando.button.classList.contains('selftext')) return;
 
 	const trackLoad = _.once(() => trackMediaLoad(element));
 

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -894,7 +894,7 @@ function updateParentHeight(e) {
 }
 
 function trackNativeExpando(expando, element) {
-	if (!module.options.markSelftextVisited.value && expando.button.classList.contains('selftext')) return;
+	if (!module.options.markSelftextVisited.value && (new Thing(expando.button)).isSelfText()) return;
 
 	const trackLoad = _.once(() => trackMediaLoad(element));
 


### PR DESCRIPTION
I'm setting it as advanced for now and defaulting to `false` since there's been some resistance to having this implemented. Nevertheless, it is useful, especially in conjunction with `hide visited links`.

Resolves #2781