### PR TITLE
selectedEntry: Fix onNewComments on outermost "load more comments"

### DIFF
--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -231,7 +231,7 @@ const onNewComments = _.throttle(thingElement => {
 			_select(thingElement);
 		}
 	}
-}, 100, { leading: true, trailing: true });
+}, 100, { leading: true, trailing: false });
 
 function updateActiveElement(selected, last) {
 	if (selected) {

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -220,25 +220,18 @@ function _select(thingOrEntry, options = { scrollStyle: 'none' }) {
 	scrollToElement(newThing.entry, options);
 
 	selectedThing = newSelected;
-	selectedContainer = newSelected && $(newSelected.thing).parent().closest('.thing');
+	selectedContainer = newSelected && $(newSelected.thing).closest('.sitetable').get(0);
 }
 
-let onNewCommentsCooldown;
-function onNewComments(entry) {
-	if (onNewCommentsCooldown) {
-		// Recently selected something, ignore remainder of batch
-		return;
-	}
-	if (selectedThing && !selectedThing.parentNode) {
+const onNewComments = _.throttle(thingElement => {
+	if (selectedThing && !document.contains(selectedThing.element)) {
 		// Selected thing was replaced, so select the replacement
-		const newContainer = $(entry).closest('.thing').parent().closest('.thing');
-		if (newContainer.filter(selectedContainer).length) {
-			_select(entry);
-			// only select the first applicable thing in a batch
-			onNewCommentsCooldown = setTimeout(() => (onNewCommentsCooldown = undefined), 100);
+		const newContainer = $(thingElement).closest('.sitetable').get(0);
+		if (newContainer === selectedContainer) {
+			_select(thingElement);
 		}
 	}
-}
+}, 100, { leading: true, trailing: true });
 
 function updateActiveElement(selected, last) {
 	if (selected) {

--- a/tests/selectedEntry.js
+++ b/tests/selectedEntry.js
@@ -1,0 +1,38 @@
+module.exports = {
+	'selecting on comments page': browser => {
+		const selectedClass = 'RES-keyNav-activeThing';
+		const parentPost = '#thing_t3_5lfy0v';
+		const stickiedComment = '#thing_t1_dbvc8xr';
+		const childComment1 = '#thing_t1_dbvc9il';
+		const childComment2 = '#thing_t1_dbvc9kg';
+		const childOfStickiedComment1 = '#thing_t1_dbvc99w';
+		const childOfStickiedComment2 = '#thing_t1_dbvc9gt';
+		const loadMoreComments = `${childComment2} .morecomments a`;
+		const loadMoreChildrenOfSticky = `${childOfStickiedComment1} .morecomments a`;
+
+		browser
+			.url('https://www.reddit.com/r/RESIntegrationTests/comments/5lfy0v/selected_entry_selecting_comments/?limit=1')
+
+			.waitForElementVisible(parentPost)
+			.assert.cssClassPresent(parentPost, selectedClass)
+
+			.click(`${stickiedComment} .usertext`) // avoid clicking "hide child comments"
+			.assert.cssClassPresent(stickiedComment, selectedClass)
+
+			.click(loadMoreComments)
+			.waitForElementVisible(childComment1)
+			.assert.cssClassPresent(childComment1, selectedClass)
+
+			.click(childComment2)
+			.assert.cssClassPresent(childComment2, selectedClass)
+
+			.click(loadMoreChildrenOfSticky)
+			.waitForElementVisible(childOfStickiedComment2)
+			.assert.cssClassPresent(childOfStickiedComment1, selectedClass)
+
+			.click(childOfStickiedComment2)
+			.assert.cssClassPresent(childOfStickiedComment2, selectedClass)
+
+			.end();
+	},
+};

--- a/tests/selectedEntry.js
+++ b/tests/selectedEntry.js
@@ -11,6 +11,17 @@ module.exports = {
 		const loadMoreChildrenOfSticky = `${childOfStickiedComment1} .morecomments a`;
 
 		browser
+			// Geckodriver has this wonderful issue where it doesn't support manually moving the mouse
+			// (the moveTo command), but after the click command it continues to hover on the same spot
+			// that was clicked.
+			// In this test, that behaviour causes the user hover info to appear after loading more comments,
+			// which breaks everything by covering up the comments we need to click on.
+			// It's too difficult to work around, so just disable user info entirely.
+			.url('https://www.reddit.com/wiki/pages#res:settings/userInfo')
+			.waitForElementVisible('#RESConsoleContainer')
+			.click('.moduleToggle')
+
+			// Run the actual test...
 			.url('https://www.reddit.com/r/RESIntegrationTests/comments/5lfy0v/selected_entry_selecting_comments/?limit=1')
 
 			.waitForElementVisible(parentPost)


### PR DESCRIPTION
The previously implementation verified that the new comment should be selected by matching a parent Thing. This matches `.sitetable` instead.

Fixes https://www.reddit.com/r/RESissues/comments/5le5xq/active_selection_resets_after_using_the_enter/