### PR TITLE
ner: Cache prevPage

### DIFF
--- a/lib/css/modules/_neverEndingReddit.scss
+++ b/lib/css/modules/_neverEndingReddit.scss
@@ -1,36 +1,5 @@
 @import '../zindex';
 
-#NERModal {
-	z-index: $zindex-ner-content - 1;
-	position: fixed;
-	top: 0;
-	left: 0;
-	right: 0;
-	bottom: 0;
-	background-color: #333;
-	opacity: .6;
-}
-
-#NERContent {
-	position: fixed;
-	top: 40px;
-	z-index: $zindex-ner-content;
-	width: 570px;
-	left: 50%;
-	transform: translateX(-50%);
-	background-color: #FFF;
-	color: #000;
-	padding: 10px;
-	font-size: 12px;
-
-	.RESCenteredLoadIndicator { margin-top: 20px; }
-}
-
-#NERModalClose {
-	float: right;
-	position: static;
-}
-
 .NERPageMarker {
 	text-align: center;
 	color: #7f7f7f;

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -9,7 +9,6 @@ import {
 	Thing,
 	addCSS,
 	elementInViewport,
-	scrollToElement,
 	newSitetable,
 } from '../utils';
 import * as Floater from './floater';
@@ -91,10 +90,11 @@ module.exclude = [
 ];
 
 const dupeSet = new Set();
+const siteTable = _.once(() => Thing.thingsContainer());
 let currPage = 1;
-let siteTable, $NREPause, isPaused, pauseReason, nextPageURL;
+let nextPageURL;
+let $NREPause, isPaused, pauseReason, pauseAfterPages, nextPausePage;
 let failMarker, lastPageMarker;
-let pauseAfterPages, nextPausePage;
 let scrollListenerAttached = false;
 
 export let loaderWidget;
@@ -118,17 +118,16 @@ module.go = () => {
 	// Original link to Chrome extension: https://chrome.google.com/extensions/detail/bjiggjllfebckflfdjbimogjieeghcpp
 
 	// store access to the siteTable div since that's where we'll append new data...
-	siteTable = Thing.thingsContainer();
-	const nextPrevLinks = siteTable && getNextPrevLinks(siteTable);
+	const nextPrevLinks = siteTable() && getNextPrevLinks(siteTable());
 
 	if (nextPrevLinks && nextPrevLinks.next) {
-		nextPageURL = nextPrevLinks.next.getAttribute('href');
+		if (!nextPageURL) nextPageURL = nextPrevLinks.next.getAttribute('href');
 		initiate();
 	}
 };
 
 function initiate() {
-	siteTable.classList.add('res-ner-listing');
+	siteTable().classList.add('res-ner-listing');
 
 	// modified from a contribution by Peter Siewert, thanks Peter!
 	// use #siteTable in selector to avoid marking duplicates found in spotlight box
@@ -213,24 +212,30 @@ function initiateReturnToPrevPage() {
 		nerHashRegex.test(location.hash) &&
 		history.state &&
 		Number.isInteger(history.state.resRestorePage) &&
-		(history.state.resRestoreURL || '').includes(location.hostname)
+		history.state.resRestoreHTML && history.state.resRestoreHTML.length
 	) {
-		({ resRestorePage: currPage, resRestoreURL: nextPageURL } = history.state);
-		returnToPrevPage();
+		let html;
+		({ resRestorePage: currPage, resRestoreURL: nextPageURL, resRestoreHTML: html } = history.state); // eslint-disable-line prefer-const
+		appendPage($(html).get(0));
 	}
 
 	function setReturnToPage(selected) {
 		let resRestorePage = 0;
 		let resRestoreURL = null;
+		let resRestoreHTML = null;
 
 		const $pageMarker = $(selected.$thing).closest('.sitetable, .search-result-listing').prev('.NERPageMarker');
-		if ($pageMarker.length) ({ currPage: resRestorePage, nextPageURL: resRestoreURL } = $pageMarker.data());
+		if ($pageMarker.length) ({ currPage: resRestorePage, nextPageURL: resRestoreURL, pageHTML: resRestoreHTML } = $pageMarker.data());
 
 		// replaceState is expensive, so avoid it when possible
 		if (history.state && history.state.resRestorePage === resRestorePage) return;
 
+		// If on page > 2, the browser will auto-scroll too far
+		const allowAutoScroll = !$pageMarker.get(0) || document.querySelector('.NERPageMarker') === $pageMarker.get(0);
+		history.scrollRestoration = allowAutoScroll ? 'auto' : 'manual';
+
 		history.replaceState(
-			{ ...history.state, resRestorePage, resRestoreURL },
+			{ ...history.state, resRestorePage, resRestoreURL, resRestoreHTML },
 			`${document.title}${resRestorePage ? `- page ${resRestorePage + 1}` : ''}`,
 			// spread because Edge always coerces the third param to string, even `undefined`
 			...(($pageMarker.length || nerHashRegex.test(location.hash)) ? [`#res:ner-page=${resRestorePage + 1}`] : [])
@@ -238,16 +243,6 @@ function initiateReturnToPrevPage() {
 	}
 
 	SelectedEntry.addListener(selected => { if (selected) setReturnToPage(selected); }, 'beforeScroll');
-}
-
-async function returnToPrevPage() {
-	Init.bodyReady.then(showReturnToPrevPageModal);
-
-	loadNextPage();
-	await loadPromise;
-	scrollToElement(lastPageMarker, { scrollStyle: 'top' });
-
-	Init.bodyReady.then(removeReturnToPrevPageModal);
 }
 
 function handleScroll() {
@@ -292,28 +287,6 @@ function duplicateCheck(newSiteTable) {
 	}
 }
 
-let removeReturnToPrevPageModal;
-
-function showReturnToPrevPageModal() {
-	const $modalWidget = $('<div>', { id: 'NERModal', html: '&nbsp;' })
-		.appendTo(document.body);
-
-	const $modalContent = $('<div>', {
-		id: 'NERContent',
-		html: `
-			<div id="NERModalClose" class="RESCloseButton">&times;</div>
-			Never Ending Reddit has detected that you are returning from a page that it loaded. Please give us a moment while we reload that content and return you to where you left off.
-			<div class="RESCenteredLoadIndicator"><span class="RESLoadingSpinner"></span></div>
-		`,
-	}).appendTo(document.body);
-
-	removeReturnToPrevPageModal = () => {
-		$modalWidget.remove();
-		$modalContent.remove();
-	};
-	$('#NERModalClose').click(removeReturnToPrevPageModal);
-}
-
 export function getNextPrevLinks(ele: HTMLElement = document.body): ?{ next?: HTMLAnchorElement, prev?: HTMLAnchorElement } {
 	const $ele = $(ele);
 	// `~ .nextprev a[rel~=next]` for /about/log, because they aren't in the siteTable.
@@ -340,7 +313,7 @@ function buildLoaderWidget() {
 
 function attachLoaderWidget(widget) {
 	loaderWidget = widget;
-	$(siteTable).after(widget);
+	$(siteTable()).after(widget);
 }
 
 function setLoaderWidgetActionText(widget) {
@@ -399,8 +372,29 @@ async function loadPage(url: string) {
 		// check for new mail
 		Orangered.updateFromPage(tempDiv);
 
-		await Init.go;
-		await appendPage(tempDiv);
+		// get the new nextLink value for the next page...
+		const nextPrevLinks = getNextPrevLinks(tempDiv);
+		if (!nextPrevLinks) {
+			const noresults = tempDiv.querySelector('#noresults');
+			if (noresults) {
+				return endNER(noresults.textContent);
+			} else {
+				throw Error('Could not find a link to the next page');
+			}
+		}
+
+		nextPageURL = nextPrevLinks.next && nextPrevLinks.next.getAttribute('href');
+
+		// grab the siteTable out of there...
+		const newSiteTable = Thing.thingsContainer(tempDiv);
+		if (!newSiteTable) {
+			throw Error('Could not find any siteTable');
+		}
+
+		const pageHTML = newSiteTable.outerHTML;
+		duplicateCheck(newSiteTable);
+		await newSitetable(newSiteTable);
+		await appendPage(newSiteTable, pageHTML);
 	} catch (e) {
 		endNER(`Could not load the next page: ${e.message}`);
 		console.error(e);
@@ -410,44 +404,24 @@ async function loadPage(url: string) {
 	if (nextPageURL) attachLoaderWidget(newLoaderWidget);
 }
 
-async function appendPage(tempDiv) {
-	// grab the siteTable out of there...
-	const newSiteTable = Thing.thingsContainer(tempDiv);
-	if (!newSiteTable) {
-		throw Error('Could not find any things');
-	}
+async function appendPage(newSiteTable, pageHTML = newSiteTable.outerHTML) {
+	lastPageMarker = $('<div>', { class: 'NERPageMarker', text: `Page ${currPage + 1}` })
+		.append(SettingsNavigation.makeUrlHashLink(module.moduleID, undefined, ' ', 'gearIcon'))
+		.data({ currPage, nextPageURL, pageHTML })
+		.get(0);
 
-	// get the new nextLink value for the next page...
-	const nextPrevLinks = getNextPrevLinks(tempDiv);
-	if (!nextPrevLinks) {
-		const noresults = tempDiv.querySelector('#noresults');
-		if (noresults) {
-			return endNER(noresults.textContent);
-		} else {
-			throw Error('Could not find a link to the next page');
-		}
-	}
+	await Init.bodyReady;
 
-	duplicateCheck(newSiteTable);
+	siteTable().appendChild(lastPageMarker);
+	siteTable().appendChild(newSiteTable);
 
-	const firstLen = $(siteTable).find('.link:last .rank').text().length;
+	const firstLen = $(siteTable()).find('.link:last .rank').text().length;
 	const lastLen = $(newSiteTable).find('.link:last .rank').text().length;
 	if (lastLen > firstLen) {
 		addCSS(`body.res > .content .link .rank { width: ${(lastLen * 1.1).toFixed(1)}ex; }`);
 	}
 
-	lastPageMarker = $('<div>', { class: 'NERPageMarker', text: `Page ${currPage + 1}` })
-		.append(SettingsNavigation.makeUrlHashLink(module.moduleID, undefined, ' ', 'gearIcon'))
-		.data({ currPage, nextPageURL })
-		.get(0);
-
-	await newSitetable(newSiteTable);
-
-	siteTable.appendChild(lastPageMarker);
-	siteTable.appendChild(newSiteTable);
-
 	currPage++;
-	nextPageURL = nextPrevLinks.next && nextPrevLinks.next.getAttribute('href');
 
 	if (!nextPageURL) endNER('No more pages');
 
@@ -470,7 +444,7 @@ function endNER(text) {
 			<a href="/r/random">random subreddit</a>
 		</p>
 	`)
-	.appendTo(siteTable);
+	.appendTo(siteTable());
 
 	window.removeEventListener('scroll', handleScroll);
 }

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -94,7 +94,6 @@ const siteTable = _.once(() => Thing.thingsContainer());
 let currPage = 1;
 let nextPageURL;
 let $NREPause, isPaused, pauseReason, pauseAfterPages, nextPausePage;
-let failMarker, lastPageMarker;
 let scrollListenerAttached = false;
 
 export let loaderWidget;
@@ -354,8 +353,6 @@ function loadNextPage() {
 async function loadPage(url: string) {
 	const page = ajax({ url });
 
-	if (failMarker) failMarker.remove();
-
 	if (loaderWidget) {
 		$(loaderWidget).html('<span class="RESLoadingSpinner"></span>');
 	}
@@ -405,7 +402,7 @@ async function loadPage(url: string) {
 }
 
 async function appendPage(newSiteTable, pageHTML = newSiteTable.outerHTML) {
-	lastPageMarker = $('<div>', { class: 'NERPageMarker', text: `Page ${currPage + 1}` })
+	const lastPageMarker = $('<div>', { class: 'NERPageMarker', text: `Page ${currPage + 1}` })
 		.append(SettingsNavigation.makeUrlHashLink(module.moduleID, undefined, ' ', 'gearIcon'))
 		.data({ currPage, nextPageURL, pageHTML })
 		.get(0);

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -19,7 +19,6 @@ import {
 import type { ScrollStyle } from '../utils/dom';
 import * as Hover from './hover';
 import * as KeyboardNav from './keyboardNav';
-import * as NeverEndingReddit from './neverEndingReddit';
 
 export const module: Module<*> = new Module('selectedEntry');
 
@@ -305,14 +304,9 @@ function updateLastSelectedCache(selected) {
 }
 
 const selectInitial = _.once(fastAsync(function*(firstThing) {
-	let scrollToSelected = module.options.scrollToSelectedThingOnLoad.value;
-	// NER may restore a page which contains the last selected thing
-	if (NeverEndingReddit.loadPromise) {
-		yield NeverEndingReddit.loadPromise;
-		scrollToSelected = true;
-	}
-
-	if (scrollToSelected) history.scrollRestoration = 'manual';
+	if (module.options.scrollToSelectedThingOnLoad.value) history.scrollRestoration = 'manual';
+	// `scrollRestoration` may also be set in neverEndingReddit
+	const scrollToSelected = history.scrollRestoration === 'manual';
 
 	const lastSelected = yield findLastSelectedThing();
 	const target = (lastSelected || firstThing).getClosestVisible() || lastSelected || firstThing;


### PR DESCRIPTION
Reduces the time to return to prev page significantly, at the cost of ~0.4 MB per 100 loaded listings. 

Before:
![image](https://cloud.githubusercontent.com/assets/1748521/22356073/e48282e8-e42e-11e6-8fd0-cee108b44d34.png)

After:
![image](https://cloud.githubusercontent.com/assets/1748521/22356110/3cd5b6ae-e42f-11e6-9cf8-1f250bd58154.png)

Closes #3402 
Closes #690