### PR TITLE
keyboardNav drawHelp: Show goMode commands properly

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -829,8 +829,8 @@ function updateCommentLinkAnnotations(selected) {
 const drawHelp = _.once(() => {
 	const keys = filterMap(getActiveCommandOptions(), opt => {
 		let keyCode	= niceKeyCode(opt.value);
-		if (opt.dependsOn && module.options[opt.dependsOn].type === 'keycode') {
-			keyCode = `${niceKeyCode(module.options[opt.dependsOn].value)}, ${keyCode}`;
+		if (opt.goMode && module.options.useGoMode.value) {
+			keyCode = `${niceKeyCode(module.options.goMode.value)} → ${keyCode}`;
 		}
 
 		return [{ keyCode, description: i18n(opt.description) }];
@@ -864,6 +864,7 @@ const getActiveCommandOptions = _.once(() =>
 	filterMap(Object.values(module.options), option => {
 		if (option.type === 'keycode' &&
 			option.callback &&
+			(!option.dependsOn || module.options[option.dependsOn].value) &&
 			(!option.include || matchesPageLocation(option.include)) &&
 			(!option.requiresModule || Modules.isRunning(option.requiresModule))) {
 			return [option];


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/1748521/22159542/b3b4886a-df41-11e6-8d37-3006377e07f2.png)

After (`useGoMode` on):
![image](https://cloud.githubusercontent.com/assets/1748521/22159613/163f9ccc-df42-11e6-8529-facc690a1af6.png)

After (`useGoMode` off):
![image](https://cloud.githubusercontent.com/assets/1748521/22159656/414e4012-df42-11e6-844d-ebb8ee51d92d.png)
