### PR TITLE
Workaround the AMO API's lack of support for destructuring

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -73,6 +73,9 @@ const configs = browsers.map(b => browserConfig[b]).map(({ target, entry, enviro
 		// In Edge 14, object destructuring with default values in arrow functions doesn't parse
 		// In Edge 15 this is fixed, but there are other issues with destructuring (soon fixed)
 		babelConfig.plugins.push('transform-es2015-arrow-functions');
+	} else if (target === 'firefox') {
+		// The Firefox API can't deal with normal array destructuring
+		babelConfig.plugins.push('transform-es2015-destructuring');
 	}
 
 	return {


### PR DESCRIPTION
Oh yes, you read that right. The API itself. Not Firefox.

And I'm not talking about some fancy object rest destructuring. Oh no. Just plain old array destructuring. You know, the kind that Firefox 45 ESR has supported for the past 11 months.

😡