### PR TITLE
Remove hideUnreadCount

### DIFF
--- a/lib/core/migrate.js
+++ b/lib/core/migrate.js
@@ -203,12 +203,6 @@ const migrations = [
 			await migrators.generic.moveOption('stylesheet', 'loadSubredditStylesheets', 'stylesheet', 'loadStylesheets', migrators.specific.subredditToUrl);
 		},
 	}, {
-		versionNumber: '4.7.0',
-		async go() {
-			await migrators.generic.forceUpdateOption('orangered', 'showUnreadCount', value => value === false);
-			await migrators.generic.moveOption('orangered', 'showUnreadCount', 'orangered', 'hideUnreadCount');
-		},
-	}, {
 		versionNumber: '4.7.0-scrubCaches',
 		async go() {
 			// Trailing '.' on some keys is important

--- a/lib/css/modules/_orangered.scss
+++ b/lib/css/modules/_orangered.scss
@@ -27,10 +27,6 @@
 	}
 }
 
-.res-orangered-hideUnreadCount {
-	.message-count { display: none !important; }
-}
-
 .res-orangered-retroUnreadCount {
 	.message-count {
 		background: none;

--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -34,12 +34,6 @@ module.options = {
 		value: true,
 		description: 'Show an envelope (inbox) icon in the top right corner',
 	},
-	hideUnreadCount: {
-		type: 'boolean',
-		value: false,
-		description: 'Hide unread message count',
-		bodyClass: true,
-	},
 	retroUnreadCount: {
 		type: 'boolean',
 		value: false,


### PR DESCRIPTION
<as previously discussed>&nbsp;

This was erroneously turned on by a migration for some users.

The only reason it exists was to preserve legacy behaviour: in the past reddit didn't show a message count, so RES had an option called `showUnreadCount` which would generate one. When this was implemented on reddit's side and removed from RES, the option was inverted to `hideUnreadCount`.

But it's kinda silly, and I can't imagine why you'd want to hide the message count alone (without, e.g. also hiding the orangered envelope).

So in lieu of trying to migrate it back, we'll just remove it.

If anyone still wants to hide the message count, they can use a CSS snippet: `.message-count { display: none !important; }`

Resolves #3348