### PR TITLE
Escape XKCD alt-text

### DIFF
--- a/lib/modules/hosts/xkcd.js
+++ b/lib/modules/hosts/xkcd.js
@@ -2,6 +2,7 @@
 
 import { Host } from '../../core/host';
 import { ajax } from '../../environment';
+import { escapeHTML } from '../../utils';
 
 export default new Host('xkcd', {
 	name: 'xkcd',
@@ -22,7 +23,7 @@ export default new Host('xkcd', {
 		return {
 			type: 'IMAGE',
 			title,
-			caption: alt,
+			caption: escapeHTML(alt),
 			// Fix API always returning non-HTTPS URL
 			src: img.replace('http://', '//'),
 		};


### PR DESCRIPTION
Fixes #3505

This does not affect security, just ensures that html-like formatting will be displayed instead of getting sanitized out.