### PR TITLE
Swap out the header image when disabling subreddit style

### DIFF
--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -11,6 +11,7 @@ import {
 	asyncSome,
 	currentSubreddit,
 	isCurrentSubreddit,
+	mutex,
 } from '../utils';
 import * as CommandLine from './commandLine';
 import * as NightMode from './nightMode';
@@ -292,15 +293,7 @@ async function toggleSubredditStyle(toggle, subreddit = currentSubreddit()) {
 
 	if (isCurrentSubreddit(subreddit)) {
 		// toggled for the current subreddit, add/remove the stylesheet
-		const stylesheetElement = await existingStylesheet();
-		if (toggle) {
-			// only add element if not mounted
-			if (!stylesheetElement.parentNode) {
-				document.head.appendChild(stylesheetElement);
-			}
-		} else {
-			stylesheetElement.remove();
-		}
+		toggleElements(toggle);
 
 		// in case it was set by the pageAction, be sure to (un)check the checkbox.
 		makeStyleToggleCheckbox().checked = toggle;
@@ -333,21 +326,81 @@ async function toggleSubredditStyle(toggle, subreddit = currentSubreddit()) {
 	Storage.set('RESmodules.styleTweaks.ignoredSubredditStyles', ignoredSubreddits);
 }
 
-const existingStylesheet = _.once(async () => {
-	const query = () => (
-		document.head.querySelector('link[title=applied_subreddit_stylesheet]') ||
-		document.head.querySelector('style[title=applied_subreddit_stylesheet]') ||
-		document.head.querySelector('style[data-apng-original-href]') // apng extension fix (see #1076)
-	);
+const toggleElements = (() => {
+	const getStylesheet = _.once(async () => {
+		const query = () => (
+			document.head.querySelector('link[title=applied_subreddit_stylesheet]') ||
+			document.head.querySelector('style[title=applied_subreddit_stylesheet]') ||
+			document.head.querySelector('style[data-apng-original-href]') // apng extension fix (see #1076)
+		);
 
-	return (
-		// <head> parsing has started
-		// the stylesheet element may or may not be in the DOM (depending on how long ago `Init.headReady` resolved)
-		await Init.headReady.then(query) ||
-		// <body> parsing has started (i.e. the entire <head> is parsed)
-		// if there is a stylesheet, the element will be in the DOM
-		await Init.bodyStart.then(query) ||
-		// subreddit styles disabled natively; no stylesheet element (so return a dummy element)
-		document.createElement('link')
-	);
-});
+		return (
+			// <head> parsing has started
+			// the stylesheet element may or may not be in the DOM (depending on how long ago `Init.headReady` resolved)
+			await Init.headReady.then(query) ||
+			// <body> parsing has started (i.e. the entire <head> is parsed)
+			// if there is a stylesheet, the element will be in the DOM
+			await Init.bodyStart.then(query) ||
+			// subreddit styles disabled natively; no stylesheet element
+			null
+		);
+	});
+
+	const toggleStylesheet = mutex(async shouldRestore => {
+		const stylesheet = await getStylesheet();
+
+		if (!stylesheet) return;
+
+		if (shouldRestore) {
+			// only add element if not mounted
+			if (!stylesheet.parentNode) {
+				document.head.appendChild(stylesheet);
+			}
+		} else {
+			if (stylesheet.parentNode) {
+				stylesheet.remove();
+			}
+		}
+	});
+
+	const getHeaderImg = _.once(async () => {
+		// subreddits with a custom header image will have:
+		// `<a id="header-img-a"><img id="header-img"/></a>`
+		// subreddits with the default will just have:
+		// `<a id="header-img" class="default-header"></a>`
+		const query = () => document.getElementById('header-img-a');
+		const imgQuery = () => document.getElementById('header-img');
+
+		const imgWrapper = (
+			await Init.bodyStart.then(query) ||
+			await Init.bodyReady.then(query)
+		);
+
+		return { imgWrapper, headerImg: imgWrapper && imgQuery() };
+	});
+
+	const toggleHeaderImg = mutex(async shouldRestore => {
+		const { imgWrapper, headerImg } = await getHeaderImg();
+
+		if (!imgWrapper || !headerImg) return;
+
+		if (shouldRestore) {
+			if (!headerImg.parentNode) {
+				imgWrapper.id = 'header-img-a';
+				imgWrapper.classList.remove('default-header');
+				imgWrapper.appendChild(headerImg);
+			}
+		} else {
+			if (headerImg.parentNode) {
+				headerImg.remove();
+				imgWrapper.id = 'header-img';
+				imgWrapper.classList.add('default-header');
+			}
+		}
+	});
+
+	return shouldRestore => Promise.all([
+		toggleStylesheet(shouldRestore),
+		toggleHeaderImg(shouldRestore),
+	]);
+})();


### PR DESCRIPTION
Fixes #3536

Will work in concert with #3528; swapping out the header image is slower than removing the stylesheet (because it's parsed later), so if the header is huge there will still be a flash of misaligned content (with this PR alone).