### PR TITLE
Fix for already submitted notification display wrong time

### DIFF
--- a/lib/modules/submitHelper.js
+++ b/lib/modules/submitHelper.js
@@ -97,7 +97,7 @@ async function updateRepostWarning() {
 			}): RedditListing<RedditLink>);
 
 			if (data && data.children.length && (data.children[0].data.url.match(stripUrlRe): any)[1] === userUrl) {
-				showRepostWarning(subreddit, userUrl, new Date(data.children[0].data.created * 1000));
+				showRepostWarning(subreddit, userUrl, new Date(data.children[0].data.created_utc * 1000));
 			} else {
 				hideRepostWarning();
 			}


### PR DESCRIPTION
Might need to be checked over, but as is, it's showing me that a post submitted an hour ago as being 7 hours old (I'm PST time). Looking at the JSON, it appears that the create_utc actually gives the local time.