### PR TITLE
commentQuickToggle: Fix wrong scroll when the selected thing is child of the collapsed

### DIFF
--- a/lib/modules/commentQuickCollapse.js
+++ b/lib/modules/commentQuickCollapse.js
@@ -134,6 +134,6 @@ function scrollOnCollapse() {
 		const target = thing.getClosest(Thing.prototype.getNextSibling, { direction: 'down' });
 		if (!target) return;
 
-		SelectedEntry.select(target, { scrollStyle: 'adopt' });
+		SelectedEntry.select(target, { scrollStyle: 'adopt', from: thing.entry });
 	});
 }

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -131,7 +131,7 @@ module.go = () => {
 	addListener((selected, unselected) => unselected && Hover.infocard('showParent').close(false), 'beforePaint');
 	addListener(updateActiveElement, 'beforePaint');
 	addListener(selected => BodyClasses.toggle(!!selected, 'res-entry-is-selected'), 'beforePaint');
-	addListener((selected, unselected, options) => scrollToElement(selected.entry, { ...options, from: unselected && unselected.entry }), 'beforePaint');
+	addListener((selected, unselected, options) => scrollToElement(selected.entry, { from: unselected && unselected.entry, ...options }), 'beforePaint');
 };
 
 const onClick = _.throttle(e => {


### PR DESCRIPTION
Override the `from` element. Otherwise it will automatically be set to the hidden child element, which `scrollToElement` cannot determine the position of.

Video of the error https://www.youtube.com/watch?v=Ncw_2STgeYs&feature=youtu.be

@KetillG 

The reason this bug emerged, is that SelectedEntry listeners now receive the correct `unselected` Thing (i.e. the one last painted) instead of the one last selected.