### PR TITLE
Init timing tweaks

### DIFF
--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -10,7 +10,7 @@ import type { BooleanOption, EnumOption, ModuleOption } from './module'; // esli
 import { // eslint-disable-line import/order
 	BodyClasses,
 	initObservers,
-	nonNull,
+	waitFor,
 	waitForChild,
 	waitForEvent,
 } from '../utils';
@@ -39,7 +39,7 @@ export function init() {
 const sourceLoaded = new Promise(resolve => (start = resolve));
 
 export const documentReady = sourceLoaded
-	.then(() => nonNull(() => document && document.documentElement));
+	.then(() => waitFor(() => document && document.documentElement));
 
 // Multiple browsers (Safari, Edge) seem to have weird bugs with MutationObservers
 // so just make a best effort at divining when the head and body are ready
@@ -47,20 +47,20 @@ export const documentReady = sourceLoaded
 export const headReady = documentReady
 	.then(() => Promise.race([
 		waitForChild(document.documentElement, 'head'),
-		(nonNull(() => document.head, 100): Promise<any>),
+		(waitFor(() => document.head, 100): Promise<any>),
 		contentLoaded,
 	]));
 
 export const bodyStart = documentReady
 	.then(() => Promise.race([
 		waitForChild(document.documentElement, 'body'),
-		(nonNull(() => document.body, 100): Promise<any>),
+		(waitFor(() => document.body, 100): Promise<any>),
 		contentLoaded,
 	]));
 
 export const bodyReady = bodyStart
 	.then(() => Promise.race([
-		nonNull(() => document.body, 10).then(body => waitForChild(body, '.debuginfo')),
+		waitFor(() => document.body, 10).then(body => waitForChild(body, '.debuginfo')),
 		contentLoaded, // in case reddit removes or changes .debuginfo
 	]));
 

--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -64,10 +64,17 @@ export const bodyReady = bodyStart
 		contentLoaded, // in case reddit removes or changes .debuginfo
 	]));
 
-export const contentLoaded = Promise.race([
-	waitForEvent(window, 'load'),
-	waitFor(() => document.readyState === 'complete', 500),
-]);
+export const contentLoaded = documentReady
+	.then(() => Promise.race([
+		waitForEvent(window, 'DOMContentLoaded', 'load'),
+		waitFor(() => document.readyState === 'interactive' || document.readyState === 'complete', 500),
+	]));
+
+export const loadComplete = contentLoaded
+	.then(() => Promise.race([
+		waitForEvent(window, 'load'),
+		waitFor(() => document.readyState === 'complete', 500),
+	]));
 
 // Module stages
 
@@ -94,7 +101,7 @@ export const beforeLoad = Promise.all([loadOptions, headReady])
 export const go = Promise.all([beforeLoad, bodyReady])
 	.then(() => allModules('go'));
 
-export const afterLoad = Promise.all([go, contentLoaded])
+export const afterLoad = Promise.all([go, loadComplete])
 	.then(() => allModules('afterLoad'));
 
 const ERRORED_KEY = Symbol('errored');

--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -64,9 +64,10 @@ export const bodyReady = bodyStart
 		contentLoaded, // in case reddit removes or changes .debuginfo
 	]));
 
-export const contentLoaded = typeof window !== 'undefined' ?
-	waitForEvent(window, 'load') :
-	Promise.reject('Environment has no window.');
+export const contentLoaded = Promise.race([
+	waitForEvent(window, 'load'),
+	waitFor(() => document.readyState === 'complete', 500),
+]);
 
 // Module stages
 

--- a/lib/utils/__tests__/async.js
+++ b/lib/utils/__tests__/async.js
@@ -2,35 +2,35 @@
 
 import test from 'ava';
 
-import { nonNull, batch, fastAsync, reifyPromise, keyedMutex, mutex } from '../async';
+import { waitFor, batch, fastAsync, reifyPromise, keyedMutex, mutex } from '../async';
 
 function sleep(ms) {
 	return new Promise(r => setTimeout(r, ms));
 }
 
-test('nonNull - basic', async t => {
+test('waitFor - basic', async t => {
 	const unique = {};
-	t.is(await nonNull(() => unique), unique);
+	t.is(await waitFor(() => unique), unique);
 });
 
-test('nonNull - repeats', async t => {
+test('waitFor - repeats', async t => {
 	t.plan(3);
 
 	let i = 3;
-	await nonNull(() => {
+	await waitFor(() => {
 		t.pass();
 		return --i ? null : {};
 	});
 });
 
-test('nonNull - fast path', async t => {
+test('waitFor - fast path', async t => {
 	t.plan(1);
 	let pass = true;
 	sleep(5).then(() => {
 		pass = false;
 	});
 	// should not repeat
-	await nonNull(() => true, 100).then(() => {
+	await waitFor(() => true, 100).then(() => {
 		t.is(pass, true);
 	});
 });

--- a/lib/utils/async.js
+++ b/lib/utils/async.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import { zip } from './generator';
 import { now } from './time';
 
-export function nonNull<T>(callback: () => ?T, interval?: number = 1): Promise<T> {
+export function waitFor<T>(callback: () => ?T, interval?: number = 1): Promise<T> {
 	return new Promise(resolve => {
 		(function repeat() {
 			const val = callback();

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -27,8 +27,8 @@ export {
 	keyedMutex,
 	mutex,
 	nextFrame,
-	nonNull,
 	reifyPromise,
+	waitFor,
 } from './async';
 
 export {


### PR DESCRIPTION
Mainly allows `afterLoad` to run if the `load` event has already fired, if that ever happens (it should be impossible, except perhaps when installing the extension).

_Not_ intended to fix the strange issue where nothing works when the extension updates in Firefox, which is probably caused by the background page crashing/not running.