### PR TITLE
Fix graphiq expando

### DIFF
--- a/lib/modules/hosts/graphiq.js
+++ b/lib/modules/hosts/graphiq.js
@@ -9,8 +9,7 @@ export default {
 	landingPage: 'https://www.graphiq.com/', // set menually as https url without www didn't work when i tried it
 	detect: ({ pathname }) => (/^\/(?:w|wlp|vlp)\/([A-z0-9]+)/i).exec(pathname),
 	async handleLink(href, [url, id]) {
-
-		const { width, height } = await ajax({
+		let { width, height } = await ajax({
 			url: 'https://oembed.graphiq.com/services/oembed',
 			data: { url },
 			type: 'json',

--- a/lib/modules/hosts/graphiq.js
+++ b/lib/modules/hosts/graphiq.js
@@ -7,14 +7,19 @@ export default {
 	domains: ['graphiq.com'],
 	logo: '//www.graphiq.com/favicon.ico',
 	landingPage: 'https://www.graphiq.com/', // set menually as https url without www didn't work when i tried it
-	detect: ({ pathname }) => (/^\/(?:w|wlp)\/([A-z0-9]+)/i).exec(pathname),
+	detect: ({ pathname }) => (/^\/(?:w|wlp|vlp)\/([A-z0-9]+)/i).exec(pathname),
 	async handleLink(href, [url, id]) {
+
 		const { width, height } = await ajax({
 			url: 'https://oembed.graphiq.com/services/oembed',
 			data: { url },
 			type: 'json',
 			cacheFor: DAY,
 		});
+
+		// Fallback if oembed api doesn't return any data
+		height = height || '360';
+		width = width || '640';
 
 		return {
 			type: 'IFRAME',

--- a/lib/modules/hosts/graphiq.js
+++ b/lib/modules/hosts/graphiq.js
@@ -9,16 +9,15 @@ export default {
 	landingPage: 'https://www.graphiq.com/', // set menually as https url without www didn't work when i tried it
 	detect: ({ pathname }) => (/^\/(?:w|wlp|vlp)\/([A-z0-9]+)/i).exec(pathname),
 	async handleLink(href, [url, id]) {
-		let { width, height } = await ajax({
+		const {
+			width = '640',
+			height = '360',
+		} = await ajax({
 			url: 'https://oembed.graphiq.com/services/oembed',
 			data: { url },
 			type: 'json',
 			cacheFor: DAY,
 		});
-
-		// Fallback if oembed api doesn't return any data
-		height = height || '360';
-		width = width || '640';
 
 		return {
 			type: 'IFRAME',


### PR DESCRIPTION
It appears the graphiq url's had changed slightly meaning the a lot of the new graphiq urls were no longer expandable. Have added a fix + also added a fallback for when the oembed api doesn't return any data for a url (which appears to happen occasionally)

Tested against: 
https://www.reddit.com/domain/graphiq.com/