### PR TITLE
Account Switcher Overflow

### DIFF
--- a/lib/css/modules/_accountSwitcher.scss
+++ b/lib/css/modules/_accountSwitcher.scss
@@ -1,8 +1,10 @@
 #RESAccountSwitcherDropdown {
-	min-width: 110px;
-	width: auto;
 	display: none;
+	height: 400px;
+	min-width: 110px;
+	overflow: scroll;
 	position: absolute;
+	width: auto;
 	z-index: 1000;
 
 	li {

--- a/lib/css/modules/_accountSwitcher.scss
+++ b/lib/css/modules/_accountSwitcher.scss
@@ -1,8 +1,9 @@
 #RESAccountSwitcherDropdown {
 	display: none;
-	height: calc(100vh - 80px);
+	max-height: calc(100vh - 80px);
 	min-width: 110px;
-	overflow: scroll;
+	overflow-x: hidden;
+	overflow-y: auto;
 	position: absolute;
 	width: auto;
 	z-index: 1000;

--- a/lib/css/modules/_accountSwitcher.scss
+++ b/lib/css/modules/_accountSwitcher.scss
@@ -1,6 +1,6 @@
 #RESAccountSwitcherDropdown {
 	display: none;
-	height: 400px;
+	height: calc(100vh - 80px);
 	min-width: 110px;
 	overflow: scroll;
 	position: absolute;


### PR DESCRIPTION
# Description

Currently, whenever a user has a large number of accounts, the overflow div becomes the height of all of those accounts, causing the list expand beyond never ending reddit. This PR fixes the issue by adding overflow to the account switcher div. 

## Before

![screen shot 2016-11-05 at 5 02 43 pm](https://cloud.githubusercontent.com/assets/15053417/20033594/54d30108-a37a-11e6-9e16-3eb10975ff3b.jpg)

## After

![screen shot 2016-11-05 at 5 01 59 pm](https://cloud.githubusercontent.com/assets/15053417/20033597/5957a198-a37a-11e6-88b6-37187e626330.jpg)
