### PR TITLE
Centralized batching

### DIFF
--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -13,6 +13,7 @@ import { // eslint-disable-line import/order
 	waitFor,
 	waitForChild,
 	waitForEvent,
+	newSitetable,
 } from '../utils';
 
 let start;
@@ -99,7 +100,10 @@ export const beforeLoad = Promise.all([loadOptions, headReady])
 	.then(() => allModules('beforeLoad'));
 
 export const go = Promise.all([beforeLoad, bodyReady])
-	.then(() => allModules('go'));
+	.then(() => {
+		initObservers();
+		return Promise.all([newSitetable(document.body), allModules('go')]);
+	});
 
 export const afterLoad = Promise.all([go, loadComplete])
 	.then(() => allModules('afterLoad'));
@@ -159,5 +163,3 @@ function _addModuleBodyClasses() {
 
 documentReady.then(() => BodyClasses.add());
 bodyStart.then(() => BodyClasses.add());
-
-Promise.all([bodyReady, go]).then(initObservers);

--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -11,11 +11,12 @@ import {
 	addCSS,
 	batch,
 	CreateElement,
-	forEachChunked,
+	downcast,
 	isPageType,
 	loggedInUser,
-	watchForElement,
 	nextFrame,
+	watchForThings,
+	watchForElements,
 } from '../utils';
 import { ajax } from '../environment';
 import { isSettingsUrl } from './settingsNavigation';
@@ -174,28 +175,26 @@ module.options = {
 		bodyClass: true,
 	},
 };
