### PR TITLE
Use derpibooru.org as canonical domain for Derpibooru links.

### DIFF
--- a/lib/modules/hosts/derpibooru.js
+++ b/lib/modules/hosts/derpibooru.js
@@ -5,11 +5,11 @@ import { batch } from '../../utils';
 const derpibooru = {
 	moduleID: 'derpibooru',
 	name: 'Derpibooru',
-	logo: 'https://derpiboo.ru/favicon.ico',
+	logo: 'https://derpibooru.org/favicon.ico',
 	domains: [
-		'derpiboo.ru',
 		'derpibooru.org',
 		'trixiebooru.org',
+		'derpiboo.ru', // Deprecated. Used for old links only.
 	],
 
 	detect: ({ pathname }) => (/^\/(?:images\/)?(\d+)$/i).exec(pathname),
@@ -18,7 +18,7 @@ const derpibooru = {
 		const maxDepth = 10;
 
 		const { images } = await ajax({
-			url: 'https://derpiboo.ru/api/v2/images/show.json',
+			url: 'https://derpibooru.org/api/v2/images/show.json',
 			data: { ids: requests.map(r => r.id).join(',') },
 			type: 'json',
 		});
@@ -30,22 +30,22 @@ const derpibooru = {
 
 			if (!result) {
 				// API doesn't return a result for this image for some unknown reason
-				// Example: https://derpiboo.ru/api/v2/images/show.json?ids=17
+				// Example: https://derpibooru.org/api/v2/images/show.json?ids=17
 				return new Error('No result');
 			} else if (result.duplicate_of) {
 				// Duplicate image.
-				// Example: https://derpiboo.ru/api/v2/images/show.json?ids=975313
+				// Example: https://derpibooru.org/api/v2/images/show.json?ids=975313
 				if (depth > maxDepth) {
 					return new Error(`Exceeded max duplicate depth: ${maxDepth}`);
 				}
 				return derpibooru.fetchInfo({ id: result.duplicate_of, depth: depth + 1 });
 			} else if (result.image) {
 				// Normal image.
-				// Example: https://derpiboo.ru/api/v2/images/show.json?ids=0
+				// Example: https://derpibooru.org/api/v2/images/show.json?ids=0
 				return result;
 			} else {
 				// Deleted image, or some other error.
-				// Example: https://derpiboo.ru/api/v2/images/show.json?ids=898402
+				// Example: https://derpibooru.org/api/v2/images/show.json?ids=898402
 				return new Error('Image deleted or other error');
 			}
 		});


### PR DESCRIPTION
Apparently there's been some sort of issue with Russia's regulatory agencies which resulted in Derpibooru having to deprecate their `.ru` vanity URL. The API no longer works when accessed through the `derpiboo.ru` domain, and instead yields this message:

![image](https://cloud.githubusercontent.com/assets/1876931/18979828/0e1860f8-8694-11e6-81d9-d197dceb96b6.png)

Example: https://derpiboo.ru/api/v2/images/show.json?ids=0

This PR updates the Derpibooru media host to access the API through the `.org` url instead.

Haven't tested this yet as I'm having a bit of trouble getting the build to work, but it's a rather trivial change so I'm fairly confident it won't break anything.