### PR TITLE
Filterline: Fix filtersToTest

### DIFF
--- a/lib/modules/filteReddit/Filterline.js
+++ b/lib/modules/filteReddit/Filterline.js
@@ -358,18 +358,16 @@ export default class Filterline {
 
 			if (currentFilterIndex === -1) {
 				// No other filters did match last time; only retest this
-				fromIndex = invokedByFilterIndex;
-				toIndex = fromIndex + 1;
+				return [invokedByFilter];
 			} else if (currentFilterIndex === invokedByFilterIndex) {
 				// The invokedBy filter matched last time; start testing from that one
 				fromIndex = invokedByFilterIndex;
 			} else if (currentFilterIndex > invokedByFilterIndex) {
-				// Only retest the invoked one, so that thing.filter always refers to the first matched filter
-				fromIndex = currentFilterIndex;
-				toIndex = fromIndex + 1;
+				// thing.filter should always refers to the first matched filter
+				return [invokedByFilter, currentFilter];
 			} else {
-				// Some other filters matched; ignore
-				toIndex = 0;
+				// Some earlier filter matched last time; ignore
+				return [];
 			}
 		}
 


### PR DESCRIPTION
The current matched filter was erroneously ignored when a filter later in the array invoked `refreshThing`.