### PR TITLE
showImages: Fix pause on non-advancedControls videos

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1840,6 +1840,8 @@ function videoAdvanced(options) {
 		time,
 	} = options;
 
+	const useVideoManager = advancedControls && module.options.onlyPlayMutedWhenVisible.value && options.muted;
+
 	// Poster is unnecessary, and will flash if loaded before the video is ready
 	if (autoplay) delete options.poster;
 
@@ -1898,7 +1900,7 @@ function videoAdvanced(options) {
 
 		ctrlTogglePause.addEventListener('click', () => {
 			if (vid.paused) vid.play(); else vid.pause();
-			if (module.options.onlyPlayMutedWhenVisible.value && options.muted) {
+			if (useVideoManager) {
 				autoplay = false; // Stop automatic control
 				mutedVideoManager().unobserve(vid);
 			}
@@ -1983,7 +1985,7 @@ function videoAdvanced(options) {
 		vid.setAttribute('src', ''); // vid.src has precedence over any child source element
 		vid.load();
 
-		if (module.options.onlyPlayMutedWhenVisible.value && options.muted) mutedVideoManager().unobserve(vid);
+		if (useVideoManager) mutedVideoManager().unobserve(vid);
 	}
 
 	function restore() {
@@ -1993,7 +1995,7 @@ function videoAdvanced(options) {
 		}
 
 		if (autoplay) {
-			if (module.options.onlyPlayMutedWhenVisible.value && options.muted) mutedVideoManager().observe(vid);
+			if (useVideoManager) mutedVideoManager().observe(vid);
 			else vid.play();
 		}
 	}

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -343,22 +343,22 @@ module.options = {
 		value: true,
 		description: 'Show controls such as pause/play, step and playback rate.',
 	},
-	autoplayVideo: {
-		type: 'boolean',
-		value: true,
-		description: 'Autoplay inline videos',
-	},
 	onlyPlayMutedWhenVisible: {
-		dependsOn: 'autoplayVideo',
+		dependsOn: 'showVideoControls',
 		type: 'boolean',
 		value: true,
 		description: 'Auto-pause muted videos when they are not visible.',
 	},
 	maxSimultaneousPlaying: {
-		dependsOn: 'autoplayVideo',
+		dependsOn: 'showVideoControls',
 		type: 'text',
 		value: '0',
 		description: 'Auto-play at most this many muted videos simultaneously. (0 for no limit)',
+	},
+	autoplayVideo: {
+		type: 'boolean',
+		value: true,
+		description: 'Autoplay inline videos',
 	},
 };
 module.exclude = [


### PR DESCRIPTION
Only auto manage videos which uses advancedControls, otherwise is it too hard to determine whether a video's pause is intentional. If the video is not unobserved upon manual pause, it will automatically be unpaused on next tick.