### PR TITLE
Make channels not recognized as YouTube expandos.

### DIFF
--- a/lib/modules/hosts/youtube.js
+++ b/lib/modules/hosts/youtube.js
@@ -5,8 +5,18 @@ export default {
 	name: 'youtube',
 	attribution: false,
 	domains: ['youtube.com', 'youtu.be'],
-	detect: ({ href }) => (/^https?:\/\/(?:youtu\.be|(?:www\.|m\.)?youtube\.com)\/?(?:watch|embed)?(?:.*?v=|v\/|\/)([\w-]+)/i).exec(href),
-	handleLink(href, [, hash]) {
+	detect: ({ pathname, hostname, search }) => {
+		const params = new URLSearchParams(search);
+		// split path excluding first /
+		const split = pathname.substring(1).split('/');
+		// short url
+		if (hostname.endsWith('youtu.be')) return split[0];
+		// long url
+		return params.has('v') ?
+			params.get('v') : // ?v=
+			(/watch|embed|v/i).exec(split[0]) && split[1]; // watch/embed/v
+	},
+	handleLink(href, hash) {
 		let src = `https://www.youtube.com/embed/${hash}?enablejsapi=1&enablecastapi=1`;
 		const params = getUrlParams(href);
 		if (params.t) {


### PR DESCRIPTION
Fixes #3353.

Making the watch/embed not optional fixes this. Also moved the youtu.be in the regex to accommodate for this change.

So far this regex still works on every link I have tested:

```
https youtu.be
http youtu.be
https youtube/watch
http youtube/watch
https youtube/embed
http youtube/embed
https m.youtube/watch
http m.youtube/watch
```

And fixes the issue on the following links (as far as I know these are the only channel links):

```
/c/
/channel/
/user/
/[username]
```