### PR TITLE
expando: Show a "return to originating expando" button after auto-scroll

### DIFF
--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -216,6 +216,15 @@ img {
 	}
 }
 
+.res-expando-restore-position {
+	cursor: pointer;
+
+	&::after {
+		content: '« return to originating expando »';
+		font-size: 9px;
+	}
+}
+
 .res-gallery {
 	.res-gallery-title {
 		margin: 3px;

--- a/lib/utils/expando.js
+++ b/lib/utils/expando.js
@@ -109,8 +109,8 @@ export class Expando {
 			// If another expando still is primary, scroll to it instead
 			if (scrollOnMoveError && !this.isPrimary()) {
 				const primary = this.getPrimary();
-				scrollToElement(primary.button, { scrollStyle: 'top' });
 				primary.expand();
+				primary.scrollToButton(this.button);
 			} else {
 				console.log('Could not expand expando', e);
 			}
@@ -159,6 +159,19 @@ export class Expando {
 		}
 
 		this.box.hidden = true;
+	}
+
+	scrollToButton(returnElement = null) {
+		if (returnElement) {
+			$('<span title="Restore position" class="res-expando-restore-position">')
+				.insertAfter(this.button)
+				.click(e => {
+					e.target.remove();
+					scrollToElement(returnElement, { scrollStyle: 'middle' });
+				});
+		}
+
+		scrollToElement(this.button, { scrollStyle: 'top' });
 	}
 
 	attachMedia() {


### PR DESCRIPTION
The auto-scroll is an edge-case which happens fairly seldom (only when the clicked expando is a duplicate of an iframe expando which still is active).

![image](https://cloud.githubusercontent.com/assets/1748521/18617554/85ef5778-7dd2-11e6-84ce-7586e215eb56.png)

Resolves https://www.reddit.com/r/RESissues/comments/54eu2q/autoscrolling_upward_when_a_duplicate_video_is/