### PR TITLE
keyboardNav: Show help only for possible commands for page

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -828,9 +828,7 @@ function updateCommentLinkAnnotations(selected) {
 }
 
 const drawHelp = _.once(() => {
-	const keys = filterMap(Object.entries(module.options), ([optionKey, opt]) => {
-		if (opt.type !== 'keycode' || optionKey.startsWith('link')) return;
-
+	const keys = filterMap(getActiveCommandOptions(), opt => {
 		let keyCode	= niceKeyCode(opt.value);
 		if (opt.dependsOn && module.options[opt.dependsOn].type === 'keycode') {
 			keyCode = `${niceKeyCode(module.options[opt.dependsOn].value)}, ${keyCode}`;
@@ -847,11 +845,9 @@ function getCommentsLinkKeys() {
 
 	function addKey(key, index) {
 		keys.push({
-			type: 'keycode',
 			value: [key, false, false, false, false], // number
 			callback() { commentLink(index); },
 		}, {
-			type: 'keycode',
 			value: [key, true, false, false, false], // alt-number
 			callback() { commentLink(index, true); },
 		});
@@ -865,14 +861,18 @@ function getCommentsLinkKeys() {
 	return keys;
 }
 
+const getActiveCommandOptions = _.once((): { callback: () => *, value: any }[] =>
+	(Object.values(module.options): any).filter(option =>
+		option.type === 'keycode' &&
+		option.callback &&
+		(!option.include || matchesPageLocation(option.include)) &&
+		(!option.requiresModule || Modules.isRunning(option.requiresModule))
+	)
+);
+
 const _commandLookup = _.once(() => {
 	const lookup = {};
-	for (const option of [...(Object.values(module.options): ModuleOption[]), ...getCommentsLinkKeys()]) {
-		if (option.type !== 'keycode') continue;
-		if (!option.callback) continue;
-		if (option.include && !matchesPageLocation(option.include)) continue;
-		if (option.requiresModule && !Modules.isRunning(option.requiresModule)) continue;
-
+	for (const option of [...getActiveCommandOptions(), ...getCommentsLinkKeys()]) {
 		const hash = hashKeyArray(option.value);
 		if (!lookup[hash]) {
 			lookup[hash] = $.Callbacks();

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -6,7 +6,6 @@ import linkAnnotationTemplate from '../templates/linkAnnotation.mustache';
 import keyHelpTemplate from '../templates/keyHelp.mustache';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
-import type { ModuleOption } from '../core/module';
 import * as Modules from '../core/modules';
 import {
 	Thing,
@@ -861,13 +860,15 @@ function getCommentsLinkKeys() {
 	return keys;
 }
 
-const getActiveCommandOptions = _.once((): { callback: () => *, value: any }[] =>
-	(Object.values(module.options): any).filter(option =>
-		option.type === 'keycode' &&
-		option.callback &&
-		(!option.include || matchesPageLocation(option.include)) &&
-		(!option.requiresModule || Modules.isRunning(option.requiresModule))
-	)
+const getActiveCommandOptions = _.once(() =>
+	filterMap(Object.values(module.options), option => {
+		if (option.type === 'keycode' &&
+			option.callback &&
+			(!option.include || matchesPageLocation(option.include)) &&
+			(!option.requiresModule || Modules.isRunning(option.requiresModule))) {
+			return [option];
+		}
+	})
 );
 
 const _commandLookup = _.once(() => {


### PR DESCRIPTION
Seeing commands that one cannot use is usually confusing.