### PR TITLE
Open settings URLs in same tab

### DIFF
--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -219,8 +219,12 @@ module.go = () => {
 function commentsLinksNewTabs(ele = document.body) {
 	const links = ele.querySelectorAll('.thing div.md a');
 	links::forEachChunked(link => {
-		link.target = '_blank';
-		link.rel = 'noopener noreferer';
+		const { baseURI, href } = link;
+
+		if (!(href.includes(baseURI) && (href.includes('#!settings') || href.includes('#res:settings')))) {
+			link.target = '_blank';
+			link.rel = 'noopener noreferer';
+		}
 	});
 }
 

--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -14,6 +14,7 @@ import {
 	watchForElement,
 } from '../utils';
 import { ajax } from '../environment';
+import { isSettingsUrl } from './settingsNavigation';
 import * as AccountSwitcher from './accountSwitcher';
 import * as SubredditManager from './subredditManager';
 
@@ -220,11 +221,10 @@ function commentsLinksNewTabs(ele = document.body) {
 	const links = ele.querySelectorAll('.thing div.md a');
 	links::forEachChunked(link => {
 		const { baseURI, href } = link;
+		if (href.includes(baseURI) && isSettingsUrl(href)) return;
 
-		if (!(href.includes(baseURI) && (href.includes('#!settings') || href.includes('#res:settings')))) {
-			link.target = '_blank';
-			link.rel = 'noopener noreferer';
-		}
+		link.target = '_blank';
+		link.rel = 'noopener noreferer';
 	});
 }
 


### PR DESCRIPTION
Settings URLs in comments should be opened in the same tab even if commentLinksNewTabs is set.

I think this addresses the issue but I might've misunderstood the scope of this change. 

Closes #2968 
