### PR TITLE
showImages: Set maxSize styles as important

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1614,7 +1614,7 @@ const setMediaMaxSizeStyle = _.once(() => {
 	let style = '';
 	if (maxWidth) style += `max-width: ${maxWidth}${maxWidthUnit};`;
 	if (maxHeight) style += `max-height: ${maxHeight}${maxHeightUnit};`;
-	if (style) addCSS(`.res-media-max-size { ${style} }`);
+	if (style) addCSS(`body .res-media-max-size { ${style} }`);
 });
 
 function setMediaMaxSize(media) {


### PR DESCRIPTION
Otherwise Reddit's stylesheet overrides `max-width` on comments pages

Fixes https://www.reddit.com/r/RESissues/comments/5hrlwk/bug_inline_image_max_width_max_height_no_longer/