### PR TITLE
record module profiling with the performance timing API

### DIFF
--- a/lib/core/profiling.js
+++ b/lib/core/profiling.js
@@ -58,6 +58,7 @@ type TimingInfo = { [key: string]: { [key: string]: {
 } } };
 
 let recordTiming = false;
+let usePerformanceApi = false;
 const timingInfo: TimingInfo = {};
 
 export function moduleStageStart(stage: string, modId: string) {
@@ -67,16 +68,35 @@ export function moduleStageStart(stage: string, modId: string) {
 	timingInfo[stage][modId] = timingInfo[stage][modId] || {};
 
 	timingInfo[stage][modId].start = now();
+
+	if (usePerformanceApi) {
+		performance.mark(`${modId}#${stage}`);
+	}
 }
 
 export function moduleStageEnd(stage: string, modId: string) {
 	if (!recordTiming) return;
 
 	timingInfo[stage][modId].end = now();
+
+	if (usePerformanceApi) {
+		const mark = `${modId}#${stage}`;
+		const measure = `${modId} (${stage})`;
+		performance.measure(measure, mark);
+		performance.clearMarks(mark);
+		performance.clearMeasures(measure);
+	}
 }
 
 function setupModulePerf() {
 	recordTiming = true;
+	usePerformanceApi = (
+		typeof performance !== 'undefined' &&
+		typeof performance.mark === 'function' &&
+		typeof performance.measure === 'function' &&
+		typeof performance.clearMarks === 'function' &&
+		typeof performance.clearMeasures === 'function'
+	);
 
 	afterLoad.then(() => {
 		prettyPrintTiming(timingInfo);


### PR DESCRIPTION
So it will show up in the Chrome and Edge debugger timelines