### PR TITLE
Firefox: do not run in iframes

### DIFF
--- a/firefox/background.entry.js
+++ b/firefox/background.entry.js
@@ -369,6 +369,7 @@ addListener('multicast', (request, worker) => {
 
 PageMod({
 	include: ['*.reddit.com'],
+	attachTo: ['top'],
 	contentScriptWhen: 'start',
 	contentScriptFile: [`./../${mainEntry}`],
 	contentStyleFile: [`./../${resCss}`],


### PR DESCRIPTION
This is already the case in Chrome, since `all_frames` is not specified https://developer.chrome.com/extensions/content_scripts

And 99% of the time it's an ad frame, which is mildly wasteful.