### PR TITLE
subredditManager: Do not await manageSubreddits

### DIFF
--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -181,7 +181,7 @@ module.go = async () => {
 
 	await getLatestShortcuts();
 
-	await manageSubreddits();
+	manageSubreddits();
 
 	const subreddit = currentSubreddit();
 	if (subreddit) {


### PR DESCRIPTION
When the `getMultiCounts` request is not cached, it will have to have to wait for Reddit to respond on the API request, which may take several seconds and holds up the `go` phase.