### PR TITLE
core options/table: Match 'key' instead of 'name'

### DIFF
--- a/lib/core/options/table.js
+++ b/lib/core/options/table.js
@@ -43,7 +43,7 @@ function addValue(module, optionKey, value) {
 	}
 	const values = option.value;
 
-	const optionValue = option.fields.map((field, i) => firstValid(value[i], value[field.name], field.value));
+	const optionValue = option.fields.map((field, i) => firstValid(value[i], value[field.key], field.value));
 
 	values.push(optionValue);
 	set(module, optionKey, values);

--- a/lib/core/options/table.js
+++ b/lib/core/options/table.js
@@ -14,7 +14,7 @@ function getMatchingValue(module, optionKey, valueIdentifiers) {
 		let containValid = false;
 		const match = option.fields.every((field, fi) => {
 			const fieldValue = value[fi];
-			const matchValue = firstValid(valueIdentifiers[fi], valueIdentifiers[field.name]);
+			const matchValue = firstValid(valueIdentifiers[fi], valueIdentifiers[field.key]);
 
 			if (matchValue === undefined) {
 				return true;


### PR DESCRIPTION
`key` has taken the role `name` had (#3842), so this needs to be updated.

I noticed the issue when `valueIdentifiers` was
```
{
	"moduleID": "filteReddit",
	"notificationID": "everyThingHidden"
}
```
and the function `getMatchingValue` returned
```
[
	"filteReddit",
	"filterSubreddit",
	false,
	false,
	0
]
```
instead of `null`.