### PR TITLE
Hide and Show the Edit Bar

### DIFF
--- a/lib/css/modules/_commentTools.scss
+++ b/lib/css/modules/_commentTools.scss
@@ -48,6 +48,18 @@
 	}
 }
 
+// Hide the edit bar
+.markdownEditor-wrapper.slide {
+	overflow: hidden;
+	max-height: 0;
+	transition: max-height .25s ease;
+}
+
+// Show the edit bar
+.markdownEditor-wrapper.slide-show {
+	max-height: 100vh;
+}
+
 // Macros
 .RESMacroDropdownTitle {
 	cursor: pointer;

--- a/lib/modules/commentPreview.js
+++ b/lib/modules/commentPreview.js
@@ -367,7 +367,7 @@ const createBigEditor = _.once(() => {
 	`);
 	$editor.append($left).append($right);
 	if (Modules.isRunning(CommentTools)) {
-		$contents.prepend(CommentTools.makeEditBar());
+		$contents.prepend(CommentTools.makeEditBar().removeClass('slide')); // Always show the edit bar in the big editor
 	}
 
 	$(document.body).append($editor);

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -329,6 +329,18 @@ const initializeEditorTools = _.once(() => {
 		});
 	}
 
+	// Hide the edit bar and show it when the textarea is selected or if it contains text
+	$body.on('focusin', '.usertext-edit textarea', function() {
+		const editBar = $(this).parent().parent().find('.markdownEditor-wrapper.slide');
+		editBar.addClass('slide-show');
+	});
+	$body.on('focusout', '.usertext-edit textarea', function() {
+		const editBar = $(this).parent().parent().find('.markdownEditor-wrapper.slide');
+		if ($(this).val().length === 0) {
+			editBar.removeClass('slide-show');
+		}
+	});
+
 	if (module.options.keyboardShortcuts.value) {
 		$body.on('keydown', '.usertext-edit textarea, #BigEditor textarea, #wiki_page_content, #ban_message', function(e: KeyboardEvent) {
 			if (e.keyCode === KEYS.ESCAPE) {
@@ -451,7 +463,7 @@ export function makeEditBar() {
 
 	const $editBar = $('<div class="markdownEditor">');
 	// Wrap the edit bar in a <div> of its own
-	const wrappedEditBar = $('<div class="markdownEditor-wrapper">').append($editBar);
+	const wrappedEditBar = $('<div class="markdownEditor-wrapper slide">').append($editBar);
 
 	if (module.options.commentingAs.value) {
 		// show who we're commenting as...


### PR DESCRIPTION
### The Edit Bar is hidden and shown when the textarea is selected or it contains text.

I love the text editing tools, but they just take up too much space for my liking, and they're useless until you start writing a comment.

This is for my feature request on Reddit: [Reddit Link](https://www.reddit.com/r/Enhancement/comments/54fuy3/feature_request_hide_all_comments_editing_tools/)

I'm sorry if you see some duplicate commits, i'm not exactly the genius of GitHub, but if it's a problem i could fix it.
