### PR TITLE
Only show NER notification when clicking on the pause button

### DIFF
--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -145,7 +145,7 @@ function addPauseControls() {
 	$NREPause = $('<div>', {
 		id: 'NREPause',
 		title: 'Pause / Restart Never Ending Reddit',
-		click: () => togglePause(!isPaused, 'manual'),
+		click: () => togglePause(!isPaused, 'manual', 'Never-Ending Reddit has been paused. Click the play/pause button to unpause it.'),
 	});
 
 	if (module.options.reversePauseIcon.value) $NREPause.addClass('reversePause');
@@ -157,7 +157,7 @@ function addPauseControls() {
 	togglePause(isPaused, pauseReason);
 }
 
-function togglePause(pause, source, pauseMessage = 'Never-Ending Reddit has been paused. Click the play/pause button to unpause it.') {
+function togglePause(pause, source, pauseMessage) {
 	isPaused = pause;
 	pauseReason = source;
 
@@ -173,11 +173,13 @@ function togglePause(pause, source, pauseMessage = 'Never-Ending Reddit has been
 
 	if (isPaused) {
 		$NREPause.addClass('paused');
-		Notifications.showNotification({
-			moduleID: module.moduleID,
-			notificationID: source || undefined,
-			message: pauseMessage,
-		});
+		if (pauseMessage) {
+			Notifications.showNotification({
+				moduleID: module.moduleID,
+				notificationID: source || undefined,
+				message: pauseMessage,
+			});
+		}
 	} else {
 		nextPausePage = currPage + pauseAfterPages;
 


### PR DESCRIPTION
Fixes #3371

Always having the correct description in the progress indicator bar (instead of just on the first pageload; fixed a while ago) should be enough to avoid confusion.