### PR TITLE
Thing: cache getSubreddit result

### DIFF
--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import _ from 'lodash';
 import { $ } from '../vendor';
 import type { Expando } from './expando';
 import { currentSubreddit, click, downcast, expandos, filterMap, regexes } from './';
@@ -250,14 +251,14 @@ export default class Thing {
 		return (this.entry.querySelector('.tagline a.author, .search-author .author'): any);
 	}
 
-	getSubreddit(): ?string {
+	getSubreddit = _.once(function(): ?string {
 		const element = this.getSubredditLink();
 		if (element) {
 			return regexes.subreddit.exec(element.pathname)[1];
 		} else {
 			return currentSubreddit();
 		}
-	}
+	});
 
 	getSubredditLink(): ?HTMLAnchorElement {
 		if (this.isPost()) {


### PR DESCRIPTION
Since `Thing.getSubreddit` may be invoked on every `Thing` by all subreddit filters, caching the result significantly reduces the time spent on filtering. (In my case 350 ms → 120 ms)