### PR TITLE
Update streamable favicon, old CDN offline.

### DIFF
--- a/lib/modules/hosts/streamable.js
+++ b/lib/modules/hosts/streamable.js
@@ -5,7 +5,7 @@ import { Host } from '../../core/host';
 export default new Host('streamable', {
 	name: 'streamable',
 	domains: ['streamable.com'],
-	logo: '//cdn.streamable.com/static/img/favicon.ico',
+	logo: '//cdn-e2.streamable.com/static/14a98f7cb1ddc5213329c039dc39cac543ba410f/img/favicon.ico',
 	detect: ({ pathname }) => (/^\/(?:e\/)?(\w+)$/i).exec(pathname),
 	handleLink(href, [, hash]) {
 		return {


### PR DESCRIPTION
Appears to use fastly with tokens to pull the images now. API docs are out of date.