### PR TITLE
Add ability to swap the preview and editor when using the big editor for comments / text posts

### DIFF
--- a/lib/css/modules/_commentPreview.scss
+++ b/lib/css/modules/_commentPreview.scss
@@ -13,18 +13,6 @@
 	}
 }
 
-.BELeft.swapped {
-	left: auto !important;
-	right: 0 !important;
-	margin-left: 0 !important;
-}
-
-.BERight.swapped {
-	right: auto !important;
-	left: 0 !important;
-	margin-right: 0 !important;
-}
-
 #banned {
 	position: relative;
 
@@ -36,6 +24,20 @@
 		float: none;
 		left: 410px;
 		position: absolute;
+	}
+}
+
+.res-commentPreview-swapBigEditorLayout #BigEditor {
+	.BELeft {
+		left: auto;
+		right: 0;
+		margin-left: 0;
+	}
+
+	.BERight {
+		right: auto;
+		left: 0;
+		margin-right: 0;
 	}
 }
 

--- a/lib/css/modules/_commentPreview.scss
+++ b/lib/css/modules/_commentPreview.scss
@@ -13,6 +13,18 @@
 	}
 }
 
+.BELeft.swapped {
+	left: auto !important;
+	right: 0 !important;
+	margin-left: 0 !important;
+}
+
+.BERight.swapped {
+	right: auto !important;
+	left: 0 !important;
+	margin-right: 0 !important;
+}
+
 #banned {
 	position: relative;
 

--- a/lib/modules/commentPreview.js
+++ b/lib/modules/commentPreview.js
@@ -330,7 +330,7 @@ let bigTextTarget;
 const createBigEditor = _.once(() => {
 	const swapped = module.options.swapBigEditorLayout.value ? 'swapped' : '';
 	const $editor = $('<div id="BigEditor" style="display: none;">');
-	const $left = $('<div class="BELeft RESDialogSmall ' + swapped + '"><h3>Editor</h3></div>');
+	const $left = $(`<div class="BELeft RESDialogSmall ${swapped}"><h3>Editor</h3></div>`);
 	const $contents = $('<div class="RESDialogContents"><textarea id="BigText" name="text" class=""></textarea></div>');
 	const $foot = $('<div class="BEFoot">');
 	if (!isBan) {

--- a/lib/modules/commentPreview.js
+++ b/lib/modules/commentPreview.js
@@ -25,6 +25,11 @@ module.options = {
 		value: true,
 		description: 'Enable the 2 column editor.',
 	},
+	swapBigEditorLayout: {
+		type: 'boolean',
+		value: false,
+		description: 'Swap the preview and editor (so preview is on left and editor is on right)'
+	},
 	openBigEditor: {
 		type: 'keycode',
 		value: [69, false, true, false], // control-e
@@ -323,8 +328,9 @@ function makePreviewBox() {
 let bigTextTarget;
 
 const createBigEditor = _.once(() => {
+	const swapped = module.options.swapBigEditorLayout ? 'swapped' : '';
 	const $editor = $('<div id="BigEditor" style="display: none;">');
-	const $left = $('<div class="BELeft RESDialogSmall"><h3>Editor</h3></div>');
+	const $left = $('<div class="BELeft RESDialogSmall ' + swapped + '"><h3>Editor</h3></div>');
 	const $contents = $('<div class="RESDialogContents"><textarea id="BigText" name="text" class=""></textarea></div>');
 	const $foot = $('<div class="BEFoot">');
 	if (!isBan) {
@@ -361,6 +367,7 @@ const createBigEditor = _.once(() => {
 		<div class="BERight RESDialogSmall"><h3>Preview</h3><div class="RESCloseButton RESFadeButton">&#xf04e;</div><div class="RESCloseButton close">X</div>
 		<div class="RESDialogContents"><div id="BigPreview" class=" md"></div></div></div>
 	`);
+	$right.addClass(swapped);
 	$editor.append($left).append($right);
 	if (Modules.isRunning(CommentTools)) {
 		$contents.prepend(CommentTools.makeEditBar());

--- a/lib/modules/commentPreview.js
+++ b/lib/modules/commentPreview.js
@@ -328,7 +328,7 @@ function makePreviewBox() {
 let bigTextTarget;
 
 const createBigEditor = _.once(() => {
-	const swapped = module.options.swapBigEditorLayout ? 'swapped' : '';
+	const swapped = module.options.swapBigEditorLayout.value ? 'swapped' : '';
 	const $editor = $('<div id="BigEditor" style="display: none;">');
 	const $left = $('<div class="BELeft RESDialogSmall ' + swapped + '"><h3>Editor</h3></div>');
 	const $contents = $('<div class="RESDialogContents"><textarea id="BigText" name="text" class=""></textarea></div>');

--- a/lib/modules/commentPreview.js
+++ b/lib/modules/commentPreview.js
@@ -29,6 +29,7 @@ module.options = {
 		type: 'boolean',
 		value: false,
 		description: 'Swap the preview and editor (so preview is on left and editor is on right)',
+		bodyClass: true,
 	},
 	openBigEditor: {
 		type: 'keycode',
@@ -328,9 +329,8 @@ function makePreviewBox() {
 let bigTextTarget;
 
 const createBigEditor = _.once(() => {
-	const swapped = module.options.swapBigEditorLayout.value ? 'swapped' : '';
 	const $editor = $('<div id="BigEditor" style="display: none;">');
-	const $left = $(`<div class="BELeft RESDialogSmall ${swapped}"><h3>Editor</h3></div>`);
+	const $left = $('<div class="BELeft RESDialogSmall"><h3>Editor</h3></div>');
 	const $contents = $('<div class="RESDialogContents"><textarea id="BigText" name="text" class=""></textarea></div>');
 	const $foot = $('<div class="BEFoot">');
 	if (!isBan) {
@@ -367,7 +367,6 @@ const createBigEditor = _.once(() => {
 		<div class="BERight RESDialogSmall"><h3>Preview</h3><div class="RESCloseButton RESFadeButton">&#xf04e;</div><div class="RESCloseButton close">X</div>
 		<div class="RESDialogContents"><div id="BigPreview" class=" md"></div></div></div>
 	`);
-	$right.addClass(swapped);
 	$editor.append($left).append($right);
 	if (Modules.isRunning(CommentTools)) {
 		$contents.prepend(CommentTools.makeEditBar());

--- a/lib/modules/commentPreview.js
+++ b/lib/modules/commentPreview.js
@@ -28,7 +28,7 @@ module.options = {
 	swapBigEditorLayout: {
 		type: 'boolean',
 		value: false,
-		description: 'Swap the preview and editor (so preview is on left and editor is on right)'
+		description: 'Swap the preview and editor (so preview is on left and editor is on right)',
 	},
 	openBigEditor: {
 		type: 'keycode',


### PR DESCRIPTION
Not as glorious as a solution as using flexbox layout, but just an overriding option that swaps the functionality of the .BELeft and .BERight css classes

Fixes #2306 