### PR TITLE
update babel-plugin-transform-dead-code-elimination

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "babel-eslint": "6.1.2",
     "babel-loader": "6.2.5",
     "babel-plugin-lodash": "3.2.8",
-    "babel-plugin-transform-dead-code-elimination": "2.2.0",
+    "babel-plugin-transform-dead-code-elimination": "2.2.1",
     "babel-plugin-transform-es2015-block-scoping": "6.15.0",
     "babel-plugin-transform-es2015-destructuring": "6.9.0",
     "babel-plugin-transform-es2015-modules-commonjs": "6.14.0",


### PR DESCRIPTION
To fix a bug with incorrectly eliminating transformed async-turned-generator functions that would be hoisted.

i.e. `updateCache` is no longer eliminated: https://github.com/honestbleeps/Reddit-Enhancement-Suite/blob/5905ba49127acd6e18d0284d5e89baa200f17680/lib/modules/nightMode.js#L181