### PR TITLE
Never ending comments

### DIFF
--- a/lib/modules/neverEndingComments.js
+++ b/lib/modules/neverEndingComments.js
@@ -1,19 +1,22 @@
+/* @flow */
+
 import * as _ from 'lodash';
 import { $ } from '../vendor';
+import { Module } from '../core/module';
 import { elementInViewport } from '../utils/dom';
 import * as SettingsConsole from './settingsConsole';
 
-export const module = {};
+export const module: Module<*> = new Module('neverEndingComments');
 
-module.moduleID = 'neverEndingComments';
-module.moduleName = 'Never Ending Comments';
-module.category = 'Comments';
-module.description = 'For those ultra-long comment pages, this will keep them flowing';
+module.moduleName = 'necName';
+module.category = 'commentsCategory';
+module.description = 'necDescription';
 module.options = {
 	loadChildComments: {
 		type: 'boolean',
 		value: false,
-		description: 'Whether or not on-screen \'load more comments\' links should be expanded when paused',
+		description: 'necLoadChildCommentsDesc',
+		title: 'necLoadChildCommentsTitle',
 	},
 };
 

--- a/lib/modules/neverEndingComments.js
+++ b/lib/modules/neverEndingComments.js
@@ -1,0 +1,50 @@
+import * as _ from 'lodash';
+import { $ } from '../vendor';
+import { elementInViewport } from '../utils/dom';
+import * as SettingsConsole from './settingsConsole';
+
+export const module = {};
+
+module.moduleID = 'neverEndingComments';
+module.moduleName = 'Never Ending Comments';
+module.category = 'Comments';
+module.description = 'For those ultra-long comment pages, this will keep them flowing';
+module.options = {
+	loadChildComments: {
+		type: 'boolean',
+		value: false,
+		description: 'Whether or not on-screen \'load more comments\' links should be expanded when paused',
+	},
+};
+
+module.include = [
+	'comments',
+];
+
+module.go = () => {
+	window.addEventListener('scroll', _.debounce(handleScroll, 300));
+};
+
+function firstVisibleLoader() {
+	const loaders = module.options.loadChildComments.value ? $('span.morecomments a') : $('span.morecomments:last a');
+	return loaders.toArray().find(el => elementInViewport(el));
+}
+
+function handleScroll() {
+	if (!SettingsConsole.isOpen) { // avoid console to close when scrolling
+		function load() {
+			const link = firstVisibleLoader();
+			if (link) {
+				const id = setInterval(() => {
+					if (document.body.contains(link)) {
+						link.click();
+					} else {
+						load();
+						clearInterval(id);
+					}
+				}, 250);
+			}
+		}
+		load();
+	}
+}

--- a/lib/modules/neverEndingComments.js
+++ b/lib/modules/neverEndingComments.js
@@ -1,10 +1,8 @@
 /* @flow */
 
 import * as _ from 'lodash';
-import { $ } from '../vendor';
 import { Module } from '../core/module';
 import { elementInViewport } from '../utils/dom';
-import * as SettingsConsole from './settingsConsole';
 
 export const module: Module<*> = new Module('neverEndingComments');
 
@@ -29,25 +27,17 @@ module.go = () => {
 };
 
 function firstVisibleLoader() {
-	const loaders = module.options.loadChildComments.value ? $('span.morecomments a') : $('span.morecomments:last a');
-	return loaders.toArray().find(el => elementInViewport(el));
+	const context = module.options.loadChildComments.value ? '' : '.commentarea > .sitetable > .thing.morechildren';
+	const loaders = document.querySelectorAll(`${context} .morecomments a:not([res-clicked])`);
+
+	return Array.from(loaders).find(el => elementInViewport(el));
 }
 
-function handleScroll() {
-	if (!SettingsConsole.isOpen) { // avoid console to close when scrolling
-		function load() {
-			const link = firstVisibleLoader();
-			if (link) {
-				const id = setInterval(() => {
-					if (document.body.contains(link)) {
-						link.click();
-					} else {
-						load();
-						clearInterval(id);
-					}
-				}, 250);
-			}
-		}
-		load();
+const handleScroll = _.throttle(() => {
+	const link = firstVisibleLoader();
+	if (link) {
+		link.setAttribute('res-clicked', '');
+		link.click();
+		handleScroll(); // throttled, so this call will be delayed
 	}
-}
+}, 2000);

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -1296,6 +1296,22 @@
         "message": "Show the π server / debug details next to the floating Never-Ending Reddit tools."
     },
 
+    "necName": {
+        "message": "Never Ending Comments"
+    },
+
+    "necDescription": {
+        "message": "Keep ultra-long comment pages flowing."
+    },
+
+    "necLoadChildCommentsTitle": {
+        "message": "Load Child Comments"
+    },
+
+    "necLoadChildCommentsDesc": {
+        "message": "Should on-screen child comments be expanded when paused, in addition to top-level comments?"
+    },
+
     "newCommentCountName": {
         "message": "New Comment Count"
     },


### PR DESCRIPTION
Added a Never Ending Comments module that by default only auto-loads
the "load more comments" link at the bottom of the page. There is an
option to also load these links for any child comments. When this is
enabled all links that are in the viewport are loaded, started from
the top. This causes lower links to potentially be pushed out of the
viewport and then not loaded until the user scrolls them down into
view again. On the other hand, it allows for nested "load more comments"
links to be loaded automatically as they appear.

fixes #3432
