### PR TITLE
Transform standard filters into 'engine' filters

### DIFF
--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -434,11 +434,11 @@ module.go = () => {
 const createFilterline = _.once(() => {
 	const filterline = new Filterline();
 
-	function buildBasicFilter(key, customFilterType, { forcePartialMatch = false }: { forcePartialMatch?: boolean } = {}) {
+	function buildBasicFilter(key, customFilterType, { fullMatch = false }: { fullMatch?: boolean } = {}) {
 		return {
 			key,
 			evaluate(thing) {
-				const { filters, sources } = getStringMatchFilters(key, customFilterType, forcePartialMatch);
+				const { filters, sources } = getStringMatchFilters(key, customFilterType, fullMatch);
 				return executeFilters(thing, filters, sources);
 			},
 			clearCache() { getStringMatchFilters.cache.delete(key); },
@@ -447,9 +447,9 @@ const createFilterline = _.once(() => {
 
 	const externalFilters = [
 		buildBasicFilter('keywords', 'postTitle'),
-		buildBasicFilter('domains', 'domain', { forcePartialMatch: true }),
+		buildBasicFilter('domains', 'domain'),
 		{
-			...buildBasicFilter('subreddits', 'subreddit'),
+			...buildBasicFilter('subreddits', 'subreddit', { fullMatch: true }),
 			state: (
 				module.options.filterSubredditsFrom.value === 'everywhere' ||
 				module.options.filterSubredditsFrom.value === 'everywhere-except-subreddit' && !currentSubreddit() ||
@@ -458,7 +458,7 @@ const createFilterline = _.once(() => {
 				isCurrentMultireddit('me/f/all')
 			) ? false : null,
 		},
-		buildBasicFilter('flair', 'linkFlair', { forcePartialMatch: true }),
+		buildBasicFilter('flair', 'linkFlair'),
 		{
 			key: 'customFilters',
 			evaluate(thing) {
@@ -550,20 +550,13 @@ function updateNsfwThingClass(thing) {
 }
 
 const regexRegex = /^\/(.*)\/([gim]+)?$/;
-const getStringMatchFilters = _.memoize((type, customFilterType, forcePartialMatch) => {
-	const sources = module.options[type].value;
-
-	const filters = sources.map(source => {
-		// $FlowIssue
-		const [matchString = '', applyTo = 'everywhere', applyList = '', except = ''] = Array.isArray(source) ? source : [source];
-
-		let matcher, flags;
-		if (module.options.regexpFilters.value && regexRegex.test(matchString)) {
+const getStringMatchFilters = _.memoize((type, customFilterType, fullMatch) => {
+	function buildMatchRegex(string, fullMatch) {
+		if (module.options.regexpFilters.value && regexRegex.test(string)) {
 			try {
-				const [, str, fl] = (regexRegex.exec(matchString): any); // guaranteed to match due to `.test()` above
-				const regexp = new RegExp(str, fl);
-				matcher = regexp.source;
-				flags = regexp.flags;
+				const [, str, flags] = (regexRegex.exec(string): any); // guaranteed to match due to `.test()` above
+
+				return new RegExp(str, flags);
 			} catch (e) {
 				Notifications.showNotification({
 					moduleID: module.moduleID,
@@ -573,7 +566,7 @@ const getStringMatchFilters = _.memoize((type, customFilterType, forcePartialMat
 					message: `
 						There was a problem parsing a RegExp in your filteReddit settings.
 						${SettingsNavigation.makeUrlHashLink(module.moduleID, type, 'Correct it now.')}
-						<p>RegExp: <code>${matchString}</code></p>
+						<p>RegExp: <code>${string}</code></p>
 						<blockquote>${e.toString()}</blockquote>
 					`,
 				});
@@ -581,12 +574,22 @@ const getStringMatchFilters = _.memoize((type, customFilterType, forcePartialMat
 				throw e;
 			}
 		} else {
-			matcher = escapeStringRegexp(matchString);
-			flags = 'i';
-
-			// flair and domains filters match if contains and the related postCases do a full match (^$) regexp
-			if (forcePartialMatch) matcher = `.*${matcher}.*`;
+			return buildPlainStringRegex(string, fullMatch);
 		}
+	}
+
+	function buildPlainStringRegex(matchString, fullMatch) {
+		let matcher = escapeStringRegexp(matchString);
+		if (fullMatch) matcher = `^${matcher}$`;
+
+		return new RegExp(matcher, 'i');
+	}
+
+	const sources = module.options[type].value;
+
+	const filters = sources.map(source => {
+		// $FlowIssue
+		const [matchString = '', applyTo = 'everywhere', applyList = '', except = ''] = Array.isArray(source) ? source : [source];
 
 		return {
 			note: `basic ${type} filter transformation`,
@@ -599,16 +602,24 @@ const getStringMatchFilters = _.memoize((type, customFilterType, forcePartialMat
 					(applyTo !== 'everywhere') && {
 						type: 'group',
 						op: applyTo === 'exclude' ? 'none' : 'any',
-						of: applyList.split(',').map(sr => ({
-							type: 'currentSub',
-							patt: sr,
-						})),
+						of: _.compact([
+							// normal subreddit include/exclude
+							...applyList.split(',').map(sr => ({
+								type: 'subreddit',
+								patt: sr,
+							})),
+							// /r/all special case
+							// (nothing is posted to /r/all, but we could be browsing it)
+							applyList.split(',').includes('all') ? {
+								type: 'currentSub',
+								patt: 'all',
+							} : null,
+						]),
 					},
 					// main filter
 					{
 						type: customFilterType,
-						patt: matcher,
-						flags,
+						patt: buildMatchRegex(matchString, fullMatch),
 					},
 					// filter exclusions
 					(except && except.length) && {
@@ -616,7 +627,7 @@ const getStringMatchFilters = _.memoize((type, customFilterType, forcePartialMat
 						op: 'none',
 						of: [{
 							type: customFilterType,
-							patt: except,
+							patt: buildPlainStringRegex(except, fullMatch),
 						}],
 					},
 				]),

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import _ from 'lodash';
+import escapeStringRegexp from 'escape-string-regexp';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
 import * as Init from '../core/init';
@@ -577,7 +578,8 @@ const getStringMatchFilters = _.memoize((type, customFilterType) =>
 				return;
 			}
 		} else {
-			matcher = matchString.toLowerCase();
+			matcher = escapeStringRegexp(matchString);
+			flags = 'i';
 
 			// flair and domains filters match if contains and the related postCases do a full match (^$) regexp
 			if (type === 'flair' || type === 'domains') matcher = `.*${matcher}.*`;

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -434,7 +434,7 @@ module.go = () => {
 const createFilterline = _.once(() => {
 	const filterline = new Filterline();
 
-	function buildBasicFilter(key, customFilterType, { fullMatch = false }: { fullMatch?: boolean } = {}) {
+	function buildBasicFilter(key, customFilterType, { fullMatch = false } = {}) {
 		return {
 			key,
 			evaluate(thing) {

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -435,11 +435,11 @@ module.go = () => {
 const createFilterline = _.once(() => {
 	const filterline = new Filterline();
 
-	function buildBasicFilter(key, customFilterType) {
+	function buildBasicFilter(key, customFilterType, { forcePartialMatch = false }: { forcePartialMatch?: boolean } = {}) {
 		return {
 			key,
 			evaluate(thing) {
-				const filters = getStringMatchFilters(key, customFilterType);
+				const filters = getStringMatchFilters(key, customFilterType, forcePartialMatch);
 				return executeFilters(thing, filters);
 			},
 			clearCache() { getStringMatchFilters.cache.delete(key); },
@@ -448,7 +448,7 @@ const createFilterline = _.once(() => {
 
 	const externalFilters = [
 		buildBasicFilter('keywords', 'postTitle'),
-		buildBasicFilter('domains', 'domain'),
+		buildBasicFilter('domains', 'domain', { forcePartialMatch: true }),
 		{
 			...buildBasicFilter('subreddits', 'subreddit'),
 			state: (
@@ -459,7 +459,7 @@ const createFilterline = _.once(() => {
 				isCurrentMultireddit('me/f/all')
 			) ? false : null,
 		},
-		buildBasicFilter('flair', 'linkFlair'),
+		buildBasicFilter('flair', 'linkFlair', { forcePartialMatch: true }),
 		{
 			key: 'customFilters',
 			evaluate(thing) {
@@ -550,7 +550,7 @@ function updateNsfwThingClass(thing) {
 }
 
 const regexRegex = /^\/(.*)\/([gim]+)?$/;
-const getStringMatchFilters = _.memoize((type, customFilterType) =>
+const getStringMatchFilters = _.memoize((type, customFilterType, forcePartialMatch) =>
 	filterMap(module.options[type].value, source => {
 		// $FlowIssue
 		const [matchString = '', applyTo = 'everywhere', applyList = '', except = ''] = Array.isArray(source) ? source : [source];
@@ -582,7 +582,7 @@ const getStringMatchFilters = _.memoize((type, customFilterType) =>
 			flags = 'i';
 
 			// flair and domains filters match if contains and the related postCases do a full match (^$) regexp
-			if (type === 'flair' || type === 'domains') matcher = `.*${matcher}.*`;
+			if (forcePartialMatch) matcher = `.*${matcher}.*`;
 		}
 
 		const filter = {

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -557,7 +557,8 @@ const getStringMatchFilters = _.memoize((type, customFilterType) =>
 		let matcher, flags;
 		if (module.options.regexpFilters.value && regexRegex.test(matchString)) {
 			try {
-				const regexp = new RegExp(...regexRegex.exec(matchString).slice(1));
+				const [, str, fl] = (regexRegex.exec(matchString): any); // guaranteed to match due to `.test()` above
+				const regexp = new RegExp(str, fl);
 				matcher = regexp.source;
 				flags = regexp.flags;
 			} catch (e) {

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -13,6 +13,7 @@ import {
 	currentSubreddit,
 	CreateElement,
 	fastAsync,
+	filterMap,
 	loggedInUser,
 	indexOptionTable,
 	isCurrentMultireddit,
@@ -20,7 +21,6 @@ import {
 	isPageType,
 	mutex,
 	reifyPromise,
-	string,
 	watchForElement,
 } from '../utils';
 import { Storage, ajax } from '../environment';
@@ -434,29 +434,36 @@ module.go = () => {
 const createFilterline = _.once(() => {
 	const filterline = new Filterline();
 
+	function buildBasicFilter(key, customFilterType) {
+		return {
+			key,
+			evaluate(thing) {
+				const filters = getStringMatchFilters(key, customFilterType);
+				return executeFilters(thing, filters);
+			},
+			clearCache() { getStringMatchFilters.cache.delete(key); },
+		};
+	}
+
 	const externalFilters = [
+		buildBasicFilter('keywords', 'postTitle'),
+		buildBasicFilter('domains', 'domain'),
 		{
-			key: 'keywords',
-			evaluate(thing) { return filtersMatchString(this.key, thing.getTitle(), thing.getSubreddit()); },
-			clearCache() { getStringMatchFilters.cache.delete(this.key); },
-		}, {
-			key: 'domains',
-			evaluate(thing) { return filtersMatchString(this.key, thing.getPostDomain(), thing.getSubreddit()); },
-			clearCache() { getStringMatchFilters.cache.delete(this.key); },
-		}, {
-			key: 'subreddits',
-			state: ((module.options.filterSubredditsFrom.value === 'everywhere') ||
-				(module.options.filterSubredditsFrom.value === 'everywhere-except-subreddit' && !currentSubreddit()) ||
-				isCurrentSubreddit('all') || currentDomain() || isCurrentMultireddit('me/f/all')) ? false : null,
-			evaluate(thing) { return filtersMatchString(this.key, thing.getSubreddit() || '', null, true); },
-			clearCache() { getStringMatchFilters.cache.delete(this.key); },
-		}, {
-			key: 'flair',
-			evaluate(thing) { return filtersMatchString(this.key, thing.getPostFlairText(), thing.getSubreddit()); },
-			clearCache() { getStringMatchFilters.cache.delete(this.key); },
-		}, {
+			...buildBasicFilter('subreddits', 'subreddit'),
+			state: (
+				module.options.filterSubredditsFrom.value === 'everywhere' ||
+				module.options.filterSubredditsFrom.value === 'everywhere-except-subreddit' && !currentSubreddit() ||
+				isCurrentSubreddit('all') ||
+				currentDomain() ||
+				isCurrentMultireddit('me/f/all')
+			) ? false : null,
+		},
+		buildBasicFilter('flair', 'linkFlair'),
+		{
 			key: 'customFilters',
-			evaluate: executeCustomFilters,
+			evaluate(thing) {
+				return executeFilters(thing, module.options.customFilters.value);
+			},
 		},
 	];
 
@@ -541,81 +548,88 @@ function updateNsfwThingClass(thing) {
 	}
 }
 
-function executeCustomFilters(thing) {
-	const { cases: config, value: filters } = module.options.customFilters;
-	return filters.find(filter => config[filter.body.type].evaluate(thing, filter.body, config));
-}
-
 const regexRegex = /^\/(.*)\/([gim]+)?$/;
-
-const getStringMatchFilters = _.memoize(type => {
-	const sources = module.options[type].value;
-
-	return sources.map(source => {
+const getStringMatchFilters = _.memoize((type, customFilterType) =>
+	filterMap(module.options[type].value, source => {
 		// $FlowIssue
-		const [matchString, applyTo = 'everywhere', applyList = '', except = ''] = Array.isArray(source) ? source : [source];
+		const [matchString = '', applyTo = 'everywhere', applyList = '', except = ''] = Array.isArray(source) ? source : [source];
 
-		let whenMatching;
+		let matcher, flags;
 		if (module.options.regexpFilters.value && regexRegex.test(matchString)) {
-			const regexp = regexRegex.exec(matchString);
 			try {
-				whenMatching = new RegExp(regexp[1], regexp[2]);
+				const regexp = new RegExp(...regexRegex.exec(matchString).slice(1));
+				matcher = regexp.source;
+				flags = regexp.flags;
 			} catch (e) {
 				Notifications.showNotification({
 					moduleID: module.moduleID,
 					optionKey: type,
 					notificationID: 'badRegexpPattern',
 					header: 'filteReddit RegExp issue',
-					message: string.escapeHTML`
+					message: `
 						There was a problem parsing a RegExp in your filteReddit settings.
 						${SettingsNavigation.makeUrlHashLink(module.moduleID, type, 'Correct it now.')}
 						<p>RegExp: <code>${matchString}</code></p>
 						<blockquote>${e.toString()}</blockquote>
 					`,
 				});
-				return null;
+				return;
 			}
 		} else {
-			whenMatching = matchString.toLowerCase();
+			matcher = matchString.toLowerCase();
+
+			// flair and domains filters match if contains and the related postCases do a full match (^$) regexp
+			if (type === 'flair' || type === 'domains') matcher = `.*${matcher}.*`;
 		}
 
-		return {
-			whenMatching,
-			applyTo,
-			applyList: applyList.toLowerCase().split(','),
-			except: except.toLowerCase(),
-			source,
+		const filter = {
+			type: 'group',
+			op: 'all',
+			of: [],
 		};
-	}).filter(v => v);
-});
 
-function filtersMatchString(
-	type,
-	compareString,
-	subreddit = currentSubreddit(),
-	matchFullString = false
-) {
-	if (subreddit) subreddit = subreddit.toLowerCase();
-	if (compareString) compareString = compareString.toLowerCase();
-	else return false;
+		// add any necessary applyTo filtering
+		if (applyTo !== 'everywhere') {
+			filter.of.push({
+				type: 'group',
+				op: applyTo === 'exclude' ? 'none' : 'any',
+				of: applyList.split(',').map(sr => ({
+					type: 'currentSub',
+					patt: sr,
+				})),
+			});
+		}
 
-	const result = getStringMatchFilters(type).find(filter => {
-		// we also want to know if we should be matching /r/all, because when getting
-		// listings on /r/all, each post has a subreddit (that does not equal "all")
-		const checkRAll = isCurrentSubreddit('all') && filter.applyList.includes('all');
-		if (
-			(filter.applyTo === 'exclude' && (filter.applyList.includes(subreddit) || checkRAll)) ||
-			(filter.applyTo === 'include' && (!filter.applyList.includes(subreddit) && !checkRAll))
-		) return false;
+		filter.of.push({
+			type: customFilterType,
+			patt: matcher,
+			flags,
+		});
 
-		if (filter.except.length && compareString.includes(filter.except)) return false;
+		if (except && except.length) {
+			filter.of.push({
+				type: 'group',
+				op: 'none',
+				of: [{
+					type: customFilterType,
+					patt: except,
+				}],
+			});
+		}
 
-		if (filter.whenMatching instanceof RegExp) return filter.whenMatching.test(compareString);
-		else if (matchFullString) return compareString === filter.whenMatching;
-		else return compareString.includes(filter.whenMatching);
-	});
+		return [{
+			body: filter,
+			note: `basic ${type} filter transformation`,
+			source,
+			ver: 1,
+		}];
+	})
+);
 
-	return result && result.source;
+function executeFilters(thing, filters) {
+	const config = module.options.customFilters.cases;
+	const filter = filters.find(filter => config[filter.body.type].evaluate(thing, filter.body, config));
+	return filter && (filter.source || filter);
 }
 
 /**

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -14,7 +14,6 @@ import {
 	currentSubreddit,
 	CreateElement,
 	fastAsync,
-	filterMap,
 	loggedInUser,
 	indexOptionTable,
 	isCurrentMultireddit,
@@ -439,8 +438,8 @@ const createFilterline = _.once(() => {
 		return {
 			key,
 			evaluate(thing) {
-				const filters = getStringMatchFilters(key, customFilterType, forcePartialMatch);
-				return executeFilters(thing, filters);
+				const { filters, sources } = getStringMatchFilters(key, customFilterType, forcePartialMatch);
+				return executeFilters(thing, filters, sources);
 			},
 			clearCache() { getStringMatchFilters.cache.delete(key); },
 		};
@@ -463,7 +462,8 @@ const createFilterline = _.once(() => {
 		{
 			key: 'customFilters',
 			evaluate(thing) {
-				return executeFilters(thing, module.options.customFilters.value);
+				const customFilters = module.options.customFilters.value;
+				return executeFilters(thing, customFilters, customFilters);
 			},
 		},
 	];
@@ -550,8 +550,10 @@ function updateNsfwThingClass(thing) {
 }
 
 const regexRegex = /^\/(.*)\/([gim]+)?$/;
-const getStringMatchFilters = _.memoize((type, customFilterType, forcePartialMatch) =>
-	filterMap(module.options[type].value, source => {
+const getStringMatchFilters = _.memoize((type, customFilterType, forcePartialMatch) => {
+	const sources = module.options[type].value;
+
+	const filters = sources.map(source => {
 		// $FlowIssue
 		const [matchString = '', applyTo = 'everywhere', applyList = '', except = ''] = Array.isArray(source) ? source : [source];
 
@@ -575,7 +577,8 @@ const getStringMatchFilters = _.memoize((type, customFilterType, forcePartialMat
 						<blockquote>${e.toString()}</blockquote>
 					`,
 				});
-				return;
+
+				throw e;
 			}
 		} else {
 			matcher = escapeStringRegexp(matchString);
@@ -585,54 +588,51 @@ const getStringMatchFilters = _.memoize((type, customFilterType, forcePartialMat
 			if (forcePartialMatch) matcher = `.*${matcher}.*`;
 		}
 
-		const filter = {
-			type: 'group',
-			op: 'all',
-			of: [],
-		};
-
-		// add any necessary applyTo filtering
-		if (applyTo !== 'everywhere') {
-			filter.of.push({
-				type: 'group',
-				op: applyTo === 'exclude' ? 'none' : 'any',
-				of: applyList.split(',').map(sr => ({
-					type: 'currentSub',
-					patt: sr,
-				})),
-			});
-		}
-
-		filter.of.push({
-			type: customFilterType,
-			patt: matcher,
-			flags,
-		});
-
-		if (except && except.length) {
-			filter.of.push({
-				type: 'group',
-				op: 'none',
-				of: [{
-					type: customFilterType,
-					patt: except,
-				}],
-			});
-		}
-
-		return [{
-			body: filter,
+		return {
 			note: `basic ${type} filter transformation`,
-			source,
 			ver: 1,
-		}];
-	})
-);
+			body: {
+				type: 'group',
+				op: 'all',
+				of: _.compact([
+					// applyTo filtering
+					(applyTo !== 'everywhere') && {
+						type: 'group',
+						op: applyTo === 'exclude' ? 'none' : 'any',
+						of: applyList.split(',').map(sr => ({
+							type: 'currentSub',
+							patt: sr,
+						})),
+					},
+					// main filter
+					{
+						type: customFilterType,
+						patt: matcher,
+						flags,
+					},
+					// filter exclusions
+					(except && except.length) && {
+						type: 'group',
+						op: 'none',
+						of: [{
+							type: customFilterType,
+							patt: except,
+						}],
+					},
+				]),
+			},
+		};
+	});
 
-function executeFilters(thing, filters) {
+	return { filters, sources };
+});
+
+function executeFilters(thing, filters, sources) {
 	const config = module.options.customFilters.cases;
-	const filter = filters.find(filter => config[filter.body.type].evaluate(thing, filter.body, config));
-	return filter && (filter.source || filter);
+	const matchingIndex = filters.findIndex(filter => config[filter.body.type].evaluate(thing, filter.body, config));
+	if (matchingIndex !== -1) {
+		return sources[matchingIndex];
+	}
 }
 
 /**

--- a/lib/modules/filteReddit/postCases.js
+++ b/lib/modules/filteReddit/postCases.js
@@ -21,6 +21,13 @@ function numericalCompare(op, a, b) {
 	}
 }
 
+function possibleRegex(patt, flags = 'i', fullMatch = true) {
+	if (patt instanceof RegExp) return patt;
+	else {
+		return new RegExp(fullMatch ? `^(${patt})$` : patt, flags);
+	}
+}
+
 export default ({
 	subreddit: {
 		name: 'Subreddit',
@@ -36,7 +43,7 @@ export default ({
 			const subreddit = thing.getSubreddit();
 			if (!subreddit) return false;
 
-			const pattern = new RegExp(`^(${data.patt})$`, 'i');
+			const pattern = possibleRegex(data.patt, data.flags);
 			return pattern.test(subreddit.trim());
 		},
 		pattern: 'RegEx',
@@ -195,7 +202,7 @@ export default ({
 			const domain = thing.getPostDomain();
 			if (!domain) return false;
 
-			const pattern = new RegExp(`^(${data.patt})$`, 'i');
+			const pattern = possibleRegex(data.patt, data.flags);
 			return pattern.test(domain);
 		},
 		pattern: 'RegEx',
@@ -217,7 +224,7 @@ export default ({
 			const text = thing.getPostFlairText();
 			if (!text) return false;
 
-			const pattern = new RegExp(`^(${data.patt})$`, 'i');
+			const pattern = possibleRegex(data.patt, data.flags);
 			return pattern.test(text.trim());
 		},
 		pattern: '[RegEx]',
@@ -303,7 +310,7 @@ export default ({
 		evaluate(thing, data) {
 			const title = thing.getTitle();
 			// Do not anchor for this case
-			return new RegExp(data.patt, 'i').test(title);
+			return possibleRegex(data.patt, data.flags, false).test(title);
 		},
 		pattern: 'RegEx',
 		parse(input) { return (input && input.length) ? this.defaultTemplate(input) : null; },

--- a/lib/modules/filteReddit/postCases.js
+++ b/lib/modules/filteReddit/postCases.js
@@ -21,10 +21,11 @@ function numericalCompare(op, a, b) {
 	}
 }
 
-function possibleRegex(patt, flags = 'i', fullMatch = true) {
-	if (patt instanceof RegExp) return patt;
-	else {
-		return new RegExp(fullMatch ? `^(${patt})$` : patt, flags);
+function possibleRegex(patt, { fullMatch = true } = {}) {
+	if (patt instanceof RegExp) {
+		return patt;
+	} else {
+		return new RegExp(fullMatch ? `^(${patt})$` : patt, 'i');
 	}
 }
 
@@ -43,7 +44,7 @@ export default ({
 			const subreddit = thing.getSubreddit();
 			if (!subreddit) return false;
 
-			const pattern = possibleRegex(data.patt, data.flags);
+			const pattern = possibleRegex(data.patt);
 			return pattern.test(subreddit.trim());
 		},
 		pattern: 'RegEx',
@@ -202,7 +203,7 @@ export default ({
 			const domain = thing.getPostDomain();
 			if (!domain) return false;
 
-			const pattern = possibleRegex(data.patt, data.flags);
+			const pattern = possibleRegex(data.patt);
 			return pattern.test(domain);
 		},
 		pattern: 'RegEx',
@@ -224,7 +225,7 @@ export default ({
 			const text = thing.getPostFlairText();
 			if (!text) return false;
 
-			const pattern = possibleRegex(data.patt, data.flags);
+			const pattern = possibleRegex(data.patt);
 			return pattern.test(text.trim());
 		},
 		pattern: '[RegEx]',
@@ -310,7 +311,7 @@ export default ({
 		evaluate(thing, data) {
 			const title = thing.getTitle();
 			// Do not anchor for this case
-			return possibleRegex(data.patt, data.flags, false).test(title);
+			return possibleRegex(data.patt, { fullMatch: false }).test(title);
 		},
 		pattern: 'RegEx',
 		parse(input) { return (input && input.length) ? this.defaultTemplate(input) : null; },

--- a/tests/filteReddit.js
+++ b/tests/filteReddit.js
@@ -164,12 +164,6 @@ module.exports = {
 			.end();
 	},
 	'regex filters': browser => {
-		if (browser.end) {
-			// skip this test because master handles it incorrectly; will be fixed in #3604
-			browser.end();
-			return;
-		}
-
 		browser
 			// basic title regex filter
 			.perform(editSettings(() => browser
@@ -185,7 +179,7 @@ module.exports = {
 				.clearValue('#optionContainer-filteReddit-keywords input')
 				.click('#optionContainer-filteReddit-subreddits .addRowButton')
 				.clearValue('#optionContainer-filteReddit-subreddits input')
-				.setValue('#optionContainer-filteReddit-subreddits input', ['/\wIntegrationTests(?!2)/'])
+				.setValue('#optionContainer-filteReddit-subreddits input', ['/\\wIntegrationTests(?!2)/'])
 			))
 			.url(byId(POST.B, POST.RESIntegrationTests2))
 			.waitForElementNotVisible(thing(POST.B))


### PR DESCRIPTION
This is a first cut at removing the custom filtering logic
for the basic filters. There is still a transformation phase
that converts the value input from the user into different
filters used by the custom filter engine (group, currentSub, etc.).
These transformations are cached and then run just like the custom
filters during the filtering phase

fixes #2839