### PR TITLE
RESTips featureTips: Avoid race condition with dailyTip

### DIFF
--- a/lib/modules/RESTips.js
+++ b/lib/modules/RESTips.js
@@ -7,6 +7,7 @@ import * as Modules from '../core/modules';
 import * as Options from '../core/options';
 import {
 	CreateElement,
+	elementInViewport,
 	mutex,
 	niceKeyCode,
 	positiveModulo,
@@ -55,10 +56,15 @@ module.go = () => {
 	}
 };
 
-module.afterLoad = () => {
+let allowFeatureTips;
+const featureTipReadyPromise = new Promise(resolve => { allowFeatureTips = resolve; });
+
+module.afterLoad = async () => {
 	if (module.options.dailyTip.value) {
-		dailyTip();
+		await dailyTip();
 	}
+
+	allowFeatureTips();
 };
 
 const newFeatureTipsCheckbox = _.once(() =>
@@ -70,13 +76,15 @@ const newFeatureTipsCheckbox = _.once(() =>
 export const showFeatureTip = _.memoize(mutex(async (id: string, tip: Tip) => {
 	if (!Modules.isRunning(module) || !module.options.newFeatureTips.value) return;
 
+	await featureTipReadyPromise;
+
 	const { enabled } = await featureTipsStorage.get(id);
 	if (!enabled) return;
 
 	// Also make the tip accessible via daily tips / tips & tricks
 	tips.push(tip);
 
-	if (tip.attachTo && !tip.attachTo.offsetParent) {
+	if (tip.attachTo instanceof Element && !elementInViewport(tip.attachTo)) {
 		// Usually happens when subreddit CSS for some reason hides the element
 		console.log('Ignoring feature tip whose attachment element is not visible:', tip);
 		return;
@@ -117,10 +125,10 @@ async function dailyTip() {
 		// mark off that we've displayed a new tooltip
 		lastTooltipStorage.set(now);
 		if (lastCheck === 0) {
-			showOrdinaryTip();
+			await showOrdinaryTip();
 		} else {
 			PenaltyBox.alterFeaturePenalty(module.moduleID, 'dailyTip', _.clamp(PenaltyBox.MAX_PENALTY / tips.length, 3, 8));
-			showOrdinaryTip('random');
+			await showOrdinaryTip('random');
 		}
 	}
 }
@@ -328,7 +336,7 @@ function showOrdinaryTip(change?: 'random' | 'prev' | 'next') {
 	const $description = generateContent(tip);
 	$description.on('click', 'a', () => { PenaltyBox.alterFeaturePenalty(module.moduleID, 'sectionMenu', -20); });
 
-	showTip({
+	return showTip({
 		buttons: [{
 			name: 'Prev',
 			onclick: () => showOrdinaryTip('prev'),


### PR DESCRIPTION
On initial boot of RES, both featureTips and dailyTip are triggered. Since dailyTip is shown in `afterLoad`, but the Filterline featureTip is shown in `go`, the dailyTip hides the featureTip. This PR delays featureTips so the conflict is avoided.