### PR TITLE
[experimental] Speed up integration tests with multiple workers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
         - npm run jpm -- xpi
         - npm run coverage && npm run report-coverage
         - node dist/node/loader.entry.js
-        - npm run test-integration -- chrome,firefox
+        - npm run test-integration -- chrome && npm run test-integration -- firefox
     - env: RES_JOB=build_deploy
       script:
         - npm run build -- all

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -7,6 +7,10 @@ const firefoxManifest = require('./firefox/package.json');
 
 module.exports = {
 	src_folders: ['tests'],
+	test_workers: {
+		enabled: true,
+		workers: 5,
+	},
 	test_settings: {
 		default: {
 			selenium_host: 'ondemand.saucelabs.com',


### PR DESCRIPTION
Sauce Labs lets us run 5 sessions in parallel, so let's take advantage of that.

Also, run the Chrome tests by themselves first (which are faster) and don't run Firefox tests if they fail.