### PR TITLE
showImages: Do not run conserveMemory while loading a new page

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -52,6 +52,7 @@ import {
 } from '../utils';
 import { addURLToHistory, ajax, isPrivateBrowsing, openNewTab, Permissions } from '../environment';
 import * as Options from '../core/options';
+import * as NeverEndingReddit from './neverEndingReddit';
 import * as SelectedEntry from './selectedEntry';
 import * as SettingsNavigation from './settingsNavigation';
 
@@ -529,6 +530,10 @@ export const thingExpandoBuildListeners: * = $.Callbacks('unique');
  */
 function enableConserveMemory() {
 	const refresh = _.throttle(frameThrottle(() => {
+		// Running this can conflict with partially-ready expandos, as is the case
+		// while NER is ready-ing a new page
+		if (NeverEndingReddit.loadPromise) return;
+
 		const activeExpandos = Array.from(primaryExpandos.values());
 		const openExpandos = [];
 


### PR DESCRIPTION
It can also delete expandos which has not yet been attached.