### PR TITLE
Mute announcement alerts if they are not relevant.

### DIFF
--- a/lib/modules/announcements.js
+++ b/lib/modules/announcements.js
@@ -197,8 +197,7 @@ function isPostRelevant(post) {
 		return true;
 	}
 
-
-	if (postTitle.search(`${BrowserDetect.browser}`) > -1) {
+	if (postTitle.search(BrowserDetect.browser) > -1) {
 		// If post mentions user's browser, post is relevant
 		return true;
 	}

--- a/lib/modules/announcements.js
+++ b/lib/modules/announcements.js
@@ -73,7 +73,7 @@ async function shouldNotify(post) {
 		return false;
 	}
 
-	if (!isPostRelevent(post)) {
+	if (!isPostRelevant(post)) {
 		return false;
 	}
 
@@ -191,16 +191,16 @@ function setMarkedRead() {
 	}
 }
 
-function isPostRelevent(post) {
+function isPostRelevant(post) {
 	const postTitle = post.title;
 
 	if (postTitle.search(/Chrome|Safari|Firefox|Opera|Edge/) === -1) {
-		// If post is not browser specific, post is relevent
+		// If post is not browser specific, post is relevant
 		return true;
 	}
 
 	if (postTitle.search(`${currentBrowser}`) > -1) {
-		// If post mentions user's browser, post is relevent
+		// If post mentions user's browser, post is relevant
 		return true;
 	}
 

--- a/lib/modules/announcements.js
+++ b/lib/modules/announcements.js
@@ -168,7 +168,7 @@ if (process.env.NODE_ENV === 'development') {
 }
 
 async function getLatestPost() {
-	const { data: { children: [{ data }]} } = await ajax({
+	const { data: { children: [{ data }] } } = await ajax({
 		url: sourceUrl,
 		type: 'json',
 		cacheFor: recheckPostAfter,

--- a/lib/modules/announcements.js
+++ b/lib/modules/announcements.js
@@ -31,8 +31,6 @@ const recheckPostAfter = HOUR;
 
 const now = Date.now();
 
-const currentBrowser = BrowserDetect.browser;
-
 let $biff;
 
 module.beforeLoad = () => {
@@ -199,7 +197,8 @@ function isPostRelevant(post) {
 		return true;
 	}
 
-	if (postTitle.search(`${currentBrowser}`) > -1) {
+
+	if (postTitle.search(`${BrowserDetect.browser}`) > -1) {
 		// If post mentions user's browser, post is relevant
 		return true;
 	}

--- a/lib/modules/announcements.js
+++ b/lib/modules/announcements.js
@@ -2,7 +2,7 @@
 import _ from 'lodash';
 import { $ } from '../vendor';
 import * as Metadata from '../core/metadata';
-import { DAY, HOUR, isCurrentSubreddit, CreateElement } from '../utils';
+import { DAY, HOUR, isCurrentSubreddit, CreateElement, BrowserDetect } from '../utils';
 import { Storage, ajax, openNewTab } from '../environment';
 import * as Menu from './menu';
 
@@ -30,6 +30,8 @@ const pizzazzAfter = 29 * DAY;
 const recheckPostAfter = HOUR;
 
 const now = Date.now();
+
+const currentBrowser = BrowserDetect.browser;
 
 let $biff;
 
@@ -68,6 +70,10 @@ async function shouldNotify(post) {
 
 	if (post.created_js <= await getMarkedRead()) {
 		// posted before last "marked read"
+		return false;
+	}
+
+	if (!isPostRelevent(post)) {
 		return false;
 	}
 
@@ -162,7 +168,7 @@ if (process.env.NODE_ENV === 'development') {
 }
 
 async function getLatestPost() {
-	const { data: { children: [{ data }] } } = await ajax({
+	const { data: { children: [{ data }]} } = await ajax({
 		url: sourceUrl,
 		type: 'json',
 		cacheFor: recheckPostAfter,
@@ -184,3 +190,21 @@ function setMarkedRead() {
 		$biff.remove();
 	}
 }
+
+function isPostRelevent(post) {
+	const postTitle = post.title;
+
+	if (postTitle.search(/Chrome|Safari|Firefox|Opera|Edge/) === -1) {
+		// If post is not browser specific, post is relevent
+		return true;
+	}
+
+	if (postTitle.search(`${currentBrowser}`) > -1) {
+		// If post mentions user's browser, post is relevent
+		return true;
+	}
+
+	return false;
+}
+
+

--- a/lib/modules/announcements.js
+++ b/lib/modules/announcements.js
@@ -2,7 +2,7 @@
 import _ from 'lodash';
 import { $ } from '../vendor';
 import * as Metadata from '../core/metadata';
-import { DAY, HOUR, isCurrentSubreddit, CreateElement, BrowserDetect } from '../utils';
+import { DAY, HOUR, isCurrentSubreddit, CreateElement } from '../utils';
 import { Storage, ajax, openNewTab } from '../environment';
 import * as Menu from './menu';
 
@@ -190,19 +190,15 @@ function setMarkedRead() {
 }
 
 function isPostRelevant(post) {
-	const postTitle = post.title;
-
-	if (postTitle.search(/Chrome|Safari|Firefox|Opera|Edge/) === -1) {
+	if (!(/chrome|safari|firefox|opera|edge/i).test(post.title)) {
 		// If post is not browser specific, post is relevant
 		return true;
 	}
 
-	if (postTitle.search(BrowserDetect.browser) > -1) {
+	if (post.title.toLowerCase().includes(process.env.BUILD_TARGET.toLowerCase())) {
 		// If post mentions user's browser, post is relevant
 		return true;
 	}
 
 	return false;
 }
-
-


### PR DESCRIPTION
This change ensures the Alert icon is only active if an annoucement is not browser specific, or if an  annoucement pertains to the user's current browser.