### PR TITLE
moveToTopComment should scroll

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -313,7 +313,12 @@ module.options = {
 		include: ['comments'],
 		value: [84, false, false, false, false], // t
 		description: 'Move to the topmost comment of the current thread (in comments).',
-		callback() { move(thing => thing.getThreadTop()); },
+		callback() {
+			move(
+				thing => thing.getThreadTop(),
+				{ scrollStyle: module.options.nonLinearScrollStyle.value }
+			);
+		},
 	},
 	moveToParent: {
 		type: 'keycode',


### PR DESCRIPTION
https://www.reddit.com/r/RESissues/comments/5haafb/bug_move_to_top_comment_navigation_key_doesnt/