### PR TITLE
init: add extra null check for document.body

### DIFF
--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -58,7 +58,7 @@ export const bodyStart = documentReady
 
 export const bodyReady = bodyStart
 	.then(() => Promise.race([
-		waitForChild(document.body, '.debuginfo'),
+		nonNull(() => document.body, 10).then(body => waitForChild(body, '.debuginfo')),
 		contentLoaded, // in case reddit removes or changes .debuginfo
 	]));
 


### PR DESCRIPTION
It should not be possible for document.body to be null here, but it is for some Chrome users.
This should not affect performance when it's non-null, because `nonNull()` has a synchronous fast path for the initial check.