### PR TITLE
Add extra throttling to "search on type" to reduce lag

### DIFF
--- a/lib/modules/search.js
+++ b/lib/modules/search.js
@@ -54,7 +54,7 @@ export function search(query?: string) {
 	SettingsNavigation.setUrlHash(module.moduleID, query);
 }
 
-const throttledSearch = _.throttle(frameThrottle(search), 1000);
+const throttledSearch = _.throttle(frameThrottle(search), 250);
 
 function showSearch() {
 	Menu.hidePrefsDropdown();

--- a/lib/modules/search.js
+++ b/lib/modules/search.js
@@ -54,7 +54,7 @@ export function search(query?: string) {
 	SettingsNavigation.setUrlHash(module.moduleID, query);
 }
 
-const throttledSearch = frameThrottle(search);
+const throttledSearch = _.throttle(frameThrottle(search), 1000);
 
 function showSearch() {
 	Menu.hidePrefsDropdown();


### PR DESCRIPTION
With just `frameThrottle` it still feels laggy.