### PR TITLE
keyboardNav: Always blur if keypress has shortcut

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -790,11 +790,7 @@ module.beforeLoad = () => {
 };
 
 module.go = () => {
-	window.addEventListener('keydown', e => {
-		if (handleKeyPress(e)) {
-			e.preventDefault();
-		}
-	}, true);
+	window.addEventListener('keydown', handleKeyPress, true);
 };
 
 function registerCommandLine() {
@@ -904,7 +900,7 @@ const _commandLookup = _.once(() => {
 	return lookup;
 });
 
-function handleKeyPress(e): boolean | void /* true if the keypress was handled */ {
+function handleKeyPress(e) {
 	if (EasterEgg.konamiActive()) return;
 
 	// Allow navigation on other elements when input has no (apparent) default behavior
@@ -924,7 +920,8 @@ function handleKeyPress(e): boolean | void /* true if the keypress was handled *
 
 	if (options.length) {
 		handleCallbacks(options);
-		return true;
+		e.preventDefault();
+		e.target.blur();
 	}
 }
 


### PR DESCRIPTION
`activeElement` may have default behavior which causes the RES to ignore the keypress, and as such not prevent it.

Fixes #3992