### PR TITLE
Add moduleID and notificationID to Konami notification object

### DIFF
--- a/lib/modules/easterEgg.js
+++ b/lib/modules/easterEgg.js
@@ -19,6 +19,8 @@ module.go = () => {
 		Notifications.showNotification({
 			header: 'RES Easter Eggies!',
 			message: 'Mmm, bacon!',
+			moduleID: module.moduleID,
+			notificationID: 'konami',
 		});
 		setTimeout(() => $baconBit.addClass('makeitrain'), 500);
 	};


### PR DESCRIPTION
Add `moduleID` and `notificationID` to notification object. This is needed to generate a proper class, see #3513 and #2835.
