### PR TITLE
showImages YouTube: Remove iframe when collapsing

### DIFF
--- a/lib/modules/hosts/youtube.js
+++ b/lib/modules/hosts/youtube.js
@@ -56,8 +56,6 @@ export default new Host('youtube', {
 			type: 'IFRAME',
 			embed: src,
 			embedAutoplay: `${src}&autoplay=1`,
-			pause: '{"event":"command","func":"stopVideo","args":""}',
-			play: '{"event":"command","func":"playVideo","args":""}',
 			fixedRatio: true,
 		};
 	},


### PR DESCRIPTION
Using the `stop` command resets the playback position to 0 (not the position specified in the URL), which often is more of a pain than having to load the iframe content anew.