### PR TITLE
Add Expando for YouTube live stream URLs

### DIFF
--- a/lib/modules/hosts/youtube.js
+++ b/lib/modules/hosts/youtube.js
@@ -12,7 +12,7 @@ export default new Host('youtube', {
 		// split path excluding first /
 		const split = pathname.substring(1).split('/');
 		// livestream channel url
-		if (split.indexOf('live') !== -1) return `live_stream?channel=${split[1]}`;
+		if (split[0] === 'channel' && split[2] === 'live') return `live_stream?channel=${split[1]}`;
 		// short url
 		if (hostname.endsWith('youtu.be')) return split[0];
 		// long url

--- a/lib/modules/hosts/youtube.js
+++ b/lib/modules/hosts/youtube.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { Host } from '../../core/host';
-import { getUrlParams } from '../../utils';
+import { getUrlParams, insertParams } from '../../utils';
 
 export default new Host('youtube', {
 	name: 'youtube',
@@ -21,12 +21,7 @@ export default new Host('youtube', {
 			(/watch|embed|v/i).exec(split[0]) && split[1]; // watch/embed/v
 	},
 	handleLink(href, hash) {
-		let src = `https://www.youtube.com/embed/${hash}`;
-		if (hash.includes('live_stream')) {
-			src = `${src}&enablejsapi=1&enablecastapi=1`;
-		} else {
-			src = `${src}?enablejsapi=1&enablecastapi=1`;
-		}
+		let src = insertParams(`https://www.youtube.com/embed/${hash}`, { enablejsapi: 1, enablecastapi: 1 });
 		const params = getUrlParams(href);
 		if (params.t) {
 			let starttime = 0;

--- a/lib/modules/hosts/youtube.js
+++ b/lib/modules/hosts/youtube.js
@@ -11,6 +11,8 @@ export default new Host('youtube', {
 		const params = getUrlParams(search);
 		// split path excluding first /
 		const split = pathname.substring(1).split('/');
+		// livestream channel url
+		if (split.indexOf('live') !== -1) return `live_stream?channel=${split[1]}`;
 		// short url
 		if (hostname.endsWith('youtu.be')) return split[0];
 		// long url
@@ -19,7 +21,12 @@ export default new Host('youtube', {
 			(/watch|embed|v/i).exec(split[0]) && split[1]; // watch/embed/v
 	},
 	handleLink(href, hash) {
-		let src = `https://www.youtube.com/embed/${hash}?enablejsapi=1&enablecastapi=1`;
+		let src = `https://www.youtube.com/embed/${hash}`;
+		if (hash.includes('live_stream')) {
+			src = `${src}&enablejsapi=1&enablecastapi=1`;
+		} else {
+			src = `${src}?enablejsapi=1&enablecastapi=1`;
+		}
 		const params = getUrlParams(href);
 		if (params.t) {
 			let starttime = 0;

--- a/lib/modules/hosts/youtube.js
+++ b/lib/modules/hosts/youtube.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { Host } from '../../core/host';
-import { getUrlParams, insertParams } from '../../utils';
+import { getUrlParams } from '../../utils';
 
 export default new Host('youtube', {
 	name: 'youtube',
@@ -21,7 +21,7 @@ export default new Host('youtube', {
 			(/watch|embed|v/i).exec(split[0]) && split[1]; // watch/embed/v
 	},
 	handleLink(href, hash) {
-		let src = insertParams(`https://www.youtube.com/embed/${hash}`, { enablejsapi: 1, enablecastapi: 1 });
+		let src = `https://www.youtube.com/embed/${hash}`;
 		const params = getUrlParams(href);
 		if (params.t) {
 			let starttime = 0;

--- a/lib/utils/location.js
+++ b/lib/utils/location.js
@@ -24,12 +24,12 @@ export function getUrlParams(url?: string): { [key: string]: string } {
 	return result;
 }
 
-export function insertParam(href: string, key: string, value: string): string {
+export function insertParam(href: string, key: string, value: string | number): string {
 	const pre = href.includes('?') ? '&' : '?';
 	return `${href}${pre}${key}=${value}`;
 }
 
-export function insertParams(href: string, paramMap: { [key: string]: string }): string {
+export function insertParams(href: string, paramMap: { [key: string]: string | number }): string {
 	return Object.entries(paramMap)
 		.reduce((str, [key, val]) => insertParam(str, key, val), href);
 }

--- a/lib/utils/location.js
+++ b/lib/utils/location.js
@@ -24,12 +24,12 @@ export function getUrlParams(url?: string): { [key: string]: string } {
 	return result;
 }
 
-export function insertParam(href: string, key: string, value: string | number): string {
+export function insertParam(href: string, key: string, value: string): string {
 	const pre = href.includes('?') ? '&' : '?';
 	return `${href}${pre}${key}=${value}`;
 }
 
-export function insertParams(href: string, paramMap: { [key: string]: string | number }): string {
+export function insertParams(href: string, paramMap: { [key: string]: string }): string {
 	return Object.entries(paramMap)
 		.reduce((str, [key, val]) => insertParam(str, key, val), href);
 }


### PR DESCRIPTION
Gets YouTube embed of live streams following a `https://www.youtube.com/channel/CHANNELID/live` format, addressing #3810 

Edit(@erikdesjardins): fixes #3810