### PR TITLE
commentNavigator: Fix sortType popular

### DIFF
--- a/lib/modules/commentNavigator.js
+++ b/lib/modules/commentNavigator.js
@@ -149,6 +149,7 @@ const sortTypes = {
 				map(([, thing]) => thing.element)
 			)();
 		},
+		nonlinear: true,
 	},
 	new: {
 		title: 'Navigate through new comments (Reddit Gold users only)',
@@ -198,6 +199,10 @@ let currentCategory = '';
 function onScroll() {
 	const category = currentCategory;
 	if (category) {
+		// Non-linear comment categories are not sorted by distance from top,
+		// so the most matching comment cannot determined by the algorithm below
+		if (sortTypes[category].nonlinear) return;
+
 		const posts = _posts[category];
 		const inx = Array.from(posts).findIndex(post => {
 			const fromViewportTop = post.getBoundingClientRect().top - getHeaderOffset();


### PR DESCRIPTION
It did not work nicely with `onScroll` since that assumes that the posts are ordered from top to bottom; `popular` sorts posts by score.