### PR TITLE
showImages: Don't force updateRevealedImages on refresh

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -598,7 +598,6 @@ function createImageButtons() {
 export function refresh() {
 	checkDeferredExpando();
 	updateAutoExpandCount();
-	if (autoExpandActive) updateRevealedImages({ onlyOpen: true });
 }
 
 const updateAutoExpandCount = _.debounce(() => {


### PR DESCRIPTION
Running it ignores the possibility that expandos are manually closed.