### PR TITLE
don't cache node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ addons:
     secure: hHF06xHY6pLdxscwYhUHdSRuUH2CPA61AUrvPiW54lnMwwkDvCQakR+aY5HbjptFIfOwkWsS4xoqXH4pZTfhMOji32S/+ELT+AqLdkIgnLYDfBj4RcsZoXyvuiLx29i4PVCnGMikctBp4dM6wORgfd1tu3uwhcoQrBjxCMW1qmY=
 cache:
   yarn: true
-  directories:
-    - node_modules
 install:
   - npm install -g yarn
   - yarn install --pure-lockfile


### PR DESCRIPTION
Yarn doesn't notice or remove extraneous [not listed in package.json or yarn.lock] dependencies, so there's a marginal chance that this could cause/hide issues. And it makes marginal difference to build times (~10s), so just remove it.