### PR TITLE
travis: Cache yarn (built-in) and node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ addons:
     secure: hHF06xHY6pLdxscwYhUHdSRuUH2CPA61AUrvPiW54lnMwwkDvCQakR+aY5HbjptFIfOwkWsS4xoqXH4pZTfhMOji32S/+ELT+AqLdkIgnLYDfBj4RcsZoXyvuiLx29i4PVCnGMikctBp4dM6wORgfd1tu3uwhcoQrBjxCMW1qmY=
 cache:
   yarn: true
+  directories:
+    - node_modules
 matrix:
   exclude:
     - node_js: 7 # exclude default job https://github.com/travis-ci/travis-ci/issues/4681

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,8 @@ addons:
     # SAUCE_ACCESS_KEY=<secure>
     secure: hHF06xHY6pLdxscwYhUHdSRuUH2CPA61AUrvPiW54lnMwwkDvCQakR+aY5HbjptFIfOwkWsS4xoqXH4pZTfhMOji32S/+ELT+AqLdkIgnLYDfBj4RcsZoXyvuiLx29i4PVCnGMikctBp4dM6wORgfd1tu3uwhcoQrBjxCMW1qmY=
 cache:
-  directories:
-    - $HOME/.cache/yarn
+  yarn: true
 install:
-  - npm i -g yarn
-  - yarn install --pure-lockfile
   - yarn check --integrity
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ cache:
   yarn: true
   directories:
     - node_modules
+install:
+  - npm install -g yarn
+  - yarn install --pure-lockfile
+  - yarn check --integrity
 matrix:
   exclude:
     - node_js: 7 # exclude default job https://github.com/travis-ci/travis-ci/issues/4681

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ addons:
     secure: hHF06xHY6pLdxscwYhUHdSRuUH2CPA61AUrvPiW54lnMwwkDvCQakR+aY5HbjptFIfOwkWsS4xoqXH4pZTfhMOji32S/+ELT+AqLdkIgnLYDfBj4RcsZoXyvuiLx29i4PVCnGMikctBp4dM6wORgfd1tu3uwhcoQrBjxCMW1qmY=
 cache:
   yarn: true
-install:
-  - yarn check --integrity
 matrix:
   exclude:
     - node_js: 7 # exclude default job https://github.com/travis-ci/travis-ci/issues/4681


### PR DESCRIPTION
This should be possible now that travis-ci/travis-ci#6720 and yarnpkg/yarn#1576 are both fixed. See also the [official Travis blog post about yarn](https://blog.travis-ci.com/2016-11-21-travis-ci-now-supports-yarn).