### PR TITLE
Date custom filter condition

### DIFF
--- a/lib/modules/filteReddit/browseContexts.js
+++ b/lib/modules/filteReddit/browseContexts.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import escapeStringRegexp from 'escape-string-regexp';
+import moment from 'moment';
 import {
 	currentMultireddit,
 	currentSubreddit,
@@ -36,6 +37,38 @@ export default ({
 			// At the time of writing Safari doesn't support the toLocaleDateString
 			// const currentDOW = new Date().toLocaleDateString('en-US', {weekday: 'short'});
 			return data.days.includes(currentDOW);
+		},
+	},
+	date: {
+		name: 'Date',
+		defaultTemplate(date) {
+			return { type: 'date', op: '<', date: date || moment().add(1, 'M').format('Y-M-D') };
+		},
+		fields: [
+			'today is ',
+			{
+				type: 'select',
+				id: 'op',
+				options: [
+					['before', '<'],
+					['on or after', '>='],
+				],
+			},
+			' ', { type: 'text', id: 'date', validator: RegExp },
+		],
+		evaluate(thing, data) {
+			const date = moment(data.date);
+			if (!date.isValid()) {
+				return false;
+			}
+			const now = moment();
+			if (data.op === '<') {
+				return now.isBefore(date);
+			} else if (data.op === '>=') {
+				return now.isSameOrAfter(date);
+			} else {
+				return false;
+			}
 		},
 	},
 	currentSub: {


### PR DESCRIPTION
Filter posts if today is before or on/after a certain date(time). Useful for filtering noise leading up to an event such as an election or hiding spoilers around a release date.

I opted for plaintext since momentjs has an excellent parser. A future update could add a `datetime` builderField to settingsConsole.
