### PR TITLE
Shrink user tagger font slightly

### DIFF
--- a/lib/css/modules/_userTagger.scss
+++ b/lib/css/modules/_userTagger.scss
@@ -143,7 +143,7 @@ a.voteWeight {
 }
 
 .userTagLink.hasTag {
-	font-size: 0.9em;
+	font-size: .9em;
 }
 
 #userTaggerPreview {

--- a/lib/css/modules/_userTagger.scss
+++ b/lib/css/modules/_userTagger.scss
@@ -142,6 +142,10 @@ a.voteWeight {
 	border-radius: 3px;
 }
 
+.userTagLink.hasTag {
+	font-size: 0.9em;
+}
+
 #userTaggerPreview {
 	display: inline-block;
 	height: 1.6em;


### PR DESCRIPTION
To prevent it from overflowing comment taglines:
Before:
![image](https://cloud.githubusercontent.com/assets/7673145/20547370/8350c336-b0e9-11e6-90a7-0df3be7f5399.png)
After:
![image](https://cloud.githubusercontent.com/assets/7673145/20547482/506e72dc-b0ea-11e6-8f03-391ad9f480ae.png)

Introduced by #3470 changing `display: inline-block;` to `display: inline;`.
