### PR TITLE
Filterline: Fix tab CSS

### DIFF
--- a/lib/css/modules/_filteReddit.scss
+++ b/lib/css/modules/_filteReddit.scss
@@ -54,7 +54,7 @@ body.hideOver18 {
 	content: '\F051';
 }
 
-.res-toggle-filterline-visibility a::after {
+.res-toggle-filterline-visibility a::before {
 	@extend %res-filterline-icon;
 }
 


### PR DESCRIPTION
Otherwise it looked like this when hiding the Filterline
![image](https://cloud.githubusercontent.com/assets/1748521/20906792/410c1ec4-bb4a-11e6-9f49-29e5121012f2.png)

