### PR TITLE
dashboard: Use local ajax over $.ajax; ajax: Create AjaxError

### DIFF
--- a/lib/environment/ajax.js
+++ b/lib/environment/ajax.js
@@ -29,6 +29,19 @@ declare function ajax(opt: AjaxOptions<'text'>): Promise<string>;
 declare function ajax(opt: AjaxOptions<'json'>): Promise<{ [key: string | number]: any }>;
 declare function ajax(opt: AjaxOptions<'raw'>): Promise<XhrResponse>;
 
+class AjaxError extends Error {
+	status: number;
+	responseText: string;
+	responseURL: string;
+
+	constructor(message, { status, responseText, responseURL }) {
+		super(message);
+		this.status = status;
+		this.responseText = responseText;
+		this.responseURL = responseURL;
+	}
+}
+
 /**
  * Sends a same-origin or cross-origin XHR.
  *
@@ -76,7 +89,9 @@ export async function ajax({ method = 'GET', url: rawUrl, headers = {}, data: ra
 		const load = Promise.race([
 			new Promise(resolve => (request.onload = resolve)),
 			new Promise(resolve => (request.onerror = resolve))
-				.then(() => { throw new Error(`XHR error - url: ${url}`); }),
+				.then(() => {
+					throw new AjaxError(`XHR error - url: ${url}`, request);
+				}),
 		]);
 
 		request.open(method, url, true);
@@ -96,7 +111,7 @@ export async function ajax({ method = 'GET', url: rawUrl, headers = {}, data: ra
 
 	// some browsers (Edge, Safari) set status to 0 for local resources
 	if (response.status !== 200 && response.status !== 0) {
-		throw new Error(`XHR status ${response.status} - url: ${url}`);
+		throw new AjaxError(`XHR status ${response.status} - url: ${url}`, response);
 	}
 
 	if (useCache) {

--- a/lib/environment/ajax.js
+++ b/lib/environment/ajax.js
@@ -23,12 +23,6 @@ type XhrResponse = { // eslint-disable-line no-unused-vars
 	responseURL: string,
 };
 
-/* eslint-disable no-redeclare */
-declare function ajax(opt: AjaxOptions<void>): Promise<string>;
-declare function ajax(opt: AjaxOptions<'text'>): Promise<string>;
-declare function ajax(opt: AjaxOptions<'json'>): Promise<{ [key: string | number]: any }>;
-declare function ajax(opt: AjaxOptions<'raw'>): Promise<XhrResponse>;
-
 class AjaxError extends Error {
 	status: number;
 	responseText: string;
@@ -41,6 +35,12 @@ class AjaxError extends Error {
 		this.responseURL = responseURL;
 	}
 }
+
+/* eslint-disable no-redeclare */
+declare function ajax(opt: AjaxOptions<void>): Promise<string>;
+declare function ajax(opt: AjaxOptions<'text'>): Promise<string>;
+declare function ajax(opt: AjaxOptions<'json'>): Promise<{ [key: string | number]: any }>;
+declare function ajax(opt: AjaxOptions<'raw'>): Promise<XhrResponse>;
 
 /**
  * Sends a same-origin or cross-origin XHR.

--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -12,7 +12,7 @@ import {
 	string,
 	newSitetable,
 } from '../utils';
-import { Storage } from '../environment';
+import { Storage, ajax } from '../environment';
 import * as Init from '../core/init';
 import * as Modules from '../core/modules';
 import * as Menu from './menu';
@@ -721,14 +721,20 @@ function WidgetObject(widgetOptions) {
 		this.url = `${location.protocol}//${location.hostname}/${this.basePath}${this.sortPath}`;
 		$(this.contents).fadeTo('fast', 0.25);
 		$(this.scrim).fadeIn();
-		$.ajax({
-			url: this.url,
-			data: {
-				limit: this.numPosts,
-			},
-			success: this.populate,
-			error: this.error,
-		});
+
+		try {
+			const response = await ajax({
+				method: 'GET',
+				url: this.url,
+				data: {
+					limit: this.numPosts,
+				},
+			});
+
+			this.populate(response);
+		} catch (e) {
+			this.error(e);
+		}
 	};
 	this.container = $('<div class="RESDashboardComponentContainer"><div class="RESDashboardComponentContents"></div></div>');
 	if (this.minimized) {
@@ -793,8 +799,8 @@ function WidgetObject(widgetOptions) {
 			newSitetable($widgetContent[0]);
 		}
 	};
-	this.error = xhr => {
-		if (xhr.status === 404) {
+	this.error = e => {
+		if (e.message.startsWith('XHR status 404 ')) {
 			$(this.contents).html('<div class="error">This widget received a 404 not found error. You may have made a typo when adding it.</div>');
 		} else {
 			$(this.contents).html('<div class="error">There was an error loading data for this widget. Reddit may be under heavy load, or you may have provided an invalid path.</div>');

--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -722,19 +722,15 @@ function WidgetObject(widgetOptions) {
 		$(this.contents).fadeTo('fast', 0.25);
 		$(this.scrim).fadeIn();
 
-		try {
-			const response = await ajax({
-				method: 'GET',
-				url: this.url,
-				data: {
-					limit: this.numPosts,
-				},
-			});
-
-			this.populate(response);
-		} catch (e) {
-			this.error(e);
-		}
+		ajax({
+			method: 'GET',
+			url: this.url,
+			data: {
+				limit: this.numPosts,
+			},
+		})
+			.then(this.populate)
+			.catch(this.error);
 	};
 	this.container = $('<div class="RESDashboardComponentContainer"><div class="RESDashboardComponentContents"></div></div>');
 	if (this.minimized) {
@@ -800,7 +796,7 @@ function WidgetObject(widgetOptions) {
 		}
 	};
 	this.error = e => {
-		if (e.message.startsWith('XHR status 404 ')) {
+		if (e.status === 404) {
 			$(this.contents).html('<div class="error">This widget received a 404 not found error. You may have made a typo when adding it.</div>');
 		} else {
 			$(this.contents).html('<div class="error">There was an error loading data for this widget. Reddit may be under heavy load, or you may have provided an invalid path.</div>');


### PR DESCRIPTION
I'm not too big of a fan of `ajax`'s error handling; any ideas for improvement?