### PR TITLE
Add Icon.png to Safari build

### DIFF
--- a/safari/Info.plist
+++ b/safari/Info.plist
@@ -16,6 +16,8 @@
 	<string>{{prop?version!../package.json}}</string>
 	<key>CFBundleVersion</key>
 	<string>{{prop?version!../package.json}}</string>
+	<!-- Icon -->
+	<!-- {{!file?name=Icon.png!../images/icon128.png}} -->
 	<key>Chrome</key>
 	<dict>
 		<key>Database Quota</key>


### PR DESCRIPTION
Resolves #3480

~~Haven't (yet) tested if `.plist` allows comments but it's just a subset of XML and the internet says it will.~~