### PR TITLE
customToggles: add nbsp in place of empty toggles

### DIFF
--- a/lib/modules/customToggles.js
+++ b/lib/modules/customToggles.js
@@ -57,7 +57,7 @@ export function toggleActive(name?: string): boolean {
 
 function createToggleMenuItems() {
 	for (const [menuItemId, toggles] of Object.entries(togglesByMenuItem())) {
-		const $toggle = $('<div>', { text: menuItemId, title: `Toggle ${menuItemId}` })
+		const $toggle = $('<div>', { text: menuItemId || '\u00A0' /* nbsp */, title: `Toggle ${menuItemId}` })
 			.append(CreateElement.toggleButton(
 				enabling => SettingsConsole.onOptionChange(module, menuItemId, enabling),
 				menuItemId,


### PR DESCRIPTION
Fixes #3732