### PR TITLE
Reattach the comment tools and preview after a post/comment has been saved

### DIFF
--- a/lib/modules/commentPreview.js
+++ b/lib/modules/commentPreview.js
@@ -285,6 +285,17 @@ function attachPreview(usertext = document.body) {
 
 		textareas.on('input', e => onTextareaInput(preview, contents, e));
 
+		$this.closest('form').submit(e => {
+			const container = $(e.target).closest('.thing').parent();
+
+			const id = setInterval(() => {
+				if (!document.body.contains(e.target)) {
+					attachPreview(container);
+					clearInterval(id);
+				}
+			}, 250);
+		});
+
 		// check for reply --> quoted text
 		$this.closest('.thing').find('.buttons a[onclick*="reply"]') /* terrible selector */
 			.on('click', () => textareas.trigger('input'));

--- a/lib/modules/commentPreview.js
+++ b/lib/modules/commentPreview.js
@@ -286,8 +286,8 @@ function attachPreview(usertext = document.body) {
 
 		textareas.on('input', e => onTextareaInput(preview, contents, e));
 
-		observeNewThing($(this).closest('.sitetable')[0]).then(mutation => {
-			attachPreview(mutation.target);
+		observeNewThing($(this).closest('.sitetable')[0]).then(target => {
+			attachPreview(target);
 		});
 
 		// check for reply --> quoted text

--- a/lib/modules/commentPreview.js
+++ b/lib/modules/commentPreview.js
@@ -13,6 +13,7 @@ import {
 	isPageType,
 	watchForElement,
 } from '../utils';
+import { observeNewThing } from '../utils/dom';
 import * as CommentTools from './commentTools';
 import * as KeyboardNav from './keyboardNav';
 import * as SettingsNavigation from './settingsNavigation';
@@ -285,15 +286,8 @@ function attachPreview(usertext = document.body) {
 
 		textareas.on('input', e => onTextareaInput(preview, contents, e));
 
-		$this.closest('form').submit(e => {
-			const container = $(e.target).closest('.thing').parent();
-
-			const id = setInterval(() => {
-				if (!document.body.contains(e.target)) {
-					attachPreview(container);
-					clearInterval(id);
-				}
-			}, 250);
+		observeNewThing($(this).closest('.sitetable')[0]).then(mutation => {
+			attachPreview(mutation.target);
 		});
 
 		// check for reply --> quoted text

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -391,6 +391,17 @@ function attachEditorToUsertext() {
 	} else {
 		$(this).parent().before(bar);
 	}
+
+	$(this).closest('form').submit(e => {
+		const container = $(e.target).closest('.thing').parent();
+
+		const id = setInterval(() => {
+			if (!document.body.contains(e.target)) {
+				getCommentTextarea(container).each(attachEditorToUsertext);
+				clearInterval(id);
+			}
+		}, 250);
+	});
 	updateCounter(this);
 }
 

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -393,8 +393,8 @@ function attachEditorToUsertext() {
 		$(this).parent().before(bar);
 	}
 
-	observeNewThing($(this).closest('.sitetable')[0]).then(mutation => {
-		getCommentTextarea(mutation.target).each(attachEditorToUsertext);
+	observeNewThing($(this).closest('.sitetable')[0]).then(target => {
+		getCommentTextarea(target).each(attachEditorToUsertext);
 	});
 	updateCounter(this);
 }

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -17,6 +17,7 @@ import {
 	range,
 	regexes,
 } from '../utils';
+import { observeNewThing } from '../utils/dom';
 import type { KeyArray } from '../utils/keycode';
 import { Storage, ajax } from '../environment';
 import type { RedditSearchSubredditNames } from '../types/reddit';
@@ -392,15 +393,8 @@ function attachEditorToUsertext() {
 		$(this).parent().before(bar);
 	}
 
-	$(this).closest('form').submit(e => {
-		const container = $(e.target).closest('.thing').parent();
-
-		const id = setInterval(() => {
-			if (!document.body.contains(e.target)) {
-				getCommentTextarea(container).each(attachEditorToUsertext);
-				clearInterval(id);
-			}
-		}, 250);
+	observeNewThing($(this).closest('.sitetable')[0]).then(mutation => {
+		getCommentTextarea(mutation.target).each(attachEditorToUsertext);
 	});
 	updateCounter(this);
 }

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -38,6 +38,18 @@ export function observe(ele: Node, options: MutationObserverInit, callback: Iter
 	return observer;
 }
 
+export function observeNewThing(ele: Node): Promise<MutationRecord> {
+	return new Promise(resolve => {
+		const observer = observe(ele, { childList: true }, mutation => {
+			if (Array.from(mutation.addedNodes).find(e => e.classList.contains('thing'))) {
+				observer.disconnect();
+				resolve(mutation);
+				return true;
+			}
+		});
+	});
+}
+
 export function waitForChild(ele: Element, selector: string): Promise<void> {
 	return new Promise(resolve => {
 		if (Array.from(ele.children).some(child => $(child).is(selector))) {

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -43,7 +43,7 @@ export function observeNewThing(ele: Node): Promise<MutationRecord> {
 		const observer = observe(ele, { childList: true }, mutation => {
 			if (Array.from(mutation.addedNodes).find(e => e.classList.contains('thing'))) {
 				observer.disconnect();
-				resolve(mutation);
+				resolve(mutation.target);
 				return true;
 			}
 		});


### PR DESCRIPTION
This is a PR to make the comment tools and comment preview available when a user edits a comment/post twice on a page without refreshing the page. Currently, when the form is posted the HTML form is completely replaced, which wipes away the attached tools and preview.

fixes #3625 