### PR TITLE
Support for properly embedding and crediting staticflickr URLs

### DIFF
--- a/lib/modules/hosts/flickr.js
+++ b/lib/modules/hosts/flickr.js
@@ -5,48 +5,41 @@ import { ajax } from '../../environment';
 
 export default new Host('flickr', {
 	name: 'flickr',
-	domains: ['flickr.com', 'flic.kr'],
+	domains: ['flickr.com', 'flic.kr', 'staticflickr.com'],
 	logo: '//s.yimg.com/pw/favicon.ico',
-	detect: ({ href }) => (
-		(/^https?:\/\/(?:\w+\.)?flickr\.com\/(?:.+)\/(\d{10,})(?:\/|$)/i).test(href) ||
-		(/^https?:\/\/(?:\w+\.)?flic\.kr\/p\/(\w+)(?:\/|$)/i).test(href) ||
-		(/^https?:\/\/(?:\w+\.)?staticflickr\.com\/(?:.+)\/(?:\d{4,4})\/(\d{10,})_(?:.+)\.jpg/i).test(href)
-	),
-	async handleLink(href) {
-		const staticRe = /^https?:\/\/(?:\w+\.)?staticflickr\.com\/(?:.+)\/(?:\d{4,4})\/(\d{10,})_(?:.+)\.jpg/i;
-		const matches = href.match(staticRe);
-		// encode a number into a base58 identifier
-		const base58Encode = num => {
-			if (typeof num !== 'number') {
-				num = parseInt(num, 10);
-			}
+	detect: (() => {
+		const alpha = '123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ';
 
-			const alpha = '123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ';
+		function base58Encode(num) {
 			let enc = '';
-			let div = num;
-			let mod;
+			let acc = num;
 
-			while (num >= 58) {
-				div = num / 58;
-				mod = num - (58 * Math.floor(div));
-				enc = `${alpha.substr(mod, 1)}${enc}`;
-				num = Math.floor(div);
-			}
+			do {
+				const div = Math.floor(acc / 58);
+				const mod = acc - (58 * div);
+				enc = `${alpha[mod]}${enc}`;
+				acc = div;
+			} while (acc);
 
-			return (div) ? `${alpha.substr(div, 1)}${enc}` : enc;
-		};
-
-		let oembedTarget = href;
-		let encodedId;
-
-		// if our href matches the `staticflickr` regular expression,
-		// then encode the id we extracted and use a Flickr short-url
-		// as the oembed target
-		if (matches && matches.length > 0) {
-			encodedId = base58Encode(matches[1]);
-			oembedTarget = `https://flic.kr/p/${encodedId}`;
+			return enc;
 		}
 
+		return ({ href }) => {
+			// normal flickr.com links and flic.kr shortlinks
+			if ((/^https?:\/\/(?:\w+\.)?flickr\.com\/(?:.+)\/(\d{10,})(?:\/|$)/i).test(href) ||
+				(/^https?:\/\/(?:\w+\.)?flic\.kr\/p\/(\w+)(?:\/|$)/i).test(href)) {
+				return href;
+			}
+
+			// direct links to staticflickr.com
+			const matches = (/^https?:\/\/(?:\w+\.)?staticflickr\.com\/(?:.+\/)?\d{4}\/(\d{10,})_/i).exec(href);
+			if (matches) {
+				// encode the id we extracted and use a Flickr short-url
+				return `https://flic.kr/p/${base58Encode(matches[1])}`;
+			}
+		};
+	})(),
+	async handleLink(href, oembedTarget) {
 		const info = await ajax({
 			url: 'https://noembed.com/embed',
 			data: { url: oembedTarget },

--- a/lib/modules/hosts/flickr.js
+++ b/lib/modules/hosts/flickr.js
@@ -9,12 +9,47 @@ export default new Host('flickr', {
 	logo: '//s.yimg.com/pw/favicon.ico',
 	detect: ({ href }) => (
 		(/^https?:\/\/(?:\w+\.)?flickr\.com\/(?:.+)\/(\d{10,})(?:\/|$)/i).test(href) ||
-		(/^https?:\/\/(?:\w+\.)?flic\.kr\/p\/(\w+)(?:\/|$)/i).test(href)
+		(/^https?:\/\/(?:\w+\.)?flic\.kr\/p\/(\w+)(?:\/|$)/i).test(href) ||
+		(/^https?:\/\/(?:\w+\.)?staticflickr\.com\/(?:.+)\/(?:\d{4,4})\/(\d{10,})_(?:.+)\.jpg/i).test(href)
 	),
 	async handleLink(href) {
+		const staticRe = /^https?:\/\/(?:\w+\.)?staticflickr\.com\/(?:.+)\/(?:\d{4,4})\/(\d{10,})_(?:.+)\.jpg/i;
+		const matches = href.match(staticRe);
+		// encode a number into a base58 identifier
+		const base58Encode = num => {
+			if (typeof num !== 'number') {
+				num = parseInt(num, 10);
+			}
+
+			const alpha = '123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ';
+			let enc = '';
+			let div = num;
+			let mod;
+
+			while (num >= 58) {
+				div = num / 58;
+				mod = num - (58 * Math.floor(div));
+				enc = `${alpha.substr(mod, 1)}${enc}`;
+				num = Math.floor(div);
+			}
+
+			return (div) ? `${alpha.substr(div, 1)}${enc}` : enc;
+		};
+
+		let oembedTarget = href;
+		let encodedId;
+
+		// if our href matches the `staticflickr` regular expression,
+		// then encode the id we extracted and use a Flickr short-url
+		// as the oembed target
+		if (matches && matches.length > 0) {
+			encodedId = base58Encode(matches[1]);
+			oembedTarget = `https://flic.kr/p/${encodedId}`;
+		}
+
 		const info = await ajax({
 			url: 'https://noembed.com/embed',
-			data: { url: href },
+			data: { url: oembedTarget },
 			type: 'json',
 		});
 


### PR DESCRIPTION
Add support for properly embedding and crediting staticflickr URLs.

Right now when people link directly to the CDN copy of a flickr image (i.e. http://c1.staticflickr.com/9/8345/8186873856_5d36a04f3e_k.jpg) it doesn't pass the detect regexes.

This code allows the photo oembed data to be retrieved by: 
- extracting the photoid embedded within the staticflickr URL
- encoding it to base 58
- rendering it into a Flickr short url for noembed to consume 

This ensures the image is shown and that the credit is preserved.