### PR TITLE
Clean-up RESTips, featureTips guiders (for filterline)

### DIFF
--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -3,6 +3,7 @@
 import type { PageType } from '../utils/location';
 import type { KeyArray } from '../utils/keycode';
 import type { default as Thing } from '../utils/Thing';
+import type { Tip } from '../modules/RESTips'; // eslint-disable-line import/no-restricted-paths
 
 // separate because indexer syntax is not supported in normal (no `declare`) classes
 declare class Indexable { // eslint-disable-line no-unused-vars
@@ -27,6 +28,8 @@ export class Module<RawOpt: { [key: string]: any }, Opt: { [key: string]: Module
 	disabledByDefault: boolean = false;
 	alwaysEnabled: boolean = false;
 	sort: number = 0;
+
+	featureTips: Array<{ id: string, options: Tip }> = [];
 
 	// no default value for cleaner profiling (modules without a stage defined won't be timed)
 	loadDynamicOptions: (() => Promise<void> | void) | void = undefined;

--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -3,7 +3,6 @@
 import type { PageType } from '../utils/location';
 import type { KeyArray } from '../utils/keycode';
 import type { default as Thing } from '../utils/Thing';
-import type { Tip } from '../modules/RESTips'; // eslint-disable-line import/no-restricted-paths
 
 // separate because indexer syntax is not supported in normal (no `declare`) classes
 declare class Indexable { // eslint-disable-line no-unused-vars
@@ -28,8 +27,6 @@ export class Module<RawOpt: { [key: string]: any }, Opt: { [key: string]: Module
 	disabledByDefault: boolean = false;
 	alwaysEnabled: boolean = false;
 	sort: number = 0;
-
-	featureTips: Array<{ id: string, options: Tip }> = [];
 
 	// no default value for cleaner profiling (modules without a stage defined won't be timed)
 	loadDynamicOptions: (() => Promise<void> | void) | void = undefined;

--- a/lib/modules/RESTips.js
+++ b/lib/modules/RESTips.js
@@ -29,6 +29,15 @@ module.options = {
 		value: true,
 		description: 'RESTipsDailyTipDesc',
 	},
+	newFeatureTips: {
+		type: 'boolean',
+		value: true,
+		description: 'Show tips about new features when they appear for the first time.',
+	},
+};
+
+module.loadDynamicOptions = () => {
+	addFeatureTips();
 };
 
 const lastTooltipStorage = Storage.wrap('RESLastToolTip', 0);
@@ -47,6 +56,92 @@ module.go = () => {
 		Init.go.then(dailyTip);
 	}
 };
+
+module.afterLoad = () => {
+	if (module.options.newFeatureTips.value) {
+		lookForNewFeatures();
+	}
+};
+
+function getFeatureTipOptionKey(moduleID, key) {
+	return `display tip ${moduleID}-${key}`;
+}
+
+const featureTips = new Map();
+
+function addFeatureTips() {
+	for (const mod of Modules.all()) {
+		for (const { id, options } of mod.featureTips) {
+			const optionKey = getFeatureTipOptionKey(mod.moduleID, id);
+			module.options[optionKey] = {
+				value: false,
+				type: 'boolean',
+				noconfig: false,
+			};
+
+			let resolver = () => {};
+			const promise = new Promise(resolve => { resolver = resolve; });
+			featureTips.set(optionKey, { options, promise, resolver });
+		}
+	}
+}
+
+export function declareFeatureTipReady(moduleID: string, key: string, newOptions: any) {
+	const optionKey = getFeatureTipOptionKey(moduleID, key);
+	const featureTip = featureTips.get(optionKey);
+	if (!featureTip) return;
+
+	const { options, resolver } = featureTip;
+
+	Object.assign(options, newOptions);
+
+	if (module.options[optionKey].value && resolver) resolver([optionKey, options]);
+
+	// Also make the tip accessible via daily tips / tips & tricks
+	if (!tips.includes(options)) tips.push(options);
+}
+
+const newFeatureTipsCheckbox = _.once(() =>
+	$('<label><input type="checkbox" name="disableNewFeatureTipsCheckbox" checked />Show these tips when new features appears</label>')
+		.click((e: Event) => Options.set(module, 'newFeatureTips', (e.target: any).checked))
+);
+
+function lookForNewFeatures() {
+	const promises = Array.from(featureTips.values()).map(v => v.promise);
+	Promise.race(promises).then(([key, tip]) => {
+		featureTips.delete(key);
+
+		if (tip.attachTo && !tip.attachTo.offsetParent) {
+			// Usually happens when subreddit CSS for some reason hides the element
+			console.log('Feature tip\'s attachment element is not visible. Ignoring.');
+			lookForNewFeatures();
+			return;
+		}
+
+		const guiderObj = {
+			description: generateContent(tip),
+			title: 'New feature',
+			onClose() {
+				Options.set(module, key, false);
+				lookForNewFeatures();
+			},
+			buttonCustomHTML: newFeatureTipsCheckbox,
+			...tip,
+		};
+
+		if (tip.continuation) {
+			guiderObj.buttons = [{
+				name: 'Continue',
+				onclick() {
+					tip.continuation();
+					$(this).parents('.guider').find('.guiders_x_button').click();
+				},
+			}];
+		}
+
+		showTip(guiderObj);
+	});
+}
 
 async function dailyTip() {
 	const lastCheck = await lastTooltipStorage.get();

--- a/lib/modules/RESTips.js
+++ b/lib/modules/RESTips.js
@@ -3,7 +3,6 @@
 import _ from 'lodash';
 import { $, guiders } from '../vendor';
 import { Module } from '../core/module';
-import * as Init from '../core/init';
 import * as Modules from '../core/modules';
 import * as Options from '../core/options';
 import { CreateElement, niceKeyCode, positiveModulo, DAY } from '../utils';
@@ -51,13 +50,13 @@ module.go = () => {
 
 		Menu.addMenuItem($menuItem, () => { showOrdinaryTip('random'); });
 	}
-
-	if (module.options.dailyTip.value) {
-		Init.go.then(dailyTip);
-	}
 };
 
 module.afterLoad = () => {
+	if (module.options.dailyTip.value) {
+		dailyTip();
+	}
+
 	if (module.options.newFeatureTips.value) {
 		lookForNewFeatures();
 	}

--- a/lib/modules/RESTips.js
+++ b/lib/modules/RESTips.js
@@ -5,7 +5,13 @@ import { $, guiders } from '../vendor';
 import { Module } from '../core/module';
 import * as Modules from '../core/modules';
 import * as Options from '../core/options';
-import { CreateElement, niceKeyCode, positiveModulo, DAY } from '../utils';
+import {
+	CreateElement,
+	mutex,
+	niceKeyCode,
+	positiveModulo,
+	DAY,
+} from '../utils';
 import { Storage, i18n } from '../environment';
 import * as PenaltyBox from './penaltyBox';
 import * as KeyboardNav from './keyboardNav';
@@ -35,10 +41,7 @@ module.options = {
 	},
 };
 
-module.loadDynamicOptions = () => {
-	addFeatureTips();
-};
-
+const featureTipsStorage = Storage.wrapDomain(id => `RESTips.featureTips.${id}`, { enabled: true });
 const lastTooltipStorage = Storage.wrap('RESLastToolTip', 0);
 
 module.go = () => {
@@ -56,91 +59,52 @@ module.afterLoad = () => {
 	if (module.options.dailyTip.value) {
 		dailyTip();
 	}
-
-	if (module.options.newFeatureTips.value) {
-		lookForNewFeatures();
-	}
 };
 
-function getFeatureTipOptionKey(moduleID, key) {
-	return `display tip ${moduleID}-${key}`;
-}
-
-const featureTips = new Map();
-
-function addFeatureTips() {
-	for (const mod of Modules.all()) {
-		for (const { id, options } of mod.featureTips) {
-			const optionKey = getFeatureTipOptionKey(mod.moduleID, id);
-			module.options[optionKey] = {
-				value: false,
-				type: 'boolean',
-				noconfig: false,
-			};
-
-			let resolver = () => {};
-			const promise = new Promise(resolve => { resolver = resolve; });
-			featureTips.set(optionKey, { options, promise, resolver });
-		}
-	}
-}
-
-export function declareFeatureTipReady(moduleID: string, key: string, newOptions: any) {
-	const optionKey = getFeatureTipOptionKey(moduleID, key);
-	const featureTip = featureTips.get(optionKey);
-	if (!featureTip) return;
-
-	const { options, resolver } = featureTip;
-
-	Object.assign(options, newOptions);
-
-	if (module.options[optionKey].value && resolver) resolver([optionKey, options]);
-
-	// Also make the tip accessible via daily tips / tips & tricks
-	if (!tips.includes(options)) tips.push(options);
-}
-
 const newFeatureTipsCheckbox = _.once(() =>
-	$('<label><input type="checkbox" name="disableNewFeatureTipsCheckbox" checked />Show these tips when new features appears</label>')
+	$('<label><input type="checkbox" name="disableNewFeatureTipsCheckbox" checked />Show these tips when new features appear</label>')
 		.click((e: Event) => Options.set(module, 'newFeatureTips', (e.target: any).checked))
 );
 
-function lookForNewFeatures() {
-	const promises = Array.from(featureTips.values()).map(v => v.promise);
-	Promise.race(promises).then(([key, tip]) => {
-		featureTips.delete(key);
+// memoize: prevent the same tip from being added multiple times
+export const showFeatureTip = _.memoize(mutex(async (id: string, tip: Tip) => {
+	if (!Modules.isRunning(module) || !module.options.newFeatureTips.value) return;
 
-		if (tip.attachTo && !tip.attachTo.offsetParent) {
-			// Usually happens when subreddit CSS for some reason hides the element
-			console.log('Feature tip\'s attachment element is not visible. Ignoring.');
-			lookForNewFeatures();
-			return;
-		}
+	const { enabled } = await featureTipsStorage.get(id);
+	if (!enabled) return;
 
-		const guiderObj = {
-			description: generateContent(tip),
-			title: 'New feature',
-			onClose() {
-				Options.set(module, key, false);
-				lookForNewFeatures();
+	// Also make the tip accessible via daily tips / tips & tricks
+	tips.push(tip);
+
+	if (tip.attachTo && !tip.attachTo.offsetParent) {
+		// Usually happens when subreddit CSS for some reason hides the element
+		console.log('Ignoring feature tip whose attachment element is not visible:', tip);
+		return;
+	}
+
+	const guiderObj = {
+		description: generateContent(tip),
+		title: 'New feature',
+		onClose() {
+			featureTipsStorage.set(id, { enabled: false });
+		},
+		buttonCustomHTML: newFeatureTipsCheckbox(),
+		...tip,
+	};
+
+	const { continuation } = tip;
+	if (continuation) {
+		guiderObj.buttons = [{
+			name: 'Continue',
+			onclick() {
+				continuation();
+				$(this).parents('.guider').find('.guiders_x_button').click();
 			},
-			buttonCustomHTML: newFeatureTipsCheckbox,
-			...tip,
-		};
+		}];
+	}
 
-		if (tip.continuation) {
-			guiderObj.buttons = [{
-				name: 'Continue',
-				onclick() {
-					tip.continuation();
-					$(this).parents('.guider').find('.guiders_x_button').click();
-				},
-			}];
-		}
-
-		showTip(guiderObj);
-	});
-}
+	await showTip(guiderObj);
+}));
 
 async function dailyTip() {
 	const lastCheck = await lastTooltipStorage.get();
@@ -233,16 +197,18 @@ function generateContentOption(option) {
 	return description;
 }
 
-export type Tip = {
+export type Tip = {|
 	message: string,
+	title?: string,
 	attachTo?: string | HTMLElement,
 	position?: number,
 	keyboard?: string,
-	options?: Array<{
+	continuation?: () => void,
+	options?: Array<{|
 		moduleID: string,
 		key?: string,
-	}>,
-};
+	|}>,
+|};
 
 const tips: Array<Tip> = [{
 	message: `
@@ -379,7 +345,9 @@ function showOrdinaryTip(change?: 'random' | 'prev' | 'next') {
 }
 
 function showTip(guiderObj) {
-	guiders.hideAll();
-	guiders.createGuider({ closeOnEscape: true, xButton: true, ...guiderObj });
-	guiders.show();
+	return new Promise(resolve => {
+		guiders.hideAll();
+		guiders.createGuider({ closeOnEscape: true, xButton: true, ...guiderObj, onHide: resolve });
+		guiders.show();
+	});
 }

--- a/lib/modules/RESTips.js
+++ b/lib/modules/RESTips.js
@@ -3,9 +3,10 @@
 import _ from 'lodash';
 import { $, guiders } from '../vendor';
 import { Module } from '../core/module';
+import * as Init from '../core/init';
 import * as Modules from '../core/modules';
 import * as Options from '../core/options';
-import { CreateElement, niceKeyCode, range, DAY } from '../utils';
+import { CreateElement, niceKeyCode, positiveModulo, DAY } from '../utils';
 import { Storage, i18n } from '../environment';
 import * as PenaltyBox from './penaltyBox';
 import * as KeyboardNav from './keyboardNav';
@@ -39,18 +40,13 @@ module.go = () => {
 			text: 'tips & tricks',
 		});
 
-		Menu.addMenuItem($menuItem, () => {
-			PenaltyBox.alterFeaturePenalty(module.moduleID, 'dailyTip', -20);
-			randomTip();
-		});
+		Menu.addMenuItem($menuItem, () => { showOrdinaryTip('random'); });
 	}
 
 	if (module.options.dailyTip.value) {
-		dailyTip();
+		Init.go.then(dailyTip);
 	}
 };
-
-let currTip = 0;
 
 async function dailyTip() {
 	const lastCheck = await lastTooltipStorage.get();
@@ -63,72 +59,45 @@ async function dailyTip() {
 		// mark off that we've displayed a new tooltip
 		lastTooltipStorage.set(now);
 		if (lastCheck === 0) {
-			showTip(0);
+			showOrdinaryTip();
 		} else {
 			PenaltyBox.alterFeaturePenalty(module.moduleID, 'dailyTip', _.clamp(PenaltyBox.MAX_PENALTY / tips.length, 3, 8));
-			setTimeout(randomTip, 500);
+			showOrdinaryTip('random');
 		}
 	}
 }
 
-function randomTip() {
-	currTip = Math.floor(Math.random() * tips.length);
-	showTip(currTip);
-}
-
-function nextTip() {
-	nextPrevTip(1);
-}
-
-function prevTip() {
-	nextPrevTip(-1);
-}
-
-function nextPrevTip(idx) {
-	PenaltyBox.alterFeaturePenalty(module.moduleID, 'dailyTip', -20);
-	hideTip();
-	currTip += idx;
-	if (currTip < 0) {
-		currTip = tips.length - 1;
-	} else if (currTip >= tips.length) {
-		currTip = 0;
-	}
-	showTip(currTip);
-}
-
-function generateTitle(help) {
-	return help.title || 'RES Tips and Tricks';
-}
-
-function generateContent(help, elem) {
+function generateContent({ message, keyboard, options }: Tip) {
 	const description = [];
 
-	if (help.message) description.push(help.message);
+	if (message) description.push(message);
 
-	if (help.keyboard) {
+	if (keyboard) {
 		// TODO: microtemplate
 		const disabled = !Modules.isEnabled(KeyboardNav);
 		description.push(`<h2 class="keyboardNav${disabled ? 'keyboardNavDisabled' : ''}">`);
 		description.push(`Keyboard Navigation${disabled ? ' (disabled)' : ''}`);
 		description.push('</h2>');
 
-		const keyboardTable = CreateElement.table(help.keyboard, generateContentKeyboard, elem);
+		const keyboardTable = CreateElement.table(keyboard, generateContentKeyboard);
 		if (keyboardTable) description.push(keyboardTable);
 	}
 
-	if (help.option) {
-		description.push('<h2 class="settingsPointer">');
-		description.push('<span class="gearIcon"></span> RES Settings');
-		description.push('</h2>');
+	if (options) {
+		for (const option of options) {
+			description.push('<h2 class="settingsPointer">');
+			description.push('<span class="gearIcon"></span> RES Settings');
+			description.push('</h2>');
 
-		const optionTable = CreateElement.table(help.option, generateContentOption, elem);
-		if (optionTable) description.push(optionTable);
+			const optionTable = CreateElement.table(option, generateContentOption);
+			if (optionTable) description.push(optionTable);
+		}
 	}
 
 	return $('<div />').html(description.join('\n'));
 }
 
-function generateContentKeyboard(keyboardNavOption) {
+function generateContentKeyboard(keyboardNavOption: string) {
 	const keyCode = niceKeyCode(KeyboardNav.module.options[keyboardNavOption].value);
 	if (!keyCode) return false;
 
@@ -170,12 +139,18 @@ function generateContentOption(option) {
 	return description;
 }
 
-const consoleTip = {
-	message: 'Roll over the gear icon <span class="gearIcon"></span> and click "settings console" to explore the RES settings.  You can enable, disable or change just about anything you like/dislike about RES!<br><br>Once you\'ve opened the console once, this message will not appear again.',
-	attachTo: '#openRESPrefs',
-	position: 5,
+export type Tip = {
+	message: string,
+	attachTo?: string | HTMLElement,
+	position?: number,
+	keyboard?: string,
+	options?: Array<{
+		moduleID: string,
+		key?: string,
+	}>,
 };
-const tips = [{
+
+const tips: Array<Tip> = [{
 	message: `
 		Welcome to RES! You can turn on, turn off, or change options for RES features using the gear icon link at the top right.
 		<p>For feature requests, or just help getting a question answered, be sure to subscribe to <a href="/r/Enhancement">/r/Enhancement</a>.</p>
@@ -187,7 +162,7 @@ const tips = [{
 	message: 'Click the tag icon next to a user to tag that user with any name you like - you can also color code the tag.',
 	attachTo: '.RESUserTagImage:visible',
 	position: 3,
-	option: { moduleID: 'userTagger' },
+	options: [{ moduleID: 'userTagger' }],
 }, {
 	message: 'If your RES data gets deleted or you move to a new computer, you can restore it from backup. <br><br><b>Firefox</b> especially sometimes loses your RES settings and data. <br><br><a href="/r/Enhancement/wiki/backing_up_res_settings" target="_blank" rel="noopener noreferer">Learn where RES stores your data and settings</a></p>',
 	title: 'Back up your RES data!',
@@ -195,14 +170,14 @@ const tips = [{
 	message: 'Don\'t forget to subscribe to <a href="/r/Enhancement">/r/Enhancement</a> to keep up to date on the latest versions of RES or suggest features! For bug reports, submit to <a href="/r/RESIssues">/r/RESIssues</a>',
 }, {
 	message: 'Don\'t want to see posts containing certain keywords? Want to filter out certain subreddits from /r/all? Try the filteReddit module!',
-	option: { moduleID: 'filteReddit' },
+	options: [{ moduleID: 'filteReddit' }],
 }, {
 	message: 'Keyboard Navigation is one of the most underutilized features in RES. You should try it!',
-	option: { moduleID: 'keyboardNav' },
+	options: [{ moduleID: 'keyboardNav' }],
 	keyboard: 'toggleHelp',
 }, {
 	message: 'Did you know you can configure the appearance of a number of things in RES? For example: keyboard navigation lets you configure the look of the "selected" box, and commentBoxes lets you configure the borders / shadows.',
-	option: [{
+	options: [{
 		moduleID: 'keyboardNav',
 		key: 'focusBGColor',
 	}, {
@@ -211,142 +186,106 @@ const tips = [{
 	}],
 }, {
 	message: 'Do you subscribe to a ton of subreddits? Give the subreddit tagger a try; it can make your homepage a bit more readable.',
-	option: {
+	options: [{
 		moduleID: 'subRedditTagger',
-	},
+	}],
 }, {
 	message: 'If you haven\'t tried it yet, Keyboard Navigation is great. Just hit ? while browsing for instructions.',
-	option: {
+	options: [{
 		moduleID: 'keyboardNav',
-	},
+	}],
 	keyboard: 'toggleHelp',
 }, {
 	message: 'Roll over a user\'s name to get information about them such as their karma, and how long they\'ve been a reddit user.',
-	option: {
+	options: [{
 		moduleID: 'userTagger',
 		key: 'hoverInfo',
-	},
+	}],
 }, {
 	message: 'Hover over the "parent" link in comments pages to see the text of the parent being referred to.',
-	option: {
+	options: [{
 		moduleID: 'showParent',
-	},
+	}],
 }, {
 	message: 'You can configure the color and style of the User Highlighter module if you want to change how the highlights look.',
-	option: {
+	options: [{
 		moduleID: 'userHighlight',
-	},
+	}],
 }, {
 	message: 'Not a fan of how comments pages look? You can change the appearance in the Style Tweaks module',
-	option: {
+	options: [{
 		moduleID: 'styleTweaks',
-	},
+	}],
 }, {
 	message: 'Don\'t like the style in a certain subreddit? RES gives you a checkbox to disable styles individually - check the right sidebar!',
 }, {
 	message: 'Looking for posts by submitter, post with photos, or posts in IAmA form? Try out the comment navigator.',
 }, {
 	message: 'Have you seen the <a href="/r/Dashboard">RES Dashboard</a>? It allows you to do all sorts of great stuff, like keep track of lower traffic subreddits, and manage your <a href="/r/Dashboard#userTaggerContents">user tags</a> and <a href="/r/Dashboard#newCommentsContents">thread subscriptions</a>!',
-	options: {
+	options: [{
 		moduleID: 'dashboard',
-	},
+	}],
 }, {
 	message: 'Sick of seeing these tips?  They only show up once every 24 hours, but you can disable that in the RES Tips and Tricks preferences.',
-	option: {
+	options: [{
 		moduleID: 'RESTips',
-	},
+	}],
 }, {
 	message: 'Did you know that there is now a "keep me logged in" option in the Account Switcher? Turn it on if you want to stay logged in to Reddit when using the switcher!',
-	option: {
+	options: [{
 		moduleID: 'accountSwitcher',
 		key: 'keepLoggedIn',
-	},
+	}],
 }, {
 	message: 'See that little [vw] next to users you\'ve voted on?  That\'s their vote weight - it moves up and down as you vote the same user up / down.',
-	option: {
+	options: [{
 		moduleID: 'userTagger',
 		key: 'vwTooltip',
-	},
+	}],
 }];
 
-const initTips = _.once(() => {
-	$('body').on('click', '#disableDailyTipsCheckbox', (e: Event) => Options.set(module, 'dailyTip', (e.target: any).checked));
+const dailyTipsCheckbox = _.once(() =>
+	$(`<label> <input type="checkbox" name="disableDailyTipsCheckbox" ${module.options.dailyTip.value ? 'checked' : ''} />Show these tips once every 24 hours</label>`)
+		.click((e: Event) => Options.set(module, 'dailyTip', (e.target: any).checked))
+);
 
-	// create the special "you have never visited the console" guider...
-	createGuider(0, 'console');
-	for (const i of range(0, tips.length)) {
-		createGuider(i);
+let currTipIndex = 0;
+
+function showOrdinaryTip(change?: 'random' | 'prev' | 'next') {
+	let tip;
+
+	PenaltyBox.alterFeaturePenalty(module.moduleID, 'dailyTip', -20);
+
+	while (!tip || (tip.attachTo && !$(tip.attachTo).is(':visible'))) {
+		if (change === 'random') currTipIndex = _.random(tips.length);
+		else if (change === 'prev') currTipIndex -= 1;
+		else if (change === 'next') currTipIndex += 1;
+		else change = 'next'; // For next iteration
+		currTipIndex = positiveModulo(currTipIndex, tips.length);
+		tip = tips[currTipIndex];
 	}
-});
 
-function createGuider(i, special) {
-	let thisID, thisTip;
+	const $description = generateContent(tip);
+	$description.on('click', 'a', () => { PenaltyBox.alterFeaturePenalty(module.moduleID, 'sectionMenu', -20); });
 
-	if (special === 'console') {
-		thisID = special;
-		thisTip = consoleTip;
-	} else {
-		thisID = `tip${i}`;
-		thisTip = tips[i];
-	}
-	const title = generateTitle(thisTip);
-	const len = tips.length;
-	const $description = generateContent(thisTip);
-	const nextidx = ((parseInt(i + 1, 10)) >= len) ? 0 : (parseInt(i + 1, 10));
-	const nextID = `tip${nextidx}`;
-	const thisChecked = (module.options.dailyTip.value) ? 'checked="checked"' : '';
-
-	const guiderObj = {
-		attachTo: thisTip.attachTo || undefined,
+	showTip({
 		buttons: [{
 			name: 'Prev',
-			onclick: prevTip,
+			onclick: () => showOrdinaryTip('prev'),
 		}, {
 			name: 'Next',
-			onclick: nextTip,
+			onclick: () => showOrdinaryTip('next'),
 		}],
 		onClose: () => { PenaltyBox.alterFeaturePenalty(module.moduleID, 'sectionMenu', 15); },
 		description: $description,
-		buttonCustomHTML: `<label class="stopper"> <input type="checkbox" name="disableDailyTipsCheckbox" id="disableDailyTipsCheckbox" ${thisChecked} />Show these tips once every 24 hours</label>`,
-		id: thisID,
-		next: nextID,
-		position: tips[i].position || undefined,
-		xButton: true,
-		title,
-	};
-	if (special === 'console') {
-		delete guiderObj.buttonCustomHTML;
-		delete guiderObj.next;
-		delete guiderObj.buttons;
-
-		guiderObj.title = 'RES is extremely configurable';
-	}
-
-	$description.on('click', 'a', () => { PenaltyBox.alterFeaturePenalty(module.moduleID, 'sectionMenu', -20); });
-
-	guiders.createGuider(guiderObj);
+		buttonCustomHTML: dailyTipsCheckbox(),
+		title: 'RES Tips and Tricks',
+		...tip,
+	});
 }
 
-function handleEscapeKey(event: KeyboardEvent) {
-	if (event.which === 27) {
-		PenaltyBox.alterFeaturePenalty(module.moduleID, 'sectionMenu', 10);
-		hideTip();
-	}
-}
-
-function showTip(idx, special) {
-	initTips();
-
-	if (!special) {
-		guiders.show(`tip${idx}`);
-	} else {
-		guiders.show('console');
-	}
-
-	$('body').on('keyup', handleEscapeKey);
-}
-
-function hideTip() {
+function showTip(guiderObj) {
 	guiders.hideAll();
-	$('body').off('keyup', handleEscapeKey);
+	guiders.createGuider({ closeOnEscape: true, xButton: true, ...guiderObj });
+	guiders.show();
 }

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -373,18 +373,15 @@ module.shouldRun = () => !(
 	module.options.excludeCommentsPage.value && isPageType('comments')
 );
 
-module.featureTips = [{
-	id: 'filterline',
-	options: {
+const featureTips = {
+	filterline: {
 		message: `
 RES allows you to easily apply complex filters to post listings. To toggle Filterline, click on the tab.
 	`,
 		title: 'Filterline',
 		position: 6,
 	},
-}, {
-	id: 'filterlineVisible',
-	options: {
+	filterlineVisible: {
 		message: `
 - Click once on a filter to enable it (e.g. clicking "has expando" will only show posts which has an expando).<br>
 - Click again to only show posts which do not match it.<br>
@@ -410,7 +407,7 @@ Any filters you choose for a subreddit / domain / user will automatically persis
 			key: 'showFilterline',
 		}],
 	},
-}];
+};
 
 const pageID = browseContexts.currentLocation.getCurrent();
 const filterlineStorage = Storage.wrap(`RESmodules.filteReddit.${pageID}`, (null: null | *));
@@ -555,7 +552,7 @@ const createFilterline = _.once(() => {
 			if (newVisibilityState) {
 				completeFilterline();
 				filterlineTab.removeAttribute('aftercontent');
-				RESTips.declareFeatureTipReady(module.moduleID, 'filterlineVisible', { attachTo: filterline.filterContainer });
+				RESTips.showFeatureTip('filterlineVisible', { ...featureTips.filterlineVisible, attachTo: filterline.filterContainer });
 			} else if (filterline.getActiveFilters().find(v => !(v instanceof ExternalFilter))) {
 				filterlineTab.setAttribute('aftercontent', ' (active)');
 			}
@@ -568,7 +565,8 @@ const createFilterline = _.once(() => {
 			}
 		}
 
-		RESTips.declareFeatureTipReady(module.moduleID, 'filterline', {
+		RESTips.showFeatureTip('filterline', {
+			...featureTips.filterline,
 			attachTo: filterlineTab,
 			continuation: () => { if (!visible) filterlineTab.click(); },
 		});

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -30,6 +30,7 @@ import type { RedditListing, RedditLink } from '../types/reddit';
 import * as CommandLine from './commandLine';
 import * as Menu from './menu';
 import * as Notifications from './notifications';
+import * as RESTips from './RESTips';
 import * as SelectedEntry from './selectedEntry';
 import * as SettingsNavigation from './settingsNavigation';
 import ExternalFilter from './filteReddit/ExternalFilter';
@@ -372,6 +373,45 @@ module.shouldRun = () => !(
 	module.options.excludeCommentsPage.value && isPageType('comments')
 );
 
+module.featureTips = [{
+	id: 'filterline',
+	options: {
+		message: `
+RES allows you to easily apply complex filters to post listings. To toggle Filterline, click on the tab.
+	`,
+		title: 'Filterline',
+		position: 6,
+	},
+}, {
+	id: 'filterlineVisible',
+	options: {
+		message: `
+- Click once on a filter to enable it (e.g. clicking "has expando" will only show posts which has an expando).<br>
+- Click again to only show posts which do not match it.<br>
+- A third click makes the filter inactive.<br>
+- To clear a filter, right-click on it.<br>
+<br>
+To find more filters, open the "more" dropdown and select a filter. These filters may take a criterion. E.g. "has expando" can be given criterion "image", which makes it filter only posts which have image expandos. Likewise, "post after" can be given criterion "1d" in order to only show posts only posted during the last day.<br>
+<br>
+You can use the currently selected post as a basis for a new filter. To do this, click on "=" to the right of the filter name.<br>
+<br>
+"Save to customFilters" extracts the current filters and inserts them into a new customFilter, which allows you to specify when the filters shall be active.<br>
+<br>
+To see why a post is hidden, go into the dropdown and check "Show filter-reason". This also gives you the opportunity to remove an external filter so that you don't have to look for it in the options console.<br>
+<br>
+You can use the command line to manipulate Filterline. Enter it by pressing the key "f".<br>
+<br>
+Any filters you choose for a subreddit / domain / user will automatically persist.<br>
+	`,
+		title: 'Filterline — how to use it',
+		position: 7,
+		options: [{
+			moduleID: 'filteReddit',
+			key: 'showFilterline',
+		}],
+	},
+}];
+
 const pageID = browseContexts.currentLocation.getCurrent();
 const filterlineStorage = Storage.wrap(`RESmodules.filteReddit.${pageID}`, (null: null | *));
 const filterlineVisibilityStorage = Storage.wrap(`RESmodules.filteReddit.filterlineVisibility.${pageID}`, (false: boolean));
@@ -515,6 +555,7 @@ const createFilterline = _.once(() => {
 			if (newVisibilityState) {
 				completeFilterline();
 				filterlineTab.removeAttribute('aftercontent');
+				RESTips.declareFeatureTipReady(module.moduleID, 'filterlineVisible', { attachTo: filterline.filterContainer });
 			} else if (filterline.getActiveFilters().find(v => !(v instanceof ExternalFilter))) {
 				filterlineTab.setAttribute('aftercontent', ' (active)');
 			}
@@ -526,6 +567,11 @@ const createFilterline = _.once(() => {
 				visible = newVisibilityState;
 			}
 		}
+
+		RESTips.declareFeatureTipReady(module.moduleID, 'filterline', {
+			attachTo: filterlineTab,
+			continuation: () => { if (!visible) filterlineTab.click(); },
+		});
 
 		if (visible) {
 			toggleVisibility(true);

--- a/lib/vendor/guiders.css
+++ b/lib/vendor/guiders.css
@@ -161,3 +161,10 @@
 .guider_contents td code {
 	white-space: nowrap;
 }
+.guiders_buttons_container label {
+	display: flex;
+	align-items: center;
+}
+.guiders_buttons_container label input[type=checkbox] {
+	margin-right: 5px;
+}


### PR DESCRIPTION
FeatureTips are multi-step guiders which may (given they're configured to do so) show guiders the first time the feature appears.

- Refactors RESTips so that only the one to be shown is generated at initialization (this improves the first-run start-up time with > 1s)
- The first guider "About RES" attaches (as intended to) to the settings cog
- Guiders for Filterline