### PR TITLE
Replace filterline "for all" icon with "filter" (upside down beaker)

### DIFF
--- a/lib/css/modules/_filteReddit.scss
+++ b/lib/css/modules/_filteReddit.scss
@@ -47,6 +47,17 @@ body.hideOver18 {
 	}
 }
 
+.res-filterline-icon {
+	display: inline-block;
+	transform: rotate(180deg);
+	font-family: 'Batch';
+	content: '\F051';
+}
+
+.res-toggle-filterline-visibility a::after {
+	@extend .res-filterline-icon;
+}
+
 .res-filterline {
 	body:not(.res-filteReddit-show-filterline) & {
 		display: none;
@@ -60,7 +71,7 @@ body.hideOver18 {
 	}
 
 	&-preamble::before {
-		content: '∀';
+		@extend .res-filterline-icon;
 		margin: 0 2px;
 	}
 

--- a/lib/css/modules/_filteReddit.scss
+++ b/lib/css/modules/_filteReddit.scss
@@ -47,7 +47,7 @@ body.hideOver18 {
 	}
 }
 
-.res-filterline-icon {
+%res-filterline-icon {
 	display: inline-block;
 	transform: rotate(180deg);
 	font-family: 'Batch';

--- a/lib/css/modules/_filteReddit.scss
+++ b/lib/css/modules/_filteReddit.scss
@@ -55,7 +55,7 @@ body.hideOver18 {
 }
 
 .res-toggle-filterline-visibility a::after {
-	@extend .res-filterline-icon;
+	@extend %res-filterline-icon;
 }
 
 .res-filterline {
@@ -71,7 +71,7 @@ body.hideOver18 {
 	}
 
 	&-preamble::before {
-		@extend .res-filterline-icon;
+		@extend %res-filterline-icon;
 		margin: 0 2px;
 	}
 

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -454,7 +454,7 @@ const createFilterline = _.once(() => {
 		let visible = yield initialFilterlineVisibility().get();
 
 		const filterlineTab = CreateElement.tabMenuItem({
-			text: '∀',
+			text: '',
 			title: 'Toggle filterline',
 			className: 'res-toggle-filterline-visibility',
 			checked: visible,

--- a/lib/templates/filterline.mustache
+++ b/lib/templates/filterline.mustache
@@ -1,5 +1,5 @@
 <div class="res-filterline">
-	<div class="res-filterline-preamble"></div>
+	<div class="res-filterline-preamble" title="Filter posts"></div>
 	<div class="res-filterline-filters"></div>
 	<div class="res-filterline-dropdown">
 		<span></span>


### PR DESCRIPTION
<img width="764" alt="screen shot 2016-12-04 at 1 12 53 pm" src="https://cloud.githubusercontent.com/assets/455632/20869265/8ce5b620-ba23-11e6-8908-805de186cbbc.png">

Technically it's an upside-down beaker instead of filter/funnel https://thenounproject.com/term/filter/101890/

Would the "equalizer" Batch icon be more appropriate? a la https://thenounproject.com/term/filter/103807/