### PR TITLE
mediahost.detect(mediaUrl, thingContainingLink)

### DIFF
--- a/lib/core/host.js
+++ b/lib/core/host.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import type { Thing } from '../utils';
 import type { ModuleOption } from './module'; // eslint-disable-line no-unused-vars
 
 export class Host<Detect, Opt: { [key: string]: ModuleOption<any> }> {
@@ -15,7 +16,7 @@ export class Host<Detect, Opt: { [key: string]: ModuleOption<any> }> {
 
 	options: Opt | void;
 
-	detect: (a: URL) => void | null | false | Detect;
+	detect: (a: URL, context: ?Thing) => void | null | false | Detect;
 	handleLink: (href: string, detectResult: Detect) => ExpandoMedia | Promise<ExpandoMedia>;
 
 	go: (() => void) | void;
@@ -39,7 +40,7 @@ export class Host<Detect, Opt: { [key: string]: ModuleOption<any> }> {
 		landingPage?: string,
 		attribution?: boolean,
 		options?: Opt,
-		detect: (a: URL) => void | null | false | Detect,
+		detect: (a: URL, context: ?Thing) => void | null | false | Detect,
 		handleLink: (href: string, detectResult: Detect) => ExpandoMedia | Promise<ExpandoMedia>,
 		go?: () => void,
 	|}) {

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -791,14 +791,14 @@ function resolveMediaUrl(element, thing) {
 	return element;
 }
 
-async function getMediaInfo(element, mediaUrl) {
+async function getMediaInfo(element, mediaUrl, thing) {
 	const matchingHosts = [
 		...modulesForHostname(mediaUrl.hostname),
 		...genericHosts,
 	];
 
 	for (const siteModule of matchingHosts) {
-		const detectResult = siteModule.detect(mediaUrl);
+		const detectResult = siteModule.detect(mediaUrl, thing);
 		if (detectResult) {
 			const requiresPermission = siteModule.permissions ? !(await Permissions.has(siteModule.permissions)) : false; // eslint-disable-line no-await-in-loop
 			return { detectResult, siteModule, requiresPermission, element, href: mediaUrl.href };
@@ -838,7 +838,7 @@ async function checkElementForMedia(element) {
 	}
 
 	const mediaUrl = resolveMediaUrl(element, thing);
-	const mediaInfo = await getMediaInfo(element, mediaUrl);
+	const mediaInfo = await getMediaInfo(element, mediaUrl, thing);
 
 	if (!mediaInfo) return;
 


### PR DESCRIPTION
For media hosts which need context like the post ID for
requesting preview images for posts.