### PR TITLE
Wikipedia: Hide citations

### DIFF
--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -541,6 +541,12 @@ body:not(.res-showImages-displayImageCaptions) {
 			font-weight: bold;
 			font-size: 1rem;
 		}
+
+		// Hide citations
+		> div > ol:last-child,
+		sup > a[href^="#cite"] {
+			display: none;
+		}
 	}
 
 	.res-text-media {

--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -541,12 +541,6 @@ body:not(.res-showImages-displayImageCaptions) {
 			font-weight: bold;
 			font-size: 1rem;
 		}
-
-		// Hide citations
-		> div > ol:last-child,
-		sup > a[href^="#cite"] {
-			display: none;
-		}
 	}
 
 	.res-text-media {

--- a/lib/modules/hosts/wikipedia.js
+++ b/lib/modules/hosts/wikipedia.js
@@ -52,7 +52,7 @@ export default {
 		// Clean up returned data
 		const $wikiData = $('<div>', { html: data.parse.text['*'] });
 		// Remove unwanted sections
-		$wikiData.find('.metadata, .hatnote, .mw-editsection').remove();
+		$wikiData.find('.metadata, .hatnote, .mw-editsection, .reference, .references').remove();
 		// Make all relative links direct
 		$wikiData.find('a[href^="/"]').attr('href', (i, old) => `https://${language}.wikipedia.org${old}`);
 


### PR DESCRIPTION
They take up much vertical space, and generally are unimportant in the this context.