### PR TITLE
Fix comment hide persistor by tracking via simply pathname

### DIFF
--- a/lib/modules/commentHidePersistor.js
+++ b/lib/modules/commentHidePersistor.js
@@ -29,7 +29,7 @@ module.go = async () => {
 let allHiddenThings = {};
 let hiddenKeys = [];
 let hiddenThings = [];
-const hiddenThingsKey = location.href;
+const hiddenThingsKey = location.pathname;
 const maxKeys = 100;
 const pruneKeysTo = 50;
 


### PR DESCRIPTION
Fixes #3897

Reddit URLs generally contain all the unique canonical bits in the pathname, and the pathname stays constant. Query parameters, anchors, and  subdomain shouldn't affect whether a comment is hidden. It's debatable whether comments should stay hidden i when focused on a comment but that's outside the scope of this fix 