### PR TITLE
filteReddit commentsOpened: Ignore query

### DIFF
--- a/lib/modules/filteReddit/postCases.js
+++ b/lib/modules/filteReddit/postCases.js
@@ -400,7 +400,9 @@ export default ({
 		get alwaysShow() { return !this.disabled; },
 		evaluate(thing) {
 			const link = thing.getCommentsLink();
-			return link && isURLVisited(link.href) || false;
+			const url = new URL(link);
+			url.search = '';
+			return url && isURLVisited(url.toString()) || false;
 		},
 		async: true,
 		parse() { return this.defaultTemplate(); },


### PR DESCRIPTION
In some instances the comment link has a query, which can vary between page loads.

Related https://www.reddit.com/r/RESissues/comments/5pzfva/bug_filtering_by_comments_opened_does_not/

-- not actually an fix