### PR TITLE
Adds /r/all to the "Go Mode" navigation

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -700,7 +700,7 @@ module.options = {
 	},
 	slashAll: {
 		type: 'keycode',
-		value: [65, false, false, false, false], // a
+		value: [65, true, false, false, false], // alt-a
 		description: 'keyboardNavSlashAllDesc',
 		title: 'keyboardNavSlashAllTitle',
 		callback() { navigateTo(false, '/r/all'); },

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -698,6 +698,14 @@ module.options = {
 		callback() { navigateTo(false, '/'); },
 		goMode: true,
 	},
+	slashAll: {
+		type: 'keycode',
+		value: [65, false, false, false, false], // a
+		description: 'keyboardNavSlashAllDesc',
+		title: 'keyboardNavSlashAllTitle',
+		callback() { navigateTo(false, '/r/all'); },
+		goMode: true,
+	},
 	subredditFrontPage: {
 		type: 'keycode',
 		value: [70, false, false, true, false], // shift-f

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -984,6 +984,14 @@
         "message": "Go to front page."
     },
 
+    "keyboardNavSlashAllTitle": {
+        "message": "/r/all"
+    },
+
+    "keyboardNavSlashAllDesc": {
+        "message": "Go to /r/all."
+    },
+
     "keyboardNavsSubredditFrontPageTitle": {
         "message": "Subreddit Front Page"
     },


### PR DESCRIPTION
Adds /r/all to the "Go Mode" navigation. 
Includes changes from commit #3909 as well to prevent the 'A' hotkey for /r/all also firing the "Upvote" default hotkey.