### PR TITLE
Change XKCD expandos to use XKCD API instead of noembed

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -64,6 +64,7 @@
 		"*://backend.deviantart.com/oembed?url=*",
 		"*://api.gyazo.com/api/oembed*",
 		"*://codepen.io/api/oembed*",
-		"*://api.tumblr.com/v2/blog/*/posts?api_key=*&id=*"
+		"*://api.tumblr.com/v2/blog/*/posts?api_key=*&id=*",
+		"https://xkcd.com/*/info.0.json"
 	]
 }

--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -63,6 +63,7 @@
 		"*://backend.deviantart.com/oembed?url=*",
 		"*://api.gyazo.com/api/oembed*",
 		"*://codepen.io/api/oembed*",
-		"*://api.tumblr.com/v2/blog/*/posts?api_key=*&id=*"
+		"*://api.tumblr.com/v2/blog/*/posts?api_key=*&id=*",
+		"https://xkcd.com/*/info.0.json"
 	]
 }

--- a/lib/modules/hosts/xkcd.js
+++ b/lib/modules/hosts/xkcd.js
@@ -4,6 +4,7 @@ export default {
 	moduleID: 'xkcd',
 	name: 'xkcd',
 	domains: ['xkcd.com'],
+	permissions: ['https://xkcd.com/*/info.0.json'],
 	logo: 'https://xkcd.com/favicon.ico',
 	detect: ({ hostname, pathname }) => (
 		// primarily to exclude what-if.xkcd.com
@@ -11,22 +12,17 @@ export default {
 		(/^\/([0-9]+)(?:\/|$)/i).exec(pathname)
 	),
 	async handleLink(href, [, id]) {
-		const { html, title } = await ajax({
-			url: 'https://noembed.com/embed',
-			data: { url: `http://xkcd.com/${id}/` }, // noembed doesn't believe in the HTTPS urls, so these need to be "http"
+		const { title, alt, img } = await ajax({
+			url: `https://xkcd.com/${id}/info.0.json`,
 			type: 'json',
 		});
-
-		// documentFragment doesn't support innerHTML, so use div instead
-		const temp = document.createElement('div');
-		temp.innerHTML = html;
-		const img = temp.querySelector('img');
 
 		return {
 			type: 'IMAGE',
 			title,
-			caption: img.getAttribute('title'),
-			src: img.getAttribute('src').replace('https://noembed.com/i/', ''), // remove noembed image proxy & link direct
+			caption: alt,
+			// Fix API always returning non-HTTPS URL
+			src: img.replace('http://', '//'),
 		};
 	},
 };

--- a/safari/Info.plist
+++ b/safari/Info.plist
@@ -62,6 +62,7 @@
 				<string>miiverse.nintendo.net</string>
 				<string>api.gyazo.com</string>
 				<string>codepen.io</string>
+				<string>xkcd.com</string>
 			</array>
 			<key>Include Secure Pages</key>
 			<true/>


### PR DESCRIPTION
The problem with the noembed API Is that it returns invalid HTML for
certain comics that include quotes in the alt text.

Example:
https://noembed.com/embed?url=http://xkcd.com/1726/
https://www.reddit.com/r/programming/comments/5a5tba/utf8_everywhere_now_please/d9e0jzn/

Unfortunately the noembed repository does not seem to be very active
anymore, so I think the best solution is to fix this on the RES side by
switching to the official XKCD API.


Edit(erikdesjardins): fixes #3384