### PR TITLE
ner: run setReturnToPage at beforeScroll

### DIFF
--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -213,7 +213,7 @@ function initiateReturnToPrevPage() {
 		);
 	}
 
-	SelectedEntry.addListener(selected => { if (selected) setReturnToPage(selected); });
+	SelectedEntry.addListener(selected => { if (selected) setReturnToPage(selected); }, 'beforeScroll');
 }
 
 async function returnToPrevPage() {


### PR DESCRIPTION
Otherwise it is run after the `click` event, which may cause `replaceState` to replace the wrong entry if a link was clicked.