-module.go = () => {
-	if (isPageType('comments', 'commentsLinklist') && module.options.commentsLinksNewTabs.value) {
-		commentsLinksNewTabs();
-		watchForElement('newComments', commentsLinksNewTabs);
-		watchForElement('siteTable', commentsLinksNewTabs);
+
+module.beforeLoad = () => {
+	if (module.options.commentsLinksNewTabs.value) {
+		watchForElements(['newComments', 'siteTable'], '.thing div.md a', commentsLinksNewTabs);
 	}
 
-	if (isPageType('linklist', 'modqueue', 'comments') && module.options.fixHideLinks.value) {
-		fixHideLinks();
-		watchForElement('siteTable', fixHideLinks);
+	if (module.options.fixHideLinks.value && isPageType('linklist', 'modqueue', 'comments')) {
+		watchForThings(['post'], fixHideLinks);
 	}
 
 	if (module.options.doNoCtrlF.value) {
-		if (isPageType('inbox', 'profile', 'linklist', 'commentsLinklist', 'modqueue')) {
-			applyNoCtrlF(document);
-			watchForElement('siteTable', applyNoCtrlF);
-		} else if (isPageType('comments')) {
-			applyNoCtrlF(document);
-			watchForElement('newComments', applyNoCtrlF);
-		}
+		watchForElements(['newComments', 'siteTable'], 'ul.flat-list.buttons li a, .side a.reddit-comment-link', applyNoCtrlF);
 	}
 
+	if (module.options.videoTimes.value) {
+		watchForThings(['post'], getVideoTimes);
+	}
+};
+
+module.go = () => {
 	if (module.options.scoreHiddenTimeLeft.value && isPageType('comments', 'commentsLinklist')) {
 		$('.sitetable').on('mouseenter', '.score-hidden', function() {
 			const timeNode = $(this).siblings('time').get(0);
@@ -218,10 +217,7 @@ module.go = () => {
 	if (module.options.restoreSavedTab.value && user && document.querySelector('.with-listing-chooser:not(.profile-page)')) {
 		restoreSavedTab(user);
 	}
-	if (module.options.videoTimes.value && isPageType('linklist', 'modqueue', 'comments', 'commentsLinklist')) {
-		getVideoTimes();
-		watchForElement('siteTable', getVideoTimes);
-	}
+
 	switch (module.options.pinHeader.value) {
 		case 'header':
 			pinHeader();
@@ -241,38 +237,24 @@ module.go = () => {
 	}
 };
 
-function commentsLinksNewTabs(ele = document.body) {
-	const links = ele.querySelectorAll('.thing div.md a');
-	forEachChunked(links, link => {
-		const { baseURI, href } = link;
-		if (href.includes(baseURI) && isSettingsUrl(href)) return;
+function commentsLinksNewTabs(link) {
+	const { baseURI, href } = link;
+	if (href.includes(baseURI) && isSettingsUrl(href)) return;
 
-		link.target = '_blank';
-		link.rel = 'noopener noreferer';
-	});
+	link.target = '_blank';
+	link.rel = 'noopener noreferer';
 }
 
-function fixHideLinks(ele = document.body) {
-	const hideLinks = ele.querySelectorAll('form.hide-button > span > a');
-	const unhideLinks = ele.querySelectorAll('form.unhide-button > span > a');
+function fixHideLinks(thing) {
+	const hideLink = thing.getHideElement();
+	if (!hideLink) return;
 
-	forEachChunked(hideLinks, link => {
-		$('<a>', {
-			text: 'hide',
-			action: 'hide',
-			href: '#',
-			click: hideLinkEventHandler,
-		}).replaceAll(link);
-	});
-
-	forEachChunked(unhideLinks, link => {
-		$('<a>', {
-			text: 'unhide',
-			action: 'unhide',
-			href: '#',
-			click: hideLinkEventHandler,
-		}).replaceAll(link);
-	});
+	$('<a>', {
+		text: 'hide',
+		action: 'hide',
+		href: '#',
+		click: hideLinkEventHandler,
+	}).replaceAll(hideLink);
 }
 
 function hideLinkEventHandler(e) {
@@ -315,36 +297,36 @@ async function hideLink(clickedLink) {
 	}
 }
 
-function getVideoTimes(obj = document) {
+async function getVideoTimes(thing) {
+	const element = thing.element.querySelector('a.title[href*="youtube.com"], a.title[href*="youtu.be"]');
+	if (!element) return;
+	const link = downcast(element, HTMLAnchorElement);
+
 	const titleHasTimeRegex = /[\[|\(][0-9]*:[0-9]*[\]|\)]/;
 	const getYoutubeIDRegex = /\/?[&|\?]?v\/?=?([\w\-]{11})&?/i;
 	const getShortenedYoutubeIDRegex = /([\w\-]{11})&?/i;
 	const getYoutubeStartTimeRegex = /\[[\d]+:[\d]+\]/i;
 
-	Array.from(((obj.querySelectorAll('a.title[href*="youtube.com"], a.title[href*="youtu.be"]'): any): NodeList<HTMLAnchorElement>))
-		.filter(link => !titleHasTimeRegex.test(link.textContent))
-		.forEach(async link => {
-			const isShortened = (/youtu\.be/i).test(link.href);
+	const isShortened = (/youtu\.be/i).test(link.href);
 
-			const match = isShortened ?
+	const match = isShortened ?
 				getShortenedYoutubeIDRegex.exec(link.href) :
 				getYoutubeIDRegex.exec(link.href);
 
-			if (!match) return;
+	if (!match) return;
 
-			const timeMatch = getYoutubeStartTimeRegex.exec(link.href);
-			const titleMatch = titleHasTimeRegex.test(link.textContent);
-			if (timeMatch && !titleMatch) {
-				link.textContent += ` (@${timeMatch[1]})`;
-			}
+	const timeMatch = getYoutubeStartTimeRegex.exec(link.href);
+	const titleMatch = titleHasTimeRegex.test(link.textContent);
+	if (timeMatch && !titleMatch) {
+		link.textContent += ` (@${timeMatch[1]})`;
+	}
 
-			const { info, title } = await getVideoInfo(match[1]);
+	const { info, title } = await getVideoInfo(match[1]);
 
-			nextFrame(() => {
-				link.textContent += ` - ${info}`;
-				link.setAttribute('title', `YouTube title: ${title}`);
-			});
-		});
+	nextFrame(() => {
+		link.textContent += ` - ${info}`;
+		link.setAttribute('title', `YouTube title: ${title}`);
+	});
 }
 
 const getVideoInfo = batch(async videoIds => {
@@ -524,11 +506,8 @@ function restoreSavedTab(user) {
 	}).addEventListener('change', () => { location.href = `/user/${user}/saved/`; });
 }
 
-function applyNoCtrlF(searchIn) {
-	const elems = searchIn.querySelectorAll('ul.flat-list.buttons li a:not(.noCtrlF), .side a.reddit-comment-link:not(.noCtrlF)');
-	forEachChunked(elems, e => {
-		e.classList.add('noCtrlF');
-		e.setAttribute('data-text', e.textContent);
-		e.textContent = '';
-	});
+function applyNoCtrlF(element) {
+	element.classList.add('noCtrlF');
+	element.setAttribute('data-text', element.textContent);
+	element.textContent = '';
 }

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -9,7 +9,6 @@ import * as Init from '../core/init';
 import * as Options from '../core/options';
 import {
 	BodyClasses,
-	Thing,
 	asyncFlow,
 	asyncSome,
 	batch,
@@ -24,7 +23,7 @@ import {
 	isPageType,
 	mutex,
 	reifyPromise,
-	watchForElement,
+	watchForThings,
 } from '../utils';
 import { Storage, ajax } from '../environment';
 import type { RedditListing, RedditLink } from '../types/reddit';
@@ -399,6 +398,8 @@ module.beforeLoad = async () => {
 		// Pad the space where the filterline will be shown, so that it won't push `siteTable` down when initialized
 		BodyClasses.add('res-filteReddit-filterline-pad-until-ready');
 	}
+
+	watchForThings(['post'], registerThing, { immediate: true });
 };
 
 const $nsfwSwitch = _.once(() => $(CreateElement.toggleButton(undefined, 'nsfwSwitchToggle', module.options.NSFWfilter.value)));
@@ -415,25 +416,19 @@ module.go = () => {
 
 	createFilterline().go();
 
-	function scanEntries(ele) {
-		const newThings = Thing.things(ele).filter(v => v.isPost());
-		for (const thing of newThings) {
-			updateNsfwThingClass(thing);
-
-			if (
-				module.options.excludeOwnPosts.value &&
-				loggedInUser() && loggedInUser() === thing.getAuthor()
-			) continue;
-
-			createFilterline().filterline.addThing(thing);
-		}
-	}
-
-	scanEntries();
-	watchForElement('siteTable', scanEntries);
-
 	registerSubredditFilterCommand();
 };
+
+function registerThing(thing) {
+	updateNsfwThingClass(thing);
+
+	if (
+		module.options.excludeOwnPosts.value &&
+		loggedInUser() && loggedInUser() === thing.getAuthor()
+	) return;
+
+	createFilterline().filterline.addThing(thing);
+}
 
 const createFilterline = _.once(() => {
 	const filterline = new Filterline();

--- a/lib/modules/hideChildComments.js
+++ b/lib/modules/hideChildComments.js
@@ -34,22 +34,22 @@ module.include = [
 	'comments',
 ];
 
-let initialHide;
-
 module.beforeLoad = () => {
-	initialHide = module.options.automatic.value &&
-		// ensure we're not in a permalinked post..
-		!((/\/comments\/(?:\w+)\/(?:\w+)\/(\w+)/).test(location.pathname));
-
 	watchForThings(['comment'], addToggleChildrenButton);
 	watchForThings(['post'], addToggleAllButton);
 };
+
+const initialHide = _.once(() =>
+	module.options.automatic.value &&
+	// ensure we're not in a permalinked post..
+	!((/\/comments\/(?:\w+)\/(?:\w+)\/(\w+)/).test(location.pathname))
+);
 
 const addToggleAllButton = _.once(thing => {
 	const menu = thing.element.querySelector('ul.buttons');
 	if (!menu) return;
 
-	function toggle(action = a.getAttribute('action')) {
+	function toggle(action) {
 		const includeChildren = module.options.nested.value && module.options.hideNested.value;
 		const selector = includeChildren ? '.commentarea .sitetable .thing' : '.commentarea > .sitetable > .thing';
 		forEachChunked(document.querySelectorAll(`${selector} > .entry .toggleChildren[action=${action}]`), toggle => {
@@ -73,10 +73,10 @@ const addToggleAllButton = _.once(thing => {
 	a.setAttribute('class', 'noCtrlF');
 	a.addEventListener('click', (e: Event) => {
 		e.preventDefault();
-		toggle();
+		toggle(a.getAttribute('action'));
 	});
 
-	toggle(initialHide ? 'hide' : 'show');
+	toggle(initialHide() ? 'hide' : 'show');
 
 	li.appendChild(a);
 	menu.appendChild(li);
@@ -90,7 +90,7 @@ function addToggleChildrenButton(comment) {
 	const menu = comment.element.querySelector('ul.buttons');
 	if (!children || !menu) return;
 
-	function toggle(action = a.getAttribute('action')) {
+	function toggle(action) {
 		if (action === 'hide') {
 			children.style.display = 'none';
 			a.setAttribute('data-text', `show ${comment.getNumberOfChildren()} child comments`);
@@ -108,10 +108,10 @@ function addToggleChildrenButton(comment) {
 	a.setAttribute('class', 'toggleChildren noCtrlF');
 	a.addEventListener('click', (e: Event) => {
 		e.preventDefault();
-		toggle();
+		toggle(a.getAttribute('action'));
 	});
 
-	toggle(initialHide ? 'hide' : 'show');
+	toggle(initialHide() ? 'hide' : 'show');
 
 	li.appendChild(a);
 	menu.appendChild(li);

--- a/lib/modules/hideChildComments.js
+++ b/lib/modules/hideChildComments.js
@@ -1,8 +1,8 @@
 /* @flow */
 
-import { $ } from '../vendor';
+import _ from 'lodash';
 import { Module } from '../core/module';
-import { click, forEachChunked } from '../utils';
+import { watchForThings, forEachChunked } from '../utils';
 
 export const module: Module<*> = new Module('hideChildComments');
 
@@ -34,96 +34,85 @@ module.include = [
 	'comments',
 ];
 
-module.go = () => {
-	const toggleButton = document.createElement('li');
-	const toggleAllLink = document.createElement('a');
-	toggleAllLink.textContent = 'hide all child comments';
-	toggleAllLink.setAttribute('action', 'hide');
-	toggleAllLink.setAttribute('href', '#');
-	toggleAllLink.setAttribute('title', 'Show only replies to original poster.');
-	toggleAllLink.addEventListener('click', function(e: Event) {
-		e.preventDefault();
-		toggleAllComments(this.getAttribute('action'));
-		if (this.getAttribute('action') === 'hide') {
-			this.setAttribute('action', 'show');
-			this.setAttribute('title', 'Show all comments.');
-			this.textContent = 'show all child comments';
-		} else {
-			this.setAttribute('action', 'hide');
-			this.setAttribute('title', 'Show only replies to original poster.');
-			this.textContent = 'hide all child comments';
-		}
-	}, true);
-	toggleButton.appendChild(toggleAllLink);
-	const commentMenu = document.querySelector('ul.buttons');
-	if (commentMenu) {
-		commentMenu.appendChild(toggleButton);
-		const comments = document.querySelectorAll(module.options.nested.value ?
-			'.commentarea .listing' :
-			'div.commentarea > div.sitetable > div.thing > div.child > div.listing'
-		);
-		forEachChunked(comments, comment => {
-			const toggleButton = document.createElement('li');
-			const toggleLink = document.createElement('a');
-			toggleLink.setAttribute('data-text', 'hide child comments');
-			toggleLink.setAttribute('action', 'hide');
-			toggleLink.setAttribute('href', '#');
-			toggleLink.setAttribute('class', 'toggleChildren noCtrlF');
-			// toggleLink.setAttribute('title','Hide child comments.');
-			toggleLink.addEventListener('click', function(e: Event) {
-				e.preventDefault();
-				toggleIndividualComment(this.getAttribute('action'), this);
-			}, true);
-			toggleButton.appendChild(toggleLink);
-			const sib = comment.parentNode.previousSibling;
-			if (sib) {
-				const sibMenu = sib.querySelector('ul.buttons');
-				if (sibMenu) sibMenu.appendChild(toggleButton);
-			}
-		});
-		if (module.options.automatic.value) {
-			// ensure we're not in a permalinked post..
-			const linkRE = /\/comments\/(?:\w+)\/(?:\w+)\/(\w+)/;
-			if (!location.pathname.match(linkRE)) {
-				click(toggleAllLink);
-			}
-		}
-	}
+let initialHide;
+
+module.beforeLoad = () => {
+	initialHide = module.options.automatic.value &&
+		// ensure we're not in a permalinked post..
+		!((/\/comments\/(?:\w+)\/(?:\w+)\/(\w+)/).test(location.pathname));
+
+	watchForThings(['comment'], addToggleChildrenButton);
+	watchForThings(['post'], addToggleAllButton);
 };
 
-function toggleIndividualComment(action, ele) {
-	toggleComments(action, $(ele).closest('.thing'));
-}
+const addToggleAllButton = _.once(thing => {
+	const menu = thing.element.querySelector('ul.buttons');
+	if (!menu) return;
 
-function toggleAllComments(action) {
-	const includeChildren = module.options.nested.value && module.options.hideNested.value;
-	const containers = includeChildren ?
-		document.querySelectorAll('.commentarea .sitetable .thing') :
-		document.querySelectorAll('.commentarea > .sitetable > .thing');
+	function toggle(action = a.getAttribute('action')) {
+		const includeChildren = module.options.nested.value && module.options.hideNested.value;
+		const selector = includeChildren ? '.commentarea .sitetable .thing' : '.commentarea > .sitetable > .thing';
+		forEachChunked(document.querySelectorAll(`${selector} > .entry .toggleChildren[action=${action}]`), toggle => {
+			toggle.click();
+		});
 
-	toggleComments(action, containers);
-}
-
-function toggleComments(action, containers) {
-	forEachChunked(containers, container => {
-		const thisChildren = container.querySelector('div.child > div.sitetable');
-		const thisToggleLink = container.querySelector('a.toggleChildren');
-		if (thisToggleLink) {
-			if (action === 'hide') {
-				const numChildrenElem = container.querySelector('.numchildren');
-				const numChildren = parseInt((/\((\d+)/).exec(numChildrenElem.textContent)[1], 10);
-				if (thisChildren) {
-					thisChildren.style.display = 'none';
-				}
-				thisToggleLink.setAttribute('data-text', `show ${numChildren} child comments`);
-				thisToggleLink.setAttribute('action', 'show');
-			} else {
-				if (thisChildren) {
-					thisChildren.style.display = 'block';
-				}
-				thisToggleLink.setAttribute('data-text', 'hide child comments');
-				thisToggleLink.setAttribute('action', 'hide');
-			}
+		if (action === 'hide') {
+			a.setAttribute('action', 'show');
+			a.setAttribute('title', 'Show all comments.');
+			a.setAttribute('data-text', 'show all child comments');
+		} else {
+			a.setAttribute('action', 'hide');
+			a.setAttribute('title', 'Show only replies to original poster.');
+			a.setAttribute('data-text', 'hide all child comments');
 		}
+	}
+
+	const li = document.createElement('li');
+	const a = document.createElement('a');
+	a.setAttribute('href', '#');
+	a.setAttribute('class', 'noCtrlF');
+	a.addEventListener('click', (e: Event) => {
+		e.preventDefault();
+		toggle();
 	});
+
+	toggle(initialHide ? 'hide' : 'show');
+
+	li.appendChild(a);
+	menu.appendChild(li);
+});
+
+function addToggleChildrenButton(comment) {
+	if (!module.options.nested.value && comment.getParent()) return;
+	if (!comment.getNumberOfChildren()) return;
+
+	const children = comment.element.querySelector('div.child');
+	const menu = comment.element.querySelector('ul.buttons');
+	if (!children || !menu) return;
+
+	function toggle(action = a.getAttribute('action')) {
+		if (action === 'hide') {
+			children.style.display = 'none';
+			a.setAttribute('data-text', `show ${comment.getNumberOfChildren()} child comments`);
+			a.setAttribute('action', 'show');
+		} else {
+			children.style.display = '';
+			a.setAttribute('data-text', 'hide child comments');
+			a.setAttribute('action', 'hide');
+		}
+	}
+
+	const li = document.createElement('li');
+	const a = document.createElement('a');
+	a.setAttribute('href', '#');
+	a.setAttribute('class', 'toggleChildren noCtrlF');
+	a.addEventListener('click', (e: Event) => {
+		e.preventDefault();
+		toggle();
+	});
+
+	toggle(initialHide ? 'hide' : 'show');
+
+	li.appendChild(a);
+	menu.appendChild(li);
 }

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1071,6 +1071,7 @@ function followLink(newWindow) {
 
 function followLinkByRank(num) {
 	const target = Thing.visibleThings().find(v => v.getRank() === num);
+	if (!target) return;
 	SelectedEntry.select(target);
 	followLink();
 }

--- a/lib/modules/menu.js
+++ b/lib/modules/menu.js
@@ -14,11 +14,14 @@ module.hidden = true;
 
 module.beforeLoad = () => {
 	renderConsoleLink();
-	addLegacyStyling();
 };
 
 module.go = () => {
 	addConsoleLink();
+};
+
+module.afterLoad = () => {
+	addLegacyStyling();
 };
 
 let RESPrefsLink;

--- a/lib/modules/menu.js
+++ b/lib/modules/menu.js
@@ -14,15 +14,11 @@ module.hidden = true;
 
 module.beforeLoad = () => {
 	renderConsoleLink();
+	addLegacyStyling();
 };
 
 module.go = () => {
 	addConsoleLink();
-};
-
-
-module.afterLoad = () => {
-	addLegacyStyling();
 };
 
 let RESPrefsLink;

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -226,9 +226,8 @@ function initiateReturnToPrevPage() {
 		const $pageMarker = $(selected.$thing).closest('.sitetable, .search-result-listing').prev('.NERPageMarker');
 		if ($pageMarker.length) ({ currPage: resRestorePage, nextPageURL: resRestoreURL } = $pageMarker.data());
 
-		// Do not have the browser auto-scroll when returning to this page
-		// returnToPrevPage will scroll to the pagemarker when ready
-		history.scrollRestoration = $pageMarker.length ? 'manual' : 'auto';
+		// replaceState is expensive, so avoid it when possible
+		if (history.state && history.state.resRestorePage === resRestorePage) return;
 
 		history.replaceState(
 			{ ...history.state, resRestorePage, resRestoreURL },

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -296,7 +296,9 @@ function displayNewCommentCount(thing) {
 
 	const newCount = Math.max(currentCount - lastOpenedCount, 0);
 
-	if (newCount) thing.element.classList.add('res-hasNewComments');
+	if (!newCount) return;
+
+	thing.element.classList.add('res-hasNewComments');
 
 	$(thing.getCommentCountElement())
 		.append(`<span class="newComments">&nbsp;(${newCount} new)</span>`);

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -9,7 +9,6 @@ import {
 	Thing,
 	escapeHTML,
 	filterMap,
-	forEachChunked,
 	formatDateDiff,
 	formatDateTime,
 	getPostMetadata,
@@ -17,7 +16,7 @@ import {
 	isPageType,
 	loggedInUser,
 	regexes,
-	watchForElement,
+	watchForThings,
 } from '../utils';
 import { Storage, isPrivateBrowsing } from '../environment';
 import * as Dashboard from './dashboard';
@@ -76,15 +75,14 @@ const commentCountStorage = Storage.wrap('RESmodules.newCommentCount.counts', ({
 let commentCounts = {};
 
 module.beforeLoad = async () => {
-	await getLatestCommentCounts();
+	commentCounts = await commentCountStorage.get();
+
+	watchForThings(['post'], displayNewCommentCount);
 };
 
 module.go = () => {
 	if (isPageType('comments')) {
-		updateCommentCount();
-
-		watchForElement('newCommentsForms', updateCommentCountFromMyComment);
-		watchForElement('newComments', updateCommentCountFromMyComment);
+		watchForThings(['comment'], updateCommentCountFromMyComment);
 		if (module.options.showSubscribeButton.value && document.querySelector('.commentarea .panestack-title')) {
 			handleToggleButton();
 		}
@@ -126,12 +124,20 @@ module.go = () => {
 			drawSubscriptionsTable($(e.target).attr('sort'), $(e.target).hasClass('descending'));
 		});
 		drawSubscriptionsTable();
-		watchForElement('siteTable', processCommentCounts);
-	} else {
-		processCommentCounts();
-		watchForElement('siteTable', processCommentCounts);
 	}
 	checkSubscriptions();
+};
+
+module.afterLoad = async () => {
+	// Clean counts every six hours
+	const lastClean = await lastCleanStorage.get() || 0;
+	if ((Date.now() - lastClean) > 0.25 * DAY) {
+		cleanOldCounts();
+	}
+
+	if (isPageType('comments')) {
+		updateCommentCount();
+	}
 };
 
 let currentSortMethod, isDescending;
@@ -280,44 +286,30 @@ function subscribe(threadid) {
 	drawSubscriptionsTable();
 }
 
-async function processCommentCounts(ele = document.body) {
-	let lastClean = await lastCleanStorage.get();
-	const now = Date.now();
-	if (!lastClean) {
-		lastClean = now;
-		lastCleanStorage.set(now);
-	}
-	// Clean cache every six hours
-	if ((now - lastClean) > 21600000) {
-		await cleanCache();
-	}
-	const IDre = /\/r\/[\w]+\/comments\/([\w]+)\//i;
-	const commentsLinks = ele.querySelectorAll('.sitetable.linklisting div.thing.link a.comments');
-	forEachChunked(commentsLinks, link => {
-		const $link = $(link);
-		const href = $link.attr('href');
-		// split number from the word comments
-		const thisCount = $link.text().replace(/\D/g, '');
-		const matches = IDre.exec(href);
-		if (matches) {
-			const thisID = matches[1];
-			if (commentCounts[thisID]) {
-				const diff = thisCount - commentCounts[thisID].count;
-				if (diff > 0) {
-					$link.append(`<span class="newComments">&nbsp;(${diff} new)</span>`);
-					// add .res-hasNewComments to this post's .thing
-					$link.closest('.thing').addClass('res-hasNewComments');
-				}
-			}
-		}
-	});
+function displayNewCommentCount(thing) {
+	const currentCount = thing.getCommentCount();
+
+	const countObj = commentCounts[thing.getFullname().split('_').slice(-1)[0]];
+	const lastOpenedCount = countObj && countObj.count;
+
+	if (!Number.isInteger(currentCount) || !Number.isInteger(lastOpenedCount)) return;
+
+	const newCount = Math.max(currentCount - lastOpenedCount, 0);
+
+	if (newCount) thing.element.classList.add('res-hasNewComments');
+
+	$(thing.getCommentCountElement())
+		.append(`<span class="newComments">&nbsp;(${newCount} new)</span>`);
 }
 
-function updateCommentCountFromMyComment(entry) {
-	const user = loggedInUser();
-	// don't update for user comment count, if detected new comment wasn't from the user
-	if (user && user === Thing.checkedFrom(entry).getAuthor()) {
-		updateCommentCount(true);
+function updateCommentCountFromMyComment(thing) {
+	if (!currentCommentID) return;
+
+	const timestamp = thing.getTimestamp();
+	const isRecent = timestamp && (Date.now() - timestamp.getTime()) < 10000;
+	const isMine = loggedInUser() === thing.getAuthor();
+	if (isRecent && isMine) {
+		saveCommentCount(currentCommentID, commentCounts[currentCommentID].count + 1);
 	}
 }
 
@@ -328,7 +320,6 @@ let currentCommentID;
  *
  * @param {string} commentID - ID of comment to store new count against
  * @param {int} newCommentCount - new number of comments to save
- * @returns {bool}
  */
 async function saveCommentCount(commentID, newCommentCount) {
 	if (!module.options.monitorPostsVisited.value) return false;
@@ -337,7 +328,7 @@ async function saveCommentCount(commentID, newCommentCount) {
 	commentCounts[commentID] = commentCounts[commentID] || {};
 
 	const patch = {
-		count: !isNaN(newCommentCount) ? newCommentCount : 0,
+		count: newCommentCount,
 		url: location.href.replace(location.hash, ''),
 		title: document.title,
 		updateTime: Date.now(),
@@ -345,77 +336,36 @@ async function saveCommentCount(commentID, newCommentCount) {
 
 	Object.assign(commentCounts[commentID], patch);
 	commentCountStorage.patch({ [commentID]: patch });
-
-	return true;
-}
-
-/**
- * Show new comments count to user
- *
- * @param {int} currentCommentCount - number of comments found on this page
- * @returns {void}
- */
-function showNewComments(currentCommentCount) {
-	const prevCommentCount = commentCounts[currentCommentID].count;
-	const diff = currentCommentCount - prevCommentCount;
-	if (diff > 0) $('#siteTable a.comments').append(`<span class="newComments">&nbsp;(${diff} new)</span>`);
 }
 
 /**
  * Handle updating page's comment counts
- *
- * @param {bool} mycomment - was this triggered by a users comments
- * @returns {bool}
  */
-function updateCommentCount(mycomment) {
-	// If currentCommentID is already defined, comment counts for this page have already been stored
-	if (currentCommentID) {
-		if (mycomment) {
-			return saveCommentCount(currentCommentID, parseInt(commentCounts[currentCommentID].count, 10) + 1);
-		}
-		return false;
-	}
+function updateCommentCount() {
+	const listingThing = Thing.from(document.querySelector('#siteTable a.comments'));
+	const matches = regexes.comments.exec(location.pathname);
 
-	// Check this is a comment page, and grab comment id
-	const IDre = /\/r\/[\w]+\/comments\/([\w]+)\//i;
-	const matches = IDre.exec(location.href);
-
-	if (matches) {
+	if (matches && listingThing) {
 		// set comment id for general use
-		currentCommentID = matches[1];
+		currentCommentID = matches[2];
 
-		// get new count of comments for this page
-		const thisCount = document.querySelector('#siteTable a.comments');
-		const currentCommentCount = parseInt(thisCount.textContent.replace(/\D/g, ''), 10);
-
-		// if there was an old count, show "new" comment count to user
-		if (commentCounts[currentCommentID]) {
-			showNewComments(currentCommentCount);
-		}
-
-		// Update settings with new comment count
-		return saveCommentCount(currentCommentID, currentCommentCount);
+		saveCommentCount(currentCommentID, listingThing.getCommentCount());
 	}
-	return false;
 }
 
-async function cleanCache() {
-	await getLatestCommentCounts();
+function cleanOldCounts() {
 	const now = Date.now();
+	lastCleanStorage.set(now);
+	const keepTrackPeriod = DAY * parseInt(module.options.cleanComments.value, 10);
 	for (const i in commentCounts) {
-		if (commentCounts[i] && ((now - commentCounts[i].updateTime) > (DAY * parseInt(module.options.cleanComments.value, 10)))) {
-			// Do not automatically delete comments belonging to actively subscribed threads
-			if (typeof commentCounts[i].subscriptionDate !== 'undefined') {
-				continue;
-			}
-			// commentCounts[i] = null;
+		// Do not automatically delete comments belonging to actively subscribed threads
+		if (commentCounts[i] && commentCounts[i].subscriptionDate) {
+			continue;
+		} else if (!commentCounts[i] || ((now - commentCounts[i].updateTime) > keepTrackPeriod)) {
 			delete commentCounts[i];
-		} else if (!commentCounts[i]) {
-			delete commentCounts[i];
+			commentCountStorage.deletePath(i);
 		}
 	}
-	commentCountStorage.set(commentCounts);
-	lastCleanStorage.set(now);
 }
 
 function handleButton(threadid, action) {
@@ -490,10 +440,6 @@ function toggleSubscription() {
 		subscribeToThread(commentID);
 	}
 	handleToggleButton();
-}
-
-async function getLatestCommentCounts() {
-	commentCounts = await commentCountStorage.get();
 }
 
 function subscribeToThread(commentID) {

--- a/lib/modules/noParticipation.js
+++ b/lib/modules/noParticipation.js
@@ -6,9 +6,9 @@ import { Module } from '../core/module';
 import {
 	BodyClasses,
 	click,
+	downcast,
 	isPageType,
 	loggedInUser,
-	watchForElement,
 } from '../utils';
 import * as CommentTools from './commentTools';
 import * as Notifications from './notifications';
@@ -185,14 +185,14 @@ export async function notifyNoVote(voteButton?: HTMLElement) {
 	}
 }
 
-function notifyNoComment() {
+const notifyNoComment = _.once(() => {
 	Notifications.showNotification({
 		moduleID: module.moduleID,
 		optionKey: 'disableCommentTextarea',
 		header: 'No Participation',
 		message: `<strong><span class="res-icon">&#xF15A;</span> Do not comment.</strong>${boilerplateNotificationText}`,
 	});
-}
+});
 
 function applyNoParticipationMode() {
 	noParticipationActive = true;
@@ -203,8 +203,13 @@ function applyNoParticipationMode() {
 
 	watchForVote();
 
-	watchForComment();
-	watchForElement('newCommentsForms', watchForComment);
+	$(document.body).on('keydown', CommentTools.commentTextareaSelector, (e: Event) => {
+		notifyNoComment();
+
+		if (module.options.disableCommentTextarea.value) {
+			downcast(e.target, HTMLTextAreaElement).disabled = true;
+		}
+	});
 }
 
 function watchForVote() {
@@ -230,15 +235,4 @@ function revertVote(voteButtons) {
 			<p><a href="${urls.moreinfo}" target="_blank" rel="noopener noreferer">Find out more</a></p>
 		`,
 	});
-}
-
-const notify = _.once(notifyNoComment);
-function watchForComment(container = document.body) {
-	const textareas = CommentTools.getCommentTextarea(container);
-
-	textareas.one('keydown', notify);
-
-	if (module.options.disableCommentTextarea.value) {
-		textareas.attr('disabled', 'true');
-	}
 }

--- a/lib/modules/saveComments.js
+++ b/lib/modules/saveComments.js
@@ -8,19 +8,16 @@ import * as Modules from '../core/modules';
 import {
 	Alert,
 	WEEK,
-	forEachChunked,
 	formatDate,
 	formatDateDiff,
 	formatDateTime,
 	isPageType,
 	niceKeyCode,
-	watchForElement,
-	Thing,
+	watchForThings,
 } from '../utils';
 import { Storage, i18n } from '../environment';
 import * as KeyboardNav from './keyboardNav';
 import * as Notifications from './notifications';
-import * as SelectedEntry from './selectedEntry';
 import * as SettingsNavigation from './settingsNavigation';
 
 export const module: Module<*> = new Module('saveComments');
@@ -64,10 +61,14 @@ const savedCommentStorage = Storage.wrap('RESmodules.saveComments.savedComments'
 |} }));
 let savedCommentIDs;
 
-module.go = async () => {
+module.beforeLoad = async () => {
 	savedCommentIDs = new Set(Object.keys(await savedCommentStorage.get()));
+
+	if (isPageType('comments', 'commentsLinklist')) watchForThings(['comment'], addSaveLinkToComment);
+};
+
+module.go = async () => {
 	if (isPageType('comments', 'commentsLinklist')) {
-		addSaveLinks();
 		$('body').on('click', 'li.saveComments', function(e: Event) {
 			e.preventDefault();
 			const $this = $(this);
@@ -84,17 +85,9 @@ module.go = async () => {
 	} else {
 		addTabs({ onSavedPage: false });
 	}
-	watchForElement('newComments', addSaveLinkToComment);
 };
 
-function addSaveLinks(ele = document.body) {
-	forEachChunked(ele.querySelectorAll('.commentarea > .sitetable > .thing .entry'), addSaveLinkToComment);
-}
-
-function addSaveLinkToComment(commentObj) {
-	const thing = Thing.from(commentObj);
-	if (!thing) return;
-
+function addSaveLinkToComment(thing) {
 	const permaLink = thing.getCommentPermalink();
 	if (!permaLink) return;
 
@@ -115,7 +108,7 @@ function addSaveLinkToComment(commentObj) {
 	}
 
 	// Insert the link right after Reddit Gold's "save" comment link
-	const whereToInsert = commentObj.querySelector('.comment-save-button');
+	const whereToInsert = thing.element.querySelector('.comment-save-button');
 	$saveLink.insertAfter(whereToInsert);
 }
 
@@ -123,14 +116,14 @@ function saveComment(obj, id, href, username) {
 	if (savedCommentIDs.has(id)) {
 		Alert.open('comment already saved!');
 	} else {
-		const selectedThing = SelectedEntry.unselect(); // un-munge annotations or other mutilations
-
 		const comment = obj.parentNode.parentNode.querySelector('div.usertext-body > div.md');
 		if (comment) {
+			const pureComment = $(comment).clone();
+			pureComment.find('.keyNavAnnotation, .expando-button, .res-expando-box, script').remove();
 			const savedComment = {
 				href,
 				username,
-				comment: comment.innerHTML.replace(/<script(.|\s)*?\/script>/g, ''),
+				comment: pureComment.html(),
 				timeSaved: new Date().toString(),
 			};
 
@@ -145,7 +138,6 @@ function saveComment(obj, id, href, username) {
 
 			$(obj).replaceWith($unsaveObj);
 		}
-		SelectedEntry.select(selectedThing); // restore munging
 	}
 }
 

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -10,9 +10,10 @@ import {
 	BodyClasses,
 	click,
 	elementInViewport,
-	isPageType,
+	fastAsync,
 	scrollToElement,
-	watchForElement,
+	watchForThings,
+	frameThrottle,
 	idleThrottle,
 } from '../utils';
 import type { ScrollStyle } from '../utils/dom';
@@ -104,10 +105,15 @@ module.options = {
 };
 
 module.beforeLoad = () => {
-	watchForElement('newComments', onNewComments);
+	if (module.options.selectThingOnLoad.value) {
+		setupLastSelectedCache();
+		watchForThings(['post', 'comment'], selectInitial);
+	}
 };
 
 module.go = () => {
+	watchForThings(['comment'], onNewComments);
+
 	if (module.options.autoSelectOnScroll.value) {
 		window.addEventListener('scroll', _.debounce(autoSelect, 300));
 	}
@@ -125,18 +131,12 @@ module.go = () => {
 	addListener((selected, unselected) => unselected && Hover.infocard('showParent').close(false), 'beforePaint');
 	addListener(updateActiveElement, 'beforePaint');
 	addListener(selected => BodyClasses.toggle(!!selected, 'res-entry-is-selected'), 'beforePaint');
-	addListener(updateLastSelectedCache);
-
-	if (module.options.selectLastThingOnLoad.value) setupLastSelectedCache();
-};
-
-module.afterLoad = () => {
-	// Do not re-select if user has already selected something
-	if (!selectedThing) selectInitial();
+	addListener((selected, unselected, options) => scrollToElement(selected.entry, options), 'beforePaint');
 };
 
 const onClick = _.throttle(e => {
-	_select(e.target, { scrollStyle: 'none' });
+	const thing = Thing.from(e.target);
+	if (thing) select(thing, { scrollStyle: 'none' });
 }, 100, { trailing: false });
 
 export function handleClick(e: MouseEvent) {
@@ -158,23 +158,13 @@ type SelectOptions = {
 	scrollStyle: ScrollStyle,
 	mediaBrowse?: boolean,
 	mediaBrowseScrollStyle?: ScrollStyle,
+	paintImmediate?: boolean, // Set `true` when `select` is invoked during the animation phase, in order for `beforePaint` not to be delayed to the next animation frame
 };
 
-export function select(thing: ?Thing | HTMLElement | JQuery, options?: SelectOptions) {
-	if (!thing) return;
-	_select(thing, options);
-}
-
 export const selectClosestVisible = _.debounce((options: SelectOptions) => {
-	const target = selectedThing.getNext({ direction: 'down' }) || selectedThing.getNext({ direction: 'up' });
-	if (target) _select(target, options);
+	const target = selectedThing.getClosestVisible(false);
+	if (target) select(target, options);
 });
-
-export function unselect() {
-	const prevSelected = selectedThing;
-	_select(undefined);
-	return prevSelected;
-}
 
 export { _selectedThing as selectedThing };
 function _selectedThing() {
@@ -183,7 +173,7 @@ function _selectedThing() {
 
 const listeners = { beforeScroll: [], beforePaint: [], idle: [] };
 
-export function addListener(callback: (new_: Thing, old: Thing, opt: SelectOptions & { direction?: 'down' | 'up' }) => mixed, when?: $Keys<typeof listeners> = 'idle'): void {
+export function addListener(callback: (new_: Thing, old: ?Thing, opt: SelectOptions & { direction?: 'down' | 'up' }) => mixed, when?: $Keys<typeof listeners> = 'idle'): void {
 	listeners[when].push(callback);
 }
 
@@ -192,43 +182,57 @@ const runCallbacks = (() => {
 		for (const listener of listeners) listener(new_, old, opt);
 	}
 
-	const runIdle = idleThrottle((new_, old, opt) => runListeners(listeners.idle, new_, old, opt));
+	function throttle(throttler, listeners) {
+		let oldest: ?Thing; // So that `oldest` will equal `new_` from the previous listener invokation
+
+		const throttled = throttler((new_, old, opt) => {
+			runListeners(listeners, new_, oldest, opt);
+			oldest = null;
+		});
+
+		return (new_, old, opt) => {
+			if (!oldest) oldest = old;
+			throttled(new_, old, opt);
+		};
+	}
+
+	const runIdle = throttle(idleThrottle, listeners.idle);
+	const runPaint = throttle(frameThrottle, listeners.beforePaint);
 
 	return (new_, old, opt) => {
 		if (listeners.beforeScroll.length) runListeners(listeners.beforeScroll, new_, old, opt);
-		if (listeners.beforePaint.length) requestAnimationFrame(() => runListeners(listeners.beforePaint, new_, old, opt));
+		if (listeners.beforePaint.length) {
+			if (opt.paintImmediate) runListeners(listeners.beforePaint, new_, old, opt);
+			else runPaint(new_, old, opt);
+		}
 		if (listeners.idle.length) runIdle(new_, old, opt);
 	};
 })();
 
-function _select(thingOrEntry, options = { scrollStyle: 'none' }) {
-	const newThing = Thing.from(thingOrEntry || Thing.visibleThingElements()[0]);
-	if (!newThing || newThing.is(selectedThing)) return;
+export function select(newSelected: Thing, options: SelectOptions = { scrollStyle: 'none' }) {
+	if (newSelected.is(selectedThing)) return;
 
-	const newSelected = newThing;
 	const oldSelected = selectedThing;
 
 	options = {
 		...options,
-		direction: newThing && newThing.isVisible() && oldSelected && oldSelected.isVisible() ?
-			(newThing.entry.getBoundingClientRect().top > oldSelected.entry.getBoundingClientRect().top ? 'down' : 'up') :
+		direction: newSelected && newSelected.isVisible() && oldSelected && oldSelected.isVisible() ?
+			(newSelected.entry.getBoundingClientRect().top > oldSelected.entry.getBoundingClientRect().top ? 'down' : 'up') :
 			undefined,
 	};
 
 	runCallbacks(newSelected, oldSelected, options);
 
-	scrollToElement(newThing.entry, options);
-
 	selectedThing = newSelected;
 	selectedContainer = newSelected && $(newSelected.thing).closest('.sitetable').get(0);
 }
 
-const onNewComments = _.throttle(thingElement => {
+const onNewComments = _.throttle(thing => {
 	if (selectedThing && !document.contains(selectedThing.element)) {
 		// Selected thing was replaced, so select the replacement
-		const newContainer = $(thingElement).closest('.sitetable').get(0);
+		const newContainer = $(thing.element).closest('.sitetable').get(0);
 		if (newContainer === selectedContainer) {
-			_select(thingElement);
+			select(thing);
 		}
 	}
 }, 100, { leading: true, trailing: false });
@@ -249,9 +253,9 @@ function autoSelect() {
 	if (KeyboardNav.recentKeyMove) return;
 	if (selectedThing && elementInViewport(selectedThing.element)) return;
 
-	for (const thing of Thing.visibleThingElements()) {
-		if (elementInViewport(thing)) {
-			_select(thing);
+	for (const thing of Thing.visibleThings()) {
+		if (elementInViewport(thing.element)) {
+			select(thing);
 			break;
 		}
 	}
@@ -289,7 +293,7 @@ function urlForSelectedCache() {
 }
 
 function updateLastSelectedCache(selected) {
-	if (!lastSelectedCache || !isPageType('linklist', 'modqueue', 'profile')) return;
+	if (!lastSelectedCache) return;
 
 	const url = urlForSelectedCache();
 	lastSelectedCache[url] = {
@@ -299,29 +303,26 @@ function updateLastSelectedCache(selected) {
 	Session.set('RESmodules.selectedThing.lastSelectedCache', lastSelectedCache);
 }
 
-async function selectInitial() {
-	if (!module.options.selectThingOnLoad.value) {
-		return;
-	}
-
+const selectInitial = _.once(fastAsync(function*(firstThing) {
 	let scrollToSelected = module.options.scrollToSelectedThingOnLoad.value;
 	// NER may restore a page which contains the last selected thing
 	if (NeverEndingReddit.loadPromise) {
-		await NeverEndingReddit.loadPromise;
+		yield NeverEndingReddit.loadPromise;
 		scrollToSelected = true;
 	}
 
-	let target = await findLastSelectedThing();
+	if (scrollToSelected) history.scrollRestoration = 'manual';
 
-	if (!target) {
-		const things = Thing.visibleThingElements();
-		target = things.find(v => elementInViewport(v)) || things[0];
-	}
+	const lastSelected = yield findLastSelectedThing();
+	const target = (lastSelected || firstThing).getClosestVisible() || lastSelected || firstThing;
 
-	_select(target, {
+	select(target, {
 		scrollStyle: scrollToSelected ? 'legacy' : 'none',
+		paintImmediate: true,
 	});
-}
+
+	addListener(updateLastSelectedCache);
+}));
 
 async function findLastSelectedThing() {
 	if (!module.options.selectLastThingOnLoad.value) {
@@ -333,7 +334,7 @@ async function findLastSelectedThing() {
 	const url = urlForSelectedCache();
 	const lastSelected = lastSelectedCache[url] && lastSelectedCache[url].fullname;
 	if (lastSelected) {
-		return Thing.visibleThings().find(v => v.getFullname() === lastSelected);
+		return Thing.things().find(v => v.getFullname() === lastSelected);
 	}
 }
 

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -161,6 +161,8 @@ type SelectOptions = {
 	paintImmediate?: boolean, // Set `true` when `select` is invoked during the animation phase, in order for `beforePaint` not to be delayed to the next animation frame
 };
 
+type SelectOptionsWithDirection = SelectOptions & { direction?: 'down' | 'up' };
+
 export const selectClosestVisible = _.debounce((options: SelectOptions) => {
 	const target = selectedThing.getClosestVisible(false);
 	if (target) select(target, options);
@@ -173,7 +175,7 @@ function _selectedThing() {
 
 const listeners = { beforeScroll: [], beforePaint: [], idle: [] };
 
-export function addListener(callback: (new_: Thing, old: ?Thing, opt: SelectOptions & { direction?: 'down' | 'up' }) => mixed, when?: $Keys<typeof listeners> = 'idle'): void {
+export function addListener(callback: (new_: Thing, old: ?Thing, opt: SelectOptionsWithDirection) => mixed, when?: $Keys<typeof listeners> = 'idle'): void {
 	listeners[when].push(callback);
 }
 
@@ -185,7 +187,7 @@ const runCallbacks = (() => {
 	function throttle(throttler, listeners) {
 		let oldest: ?Thing; // So that `oldest` will equal `new_` from the previous listener invokation
 
-		const throttled = throttler((new_, old, opt) => {
+		const throttled = throttler((new_: Thing, old: ?Thing, opt: SelectOptionsWithDirection) => {
 			runListeners(listeners, new_, oldest, opt);
 			oldest = null;
 		});

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -48,7 +48,7 @@ import {
 	isPageType,
 	string,
 	waitForEvent,
-	watchForElement,
+	watchForElements,
 	getPercentageVisibleYAxis,
 } from '../utils';
 import { addURLToHistory, ajax, isPrivateBrowsing, openNewTab, Permissions } from '../environment';
@@ -417,15 +417,33 @@ module.beforeLoad = () => {
 			}
 		`);
 	}
+
+	watchForElements(['siteTable'], getSelector(), checkElementForMedia);
+	watchForElements(['selfText', 'newComments'], getSelector(true), checkElementForMedia);
 };
+
+function getSelector(isSelfText) {
+	// get elements common across all pages first...
+	// if we're on a comments page, get those elements too...
+	if (isPageType('comments', 'commentsLinklist', 'profile')) {
+		return '#siteTable a.title, .expando .usertext-body > div.md a, .content .usertext-body > div.md a';
+	} else if (isSelfText) {
+		// We're scanning newly opened (from an expando) selftext...
+		return '.usertext-body > div.md a';
+	} else if (isPageType('wiki')) {
+		return '.wiki-page-content a';
+	} else if (isPageType('inbox')) {
+		return '#siteTable div.entry .md a';
+	} else if (isPageType('search')) {
+		return '#siteTable a.title, .contents a.search-link';
+	} else {
+		return '#siteTable a.title, #siteTable_organic a.title';
+	}
+}
 
 const elementResizeDetector = _.once(() => elementResizeDetectorMaker({ strategy: 'object' }));
 
 module.go = () => {
-	watchForElement('siteTable', findAllImages);
-	watchForElement('selfText', v => findAllImages(v, true));
-	watchForElement('newComments', v => findAllImages(v, true));
-
 	createImageButtons();
 
 	for (const siteModule of Object.values(siteModules)) {
@@ -433,8 +451,6 @@ module.go = () => {
 			if (siteModule.go) siteModule.go();
 		}
 	}
-
-	findAllImages(document.body);
 
 	SelectedEntry.addListener(mediaBrowse, 'beforeScroll');
 
@@ -737,29 +753,6 @@ function isExpandWanted(expando: Expando, {
 		(autoExpandFirstVisibleNonMutedInThing && elementInViewport(expando.button) && !hasEntryAnyExpandedNonMuted(thing));
 
 	return autoExpand && muteCriteriaOK && typeCriteriaOK;
-}
-
-function findAllImages(elem, isSelfText) {
-	// get elements common across all pages first...
-	// if we're on a comments page, get those elements too...
-	let selectors: string;
-	if (isPageType('comments', 'commentsLinklist', 'profile')) {
-		selectors = '#siteTable a.title, .expando .usertext-body > div.md a, .content .usertext-body > div.md a';
-	} else if (isSelfText) {
-		// We're scanning newly opened (from an expando) selftext...
-		selectors = '.usertext-body > div.md a';
-	} else if (isPageType('wiki')) {
-		selectors = '.wiki-page-content a';
-	} else if (isPageType('inbox')) {
-		selectors = '#siteTable div.entry .md a';
-	} else if (isPageType('search')) {
-		selectors = '#siteTable a.title, .contents a.search-link';
-	} else {
-		selectors = '#siteTable a.title, #siteTable_organic a.title';
-	}
-
-	const allElements = elem.querySelectorAll(selectors);
-	return forEachChunked(allElements, checkElementForMedia);
 }
 
 async function convertGifToVideo(options) {

--- a/lib/modules/singleClick.js
+++ b/lib/modules/singleClick.js
@@ -2,7 +2,7 @@
 
 import { $ } from '../vendor';
 import { Module } from '../core/module';
-import { Thing, watchForElement } from '../utils';
+import { Thing, watchForThings } from '../utils';
 import { openNewTabs } from '../environment';
 
 export const module: Module<*> = new Module('singleClick');
@@ -40,10 +40,12 @@ module.exclude = [
 	'comments',
 	/^\/subreddits(?:\/|$)/i,
 ];
-module.go = () => {
-	watchForElement('siteTable', applyLinks);
-	applyLinks();
 
+module.beforeLoad = () => {
+	watchForThings(['post'], applyLinks);
+};
+
+module.go = () => {
 	// mousedown because Firefox doesn't fire click events on middle click...
 	$(document.body).on('mousedown', '.redditSingleClick', (e: MouseEvent) => {
 		if (e.button !== 2) {
@@ -68,14 +70,8 @@ export function openTabs(thing: Thing, focused: boolean) {
 	openNewTabs(focused, ...urls);
 }
 
-function applyLinks(ele = document) {
-	const entries = ele.querySelectorAll('#siteTable .entry, #siteTable_organic .entry');
-	for (const entry of entries) {
-		if (entry.classList.contains('lcTagged')) continue;
-		entry.classList.add('lcTagged');
-		// changed from a link to a span because you can't cancel a new window on middle click of a link during the mousedown event, and a click event isn't triggered.
-		$(entry)
-			.find('ul.flat-list')
-			.append('<li><span class="redditSingleClick"></span></li>');
-	}
+function applyLinks(thing) {
+	thing.$thing
+		.find('ul.flat-list')
+		.append('<li><span class="redditSingleClick"></span></li>');
 }

--- a/lib/modules/sourceSnudown.js
+++ b/lib/modules/sourceSnudown.js
@@ -3,7 +3,7 @@
 import { $ } from '../vendor';
 import { Module } from '../core/module';
 import { ajax } from '../environment';
-import { forEachChunked, isPageType, watchForElement, regexes, keyedMutex } from '../utils';
+import { watchForThings, isPageType, regexes, keyedMutex } from '../utils';
 
 export const module: Module<*> = new Module('sourceSnudown');
 
@@ -14,8 +14,11 @@ module.include = [
 	'comments',
 	'commentsLinklist',
 	'inbox',
-	'profile',
 ];
+
+module.beforeLoad = () => {
+	watchForThings(['post', 'comment'], attachViewSourceButton);
+};
 
 module.go = () => {
 	$(document.body)
@@ -26,28 +29,13 @@ module.go = () => {
 		.on('click', '.usertext-edit.viewSource .cancel', function() {
 			$(this).parents('.usertext-edit.viewSource').hide();
 		});
-
-	attachViewSourceButtons();
-	watchForElement('newComments', attachViewSourceButtons);
 };
 
-function attachViewSourceButtons(entry) {
-	if (isPageType('comments', 'commentsLinklist', 'inbox')) {
-		let $menus;
-
-		if (isPageType('comments', 'commentsLinklist')) {
-			// entry may be undefined, as intended: undefined context => normal (global) selector
-			$menus = $('.flat-list.buttons li.first', entry);
-		} else {
-			$menus = $('.flat-list.buttons a.bylink');
-		}
-
-		forEachChunked($menus, item => {
-			const $item = $(item).closest('li');
-			if ($item.siblings('li.viewSource').length) return; // guard against adding "source" button multiple times for whatever buggy reason
-			$item.after('<li class="viewSource"><a class="noCtrlF" href="javascript:void 0" data-text="source"></a></li>');
-		});
-	}
+function attachViewSourceButton(thing) {
+	thing.$thing
+		.find(isPageType('inbox') ? '.flat-list a.bylink:first' : '.flat-list.buttons li.first:first')
+		.closest('li')
+		.after('<li class="viewSource"><a class="noCtrlF" href="javascript:void 0" data-text="source"></a></li>');
 }
 
 const viewSource = keyedMutex(async button => {

--- a/lib/modules/sourceSnudown.js
+++ b/lib/modules/sourceSnudown.js
@@ -14,6 +14,7 @@ module.include = [
 	'comments',
 	'commentsLinklist',
 	'inbox',
+	'profile',
 ];
 
 module.beforeLoad = () => {

--- a/lib/modules/spamButton.js
+++ b/lib/modules/spamButton.js
@@ -3,10 +3,8 @@
 import { $ } from '../vendor';
 import { Module } from '../core/module';
 import {
-	currentUserProfile,
-	forEachChunked,
 	loggedInUser,
-	watchForElement,
+	watchForThings,
 } from '../utils';
 
 export const module: Module<*> = new Module('spamButton');
@@ -18,43 +16,26 @@ module.description = 'spamButtonDesc';
 
 module.include = ['linklist', 'modqueue', 'comments', 'profile'];
 
-module.go = () => {
-	// credit to tico24 for the idea, here: http://userscripts.org/scripts/review/84454
-	// code adapted for efficiency...
-	if (loggedInUser() !== currentUserProfile()) {
-		watchForElement('siteTable', addSpamButtons);
-		watchForElement('newComments', addSpamButtons);
-		addSpamButtons();
-	}
+module.beforeLoad = () => {
+	watchForThings(['post', 'comment'], addSpamButton);
 };
 
-function addSpamButtons(ele = document) {
-	const allLists = ele.querySelectorAll('.thing:not(.deleted):not(.morerecursion):not(.morechildren) > .entry .buttons');
-	forEachChunked(allLists, list => {
-		const spam = document.createElement('li');
-		// insert spam button second to last in the list... this is a bit hacky and assumes singleClick is enabled...
-		// it should probably be made smarter later, but there are so many variations of configs, etc, that it's a bit tricky.
-		$(list.lastChild).before(spam);
+function addSpamButton(thing) {
+	const authorName = thing.getAuthor();
+	if (!authorName || loggedInUser() === authorName) return;
 
-		// it's faster to figure out the author only if someone actually clicks the link, so we're modifying the code to listen for clicks and not do all that queryselector stuff.
-		const a = document.createElement('a');
-		a.setAttribute('class', 'option');
-		a.setAttribute('title', 'Report this user as a spammer');
-		a.addEventListener('click', reportPost);
-		a.setAttribute('href', '#');
-		a.textContent = 'rts';
-		a.title = 'spam';
-		spam.appendChild(a);
-	});
-}
+	const list = thing.entry.querySelector('.buttons');
+	const spam = document.createElement('li');
+	// insert spam button second to last in the list... this is a bit hacky and assumes singleClick is enabled...
+	// it should probably be made smarter later, but there are so many variations of configs, etc, that it's a bit tricky.
+	$(list.lastChild).before(spam);
 
-function reportPost(e: Event) {
-	const $spamButton = $(e.target);
-	const $author = $spamButton.closest('.entry').find('.author');
-	const href = $author.attr('href');
-	const authorName = $author.text();
-	$spamButton
-		.attr('href', `/r/spam/submit?url=${href}&title=overview for ${authorName}`)
-		.attr('target', '_blank')
-		.attr('rel', 'noopener noreferer');
+	const a = document.createElement('a');
+	a.setAttribute('class', 'option');
+	a.setAttribute('title', 'Report this user as a spammer');
+	a.href = `/r/spam/submit?url=${thing.getAuthorUrl()}&title=overview for ${authorName}`;
+	a.target = '_blank';
+	a.rel = 'noopener noreferer';
+	a.textContent = 'rts';
+	spam.appendChild(a);
 }

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -14,7 +14,7 @@ import {
 	loggedInUser,
 	regexes,
 	string,
-	watchForElement,
+	watchForThings,
 } from '../utils';
 import { Session, Storage, ajax, isPrivateBrowsing, i18n } from '../environment';
 import type { RedditListing, RedditSubreddit } from '../types/reddit';
@@ -169,7 +169,15 @@ const subredditShortcutsStorage = Storage.wrap(() => {
 	addedDate: number,
 |}>));
 
-module.go = async () => {
+module.beforeLoad = async () => {
+	if (/^\/(?:sub)?reddits\/?(?:\?[\w=&]+)*/.test(location.pathname)) {
+		watchForThings(['subreddit'], browsingReddits);
+	}
+
+	await getLatestShortcuts();
+};
+
+module.go = () => {
 	if (module.options.linkMyRandom.value) {
 		const originalMyRandom = document.querySelector('#sr-header-area a[href$="/r/myrandom/"]');
 		if (originalMyRandom) {
@@ -183,8 +191,6 @@ module.go = async () => {
 	if (module.options.lastUpdate.value && document.getElementsByClassName('listing-chooser').length) {
 		lastUpdate();
 	}
-
-	await getLatestShortcuts();
 
 	manageSubreddits();
 
@@ -263,47 +269,34 @@ function manageSubreddits() {
 			}
 		}
 	}
-
-	// If we're on the reddit-browsing page (/reddits or /subreddits), add +shortcut and -shortcut buttons...
-	if (/^https?:\/\/www\.reddit\.com\/(?:sub)?reddits\/?(?:\?[\w=&]+)*/.test(location.href)) {
-		browsingReddits();
-		watchForElement('siteTable', browsingReddits);
-	}
 }
 
-function browsingReddits() {
-	$('.subreddit').each(function() {
-		// Skip subreddit links that already have a shortcut button
-		if ($(this).data('hasShortcutButton')) {
-			return;
-		}
+function browsingReddits(thing) {
+	const titleElement = thing.getTitleElement();
+	if (!titleElement) return;
 
-		// Otherwise, indicate that this link now has a shortcut button
-		$(this).data('hasShortcutButton', true);
-
-		const subreddit = regexes.subreddit.exec(($(this).find('a.title').get(0): any).pathname)[1];
-		const $theSC = $('<span>')
+	const subreddit = regexes.subreddit.exec(titleElement.pathname)[1];
+	const $theSC = $('<span>')
 			.css({ 'margin-right': '0' })
 			.addClass('res-fancy-toggle-button')
 			.data('subreddit', subreddit);
-		const isShortcut = mySubredditShortcuts.some(shortcut => shortcut.subreddit === subreddit);
+	const isShortcut = mySubredditShortcuts.some(shortcut => shortcut.subreddit === subreddit);
 
-		if (isShortcut) {
-			$theSC
+	if (isShortcut) {
+		$theSC
 				.attr('title', 'Remove this subreddit from your shortcut bar')
 				.text('-shortcut')
 				.addClass('remove');
-		} else {
-			$theSC
+	} else {
+		$theSC
 				.attr('title', 'Add this subreddit to your shortcut bar')
 				.text('+shortcut')
 				.removeClass('remove');
-		}
+	}
 
-		$theSC
+	$theSC
 			.on('click', toggleSubredditShortcut)
-			.appendTo($(this).find('.midcol'));
-	});
+			.appendTo(thing.element.querySelector('.midcol'));
 }
 
 let hideSubredditGroupDropdownTimer, showSubredditGroupDropdownTimer;

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -173,11 +173,9 @@ module.beforeLoad = async () => {
 	if (/^\/(?:sub)?reddits\/?(?:\?[\w=&]+)*/.test(location.pathname)) {
 		watchForThings(['subreddit'], browsingReddits);
 	}
-
-	await getLatestShortcuts();
 };
 
-module.go = () => {
+module.go = async () => {
 	if (module.options.linkMyRandom.value) {
 		const originalMyRandom = document.querySelector('#sr-header-area a[href$="/r/myrandom/"]');
 		if (originalMyRandom) {
@@ -191,6 +189,9 @@ module.go = () => {
 	if (module.options.lastUpdate.value && document.getElementsByClassName('listing-chooser').length) {
 		lastUpdate();
 	}
+
+	// depends on loggedInUser; must be called after body is ready
+	await getLatestShortcuts();
 
 	manageSubreddits();
 

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -169,7 +169,7 @@ const subredditShortcutsStorage = Storage.wrap(() => {
 	addedDate: number,
 |}>));
 
-module.beforeLoad = async () => {
+module.beforeLoad = () => {
 	if (/^\/(?:sub)?reddits\/?(?:\?[\w=&]+)*/.test(location.pathname)) {
 		watchForThings(['subreddit'], browsingReddits);
 	}

--- a/lib/modules/subredditTagger.js
+++ b/lib/modules/subredditTagger.js
@@ -2,7 +2,7 @@
 
 import { $ } from '../vendor';
 import { Module } from '../core/module';
-import { Thing, escapeHTML, forEachChunked, watchForElement } from '../utils';
+import { escapeHTML, watchForThings } from '../utils';
 
 export const module: Module<*> = new Module('subRedditTagger');
 
@@ -34,11 +34,12 @@ module.options = {
 const SRTDoesntContain = {};
 const SRTTagWith = {};
 
+module.beforeLoad = () => {
+	watchForThings(['post'], scanTitle);
+};
+
 module.go = () => {
 	loadSRTRules();
-
-	watchForElement('siteTable', scanTitles);
-	scanTitles();
 };
 
 function loadSRTRules() {
@@ -48,38 +49,26 @@ function loadSRTRules() {
 	}
 }
 
-function scanTitles(obj) {
-	let qs = '#siteTable > .thing > DIV.entry';
-	if (obj) {
-		qs = '.thing > DIV.entry';
-	} else {
-		obj = document;
+function scanTitle(thing) {
+	const tagToAdd = getTag(thing);
+	if (tagToAdd !== undefined) {
+		const tagText = $('<span>').append(escapeHTML(tagToAdd)).append('&nbsp;');
+		$(thing.getTitleElement()).prepend(tagText);
 	}
-	forEachChunked(obj.querySelectorAll(qs), entry => {
-		const title = $(entry).find('a.title');
-		if (title.is('.srTagged')) return;
-		title.addClass('srTagged');
-
-		const tagToAdd = getTagForEntry(entry);
-		if (tagToAdd !== undefined) {
-			const tagText = $('<span>').append(escapeHTML(tagToAdd)).append('&nbsp;');
-			title.prepend(tagText);
-		}
-	});
 }
 
-function getTagForEntry(entry) {
+function getTag(thing) {
 	let hasTag = false;
 
-	const thisSubReddit = (Thing.checkedFrom(entry).getSubreddit() || '').toLowerCase();
-	if (thisSubReddit.length) {
+	const thisSubReddit = (thing.getSubreddit() || '').toLowerCase();
+	if (thisSubReddit) {
 		if (SRTTagWith.hasOwnProperty(thisSubReddit)) {
 			if (thisSubReddit && !SRTDoesntContain[thisSubReddit]) {
 				SRTDoesntContain[thisSubReddit] = `[${thisSubReddit}]`;
 			}
 			const thisString = SRTDoesntContain[thisSubReddit];
-			hasTag = entry.querySelector('a.title').innerText.includes(thisString) ||
-				$(entry).find('.linkflairlabel').text().includes(thisString);
+			hasTag = thing.getTitle().includes(thisString) ||
+				thing.getPostFlairText().includes(thisString);
 		}
 	}
 

--- a/lib/modules/userHighlight.js
+++ b/lib/modules/userHighlight.js
@@ -1,13 +1,11 @@
 /* @flow */
 
-import { $ } from '../vendor';
 import { Module } from '../core/module';
 import {
 	Alert,
 	addCSS,
-	forEachChunked,
 	hashCode,
-	watchForElement,
+	watchForThings,
 } from '../utils';
 import { i18n } from '../environment';
 import * as SettingsConsole from './settingsConsole';
@@ -180,7 +178,18 @@ module.options = {
 
 let colorTable;
 
-module.go = () => {
+module.beforeLoad = () => {
+	// Run these immediately since they add styles.
+	// Adding styles would cause style recalculation at the end of every chunk, which is very expensive
+
+	if (module.options.autoColorUsernames.value) {
+		watchForThings(['post', 'comment'], updateNewUsernames, { immediate: true });
+	}
+
+	if (module.options.highlightFirstCommenter.value) {
+		watchForThings(['comment'], updateFirstComments, { immediate: true });
+	}
+
 	colorTable = {
 		admin: {
 			color: module.options.adminColor.value,
@@ -226,68 +235,36 @@ module.go = () => {
 	if (module.options.highlightAlum.value) {
 		highlight('alum');
 	}
-
-	if (module.options.autoColorUsernames.value) {
-		watchForElement('newComments', scanPageForNewUsernames);
-		watchForElement('siteTable', scanPageForNewUsernames);
-		scanPageForNewUsernames();
-	}
-
-	if (module.options.highlightFirstCommenter.value) {
-		watchForElement('newComments', scanPageForFirstComments);
-		scanPageForFirstComments();
-	}
 };
 
-const firstComments = {};
+function updateFirstComments(thing) {
+	const idClass = Array.from(thing.element.classList).find(cls => /*:: cls && */ cls.startsWith('id-t1_'));
+	if (!idClass) return;
 
-function scanPageForFirstComments(ele) {
-	const comments = ele ? $(ele).closest('.commentarea > .sitetable > .comment') : document.body.querySelectorAll('.commentarea > .sitetable > .comment');
+	const author = thing.getAuthorElement();
+	if (!author) return;
 
-	forEachChunked(comments, element => {
-		// Get identifiers
-		const idClass = Array.from(element.classList).find(cls => cls.startsWith('id-t1_'));
+	const authorClass = Array.from(author.classList).find(cls => /*:: cls && */ cls.startsWith('id-t2_'));
 
-		if (idClass === undefined || firstComments[idClass]) return;
-		firstComments[idClass] = true;
-
-		const entry = element.querySelector('.entry');
-		const author = entry.querySelector('.author');
-		if (!author) return;
-
-		const authorClass = Array.from(author.classList).find(cls => cls.startsWith('id-t2_'));
-
-		if (authorClass === undefined) return;
-
-		let container = `.${idClass}`;
-		if (module.options.dontHighlightFirstComment.value) {
-			container += ' .child';
-		}
+	if (authorClass) {
+		const container = `.${idClass}${module.options.dontHighlightFirstComment.value ? ' .child' : ''}`;
 		highlight('firstComment', authorClass, container);
-	});
+	}
 }
 
-const coloredUsernames = {};
+function updateNewUsernames(thing) {
+	const element = thing.getAuthorElement();
+	if (!element) return;
 
-function scanPageForNewUsernames(ele = document.body) {
 	const colorGetter = autoColorUsing[module.options.autoColorUsing.value];
-	const authors = ele.querySelectorAll('.author');
-	forEachChunked(authors, element => {
-		// Get identifiers
-		const idClass = Array.from(element.classList).find(cls => cls.startsWith('id-t2_'));
 
-		if (idClass === undefined) return;
+	// Get identifiers
+	const idClass = Array.from(element.classList).find(cls => /*:: cls && */ cls.startsWith('id-t2_'));
 
-		const username = element.textContent;
-
-		if (coloredUsernames[idClass]) return;
-		coloredUsernames[idClass] = true;
-
-		const color = colorGetter(idClass, element, username);
-
-		// Apply color
+	if (idClass) {
+		const color = colorGetter(idClass, element, thing.getAuthor());
 		doTextColor(`.${idClass}`, color);
-	});
+	}
 }
 
 const autoColorTemplate = `

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -11,12 +11,11 @@ import {
 	Thing,
 	click,
 	downcast,
-	forEachChunked,
 	isCurrentSubreddit,
 	isPageType,
 	loggedInUser,
 	string,
-	watchForElement,
+	watchForElements,
 } from '../utils';
 import { Storage, openNewTabs, i18n } from '../environment';
 import * as CommandLine from './commandLine';
@@ -106,6 +105,8 @@ export let tags = {};
 
 module.beforeLoad = async () => {
 	tags = await tagStorage.get();
+
+	watchForElements(['siteTable'], usernameSelector, applyTagToAuthor);
 };
 
 module.go = () => {
@@ -206,16 +207,10 @@ module.go = () => {
 
 	addTagger();
 
-	applyTags();
-
-	if (isPageType('comments')) {
-		watchForElement('newComments', applyTags);
-	} else {
-		watchForElement('siteTable', applyTags);
-	}
-
 	registerCommandLine();
 };
+
+export const usernameSelector = '.contents .author, .noncollapsed a.author, p.tagline a.author, #friend-table span.user a, .sidecontentbox .author, div.md a[href^="/u/"]:not([href*="/m/"]), div.md a[href*="reddit.com/u/"]:not([href*="/m/"]), .usertable a.author, .usertable span.user a, div.wiki-page-content .author';
 
 const $tagDialog = _.once(() => {
 	const colors = Object.entries(bgToTextColorMap)
@@ -764,19 +759,8 @@ function setUserTag(username, tag, color, ignore, link, votes, noclick) {
 	closeUserTagPrompt();
 }
 
-export const usernameSelector = '.contents .author, .noncollapsed a.author, p.tagline a.author, #friend-table span.user a, .sidecontentbox .author, div.md a[href^="/u/"]:not([href*="/m/"]), div.md a[href*="reddit.com/u/"]:not([href*="/m/"]), .usertable a.author, .usertable span.user a, div.wiki-page-content .author';
-
-function applyTags(ele = document) {
-	const authors = ele.querySelectorAll(usernameSelector);
-	forEachChunked(authors, applyTagToAuthor);
-}
-
-const appliedAuthorObjs = new WeakMap();
 
 export function applyTagToAuthor(thisAuthorObj: HTMLAnchorElement, noEdit: boolean = false): void {
-	if (!thisAuthorObj || appliedAuthorObjs.has(thisAuthorObj)) return;
-	appliedAuthorObjs.set(thisAuthorObj, true);
-
 	let thisAuthor;
 	if (thisAuthorObj.href) {
 		const test = thisAuthorObj.href.match(usernameRE);

--- a/lib/modules/voteEnhancements.js
+++ b/lib/modules/voteEnhancements.js
@@ -5,16 +5,14 @@ import { $ } from '../vendor';
 import { Module } from '../core/module';
 import { i18n } from '../environment';
 import {
-	Thing,
 	addCSS,
 	colorFromArray,
 	colorToArray,
-	forEachChunked,
 	formatNumber,
 	isPageType,
 	projectInto,
 	string,
-	watchForElement,
+	watchForThings,
 	zip,
 } from '../utils';
 
@@ -162,21 +160,20 @@ module.options = {
 };
 module.include = ['comments', 'commentsLinklist', 'linklist', 'modqueue', 'profile', 'inbox'];
 
+module.beforeLoad = () => {
+	if (module.options.colorLinkScore.value !== 'none') {
+		watchForThings(['post'], applyLinkScoreColor);
+	}
+	if (module.options.colorCommentScore.value !== 'none') {
+		watchForThings(['comment'], applyCommentScoreColor);
+	}
+};
+
 module.go = () => {
 	if (isPageType('comments')) {
 		if (module.options.estimatePostScore.value || module.options.estimatePostVotes.value) {
 			estimatePostScoreVotes();
 		}
-	}
-	if (module.options.colorLinkScore.value !== 'none') {
-		applyLinkScoreColor();
-		watchForElement('siteTable', applyLinkScoreColor);
-	}
-	if (module.options.colorCommentScore.value !== 'none') {
-		const commentsIn = ele => Thing.things(ele).filter(t => t.isComment());
-		applyCommentScoreColor(commentsIn(document.body));
-		watchForElement('newComments', entry => applyCommentScoreColor([Thing.checkedFrom(entry)]));
-		watchForElement('siteTable', siteTable => applyCommentScoreColor(commentsIn(siteTable)));
 	}
 	if (module.options.highlightControversial.value) {
 		highlightControversial();
@@ -252,10 +249,6 @@ function interpolateScoreColor(score, colors, defaultColor) {
 }
 
 function getLinkScoreColor(score) {
-	if (isNaN(score)) {
-		return false;
-	}
-
 	if (module.options.colorLinkScore.value === 'automatic') {
 		return `hsl(${180 + 360 * (1 - 100 / (150 + score))}, 75%,50%)`;
 	} else {
@@ -264,10 +257,6 @@ function getLinkScoreColor(score) {
 }
 
 function getCommentScoreColor(score) {
-	if (isNaN(score)) {
-		return false;
-	}
-
 	if (module.options.colorCommentScore.value === 'automatic') {
 		return `hsl(${180 + 360 * (1 - 50 / (100 + score))}, 75%,50%)`;
 	} else {
@@ -288,28 +277,24 @@ function getCommentScoreColor(score) {
 	}
 }
 
-function applyLinkScoreColor(ele = document.body) {
-	forEachChunked(Thing.things(ele).filter(t => t.isPost()), thing => {
-		const score = thing.getScore();
-		const rankEle = thing.getRankElement();
-		const color = getLinkScoreColor(score);
+function applyLinkScoreColor(thing) {
+	const score = thing.getScore();
+	const rankEle = thing.getRankElement();
+	const color = typeof score === 'number' && getLinkScoreColor(score);
 
-		if (rankEle && color) {
-			rankEle.style.background = color;
-		}
-	});
+	if (rankEle && color) {
+		rankEle.style.background = color;
+	}
 }
 
-function applyCommentScoreColor(things) {
-	forEachChunked(things, thing => {
-		for (const [scoreEle, score] of thing.getAllScoreElements()) {
-			const color = getCommentScoreColor(score);
+function applyCommentScoreColor(thing) {
+	for (const [scoreEle, score] of thing.getAllScoreElements()) {
+		const color = getCommentScoreColor(score);
 
-			if (color) {
-				scoreEle.style.color = color;
-			}
+		if (color) {
+			scoreEle.style.color = color;
 		}
-	});
+	}
 }
 
 function highlightControversial() {

--- a/lib/modules/xPostLinks.js
+++ b/lib/modules/xPostLinks.js
@@ -2,7 +2,7 @@
 
 import { $ } from '../vendor';
 import { Module } from '../core/module';
-import { Thing, forEachChunked, isPageType, string, watchForElement } from '../utils';
+import { watchForThings, string } from '../utils';
 import { i18n } from '../environment';
 
 export const module: Module<*> = new Module('xPostLinks');
@@ -19,14 +19,8 @@ module.include = [
 	'search',
 ];
 
-module.go = () => {
-	if (isPageType('comments')) {
-		// Optimize by restricting to the one in the top
-		createLinks(document.querySelector('.sitetable'));
-	} else {
-		createLinks();
-		watchForElement('siteTable', createLinks);
-	}
+module.beforeLoad = () => {
+	watchForThings(['post'], createLinks);
 };
 
 const xpostRe = /(?:x|cross)[\s-]?post\S*(.+)/i;
@@ -50,7 +44,7 @@ function parseSubreddit(title) {
 function appendToTagline(sub, thing) {
 	$()
 		.add($(thing.getSubredditLink()).prev())
-		.add(thing.getUserattrsElement())
+		.add(thing.getUserattrsElement() || '')
 		.first() // first valid (thing.getSubredditLink() may be null)
 		.after(
 			string.escapeHTML` ${i18n('xPostLinksXpostedFrom')} `,
@@ -62,13 +56,7 @@ function appendToTagline(sub, thing) {
 		);
 }
 
-function createLinks(container) {
-	const things = Thing.things(container);
-
-	forEachChunked(things, thing => {
-		if (thing.isPost()) {
-			const sub = parseSubreddit(thing.getTitle());
-			if (sub) appendToTagline(sub, thing);
-		}
-	});
+function createLinks(thing) {
+	const sub = parseSubreddit(thing.getTitle());
+	if (sub) appendToTagline(sub, thing);
 }

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -5,8 +5,8 @@ import { $ } from '../vendor';
 import type { Expando } from './expando';
 import { currentSubreddit, click, downcast, expandos, filterMap, regexes } from './';
 
-const things = new WeakMap();
-
+const elementMap = new WeakMap();
+const things = new Set();
 const SECRET_TOKEN = new class {}();
 
 export default class Thing {
@@ -21,14 +21,21 @@ export default class Thing {
 	}
 
 	static $things(container: HTMLElement = Thing.thingsContainer()): JQuery {
-		return $(container).find(Thing.thingSelector);
+		const $container = $(container);
+		const things = $container.find(Thing.thingSelector);
+		if ($container.is(Thing.thingSelector)) return $(container).add(things);
+		return things;
 	}
 
-	static things(container?: HTMLElement): Thing[] {
+	static findThings(container?: HTMLElement): Thing[] {
 		return filterMap(Thing.$things(container).toArray(), ele => {
 			const thing = Thing.from(ele);
 			if (thing) return [thing];
 		});
+	}
+
+	static things(): Thing[] {
+		return Array.from(things);
 	}
 
 	static thingElements(): HTMLElement[] {
@@ -66,23 +73,25 @@ export default class Thing {
 
 	static from(element: ?Element | JQuery | Thing): ?Thing {
 		if (!element) return null;
-
+		if (elementMap.has(element)) return elementMap.get(element);
 		if (element instanceof Thing) return element;
-
-		if (things.has(element)) return things.get(element);
 
 		const $thing = $(element).closest(Thing.thingSelector);
 		if (!$thing.length) return null;
 
 		const thingElement = $thing.get(0);
+		let thing;
 
-		if (thingElement !== element && things.has(thingElement)) return things.get(thingElement);
+		if (elementMap.has(thingElement)) {
+			thing = elementMap.get(thingElement);
+		} else {
+			const entry = thingElement.querySelector(Thing.entrySelector) || thingElement;
+			thing = new Thing(SECRET_TOKEN, $thing, thingElement, entry);
+			elementMap.set(thingElement, thing);
+			things.add(thing);
+		}
 
-		const entry = thingElement.querySelector(Thing.entrySelector) || thingElement;
-
-		const thing = new Thing(SECRET_TOKEN, $thing, thingElement, entry);
-
-		things.set(thingElement, thing);
+		elementMap.set(element, thing);
 
 		return thing;
 	}
@@ -107,7 +116,10 @@ export default class Thing {
 	}
 
 	getParent(): ?Thing {
-		return Thing.from(this.$thing.parents(Thing.thingSelector).get(0));
+		let current = this.element;
+		while ((current = current.parentElement)) {
+			if (current.classList.contains('thing')) return Thing.checkedFrom(downcast(current, HTMLElement));
+		}
 	}
 
 	getNext({ direction = 'down' }: { direction?: 'up' | 'down' } = {}, things: HTMLElement[] = Thing.thingElements()): ?Thing {
@@ -136,6 +148,15 @@ export default class Thing {
 			const parent = this.getParent();
 			if (parent) return parent.getClosest(func, ...args);
 		}
+	}
+
+	getClosestVisible(includeSelf: boolean = true): ?Thing {
+		if (includeSelf && this.isVisible()) return this;
+		return this.getNext({ direction: 'down' }) || this.getNext({ direction: 'up' });
+	}
+
+	isSubreddit(): boolean {
+		return this.thing.classList.contains('subreddit');
 	}
 
 	isPost(): boolean {
@@ -200,6 +221,11 @@ export default class Thing {
 
 	getHideElement(): ?HTMLAnchorElement {
 		return (this.entry.querySelector('.hide-button a, .unhide-button a'): any);
+	}
+
+	getNumberOfChildren(): number {
+		const numChildrenElem = this.element.querySelector('.numchildren');
+		return numChildrenElem && parseInt((/\((\d+)/).exec(numChildrenElem.textContent)[1], 10) || 0;
 	}
 
 	static _parseScore(scoreEle: HTMLElement): number {
@@ -488,10 +514,15 @@ export default class Thing {
 		return this.thing.classList.contains('RESFiltered');
 	}
 
+	isInCollapsed(): boolean {
+		const parent_ = this.getParent();
+		return !!(parent_ && parent_.getClosest(function() { return this.thing.classList.contains('collapsed'); }));
+	}
+
 	isVisible(): boolean {
 		return (
 			!this.isFiltered() &&
-			!this.getClosest(function() { return this.thing.classList.contains('collapsed'); })
+			!this.isInCollapsed()
 		);
 	}
 

--- a/lib/utils/async.js
+++ b/lib/utils/async.js
@@ -27,10 +27,12 @@ export function waitFor<T>(callback: () => ?T, interval?: number = 1): Promise<T
 export const forEachChunked = (() => {
 	const framerate = 15;
 	const frameTime = 1000 / framerate;
+	const minSlot = frameTime / 2; // In case there's much else going on, don't compromise this too much
 
 	const queues = [];
 
 	const run = frameThrottle((start: number) => {
+		const slotEnd = Math.max(start + frameTime, now() + minSlot);
 		do {
 			_.remove(queues, ({ generator, callback, resolve, reject }): ?boolean => {
 				const { value, done } = generator.next();
@@ -52,7 +54,7 @@ export const forEachChunked = (() => {
 			if (!queues.length) {
 				return;
 			}
-		} while (now() - start < frameTime);
+		} while (now() < slotEnd);
 		run();
 	});
 
@@ -266,6 +268,7 @@ export const nextFrame = (() => {
 /* eslint-disable no-redeclare */
 // rest params can't be placed before non-rest params, so this is unfortunately necessary
 // add another case if you need more params
+declare function frameThrottle<A, B, C>(callback: (a: A, b: B, c: C, start: number) => void): () => void;
 declare function frameThrottle(callback: (start: number) => void): () => void;
 declare function frameThrottle<A>(callback: (a: A, start: number) => void): (a: A) => void;
 

--- a/lib/utils/async.js
+++ b/lib/utils/async.js
@@ -268,9 +268,10 @@ export const nextFrame = (() => {
 /* eslint-disable no-redeclare */
 // rest params can't be placed before non-rest params, so this is unfortunately necessary
 // add another case if you need more params
-declare function frameThrottle<A, B, C>(callback: (a: A, b: B, c: C, start: number) => void): () => void;
 declare function frameThrottle(callback: (start: number) => void): () => void;
 declare function frameThrottle<A>(callback: (a: A, start: number) => void): (a: A) => void;
+declare function frameThrottle<A, B>(callback: (a: A, b: B, start: number) => void): (a: A, b: B) => void;
+declare function frameThrottle<A, B, C>(callback: (a: A, b: B, c: C, start: number) => void): (a: A, b: B, c: C) => void;
 
 /**
  * Returns a wrapper function, similar to _.throttle, that will invoke `callback` at most once per frame.

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -149,8 +149,9 @@ export {
 
 export {
 	initObservers,
-	watchForElement,
 	newSitetable,
+	watchForElements,
+	watchForThings,
 } from './watchers';
 
 export * as BodyClasses from './bodyClasses';

--- a/lib/utils/watchers.js
+++ b/lib/utils/watchers.js
@@ -1,142 +1,137 @@
 /* @flow */
 
-import { $ } from '../vendor';
-import { isPageType, observe, downcast } from './';
+import _ from 'lodash';
+import { sortBy, map, flow } from 'lodash/fp';
+import { Thing, isPageType, observe, downcast, forEachChunked } from './';
 
-type WatcherType = 'siteTable' | 'newComments' | 'selfText' | 'newCommentsForms';
-type WatcherCallback = (e: HTMLElement) => void | Promise<void>;
+type WatcherOptions = {| immediate?: boolean |};
 
-export const watchers: { [key: WatcherType]: WatcherCallback[] } = {
+type ElementWatcherType = $Keys<typeof elementWatchers>;
+type ElementWatcherCallback = (e: any) => void | Promise<void>;
+
+const elementWatchers: {
+	[key: ElementWatcherType]: Array<{
+		selector: ?string,
+		callback: ElementWatcherCallback,
+		options?: WatcherOptions,
+	}>,
+} = {
 	siteTable: [],
-	newComments: [],
 	selfText: [],
-	newCommentsForms: [],
+	newComments: [],
 };
 
-export function watchForElement(type: WatcherType, callback: WatcherCallback) {
-	watchers[type].push(callback);
-}
+type ThingWatcherType = $Keys<typeof thingWatchers>;
+type ThingWatcherCallback = (thing: Thing) => void | Promise<void>;
 
-export function newSitetable(siteTable: HTMLElement) {
-	// when a new sitetable is loaded, we need to add new observers for selftexts within that sitetable...
-	for (const expando of siteTable.querySelectorAll('.entry div.expando')) {
-		addSelfTextObserver(expando);
-	}
-	return Promise.all(watchers.siteTable.map(v => v(siteTable)));
-}
+const thingWatchers: {
+	[key: ThingWatcherType]: Array<{
+		callback: ThingWatcherCallback,
+		options?: WatcherOptions,
+	}>,
+} = {
+	comment: [],
+	post: [],
+	subreddit: [],
+};
 
-export function initObservers() {
-	if (isPageType('comments')) {
-		// initialize sitetable observer...
-		const siteTable = document.querySelector('.commentarea > .sitetable') || document.querySelector('.sitetable');
+function registerElement(type, element, sorter = callback => callback) {
+	const elementCallbacks: Map<HTMLElement, Array<() => *>> = new Map();
 
-		if (siteTable) {
-			observe(siteTable, { childList: true }, mutation => {
-				if (!mutation.addedNodes.length) return;
-
-				const addedNode = downcast(mutation.addedNodes[0], HTMLElement);
-
-				// handle comment listing pages (not within a post)
-				if ($(addedNode).is('[id^="siteTable"]')) {
-					// when a new sitetable is loaded, we need to add new observers for selftexts within that sitetable...
-					for (const expando of addedNode.querySelectorAll('.entry div.expando')) {
-						addSelfTextObserver(expando);
-					}
-					for (const fn of watchers.siteTable) fn(addedNode);
-				}
-
-				if (addedNode.classList.contains('thing')) {
-					const newCommentEntry = addedNode.querySelector('.entry');
-					if (!$(newCommentEntry).data('alreadyDetected')) {
-						$(newCommentEntry).data('alreadyDetected', true);
-						for (const child of addedNode.querySelectorAll('.child')) {
-							addNewCommentFormObserver(child);
-						}
-						for (const fn of watchers.newComments) fn(newCommentEntry);
-					}
-				}
-			});
+	function addCallback(callback, actingOnElement, options) {
+		if (options && options.immediate) {
+			try { callback(); } catch (e) { console.error(e); }
+		} else {
+			const callbacks = elementCallbacks.get(actingOnElement);
+			if (callbacks) callbacks.push(callback);
+			else elementCallbacks.set(actingOnElement, [callback]);
 		}
 	}
 
-	for (const expando of document.querySelectorAll('.entry div.expando')) {
-		addSelfTextObserver(expando);
+	for (const thing of Thing.findThings(element)) {
+		const thingWatcherCallbacks =
+			thing.isPost() && thingWatchers.post ||
+			thing.isComment() && thingWatchers.comment ||
+			thing.isSubreddit() && thingWatchers.subreddit ||
+			[];
+
+		for (const { callback, options } of thingWatcherCallbacks) {
+			addCallback(() => callback(thing), thing.element, options);
+		}
 	}
 
-	// initialize new comments observers on demand, by first wiring up click listeners to "load more comments" buttons.
-	// on click, we'll add a mutation observer...
-	$('.morecomments a').on('click', addNewCommentObserverToTarget);
+	for (const { selector, callback, options } of elementWatchers[type]) {
+		const elements = selector ? Array.from(element.querySelectorAll(selector)) : [element];
+		for (const e of elements) {
+			// Avoid excessive number of chunked callbacks by tying the callback to an existing Thing
+			const closest = e.closest && (e.parentElement: any).closest('.thing') || e;
+			addCallback(() => callback(e), closest, options);
+		}
+	}
 
-	// on click, we'll add a mutation observer...
-	for (const child of document.querySelectorAll('.thing .child')) {
-		addNewCommentFormObserver(child);
+	return flow(
+		sorter,
+		map(v => v[1]),
+		forEachChunked(c => { for (const callback of c) try { callback(); } catch (e) { console.error(e); } })
+	)(Array.from(elementCallbacks));
+}
+
+export function watchForThings(types: Array<ThingWatcherType>, callback: ThingWatcherCallback, options?: WatcherOptions) {
+	for (const type of types) thingWatchers[type].push({ callback, options });
+}
+
+export function watchForElements(types: Array<ElementWatcherType>, selector: ?string, callback: ElementWatcherCallback, options?: WatcherOptions) {
+	for (const type of types) elementWatchers[type].push({ selector, callback, options });
+}
+
+export function initObservers() {
+	watchForElements(['siteTable'], '.entry div.expando', addSelfTextObserver);
+
+	if (isPageType('comments')) {
+		watchForElements(['siteTable', 'newComments'], '.sitetable', addCommentsObserver);
 	}
 }
 
-function addNewCommentObserverToTarget(e: Event) {
-	const ele = $(e.currentTarget).closest('.sitetable')[0];
-	// mark this as having an observer so we don't add multiples...
-	if (!$(ele).hasClass('hasObserver')) {
-		$(ele).addClass('hasObserver');
-		addNewCommentObserver(ele);
+export function newSitetable(siteTable: HTMLElement) {
+	let sorter;
+	if (document.contains(siteTable)) {
+		const viewportHeight = _.once(() => document.documentElement.clientHeight);
+		sorter = sortBy(([element]) => {
+			const fromTop = element.getBoundingClientRect().top;
+			return element.offsetParent ?
+					(fromTop >= 0 ? fromTop : -fromTop + viewportHeight()) :
+					Infinity;
+		});
 	}
+
+	return registerElement('siteTable', siteTable, sorter);
 }
 
-function addNewCommentObserver(ele) {
+function addCommentsObserver(ele) {
 	const observer = observe(ele, { childList: true }, mutation => {
-		// look at the added nodes, and find comment containers.
-		for (const node of Array.from(mutation.addedNodes).map(n => downcast(n, Element))) {
-			if (node.classList.contains('thing')) {
-				for (const child of node.querySelectorAll('.child')) {
-					addNewCommentFormObserver(child);
-				}
+		if (!mutation.addedNodes.length) return;
 
-				// check for "load new comments" links within this group as well...
-				$(node).find('.morecomments a').click(addNewCommentObserverToTarget);
+		const addedNode = downcast(mutation.addedNodes[0], HTMLElement);
 
-				// look at the comment containers and find actual comments...
-				for (const subComment of node.querySelectorAll('.entry')) {
-					const $subComment = $(subComment);
-					if (!$subComment.data('alreadyDetected')) {
-						$subComment.data('alreadyDetected', true);
-						for (const fn of watchers.newComments) fn(subComment);
-					}
-				}
-			}
+		if (addedNode.classList.contains('thing')) {
+			registerElement('newComments', addedNode);
 		}
 
 		// disconnect this observer once all callbacks have been run.
 		// unless we have the nestedlisting class, in which case don't disconnect because that's a
 		// bottom level load more comments where even more can be loaded after, so they all drop into this
 		// same .sitetable div.
-		if (!$(ele).hasClass('nestedlisting')) {
+		if (!ele.classList.contains('nestedlisting')) {
 			observer.disconnect();
 		}
 	});
 }
 
-function addNewCommentFormObserver(ele) {
-	observe(ele, { childList: true }, mutation => {
-		const form = $(mutation.target).children('form');
-		if (form.length === 1) {
-			for (const fn of watchers.newCommentsForms) fn(form[0]);
-		} else {
-			const newOwnComment = $(mutation.target).find(' > div.sitetable > .thing:first-child'); // assumes new comment will be prepended to sitetable's children
-			if (newOwnComment.length === 1) {
-				// new comment detected from the current user...
-				for (const fn of watchers.newComments) fn(newOwnComment[0]);
-			}
-		}
-		// only the first mutation (legacy behavior)
-		return true;
-	});
-}
-
 function addSelfTextObserver(ele) {
 	observe(ele, { childList: true }, mutation => {
-		const form = $(mutation.target).find('form');
-		if (form.length) {
-			for (const fn of watchers.selfText) fn(form[0]);
+		const form = downcast(mutation.target, HTMLElement).querySelector('form');
+		if (form) {
+			registerElement('selfText', form);
 		}
 		// only the first mutation (legacy behavior)
 		return true;

--- a/lib/utils/watchers.js
+++ b/lib/utils/watchers.js
@@ -35,8 +35,8 @@ const thingWatchers: {
 	subreddit: [],
 };
 
-function registerElement(type, element, sorter = callback => callback) {
-	const elementCallbacks: Map<HTMLElement, Array<() => *>> = new Map();
+function registerElement(type, element, sorter = callbacks => callbacks) {
+	const elementCallbacks: Map<HTMLElement, Array<() => mixed>> = new Map();
 
 	function addCallback(callback, actingOnElement, options) {
 		if (options && options.immediate) {

--- a/lib/utils/watchers.js
+++ b/lib/utils/watchers.js
@@ -6,7 +6,7 @@ import { Thing, isPageType, observe, downcast, forEachChunked } from './';
 
 type WatcherOptions = {| immediate?: boolean |};
 
-type ElementWatcherType = $Keys<typeof elementWatchers>;
+type ElementWatcherType = 'siteTable' | 'selfText' | 'newComments';
 type ElementWatcherCallback = (e: any) => void | Promise<void>;
 
 const elementWatchers: {
@@ -21,7 +21,7 @@ const elementWatchers: {
 	newComments: [],
 };
 
-type ThingWatcherType = $Keys<typeof thingWatchers>;
+type ThingWatcherType = 'comment' | 'post' | 'subreddit';
 type ThingWatcherCallback = (thing: Thing) => void | Promise<void>;
 
 const thingWatchers: {


### PR DESCRIPTION
New watcher functions:
 - WatchForThing: Used for enhancement which are Thing-centric
 - WatchForElements (replaces `WatchForElement`): Used when changes doesn't act on Thing

Performance improvements:
- All callbacks are organized and executed based on visibility / distance from viewport on the initial execution, so that only things which can be seen are prioritized.
- KeyboardNavigation move functions are available earlier, and are more responsive

Minor bugfixes:
- SelectedEntry: If several selects occurred during 1 frame, listeners was invoked with the wrong `old` Thing
- scrollType `middle` didn't always scroll when transitioning to/from a collapsed Thing
- userHighlight `highlightFirstCommenter` and `autoColorUsernames` caused severe jank due to chunking
- newCommentCount only indicated that comment page had been opened if there are additional comments (now it only highlights when there are new comments)
- saveComments included `.keyNavAnnotation` and `.expando-button` 

Observers and hideChildComments are refactored.

Resolves #2294
Closes #3009