### PR TITLE
dashboard: work around Edge issue with jQuery

### DIFF
--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -234,7 +234,7 @@ function attachEditComponent() {
 		</div>
 	`);
 
-	$dashboardEditComponent.find('#editRedditForm').submit(e => {
+	$dashboardEditComponent.find('#editRedditForm').get(0).addEventListener('submit', e => {
 		e.preventDefault();
 		let thisBasePath = $('#editReddit').val();
 		if (thisBasePath !== '') {
@@ -251,7 +251,7 @@ function attachEditComponent() {
 			updateWidget();
 		}
 	});
-	$dashboardEditComponent.find('#editSearchForm').submit(e => {
+	$dashboardEditComponent.find('#editSearchForm').get(0).addEventListener('submit', e => {
 		e.preventDefault();
 		const thisBasePath = $('#editSearch').val();
 		widgetBeingEdited.formerBasePath = widgetBeingEdited.basePath;
@@ -484,7 +484,7 @@ function attachAddComponent($tabPage) {
 		},
 	});
 
-	$dashboardAddComponent.find('#addRedditForm').submit(e => {
+	$dashboardAddComponent.find('#addRedditForm').get(0).addEventListener('submit', e => {
 		e.preventDefault();
 		let thisBasePath = $('#addReddit').val();
 		if (thisBasePath !== '') {
@@ -504,7 +504,7 @@ function attachAddComponent($tabPage) {
 			});
 		}
 	});
-	$dashboardAddComponent.find('#addUserForm').submit(e => {
+	$dashboardAddComponent.find('#addUserForm').get(0).addEventListener('submit', e => {
 		e.preventDefault();
 		const thisBasePath = `/user/${$('#addUser').val()}`;
 		addWidget({
@@ -513,7 +513,7 @@ function attachAddComponent($tabPage) {
 		$('#addUser').val('').blur();
 		$('#addUserFormContainer').fadeOut(() => $('#addWidgetButtons').fadeIn());
 	});
-	$dashboardAddComponent.find('#addSearchForm').submit(e => {
+	$dashboardAddComponent.find('#addSearchForm').get(0).addEventListener('submit', e => {
 		e.preventDefault();
 		const thisBasePath = string.encode`/search?q=${$('#addSearch').val()}`;
 		const thisDisplayName = ($('#addSearchDisplayName').val()) ? $('#addSearchDisplayName').val() : thisBasePath;


### PR DESCRIPTION
Fixes #3357

There's an issue in a very specific situation in Edge where the jQuery handler gets dropped (the native `addEventListener` handler is correctly added by jQuery, but when it fires, the `handlers` array in `dataPriv` for the element is empty).

I can't be bothered to expend any more effort trying to figure out what causes this; it's extremely resistant to reproduction. Copying the entire `attachEditComponent()` function verbatim to Codepen, same version of jQuery and everything else? Nope, it all works as expected. Unsurprisingly, trying to hand-code a minimal reproduction is right out. Stepping through with the debugger is unenlightening; I can watch the listener get added correctly and the event fire correctly (to an empty array of handlers), but something is messing with the handlers in between (or the element itself changes somehow) and it's nigh impossible to detect. There are no `.off()` calls in dashboard.js or anything that touches the same elements.