### PR TITLE
Support `staticflickr` URLs

### DIFF
--- a/lib/modules/hosts/flickr.js
+++ b/lib/modules/hosts/flickr.js
@@ -9,12 +9,21 @@ export default new Host('flickr', {
 	logo: '//s.yimg.com/pw/favicon.ico',
 	detect: ({ href }) => (
 		(/^https?:\/\/(?:\w+\.)?flickr\.com\/(?:.+)\/(\d{10,})(?:\/|$)/i).test(href) ||
-		(/^https?:\/\/(?:\w+\.)?flic\.kr\/p\/(\w+)(?:\/|$)/i).test(href)
+		(/^https?:\/\/(?:\w+\.)?flic\.kr\/p\/(\w+)(?:\/|$)/i).test(href) ||
+		(/^https?:\/\/(?:\w+\.)?staticflickr\.com\/(?:.+)\/(?:\d{4,4})\/(\d{10,})_(?:.+)\.jpg/i).test(href)
 	),
 	async handleLink(href) {
+		const staticRe = /^https?:\/\/(?:\w+\.)?staticflickr\.com\/(?:.+)\/(?:\d{4,4})\/(\d{10,})_(?:.+)\.jpg/i;
+		const matches = href.match(staticRe);
+		let oembedTarget = href;
+
+		if (matches && matches.length > 0) {
+			oembedTarget = `https://www.flickr.com/photo.gne?id=${matches[1]}`;
+		}
+		
 		const info = await ajax({
 			url: 'https://noembed.com/embed',
-			data: { url: href },
+			data: { url: oembedTarget },
 			type: 'json',
 		});
 


### PR DESCRIPTION
Add support for properly embedding and crediting `staticflickr` URLs.

Right now when people link directly to the CDN copy of a flickr image (i.e. `http://c1.staticflickr.com/9/8345/8186873856_5d36a04f3e_k.jpg`) it doesn't pass the `detect` regexes.  

This code allows the photo oembed data to be retrieved using the photoid embedded within the `staticflickr` URL.  This ensures the image is shown and that the credit is preserved.