### PR TITLE
Fix a typo in betteRedditShowTimestampPostsDesc key

### DIFF
--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -99,7 +99,7 @@ module.options = {
 	showTimestampPosts: {
 		type: 'boolean',
 		value: false,
-		description: 'betteRedditShowTimestapPostsDesc',
+		description: 'betteRedditShowTimestampPostsDesc',
 		bodyClass: true,
 	},
 	showTimestampComments: {

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -720,7 +720,7 @@
         "message": "When hovering over [score hidden] show time left instead of hide duration."
     },
 
-    "betteRedditShowTimestapPostsDesc": {
+    "betteRedditShowTimestampPostsDesc": {
         "message": "Show the precise date (Sun Nov 16 20:14:56 2014 UTC) instead of a relative date (7 days ago), for posts."
     },
 


### PR DESCRIPTION
That could prevent someone from successfully finding this key later.