### PR TITLE
commentTools: inclusive rather than exclusive commentTextareaSelector

### DIFF
--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -362,11 +362,14 @@ const initializeEditorTools = _.once(() => {
 	}
 });
 
-export const commentTextareaSelector = 'textarea[name][name!=share_to][name!=message]';
-
-export function getCommentTextarea(elem?: HTMLElement = document.body) {
-	return $(elem).find(commentTextareaSelector);
-}
+export const commentTextareaSelector = [
+	'textarea[name=text]',
+	'textarea[name=description]',
+	'textarea[name=public_description]',
+	'textarea[name=body]',
+	'textarea[name=ban_message]',
+	'textarea[name=content]',
+].join(',');
 
 function getFieldLimit(elem) {
 	switch (elem.name) {


### PR DESCRIPTION
This avoids matching textareas like the customFilters description, etc.