### PR TITLE
Don't display gold icon in user bar by default

### DIFF
--- a/lib/modules/showKarma.js
+++ b/lib/modules/showKarma.js
@@ -28,7 +28,7 @@ module.options = {
 	},
 	showGold: {
 		type: 'boolean',
-		value: true,
+		value: false,
 		description: 'Display gilded icon if current user has gold status',
 	},
 };


### PR DESCRIPTION
It's noisy and breaks some themes e.g. Naut.