### PR TITLE
commentsOpened filter: newCommentCount criteria [WIP]

### DIFF
--- a/lib/modules/filteReddit/postCases.js
+++ b/lib/modules/filteReddit/postCases.js
@@ -5,6 +5,7 @@ import escapeStringRegexp from 'escape-string-regexp';
 import {
 	loggedInUser,
 } from '../../utils';
+import * as NewCommentCount from '../newCommentCount';
 import * as ShowImages from '../showImages';
 import * as FilteReddit from '../filteReddit';
 import { isURLVisited } from '../../environment';
@@ -407,20 +408,39 @@ export default ({
 		unique: true,
 		trueText: 'comments opened',
 		falseText: '¬ comments opened',
-		defaultTemplate() {
-			return { type: 'commentsOpened' };
+		defaultTemplate(val = 0) {
+			return { type: 'commentsOpened', val };
 		},
 		fields: [
-			'comment link has not been visited',
+			'Comments page not been visited, or there are less than',
+			{ type: 'number', id: 'val' },
+			'new comments',
 		],
 		disabled: process.env.BUILD_TARGET === 'safari' || process.env.BUILD_TARGET === 'edge',
 		get alwaysShow() { return !this.disabled; },
-		evaluate(thing) {
+		evaluate(thing, data) {
+			if (data.val > 0) {
+				const newCount = NewCommentCount.getNewCount(thing);
+				if (!isNaN(newCount)) return newCount < data.val;
+			}
+
 			const link = thing.getCommentsLink();
 			return link && isURLVisited(link.href) || false;
 		},
 		async: true,
-		parse() { return this.defaultTemplate(); },
+		pattern: '?integer',
+		parse(input) {
+			if (input) {
+				this.trueText = 'comments opened with new comments <';
+				this.falseText = 'comments not opened or new comments >=';
+				const value = parseInt(input, 10);
+				return value >= 0 ? this.defaultTemplate(input) : null;
+			} else {
+				this.trueText = 'comments opened';
+				this.falseText = '¬ comments opened';
+				return this.defaultTemplate();
+			}
+		},
 	},
 	hasExpando: {
 		name: 'Has expando',

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -295,7 +295,7 @@ function subscribe(threadid) {
 	drawSubscriptionsTable();
 }
 
-function displayNewCommentCount(thing) {
+export function getNewCount(thing: Thing): ?number {
 	const currentCount = thing.getCommentCount();
 
 	const countObj = commentCounts[thing.getFullname().split('_').slice(-1)[0]];
@@ -303,8 +303,11 @@ function displayNewCommentCount(thing) {
 
 	if (!Number.isInteger(currentCount) || !Number.isInteger(lastOpenedCount)) return;
 
-	const newCount = Math.max(currentCount - lastOpenedCount, 0);
+	return Math.max(currentCount - lastOpenedCount, 0);
+}
 
+function displayNewCommentCount(thing) {
+	const newCount = getNewCount(thing);
 	if (!newCount) return;
 
 	thing.element.classList.add('res-hasNewComments');


### PR DESCRIPTION
Useful in order to hide posts with less than n new comments.

WIP since modifying `trueText`/`falseText` in `parse` is hacky.