### PR TITLE
Replace URLSearchParams() with getUrlParams()

### DIFF
--- a/lib/modules/hosts/youtube.js
+++ b/lib/modules/hosts/youtube.js
@@ -6,14 +6,14 @@ export default {
 	attribution: false,
 	domains: ['youtube.com', 'youtu.be'],
 	detect: ({ pathname, hostname, search }) => {
-		const params = new URLSearchParams(search);
+		const params = getUrlParams(search);
 		// split path excluding first /
 		const split = pathname.substring(1).split('/');
 		// short url
 		if (hostname.endsWith('youtu.be')) return split[0];
 		// long url
-		return params.has('v') ?
-			params.get('v') : // ?v=
+		return 'v' in params ?
+			params.v : // ?v=
 			(/watch|embed|v/i).exec(split[0]) && split[1]; // watch/embed/v
 	},
 	handleLink(href, hash) {


### PR DESCRIPTION
Since it's not yet implemented in Edge

Fixes #3504