### PR TITLE
accountSwitcher: clear `token` cookie for new modmail

### DIFF
--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -310,9 +310,11 @@ async function switchTo(user) {
 	if (!account) return;
 	const [username, password] = account;
 
-	// Remove old session cookie (reddit_session)
-	// in FF we also need to remove this (secure_session), but it should be safe to remove either way.
-	await deleteCookies('reddit_session', 'secure_session');
+	await deleteCookies(
+		'reddit_session', // old session cookie
+		'secure_session', // we also need to remove this in FF
+		'token' // new modmail
+	);
 
 	const response = await ajax({
 		method: 'POST',


### PR DESCRIPTION
Fixes #3822

As #3822 predicted, all we need to do is remove the cookie and new modmail will start a new session on next pageload.