### PR TITLE
Defer add diagnostics to self-text on submit page

### DIFF
--- a/lib/modules/submitIssue.js
+++ b/lib/modules/submitIssue.js
@@ -169,7 +169,7 @@ function createAndAddWizard() {
 		});
 
 
-	$wizard.insertAfter('#text-desc');
+	$('form.submit.content').prepend($wizard);
 	$wizard.fadeIn();
 
 	return $wizard;

--- a/lib/modules/submitIssue.js
+++ b/lib/modules/submitIssue.js
@@ -41,13 +41,14 @@ const diagnostics = _.once(() => diagnosticsTemplate({
 
 function checkIfSubmitting() {
 	const subredditInput: ?HTMLInputElement = (document.getElementById('sr-autocomplete'): any);
+	const selfText: ?HTMLTextAreaElement = (document.querySelector('.usertext-edit textarea'): any);
+	const title: HTMLTextAreaElement = (document.querySelector('textarea[name=title]'): any);
+
 	if (subredditInput) {
 		let $submittingToEnhancement;
 
 		function check() {
 			const subreddit = subredditInput.value;
-			const title: HTMLTextAreaElement = (document.querySelector('textarea[name=title]'): any);
-			const $selfText = $('.usertext-edit textarea');
 
 			if (subreddits.includes(subreddit.toLowerCase())) {
 				$submittingToEnhancement = createAndAddWizard();
@@ -58,14 +59,6 @@ function checkIfSubmitting() {
 						title.value = '';
 					}
 				}
-
-				if (subredditsForDiagnostics.includes(subreddit.toLowerCase())) {
-					$selfText.val(diagnostics());
-				} else {
-					if ($selfText.val() === diagnostics()) {
-						$selfText.val('');
-					}
-				}
 			}
 		}
 
@@ -74,6 +67,19 @@ function checkIfSubmitting() {
 		subredditInput.addEventListener('change', e => {
 			if (e.res) return;
 			check();
+		});
+	}
+
+	if (selfText && subredditInput) {
+		 $(selfText).add(subredditInput).on('blur', e => {
+		 	const subreddit = subredditInput.value;
+			if (subreddits.concat(subredditsForDiagnostics).includes(subreddit.toLowerCase())) {
+				if (selfText.value.indexOf(diagnostics()) === -1) {
+					selfText.value += diagnostics();
+				}
+			} else {
+				selfText.value = selfText.value.replace(diagnostics(), '');
+			}
 		});
 	}
 }
@@ -122,7 +128,7 @@ function createAndAddWizard() {
 			$('li a.text-button').click();
 			$('#submittingToEnhancement').fadeOut();
 
-			const body = (submitIssueDefaultBodyTemplate() + diagnostics()).trim();
+			const body = submitIssueDefaultBodyTemplate().trim();
 
 			$('.usertext-edit textarea').val(body);
 

--- a/lib/modules/submitIssue.js
+++ b/lib/modules/submitIssue.js
@@ -71,8 +71,8 @@ function checkIfSubmitting() {
 	}
 
 	if (selfText && subredditInput) {
-		 $(selfText).add(subredditInput).on('blur', e => {
-		 	const subreddit = subredditInput.value;
+		$(selfText).add(subredditInput).on('blur', () => {
+			const subreddit = subredditInput.value;
 			if (subreddits.concat(subredditsForDiagnostics).includes(subreddit.toLowerCase())) {
 				if (selfText.value.indexOf(diagnostics()) === -1) {
 					selfText.value += diagnostics();

--- a/lib/modules/submitIssue.js
+++ b/lib/modules/submitIssue.js
@@ -81,9 +81,8 @@ function checkIfSubmitting() {
 function createAndAddWizard() {
 	const title: HTMLTextAreaElement = (document.querySelector('textarea[name=title]'): any);
 
-	return $('<div>', { id: 'submittingToEnhancement', class: 'RESDialogSmall' })
+	const $wizard = $('<div>', { id: 'submittingToEnhancement', class: 'RESDialogSmall' })
 		.html(submitWizardTemplate({ foolin: foolin() }))
-		.insertAfter('#text-desc')
 		.on('click', '#RESSubmitBug', () => {
 			$('#RESSubmitOptions').fadeOut(async () => {
 				$('#RESBugReport').fadeIn();
@@ -167,8 +166,13 @@ function createAndAddWizard() {
 			updateSubreddit('Enhancement');
 			$('#submittingToEnhancement').fadeOut();
 			title.value = '';
-		})
-		.fadeIn();
+		});
+
+
+	$wizard.insertAfter('#text-desc');
+	$wizard.fadeIn();
+
+	return $wizard;
 }
 
 function updateSubreddit(subreddit) {

--- a/lib/modules/submitIssue.js
+++ b/lib/modules/submitIssue.js
@@ -73,8 +73,8 @@ function checkIfSubmitting() {
 	if (selfText && subredditInput) {
 		$(selfText).add(subredditInput).on('blur', () => {
 			const subreddit = subredditInput.value;
-			if (subreddits.concat(subredditsForDiagnostics).includes(subreddit.toLowerCase())) {
-				if (selfText.value.indexOf(diagnostics()) === -1) {
+			if ([...subreddits, ...subredditsForDiagnostics].includes(subreddit.toLowerCase())) {
+				if (!selfText.value.includes(diagnostics())) {
 					selfText.value += diagnostics();
 				}
 			} else {


### PR DESCRIPTION
The diagnostic info is added after the user leaves the textbox, and is removed (or injected if appropriate) if the user changes the "submit to" to a subreddit that doesn't want diagnostics.