### PR TITLE
Notify if subscribed post is edited

### DIFF
--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -46,6 +46,12 @@ module.options = {
 		description: 'newCommentCountShowSubscribeButtonDesc',
 		title: 'newCommentCountShowSubscribeButtonTitle',
 	},
+	notifyEditedPosts: {
+		type: 'boolean',
+		value: false,
+		description: 'Notify if a subscribed post is edited.',
+		advanced: true,
+	},
 	monitorPostsVisited: {
 		type: 'boolean',
 		value: true,
@@ -67,6 +73,7 @@ const lastCleanStorage = Storage.wrap('RESmodules.newCommentCount.lastClean', (n
 const commentCountStorage = Storage.wrap('RESmodules.newCommentCount.counts', ({}: { [key: string]: {
 	subscriptionDate?: number,
 	count: number,
+	editedTime: number,
 	url: string,
 	title: string,
 	updateTime: number,
@@ -323,7 +330,7 @@ let currentCommentID;
  * @param {string} commentID - ID of comment to store new count against
  * @param {int} newCommentCount - new number of comments to save
  */
-async function saveCommentCount(commentID, newCommentCount) {
+async function saveCommentCount(commentID, newCommentCount, newEditedTime) {
 	if (!module.options.monitorPostsVisited.value) return false;
 	if (!module.options.monitorPostsVisitedIncognito.value && await isPrivateBrowsing()) return false;
 
@@ -334,6 +341,7 @@ async function saveCommentCount(commentID, newCommentCount) {
 		url: location.href.replace(location.hash, ''),
 		title: document.title,
 		updateTime: Date.now(),
+		editedTime: !isNaN(newEditedTime) ? newEditedTime : 0,
 	};
 
 	Object.assign(commentCounts[commentID], patch);
@@ -351,7 +359,7 @@ function updateCommentCount() {
 		// set comment id for general use
 		currentCommentID = matches[2];
 
-		saveCommentCount(currentCommentID, listingThing.getCommentCount());
+		saveCommentCount(currentCommentID, listingThing.getCommentCount(), listingThing.getPostEditTimestamp());
 	}
 }
 
@@ -493,8 +501,8 @@ function checkSubscriptions() {
 }
 
 async function checkThread(id) {
-	const { count, url, title } = commentCounts[id];
-	const { num_comments: newCount } = await getPostMetadata({ id });
+	const { count, editedTime, url, title } = commentCounts[id];
+	const { num_comments: newCount, edited: newEditedTime } = await getPostMetadata({ id });
 
 	if (newCount > count) {
 		commentCounts[id].count = newCount;
@@ -504,6 +512,24 @@ async function checkThread(id) {
 			header: 'New comments',
 			notificationID: 'newCommentCount',
 			moduleID: 'newCommentCount',
+			noDisable: true,
+			message: `<p><a href="${url}">${escapeHTML(title)}</a></p>`,
+		}, 10000);
+
+		// add button to unsubscribe from within notification.
+		const unsubscribeButton = handleButton(id, 'unsubscribe');
+		unsubscribeButton.addEventListener('click', notification.close);
+		$(notification.element).find('.RESNotificationContent').append(unsubscribeButton);
+	}
+	if (module.options.notifyEditedPosts.value && newEditedTime && newEditedTime > editedTime) {
+		commentCounts[id].editedTime = newEditedTime;
+		commentCountStorage.patch({ [id]: { editedTime: newEditedTime } });
+
+		const notification = await Notifications.showNotification({
+			header: 'Post edited',
+			notificationID: 'newCommentCount',
+			moduleID: 'newCommentCount',
+			optionKey: 'notifyEditedPosts',
 			noDisable: true,
 			message: `<p><a href="${url}">${escapeHTML(title)}</a></p>`,
 		}, 10000);

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -47,9 +47,11 @@ module.options = {
 		title: 'newCommentCountShowSubscribeButtonTitle',
 	},
 	notifyEditedPosts: {
+		dependsOn: 'showSubscribeButton',
 		type: 'boolean',
 		value: false,
-		description: 'Notify if a subscribed post is edited.',
+		description: 'newCommentCountNotifyEditedPostsDesc',
+		title: 'newCommentCountNotifyEditedPostsTitle',
 		advanced: true,
 	},
 	monitorPostsVisited: {

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -318,7 +318,7 @@ function updateCommentCountFromMyComment(thing) {
 	const isRecent = timestamp && (Date.now() - timestamp.getTime()) < 10000;
 	const isMine = loggedInUser() === thing.getAuthor();
 	if (isRecent && isMine) {
-		saveCommentCount(currentCommentID, commentCounts[currentCommentID].count + 1);
+		saveCommentCount(currentCommentID, commentCounts[currentCommentID].count + 1, commentCounts[currentCommentID].editedTime);
 	}
 }
 
@@ -341,7 +341,7 @@ async function saveCommentCount(commentID, newCommentCount, newEditedTime) {
 		url: location.href.replace(location.hash, ''),
 		title: document.title,
 		updateTime: Date.now(),
-		editedTime: !isNaN(newEditedTime) ? newEditedTime : 0,
+		editedTime: newEditedTime,
 	};
 
 	Object.assign(commentCounts[commentID], patch);

--- a/lib/types/reddit.js
+++ b/lib/types/reddit.js
@@ -40,6 +40,7 @@ export type RedditLink = {
 		author: string,
 		created: number,
 		created_utc: number,
+		edited: number,
 		domain: string,
 		id: string,
 		num_comments: number,

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -470,6 +470,15 @@ export default class Thing {
 		return this.entry.querySelector('time');
 	}
 
+	getPostEditTimestamp(): number {
+		const element = this.getPostEditTimestampElement();
+		return element ? Date.parse(element.getAttribute('datetime')) / 1000 : 0;
+	}
+
+	getPostEditTimestampElement(): ?HTMLElement {
+		return this.entry.querySelector('#siteTable time.edited-timestamp');
+	}
+
 	getFullname(): string {
 		return this.thing.getAttribute('data-fullname') || '';
 	}

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -472,7 +472,7 @@ export default class Thing {
 
 	getPostEditTimestamp(): number {
 		const element = this.getPostEditTimestampElement();
-		return element ? Date.parse(element.getAttribute('datetime')) / 1000 : 0;
+		return element && (Date.parse(element.getAttribute('datetime')) / 1000) || 0;
 	}
 
 	getPostEditTimestampElement(): ?HTMLElement {

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -476,7 +476,7 @@ export default class Thing {
 	}
 
 	getPostEditTimestampElement(): ?HTMLElement {
-		return this.entry.querySelector('#siteTable time.edited-timestamp');
+		return this.entry.querySelector('time.edited-timestamp');
 	}
 
 	getFullname(): string {

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -1385,6 +1385,14 @@
         "message": "Show the Subscribe button?"
     },
 
+    "newCommentCountNotifyEditedPostsTitle": {
+        "message": "Notify Edited Posts"
+    },
+
+    "newCommentCountNotifyEditedPostsDesc": {
+        "message": "Notify if a subscribed post is edited."
+    },
+
     "newCommentCountMonitorPostsVisitedTitle": {
         "message": "Monitor Posts Visited"
     },

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -1390,7 +1390,7 @@
     },
 
     "newCommentCountMonitorPostsVisitedDesc": {
-        "message": "Monitor the number of comments on posts you have visited."
+        "message": "Monitor the number of comments and edit dates of posts you have visited."
     },
 
     "newCommentCountMonitorPostsVisitedIncognitoTitle": {
@@ -1398,7 +1398,7 @@
     },
 
     "newCommentCountMonitorPostsVisitedIncognitoDesc": {
-        "message": "Monitor the number of comments on posts you have visited while browsing in incognito/private mode."
+        "message": "Monitor the number of comments and edit dates of posts you have visited while browsing in incognito/private mode."
     },
 
     "nightModeName": {


### PR DESCRIPTION
Requested in Issue #3622 
If a user has subscribed to new comment notifications on a post, and the post has been edited since the last visit to that page, then a notification should show. This is optional and off by default.

NOTE: I've already pull requested this (#3764) but due to some issues with my organization, I'm doing it again.