### PR TITLE
Don't stage options that haven't changed

### DIFF
--- a/lib/core/options/stage.js
+++ b/lib/core/options/stage.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import _ from 'lodash';
+import * as Modules from '../modules';
 import { set } from './';
 
 let stagedOptions;
@@ -9,10 +10,24 @@ clearStagedOptions();
 
 export { stageOption as add };
 function stageOption(moduleID: string, optionName: string, optionValue: mixed) {
+	const mod = Modules.get(moduleID);
+
 	stagedOptions[moduleID] = stagedOptions[moduleID] || {};
-	stagedOptions[moduleID][optionName] = {
-		value: optionValue,
-	};
+
+	if (!_.isEqual(mod.options[optionName].value, optionValue)) {
+		// new option value, add to stage
+		stagedOptions[moduleID][optionName] = {
+			value: optionValue,
+		};
+	} else {
+		// staged value is the same as stored, remove option from stage
+		delete stagedOptions[moduleID][optionName];
+	}
+
+	if (_.isEmpty(stagedOptions[moduleID])) {
+		// no staged options for module, remove module from stage
+		delete stagedOptions[moduleID];
+	}
 }
 
 export { commitStagedOptions as commit };


### PR DESCRIPTION
So all #3690 callbacks in a module don't fire every time you save.