### PR TITLE
customFilters postAge: Set default comparison operator

### DIFF
--- a/lib/modules/filteReddit/postCases.js
+++ b/lib/modules/filteReddit/postCases.js
@@ -228,7 +228,7 @@ export default ({
 		name: 'Post age',
 		defaultTemplate(op, age) {
 			// 4 hours in milliseconds
-			return { type: 'postAge', op, age: age || 4 * 60 * 60 * 1000 };
+			return { type: 'postAge', op: op || '<=', age: age || 4 * 60 * 60 * 1000 };
 		},
 		trueText: 'age ≤',
 		falseText: 'age >',


### PR DESCRIPTION
Otherwise there will be no operator by default, which when not changed will cause RES to crash when the filter is executed.