### PR TITLE
frameThrottle: Run as ordinary throttle (via setTimeout) if document is hidden

### DIFF
--- a/lib/utils/async.js
+++ b/lib/utils/async.js
@@ -294,7 +294,8 @@ export function frameThrottle(callback) {
 		if (queued) return;
 		queued = true;
 
-		nextFrame(runCallback);
+		if (document.hidden) setTimeout(() => { runCallback(now()); });
+		else nextFrame(runCallback);
 	};
 }
 /* eslint-enable no-redeclare */


### PR DESCRIPTION
This so that `watchForThing` / `watchForElement` listeners will run even when the page is opened in the background.