### PR TITLE
Escape the lookup url during reverse image search

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1520,7 +1520,8 @@ function setMediaControls(media, lookupUrl, downloadUrl) {
 				break;
 			case 'imageLookup':
 				// Google doesn't like image url's without a protacol
-				lookupUrl = new URL(downcast(lookupUrl, 'string'), location.href).href;
+				// Escape query string parameters
+				lookupUrl = escape(new URL(downcast(lookupUrl, 'string'), location.href).href);
 
 				openNewTab(`https://images.google.com/searchbyimage?image_url=${lookupUrl}`);
 				break;

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1521,9 +1521,9 @@ function setMediaControls(media, lookupUrl, downloadUrl) {
 				break;
 			case 'imageLookup':
 				// Google doesn't like image url's without a protacol
-				// Escape query string parameters
 				lookupUrl = new URL(downcast(lookupUrl, 'string'), location.href).href;
 
+				// Escape query string parameters
 				openNewTab(string.encode`https://images.google.com/searchbyimage?image_url=${lookupUrl}`);
 				break;
 			case 'showImageSettings':

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1521,7 +1521,7 @@ function setMediaControls(media, lookupUrl, downloadUrl) {
 			case 'imageLookup':
 				// Google doesn't like image url's without a protacol
 				// Escape query string parameters
-				lookupUrl = escape(new URL(downcast(lookupUrl, 'string'), location.href).href);
+				lookupUrl = encodeURIComponent(new URL(downcast(lookupUrl, 'string'), location.href).href);
 
 				openNewTab(`https://images.google.com/searchbyimage?image_url=${lookupUrl}`);
 				break;

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -46,6 +46,7 @@ import {
 	frameThrottle,
 	nextFrame,
 	isPageType,
+	string,
 	waitForEvent,
 	watchForElement,
 	getPercentageVisibleYAxis,
@@ -1521,9 +1522,9 @@ function setMediaControls(media, lookupUrl, downloadUrl) {
 			case 'imageLookup':
 				// Google doesn't like image url's without a protacol
 				// Escape query string parameters
-				lookupUrl = encodeURIComponent(new URL(downcast(lookupUrl, 'string'), location.href).href);
+				lookupUrl = new URL(downcast(lookupUrl, 'string'), location.href).href;
 
-				openNewTab(`https://images.google.com/searchbyimage?image_url=${lookupUrl}`);
+				openNewTab(string.encode`https://images.google.com/searchbyimage?image_url=${lookupUrl}`);
 				break;
 			case 'showImageSettings':
 				SettingsNavigation.loadSettingsPage(module.moduleID, 'mediaControls');


### PR DESCRIPTION
Fixes #3904 
The lookup url should be escaped because of the query string parameters.