### PR TITLE
Remove unneeded deps

### DIFF
--- a/build/version.js
+++ b/build/version.js
@@ -1,20 +1,19 @@
-/* eslint-disable import/no-nodejs-modules */
+/* eslint-disable import/no-commonjs, import/no-nodejs-modules */
 
-import { execSync } from 'child_process';
-import path from 'path';
-import fs from 'fs-extra';
-import prependFile from 'prepend-file';
-import { version, repository } from '../package.json';
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const { version, repository } = require('../package.json');
 
 const dir = 'changelog';
 const unreleasedChangelog = changelogPath('UNRELEASED.md');
 const templateChangelog = changelogPath('_EXAMPLE.md');
 const newChangelog = changelogPath(`v${version}.md`);
 
-fs.copySync(unreleasedChangelog, newChangelog);
-prependFile.sync(newChangelog, `## [v${version}](https://github.com/${repository.username}/${repository.repository}/releases/v${version})\n\n`);
+const changelogContents = fs.readFileSync(unreleasedChangelog, { encoding: 'utf8' });
+fs.writeFileSync(newChangelog, `## [v${version}](https://github.com/${repository.username}/${repository.repository}/releases/v${version})\n\n${changelogContents}`);
 
-fs.copySync(templateChangelog, unreleasedChangelog);
+fs.writeFileSync(unreleasedChangelog, fs.readFileSync(templateChangelog));
 
 gitAdd(unreleasedChangelog);
 gitAdd(newChangelog);
@@ -27,4 +26,3 @@ function gitAdd(file) {
 	console.log('git add', file);
 	return execSync(`git add ${file}`);
 }
-

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "cross-env NODE_ENV=test ava",
     "coverage": "cross-env NODE_ENV=test nyc ava",
     "report-coverage": "nyc report --reporter=text-lcov | coveralls",
-    "version": "babel-node build/version.js"
+    "version": "node build/version.js"
   },
   "ava": {
     "files": [
@@ -68,7 +68,6 @@
   "devDependencies": {
     "autoprefixer": "6.5.1",
     "ava": "0.15.2",
-    "babel-cli": "6.16.0",
     "babel-core": "6.17.0",
     "babel-eslint": "7.0.0",
     "babel-loader": "6.2.5",
@@ -107,7 +106,6 @@
     "extricate-loader": "0.0.2",
     "file-loader": "0.9.0",
     "firefox-extension-deploy": "0.0.2",
-    "fs-extra": "0.30.0",
     "globby": "6.0.0",
     "gulp": "3.9.1",
     "gulp-zip": "3.2.0",
@@ -122,7 +120,6 @@
     "node-sass": "3.10.1",
     "nyc": "8.3.1",
     "postcss-loader": "0.13.0",
-    "prepend-file": "1.3.0",
     "progress-bar-webpack-plugin": "1.9.0",
     "prop-loader": "0.0.5",
     "rimraf": "2.5.4",


### PR DESCRIPTION
It's fine to use `require()` in simple standalone Node scripts.