### PR TITLE
appveyor: remove clone_depth

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 build: off
 version: '{build}'
-clone_depth: 1
 environment:
   nodejs_version: 7
 cache:


### PR DESCRIPTION
With it, we don't get any tags (unless the previous commit was tagged), so we don't get accurate information for #3698.

Will verify that it doesn't notably increase build time.