### PR TITLE
travis: Install yarn in before_install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,10 @@ addons:
     secure: hHF06xHY6pLdxscwYhUHdSRuUH2CPA61AUrvPiW54lnMwwkDvCQakR+aY5HbjptFIfOwkWsS4xoqXH4pZTfhMOji32S/+ELT+AqLdkIgnLYDfBj4RcsZoXyvuiLx29i4PVCnGMikctBp4dM6wORgfd1tu3uwhcoQrBjxCMW1qmY=
 cache:
   yarn: true
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
 install:
-  - travis_retry npm install -g yarn
   - travis_retry yarn install --pure-lockfile
   - yarn check --integrity
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ addons:
 cache:
   yarn: true
 install:
-  - npm install -g yarn
-  - yarn install --pure-lockfile
+  - travis_retry npm install -g yarn
+  - travis_retry yarn install --pure-lockfile
   - yarn check --integrity
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
 install:
-  - travis_retry yarn install --pure-lockfile
+  - yarn install --pure-lockfile
   - yarn check --integrity
 matrix:
   exclude:


### PR DESCRIPTION
This probably won't make very much of a difference, since yarn packages are being cached, but it'll help with intermittent network issues for new packages.