### PR TITLE
showImages: Fix toggleThingExpandos duplicate scope

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -669,7 +669,7 @@ export function toggleThingExpandos(thing: Thing, scrollOnExpando?: boolean): vo
 		for (const expando of expandos) {
 			if (
 				!(expando instanceof Expando) ||
-				isExpandWanted(expando, { thing, autoExpandFirstVisibleNonMutedInThing: true, autoExpand: true, autoExpandTypes: ['any'], ignoreDuplicatesScope: thing.element })
+				isExpandWanted(expando, { thing, autoExpandFirstVisibleNonMutedInThing: true, autoExpand: true, autoExpandTypes: ['any'], ignoreDuplicatesScope: thing.entry })
 			) {
 				expando.expand();
 			}


### PR DESCRIPTION
```
<andytuba> oh boo i can’t X to open a dupe expando?
<andytuba> i .. wait, this is weird
<andytuba> https://www.reddit.com/r/nononono/comments/5pw77s/ill_just_gracefully_hop_over_th_umphh/dcufk4b/?context=2&depth=3
<andytuba> vs https://www.reddit.com/r/nononono/comments/5pw77s/ill_just_gracefully_hop_over_th_umphh/dcudemn/?depth=3
<andytuba> the second version, if you select hedgecore’s comment then select db2’s parent comment you can’t X to open
<andytuba> on the first version you can’t X to open initially
```

It checked whether the expando was opened in the entire Thing element, which includes any child comment. Fixed by changing the scope to `entry`.