### PR TITLE
Don't show QuickMessage is modifier key is pressed

### DIFF
--- a/lib/modules/quickMessage.js
+++ b/lib/modules/quickMessage.js
@@ -177,7 +177,8 @@ function updateModeratorIcon(state) {
 
 function messageLinkEventHandler(e) {
 	const { href, pathname } = e.target;
-	if (e.which === 1 && regexes.composeMessage.test(pathname)) {
+	const hasModifier = e.ctrlKey || e.altKey || e.metaKey || e.shiftKey;
+	if (e.which === 1 && !hasModifier && regexes.composeMessage.test(pathname)) {
 		e.preventDefault();
 
 		const { to, subject, message: body } = getUrlParams(href);


### PR DESCRIPTION
Fixes #2027