### PR TITLE
saveComments: Update ID

### DIFF
--- a/lib/modules/saveComments.js
+++ b/lib/modules/saveComments.js
@@ -8,6 +8,7 @@ import {
 	isPageType,
 	niceKeyCode,
 	watchForElement,
+	Thing,
 } from '../utils';
 import { Storage } from '../environment';
 import * as KeyboardNav from './keyboardNav';
@@ -86,17 +87,14 @@ function addSaveLinks(ele = document.body) {
 }
 
 function addSaveLinkToComment(commentObj) {
-	const commentsUL = commentObj.querySelector('ul.flat-list');
-	const permaLink = commentsUL.querySelector('li.first a.bylink');
+	const thing = new Thing(commentObj);
+	const permaLink = thing.getCommentPermalink();
 
 	if (!permaLink) return;
 
-	// Insert the link right after Reddit Gold's "save" comment link
-	const userLink = commentObj.querySelector('a.author');
-	const saveUser = userLink ? userLink.innerText : '[deleted]';
-
 	const saveHref = permaLink.href;
-	const saveID = saveHref.split('/').slice(-1)[0];
+	const saveID = thing.getFullname().split('_').slice(-1)[0];
+	const saveUser = thing.getAuthor() || '[deleted]';
 
 	const $saveLink = $('<li>');
 
@@ -110,7 +108,8 @@ function addSaveLinkToComment(commentObj) {
 			.data('saveUser', saveUser);
 	}
 
-	const whereToInsert = commentsUL.querySelector('.comment-save-button');
+	// Insert the link right after Reddit Gold's "save" comment link
+	const whereToInsert = commentObj.querySelector('.comment-save-button');
 	$saveLink.insertAfter(whereToInsert);
 }
 
@@ -277,6 +276,7 @@ async function drawSavedComments() {
 
 function unsaveComment(id, unsaveLink) {
 	Storage.deletePath('RESmodules.saveComments.savedComments', id);
+	savedCommentIDs.delete(id);
 	if ($savedCommentsContent) {
 		$savedCommentsContent.remove();
 		drawSavedComments();


### PR DESCRIPTION
Seems like the permalink got a trailing slash, so that `saveID` always becomes an empty string.

Fixes https://www.reddit.com/r/RESissues/comments/58mjna/bug_cant_res_save_comments_under_comments_it/