### PR TITLE
Change to allow reuse of hotkeys for "Go Mode" without double firing

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -880,7 +880,7 @@ const _commandLookup = _.once(() => {
 		}
 
 		if (option.goMode) lookup[hash].add(() => { handleGoModeCommand((option.callback: any)); });
-		else lookup[hash].add(option.callback);
+		else lookup[hash].add(() => { if (!goModeActive) option.callback(); });
 	}
 	return lookup;
 });


### PR DESCRIPTION
Non-"GoMode" callbacks will check for goModeActive being false before firing. This will allow the reuse of key bindings for GoMode navigation without firing both events.