### PR TITLE
showParent: Fix the vote score after upvoting/downvoting

### DIFF
--- a/lib/modules/showParent.js
+++ b/lib/modules/showParent.js
@@ -63,9 +63,9 @@ module.go = () => {
 function handleVoteClick() {
 	const $this = $(this);
 	const voteClasses = {
-		up: 'dislikes',
+		up: 'likes',
 		none: 'unvoted',
-		down: 'likes',
+		down: 'dislikes',
 	};
 	const id = $this.parent().parent().attr('data-fullname');
 	let direction = (/(up|down)(?:mod)?/).exec(this.className);


### PR DESCRIPTION
The vote score in the parent hover was moving in the wrong direction.