### PR TITLE
Filterline filter: Always remove from storage when empty

### DIFF
--- a/lib/modules/filteReddit/Filter.js
+++ b/lib/modules/filteReddit/Filter.js
@@ -129,8 +129,9 @@ export default class Filter<Parsed: { [key: any]: any }> {
 		this.state = state;
 
 		this.parent.updateFilter(this);
-		// Remove if filter is no longer used by parent
-		const remove = !this.parent.filters.includes(this);
+		// Remove from storage if empty or parentless
+		const remove = (this.state === null && this.criterion === null) ||
+			!this.parent.filters.includes(this);
 
 		if (remove) this.delete();
 		else if (save) this.save();


### PR DESCRIPTION
Otherwise it will needlessly invoke `refreshThing` when restored.