### PR TITLE
Move alwaysEnabled check to init

### DIFF
--- a/lib/core/modules/modules.js
+++ b/lib/core/modules/modules.js
@@ -27,7 +27,9 @@ export async function _loadModulePrefs() {
 	const storedPrefs = await Storage.get('RES.modulePrefs') || {};
 
 	for (const id in modules) {
-		if (id in storedPrefs) {
+		if (modules[id].alwaysEnabled) {
+			enabled[id] = true;
+		} else if (id in storedPrefs) {
 			enabled[id] = storedPrefs[id];
 		} else {
 			enabled[id] = !modules[id].disabledByDefault;
@@ -37,9 +39,6 @@ export async function _loadModulePrefs() {
 
 export function setEnabled(opaqueId, enable) {
 	const module = get(opaqueId);
-	if (module.alwaysEnabled) {
-		return;
-	}
 	enable = !!enable;
 	// set enabled state of module
 	enabled[module.moduleID] = enable;


### PR DESCRIPTION
So that if a module was somehow disabled (or `alwaysEnabled` was set retroactively) it still won't act disabled.

Fixes https://www.reddit.com/r/Enhancement/comments/54m9gp/im_trying_to_copy_my_res_preferences_between/ and other reports.