### PR TITLE
pageNavigator showLink: Avoid jank on initialization

### DIFF
--- a/lib/css/modules/_pageNavigator.scss
+++ b/lib/css/modules/_pageNavigator.scss
@@ -15,6 +15,7 @@ $page-offsetleft: 15px;
 	overflow-y: hidden;
 	position: fixed;
 	will-change: transform;
+	height: 27px;
 	top: 0;
 	left: $page-offsetleft;
 	max-width: calc(100% - #{2 * $page-offsetleft});

--- a/lib/modules/pageNavigator.js
+++ b/lib/modules/pageNavigator.js
@@ -55,16 +55,14 @@ function showLinkTitle() {
 	const $submission = $('body > .content > .sitetable > .thing');
 	const submissionThing = Thing.checkedFrom($submission);
 	let belowSubmission = true;
-
-	const visibleTop = _.once(() => getHeaderOffset(true));
-	const hiddenTop = _.once(() => -$widget.outerHeight());
+	let baseHeight, hoverHeight;
 
 	function showWidget() {
-		$widget.css({ top: visibleTop() }).removeClass('hide');
+		$widget.css({ top: getHeaderOffset(true) }).removeClass('hide');
 	}
 
 	function hideWidget() {
-		$widget.css({ top: hiddenTop() }).addClass('hide');
+		$widget.css({ top: -baseHeight }).addClass('hide');
 	}
 
 	function renderWidget() {
@@ -96,17 +94,13 @@ function showLinkTitle() {
 	});
 
 	const initialize = _.once(() => {
-		$widget = renderWidget().appendTo(document.body);
+		$widget = renderWidget()
+			.on('mouseenter', () => $widget.css({ height: hoverHeight }))
+			.on('mouseleave', () => $widget.css({ height: baseHeight }))
+			.appendTo(document.body);
 
-		// Set the two heights for the bar.
-		// Due to a Firefox bug with scrollHeight we avoid adding padding to container.
-		// jQuery.height() does extra stuff, use plain CSS instead.
-		const crop = $widget.find('.res-show-link-content').outerHeight(true) - $widget.find('.res-show-link-tagline').outerHeight();
-
-		$widget
-			.css({ height: crop })
-			.on('mouseenter', (e: Event) => $widget.css({ height: e.currentTarget.scrollHeight }))
-			.on('mouseleave', () => $widget.css({ height: crop }));
+		baseHeight = $widget.get(0).getBoundingClientRect().height;
+		hoverHeight = $widget.get(0).scrollHeight;
 
 		// $FlowIssue TODO
 		new IntersectionObserver(entries => {


### PR DESCRIPTION
Using `outerHeight(true)` is expensive since it causes reflow of the whole document, which on larger comment pages takes > 100 ms.