### PR TITLE
Add autocomplete for wiki pages of current subreddit

### DIFF
--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -10,6 +10,7 @@ import {
 	Thing,
 	checkKeysForEvent,
 	click,
+	currentSubreddit,
 	escapeHTML,
 	isPageType,
 	loggedInUser,
@@ -1102,9 +1103,7 @@ function addAutoCompletePop() {
 	$autoCompletePop = $('<div id="autocomplete_dropdown" class="drop-choices srdrop inuse" style="display:none;">');
 	$autoCompletePop.on('click mousedown', '.choice', function() {
 		autoCompleteHideDropdown();
-		const fullReplace = !!this.getAttribute('data-label');
-		const label = fullReplace ? this.getAttribute('data-label') : this.innerText.trim();
-		autoCompleteInsert(label, fullReplace);
+		autoCompleteInsert(this.innerText);
 	});
 
 	$('body').append($autoCompletePop);
@@ -1128,7 +1127,7 @@ const autoCompleteDebounce = _.debounce(async (type, query, subreddit) => {
 		case 'r':
 			names = await getSubredditCompletions(query);
 			break;
-		case 'wiki':
+		case 'w':
 			names = await getWikiCompletions(query, subreddit);
 			break;
 		default:
@@ -1139,53 +1138,42 @@ const autoCompleteDebounce = _.debounce(async (type, query, subreddit) => {
 	autoCompleteSetNavIndex(0);
 }, 200);
 
+/**
+ * Matches the following:
+ * [0]: Full match
+ * [1]: preceding character
+ * [2]: subreddit name (no '/r/') (optional)
+ * [3]: 'r', 'u', 'w', 'wiki'
+ * [4]: query
+ */
+const autoCompleteMatchRegExp = /(^|\W)\/?(?:r\/([\w]+)\/)?(wiki|w|r|u)\/([\w]+)$/;
+
 function autoCompleteTrigger(e) {
 	// \0x08 is backspace
 	if (/[^A-Za-z0-9 \x08]/.test(String.fromCharCode(e.keyCode))) {
 		return true;
 	}
 	autoCompleteLastTarget = e.target;
-	/**
-	 * Matches the following:
-	 * [0]: Full match
-	 * [1]: r, u, wiki, r/{subreddit name}/wiki
-	 * [2]: subreddit name r/{subreddit name} (optional)
-	 * [3]: query
-	 */
-	const matchRegExp = /\W\/?((r\/[\w]{1,}\/)?wiki|r|u)\/([\w]{1,})$/;
-	const matchSkipRE = /\W\/?([ru])\/([\w\.]*)\s$/;
 
-	const fullText = this.value;
-	const prefixText = fullText.slice(0, this.selectionStart);
+	const prefixText = this.value.slice(0, this.selectionStart);
 
-	const match = matchRegExp.exec(` ${prefixText}`);
+	const match = autoCompleteMatchRegExp.exec(prefixText);
+	if (!match) {
+		autoCompleteHideDropdown();
+		return;
+	}
 
-	if (!match) return;
-
-	const [type, subreddit, query] = match.slice(1);
+	const [,, subreddit, [type], query] = match;
 
 	if (
 		(type === 'r' && !module.options.subredditAutocomplete.value) ||
 		(type === 'u' && !module.options.userAutocomplete.value) ||
-		(type.endsWith('wiki') && !module.options.wikiAutocomplete.value)
+		(type === 'w' && !module.options.wikiAutocomplete.value)
 	) {
 		return;
 	}
 
-	// Gets rid of subreddit name from type variable
-	const simplifiedType = type.endsWith('wiki') ? 'wiki' : type;
-
-	if (!query || query === '' || query.length > 10) {
-		if (e.keyCode === KEYS.SPACE || e.keyCode === KEYS.ENTER) {
-			const matchEnd = matchSkipRE.exec(` ${prefixText}`);
-			if (matchEnd) {
-				autoCompleteInsert(query);
-			}
-		}
-		return autoCompleteHideDropdown();
-	}
-
-	autoCompleteDebounce(simplifiedType, query, subreddit);
+	autoCompleteDebounce(type, query, subreddit || currentSubreddit());
 }
 
 async function getSubredditCompletions(query) {
@@ -1197,7 +1185,7 @@ async function getSubredditCompletions(query) {
 		cacheFor: DAY,
 	}): RedditSearchSubredditNames);
 
-	return names;
+	return names.map(name => `/r/${name}`);
 }
 
 async function getUserCompletions(query) {
@@ -1205,7 +1193,7 @@ async function getUserCompletions(query) {
 	const tagNames = Object.keys(tags);
 	const pageNames = Array.from(document.querySelectorAll('.author')).map(e => e.textContent);
 	return [...tagNames, ...pageNames]
-		.filter(e => e.toLowerCase().startsWith(query))
+		.filter(e => e.toLowerCase().startsWith(query.toLowerCase()))
 		.sort()
 		.reduce((prev, current) => {
 			// Removing duplicates
@@ -1213,28 +1201,21 @@ async function getUserCompletions(query) {
 				prev.push(current);
 			}
 			return prev;
-		}, []);
+		}, [])
+		.map(user => `/u/${user}`);
 }
 
-async function getWikiCompletions(query, subreddit = window.location.pathname.match(/\/(r\/[^\/]*\/)/)[1]) {
-	const result = (await ajax({
+async function getWikiCompletions(query, subreddit) {
+	const { data: wikiPages } = (await ajax({
 		method: 'GET',
-		url: `/${subreddit}wiki/pages.json`,
+		url: `/r/${subreddit}/wiki/pages.json`,
 		type: 'json',
 		cacheFor: DAY,
 	}): RedditSearchWikiNames);
 
-	if (result) {
-		const wikiPages = result.data;
-		return wikiPages
-			.map(wikiPage => ({
-				label: `/${subreddit}wiki/${wikiPage}`,
-				shortLabel: wikiPage,
-			}))
-			.filter(wikiPage => `/${wikiPage.shortLabel.toLowerCase()}`.includes(`/${query}`));
-	}
-
-	return null;
+	return wikiPages
+		.filter(wikiPage => wikiPage.toLowerCase().startsWith(query.toLowerCase()))
+		.map(wikiPage => `/r/${subreddit}/wiki/${wikiPage}`);
 }
 
 function autoCompleteNavigate(e) {
@@ -1281,21 +1262,11 @@ function autoCompleteHideDropdown() {
 	$autoCompletePop.hide();
 }
 
-function autoCompleteUpdateDropdown(items) {
-	if (!items.length) return autoCompleteHideDropdown();
+function autoCompleteUpdateDropdown(names) {
+	if (!names.length) return autoCompleteHideDropdown();
 	$autoCompletePop.empty();
-	items.slice(0, 20).forEach((item, i) => {
-		const shortLabel = item.shortLabel || item.label || item;
-		const label = item.label;
-		$autoCompletePop.append(`
-			<a
-				class="choice"
-				data-index="${i}"
-				${label ? ` data-label="${label}"` : ''}
-			>
-				${shortLabel}
-			</a>
-		`);
+	names.slice(0, 20).forEach((name, i) => {
+		$autoCompletePop.append(`<a class="choice" data-index="${i}">${name}</a>`);
 	});
 
 	const textareaOffset = $(autoCompleteLastTarget).offset();
@@ -1305,22 +1276,12 @@ function autoCompleteUpdateDropdown(items) {
 	autoCompleteSetNavIndex(0);
 }
 
-/**
- * Inserts given inputValue instead of incompleted text.
- *
- * @param {String} shortLabel A value that shall replace user's query.
- * @param {String} fullReplace Whether to replace the whole autocomplete-triggering phrase.
- */
-function autoCompleteInsert(inputValue, fullReplace) {
+function autoCompleteInsert(inputValue) {
 	const textarea = autoCompleteLastTarget;
 	const caretPos = textarea.selectionStart;
 	let left = textarea.value.substr(0, caretPos);
 	const right = textarea.value.substr(caretPos);
-	if (fullReplace) {
-		left = left.replace(/\/?((r\/[\w\.]*)\/)?wiki\/([\w\.]*)$/, `${inputValue} `);
-	} else {
-		left = left.replace(/(\/?[ruw])\/(\w*)\s?$/, `$1/${inputValue} `);
-	}
+	left = left.replace(autoCompleteMatchRegExp, `$1${inputValue} `);
 	textarea.value = left + right;
 	textarea.selectionStart = textarea.selectionEnd = left.length;
 	textarea.focus();

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -19,7 +19,7 @@ import {
 } from '../utils';
 import type { KeyArray } from '../utils/keycode';
 import { ajax, i18n } from '../environment';
-import type { RedditSearchSubredditNames } from '../types/reddit';
+import type { RedditSearchSubredditNames, RedditSearchWikiNames } from '../types/reddit';
 import * as AccountSwitcher from './accountSwitcher';
 import * as SettingsNavigation from './settingsNavigation';
 import * as UserTagger from './userTagger';
@@ -44,6 +44,13 @@ module.options = {
 		description: 'commentToolsSubredditAutocompleteDesc',
 		title: 'commentToolsSubredditAutocompleteTitle',
 		keywords: ['autosuggest'],
+		advanced: true,
+	},
+	wikiAutocomplete: {
+		type: 'boolean',
+		value: true,
+		description: 'commentToolsWikiAutocompleteDesc',
+		title: 'commentToolsWikiAutocompleteTitle',
 		advanced: true,
 	},
 	formattingToolButtons: {
@@ -357,7 +364,11 @@ const initializeEditorTools = _.once(() => {
 		});
 	}
 
-	if (module.options.subredditAutocomplete.value || module.options.userAutocomplete.value) {
+	if (
+		module.options.subredditAutocomplete.value ||
+		module.options.userAutocomplete.value ||
+		module.options.wikiAutocomplete.value
+	) {
 		addAutoCompletePop();
 	}
 });
@@ -1091,8 +1102,11 @@ function addAutoCompletePop() {
 	$autoCompletePop = $('<div id="autocomplete_dropdown" class="drop-choices srdrop inuse" style="display:none;">');
 	$autoCompletePop.on('click mousedown', '.choice', function() {
 		autoCompleteHideDropdown();
-		autoCompleteInsert(this.innerHTML);
+		const fullReplace = !!this.getAttribute('data-label');
+		const label = fullReplace ? this.getAttribute('data-label') : this.innerText.trim();
+		autoCompleteInsert(label, fullReplace);
 	});
+
 	$('body').append($autoCompletePop);
 
 	$('body').on({
@@ -1104,15 +1118,21 @@ function addAutoCompletePop() {
 
 let autoCompleteLastTarget;
 
-const autoCompleteDebounce = _.debounce(async (type, query) => {
+const autoCompleteDebounce = _.debounce(async (type, query, subreddit) => {
 	let names;
 
-	if (type === 'r') {
-		names = await getSubredditCompletions(query);
-	} else if (type === 'u') {
-		names = await getUserCompletions(query);
-	} else {
-		throw new Error(`Invalid autocomplete type: ${type}`);
+	switch (type) {
+		case 'u':
+			names = await getUserCompletions(query);
+			break;
+		case 'r':
+			names = await getSubredditCompletions(query);
+			break;
+		case 'wiki':
+			names = await getWikiCompletions(query, subreddit);
+			break;
+		default:
+			throw new Error(`Invalid autocomplete type: ${type}`);
 	}
 
 	autoCompleteUpdateDropdown(names);
@@ -1125,35 +1145,47 @@ function autoCompleteTrigger(e) {
 		return true;
 	}
 	autoCompleteLastTarget = e.target;
-	const matchRE = /\W\/?([ru])\/([\w\.]*)$/;
+	/**
+	 * Matches the following:
+	 * [0]: Full match
+	 * [1]: r, u, wiki, r/{subreddit name}/wiki
+	 * [2]: subreddit name r/{subreddit name} (optional)
+	 * [3]: query
+	 */
+	const matchRegExp = /\W\/?((r\/[\w]{1,}\/)?wiki|r|u)\/([\w]{1,})$/;
 	const matchSkipRE = /\W\/?([ru])\/([\w\.]*)\s$/;
-	const fullText = $(this).val();
-	const prefixText = fullText.slice(0, this.selectionStart);
-	let match = matchRE.exec(` ${prefixText}`);
 
-	if (match) {
-		if (match[1] === 'r' && !module.options.subredditAutocomplete.value) {
-			return;
-		}
-		if (match[1] === 'u' && !module.options.userAutocomplete.value) {
-			return;
-		}
+	const fullText = this.value;
+	const prefixText = fullText.slice(0, this.selectionStart);
+
+	const match = matchRegExp.exec(` ${prefixText}`);
+
+	if (!match) return;
+
+	const [type, subreddit, query] = match.slice(1);
+
+	if (
+		(type === 'r' && !module.options.subredditAutocomplete.value) ||
+		(type === 'u' && !module.options.userAutocomplete.value) ||
+		(type.endsWith('wiki') && !module.options.wikiAutocomplete.value)
+	) {
+		return;
 	}
 
-	if (!match || match[2] === '' || match[2].length > 10) {
+	// Gets rid of subreddit name from type variable
+	const simplifiedType = type.endsWith('wiki') ? 'wiki' : type;
+
+	if (!query || query === '' || query.length > 10) {
 		if (e.keyCode === KEYS.SPACE || e.keyCode === KEYS.ENTER) {
-			match = matchSkipRE.exec(` ${prefixText}`);
-			if (match) {
-				autoCompleteInsert(match[2]);
+			const matchEnd = matchSkipRE.exec(` ${prefixText}`);
+			if (matchEnd) {
+				autoCompleteInsert(query);
 			}
 		}
 		return autoCompleteHideDropdown();
 	}
 
-	const type = match[1];
-	const query = match[2].toLowerCase();
-
-	autoCompleteDebounce(type, query);
+	autoCompleteDebounce(simplifiedType, query, subreddit);
 }
 
 async function getSubredditCompletions(query) {
@@ -1182,6 +1214,27 @@ async function getUserCompletions(query) {
 			}
 			return prev;
 		}, []);
+}
+
+async function getWikiCompletions(query, subreddit = window.location.pathname.match(/\/(r\/[^\/]*\/)/)[1]) {
+	const result = (await ajax({
+		method: 'GET',
+		url: `/${subreddit}wiki/pages.json`,
+		type: 'json',
+		cacheFor: DAY,
+	}): RedditSearchWikiNames);
+
+	if (result) {
+		const wikiPages = result.data;
+		return wikiPages
+			.map(wikiPage => ({
+				label: `/${subreddit}wiki/${wikiPage}`,
+				shortLabel: wikiPage,
+			}))
+			.filter(wikiPage => `/${wikiPage.shortLabel.toLowerCase()}`.includes(`/${query}`));
+	}
+
+	return null;
 }
 
 function autoCompleteNavigate(e) {
@@ -1228,11 +1281,21 @@ function autoCompleteHideDropdown() {
 	$autoCompletePop.hide();
 }
 
-function autoCompleteUpdateDropdown(names) {
-	if (!names.length) return autoCompleteHideDropdown();
+function autoCompleteUpdateDropdown(items) {
+	if (!items.length) return autoCompleteHideDropdown();
 	$autoCompletePop.empty();
-	names.slice(0, 20).forEach((name, i) => {
-		$autoCompletePop.append(`<a class="choice" data-index="${i}">${name}</a>`);
+	items.slice(0, 20).forEach((item, i) => {
+		const shortLabel = item.shortLabel || item.label || item;
+		const label = item.label;
+		$autoCompletePop.append(`
+			<a
+				class="choice"
+				data-index="${i}"
+				${label ? ` data-label="${label}"` : ''}
+			>
+				${shortLabel}
+			</a>
+		`);
 	});
 
 	const textareaOffset = $(autoCompleteLastTarget).offset();
@@ -1242,12 +1305,22 @@ function autoCompleteUpdateDropdown(names) {
 	autoCompleteSetNavIndex(0);
 }
 
-function autoCompleteInsert(inputValue) {
+/**
+ * Inserts given inputValue instead of incompleted text.
+ *
+ * @param {String} shortLabel A value that shall replace user's query.
+ * @param {String} fullReplace Whether to replace the whole autocomplete-triggering phrase.
+ */
+function autoCompleteInsert(inputValue, fullReplace) {
 	const textarea = autoCompleteLastTarget;
 	const caretPos = textarea.selectionStart;
 	let left = textarea.value.substr(0, caretPos);
 	const right = textarea.value.substr(caretPos);
-	left = left.replace(/(\/?[ru])\/(\w*)\s?$/, `$1/${inputValue} `);
+	if (fullReplace) {
+		left = left.replace(/\/?((r\/[\w\.]*)\/)?wiki\/([\w\.]*)$/, `${inputValue} `);
+	} else {
+		left = left.replace(/(\/?[ruw])\/(\w*)\s?$/, `$1/${inputValue} `);
+	}
 	textarea.value = left + right;
 	textarea.selectionStart = textarea.selectionEnd = left.length;
 	textarea.focus();

--- a/lib/types/reddit.js
+++ b/lib/types/reddit.js
@@ -121,6 +121,11 @@ export type RedditSearchSubredditNames = {
 	names: string[],
 };
 
+export type RedditSearchWikiNames = {
+	kind: 'wikipagelisting',
+	data: Array<string>,
+};
+
 export type RedditStylesheet = {
 	kind: 'stylesheet',
 	data: {

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -2393,6 +2393,14 @@
         "message": "Show subreddit autocomplete tool when typing in posts, comments, and replies."
     },
 
+    "commentToolsWikiAutocompleteTitle": {
+        "message": "Wiki Autocomplete"
+    },
+
+    "commentToolsWikiAutocompleteDesc": {
+        "message": "Show wiki autocomplete tool when typing in posts, comments, and replies."
+    },
+
     "commentToolsFormattingToolButtonsTitle": {
         "message": "Formatting Tool Buttons"
     },


### PR DESCRIPTION
I've added a feature (requested in #3785) that enables the users to get autocomplete for wiki pages belonging to the subreddit they are currently on.

![image](https://cloud.githubusercontent.com/assets/5426427/21292602/aea1853a-c50b-11e6-9a38-36e8963b1917.png)

It works similarly to /r/ and /u/ autocomplete. For example, typing `/wiki/bette` on /r/Enhancement will result in `/index/ui/betteReddit` being suggested. If the user wants to link other's subreddit's wiki, they can write `/r/subredditname/wiki/...` to get the result from this wiki. 

As links to wiki are working in a slightly more complicated way than `/r/...` and `/u/...` links (plain /wiki/ won't work without prepending subreddit link), along with autosuggest item "shortLabel" (the one being displayed), I now pass url in `data-label` attribute.

It is then sent to a function that pastes autosuggestion into an input field. This function, given label, will completely replace autosuggest-triggering phrase, and in other cases will behave like it always used to.

In our case, the final result of this autosuggestion will be: 
`/r/Enhancement/wiki/index/ui/bettereddit`.

Enjoy!

Edit(@erikdesjardins): fixes #3785