### PR TITLE
Submit Issue refactor and rephrase

### DIFF
--- a/lib/css/modules/_submitIssue.scss
+++ b/lib/css/modules/_submitIssue.scss
@@ -1,45 +1,23 @@
-#submittingToEnhancement {
-	display: none;
-	min-height: 300px;
-	font-size: 14px;
-	line-height: 15px;
-	margin-top: 10px;
-	width: 518px;
-	position: absolute;
-	z-index: 999;
 
-	ol {
-		margin-left: 10px;
-		margin-top: 15px;
-		list-style-type: decimal;
+#RESSubmitWizard {
+	padding: 0;
+
+	.guiders_content {
+		max-height: 90vh;
+		overflow-y: scroll;
+		padding: 5px 12px;
 	}
 
-	li {
-		margin-left: 25px;
+	#RESSubmitAprilFools {
+		background: #F87;
+		color: black;
+		margin-top: 2em;
+		padding: 1em;
 	}
-}
 
-.submittingToEnhancementButton {
-	border: 1px solid #444;
-	border-radius: 2px;
-	padding: 3px 6px;
-	cursor: pointer;
-	display: inline-block;
-	margin-top: 12px;
-}
-
-#RESSubmitOptions .submittingToEnhancementButton {
-	margin-top: 30px;
-}
-
-#RESSubmitAprilFools {
-	background: #F87;
-	color: black;
-	margin-top: 2em;
-	padding: 1em;
-}
-
-#RESBugReport,
-#RESFeatureRequest {
-	display: none;
+	h2:not(:first-child) {
+		margin-top: 1em;
+		border-top: 1px gray dashed;
+		padding-top: 1em;
+	}
 }

--- a/lib/css/res.scss
+++ b/lib/css/res.scss
@@ -1230,6 +1230,10 @@ span.multi-count {
 	}
 }
 
+.guider ol {
+	margin: 1em 1em 1em 2em;
+}
+
 .guider dl {
 	margin-top: .6em;
 	margin-bottom: .6em;

--- a/lib/modules/submitIssue.js
+++ b/lib/modules/submitIssue.js
@@ -7,10 +7,11 @@ import diagnosticsTemplate from '../templates/diagnostics.mustache';
 import * as Metadata from '../core/metadata';
 import { $, guiders } from '../vendor';
 import { Module } from '../core/module';
-import { BrowserDetect } from '../utils';
+import { BrowserDetect, regexes } from '../utils';
 import { ajax } from '../environment';
 import type { RedditWikiPage } from '../types/reddit';
 import * as NightMode from './nightMode';
+import * as SettingsNavigation from './settingsNavigation';
 
 export const module: Module<*> = new Module('submitIssue');
 
@@ -42,23 +43,19 @@ const diagnostics = _.once(() => diagnosticsTemplate({
 function checkIfSubmitting() {
 	const subredditInput: ?HTMLInputElement = (document.getElementById('sr-autocomplete'): any);
 	const selfText: ?HTMLTextAreaElement = (document.querySelector('.usertext-edit textarea'): any);
-	const title: HTMLTextAreaElement = (document.querySelector('textarea[name=title]'): any);
 
 	if (subredditInput) {
-		let $submittingToEnhancement;
-
 		function check() {
 			const subreddit = subredditInput.value;
 
 			if (subreddits.includes(subreddit.toLowerCase())) {
-				$submittingToEnhancement = createAndAddWizard();
-			} else {
-				if ($submittingToEnhancement) {
-					$submittingToEnhancement.remove();
-					if (title.value === 'Submitting a bug? Please read the box above...') {
-						title.value = '';
-					}
+				showWizard();
+				if (!selfText.value) {
+					injectTemplate();
 				}
+			} else {
+				hideWizard();
+				// User can be smart about clearing the template on their own
 			}
 		}
 
@@ -68,6 +65,10 @@ function checkIfSubmitting() {
 			if (e.res) return;
 			check();
 		});
+		// don't delegate, reddit cancels bubbling
+		// wait a moment, reddit loads some metadata
+		// really this should be a MutationObserver on subredditInput
+		$('#suggested-reddits .sr-suggestion').on('click', () => setTimeout(check, 500));
 	}
 
 	if (selfText && subredditInput) {
@@ -86,102 +87,6 @@ function checkIfSubmitting() {
 	}
 }
 
-function createAndAddWizard() {
-	const title: HTMLTextAreaElement = (document.querySelector('textarea[name=title]'): any);
-
-	const $wizard = $('<div>', { id: 'submittingToEnhancement', class: 'RESDialogSmall' })
-		.html(submitWizardTemplate({ foolin: foolin() }))
-		.on('click', '#RESSubmitBug', () => {
-			$('#RESSubmitOptions').fadeOut(async () => {
-				$('#RESBugReport').fadeIn();
-				const { data } = (await ajax({
-					url: '/r/Enhancement/wiki/knownbugs.json',
-					type: 'json',
-				}): RedditWikiPage);
-
-				if (data && data.content_md) {
-					const objects = parseObjectList(data.content_md);
-					const listItems = createLinkList(objects);
-					$('#RESKnownBugs')
-						.empty()
-						.append(listItems);
-				}
-			});
-		})
-		.on('click', '#RESSubmitFeatureRequest', () => {
-			$('#RESSubmitOptions').fadeOut(async () => {
-				$('#RESFeatureRequest').fadeIn();
-				const { data } = (await ajax({
-					url: '/r/Enhancement/wiki/knownrequests.json',
-					type: 'json',
-				}): RedditWikiPage);
-
-				if (data && data.content_md) {
-					const objects = parseObjectList(data.content_md);
-					const listItems = createLinkList(objects);
-					$('#RESKnownFeatureRequests')
-						.empty()
-						.append(listItems);
-				}
-			});
-		})
-		.on('click', '#submittingBug', () => {
-			updateSubreddit('RESIssues');
-			$('li a.text-button').click();
-			$('#submittingToEnhancement').fadeOut();
-
-			const body = submitIssueDefaultBodyTemplate().trim();
-
-			$('.usertext-edit textarea').val(body);
-
-			title.value = '[bug]  ???';
-
-			const guiderText = `
-				<p>Summarize your problem in the title and add details in the text:</p>
-				<dl>
-					<dt>Screenshots!</dt> <dd>A picture is worth a thousand words.</dd>
-					<dt>What makes this happen?</dt> <dd>clicked a link, clicked a button, opened an image expando, ... </dd>
-					<dt>Where does this happen?</dt> <dd>in a particular subreddit, on comments posts, on frontpage (reddit.com), on /r/all, ...</dd>
-				</dl>
-				<p>More detail means faster fixes.  Thanks!</p>
-			`;
-			const buttons = `
-				<footer>
-					<small>
-						<a href="/r/RESissues/wiki/knownissues">known issues</a>
-						|  <a href="/r/RESissues/wiki/postanissue">troubleshooting</a>
-					</small>
-				</footer>
-			`;
-
-			guiders.createGuider({
-				attachTo: '#title-field',
-				description: guiderText,
-				buttonCustomHTML: buttons,
-				id: 'first',
-				next: 'second',
-				// offset: { left: -200, top: 120 },
-				position: 3,
-				title: 'Please fill out all the ??? questions',
-			}).show();
-		})
-		.on('click', '#submittingFeature', () => {
-			updateSubreddit('Enhancement');
-			$('#submittingToEnhancement').fadeOut();
-			title.value = '[feature request]    ???';
-		})
-		.on('click', '#RESSubmitOther', () => {
-			updateSubreddit('Enhancement');
-			$('#submittingToEnhancement').fadeOut();
-			title.value = '';
-		});
-
-
-	$('form.submit.content').prepend($wizard);
-	$wizard.fadeIn();
-
-	return $wizard;
-}
 
 function updateSubreddit(subreddit) {
 	const input: HTMLInputElement = (document.querySelector('#sr-autocomplete'): any);
@@ -191,44 +96,100 @@ function updateSubreddit(subreddit) {
 	input.dispatchEvent(e);
 }
 
-function parseObjectList(text) {
-	const bugs = text.split('---');
+function injectTemplate() {
+	const selfText: ?HTMLTextAreaElement = (document.querySelector('.usertext-edit textarea'): any);
+	if (selfText && !selfText.value) {
+		selfText.value = submitIssueDefaultBodyTemplate();
+	}
+}
 
-	if (bugs && bugs[0].length === 0) {
-		bugs.shift();
+function wizard() {
+	return Promise.all([
+		fetchLinks('/r/Enhancement/wiki/knownbugs.json'),
+		fetchLinks('/r/Enhancement/wiki/knownrequests.json'),
+	]).then(([bugs, requests]) => submitWizardTemplate({
+		foolin: foolin(),
+		bugs,
+		requests,
+		settings: SettingsNavigation.makeUrlHash(),
+	}));
+}
+
+const guiderId = 'RESSubmitWizard';
+async function showWizard() {
+	const guider = guiders.get(guiderId);
+	if (guider) {
+		guiders.show(guider.id);
+		return;
 	}
 
-	return bugs.map(bugText => {
-		const bugObj = {};
-		const bugData = bugText.replace(/\r/g, '').split('\n');
+	const description = await wizard();
 
-		for (const rawLine of bugData) {
+	const buttonCustomHTML = `
+		<footer>
+			<small>
+				<a href="/r/RESissues/wiki/knownissues">known issues</a>
+				|  <a href="/r/RESissues/wiki/postanissue">troubleshooting</a>
+			</small>
+		</footer>
+	`;
+
+	guiders.createGuider({
+		attachTo: '.submit .usertext',
+		description,
+		buttonCustomHTML,
+		id: guiderId,
+		// offset: { left: -200, top: 120 },
+		position: 3,
+		title: 'What are you posting about?',
+	}).show();
+
+	$(document.body).on('click', '#RESSubmitWizard a[href$="/submit/"]', e => {
+		const match = e.target.pathname.match(regexes.submit);
+		if (!match) return;
+		updateSubreddit(match[1]);
+		e.preventDefault();
+	});
+}
+
+function hideWizard() {
+	if (guiders.get(guiderId)) {
+		// Why is there no `guiders.hide(id)`
+		guiders.hideAll();
+	}
+}
+
+function fetchLinks(url) {
+	return (ajax({
+		url,
+		type: 'json',
+	}): RedditWikiPage)
+	.then(({ data }) => parseObjectList(data && data.content_md))
+	.catch(() => []);
+}
+
+function parseObjectList(text) {
+	if (!text) {
+		return [];
+	}
+
+	const items = text.split(/\s*-{3,}\s*/).filter(x => x.match(/[^\s\n]/));
+
+	return items.map(dictText => {
+		const item = {};
+		const dictMapping = dictText.replace(/\r/g, '').split('\n');
+
+		for (const rawLine of dictMapping) {
 			const line = $.trim(rawLine).split(':');
 			if (line.length > 0) {
 				const key = line.shift();
 				if (key) {
-					bugObj[key] = line.join(':');
+					item[key] = line.join(':');
 				}
 			}
 		}
 
-		return bugObj;
-	});
-}
-
-function createLinkList(objects) {
-	return objects.map(bugObj => {
-		if (bugObj.title) {
-			const $bugLI = $('<li>');
-			if (bugObj.url) {
-				const $bugHTML = $('<a target="_blank" rel="noopener noreferer">');
-				$bugHTML.attr('href', bugObj.url).text(bugObj.title);
-				$bugLI.append($bugHTML);
-			} else {
-				$bugLI.text(bugObj.title);
-			}
-			return $bugLI;
-		}
+		return item;
 	});
 }
 

--- a/lib/modules/submitIssue.js
+++ b/lib/modules/submitIssue.js
@@ -50,9 +50,7 @@ function checkIfSubmitting() {
 
 			if (subreddits.includes(subreddit.toLowerCase())) {
 				showWizard();
-				if (!selfText.value) {
-					injectTemplate();
-				}
+				injectTemplate(selfText);
 			} else {
 				hideWizard();
 				// User can be smart about clearing the template on their own
@@ -96,23 +94,24 @@ function updateSubreddit(subreddit) {
 	input.dispatchEvent(e);
 }
 
-function injectTemplate() {
-	const selfText: ?HTMLTextAreaElement = (document.querySelector('.usertext-edit textarea'): any);
+function injectTemplate(selfText) {
 	if (selfText && !selfText.value) {
 		selfText.value = submitIssueDefaultBodyTemplate();
 	}
 }
 
-function wizard() {
-	return Promise.all([
+async function wizard() {
+	const [bugs, requests] = await Promise.all([
 		fetchLinks('/r/Enhancement/wiki/knownbugs.json'),
 		fetchLinks('/r/Enhancement/wiki/knownrequests.json'),
-	]).then(([bugs, requests]) => submitWizardTemplate({
+	]);
+
+	return submitWizardTemplate({
 		foolin: foolin(),
 		bugs,
 		requests,
 		settings: SettingsNavigation.makeUrlHash(),
-	}));
+	});
 }
 
 const guiderId = 'RESSubmitWizard';
@@ -144,8 +143,8 @@ async function showWizard() {
 		title: 'What are you posting about?',
 	}).show();
 
-	$(document.body).on('click', '#RESSubmitWizard a[href$="/submit/"]', e => {
-		const match = e.target.pathname.match(regexes.submit);
+	$(document.body).on('click', '#RESSubmitWizard a[href$="/submit/"]', (e: Event) => {
+		const match = (e.target: any).pathname.match(regexes.submit);
 		if (!match) return;
 		updateSubreddit(match[1]);
 		e.preventDefault();
@@ -159,13 +158,13 @@ function hideWizard() {
 	}
 }
 
-function fetchLinks(url) {
-	return (ajax({
-		url,
-		type: 'json',
-	}): RedditWikiPage)
-	.then(({ data }) => parseObjectList(data && data.content_md))
-	.catch(() => []);
+async function fetchLinks(url) {
+	try {
+		const { data } = (await ajax({ url, type: 'json' }): RedditWikiPage);
+		return parseObjectList(data && data.content_md);
+	} catch (e) {
+		return [];
+	}
 }
 
 function parseObjectList(text) {

--- a/lib/templates/submitIssueDefaultBody.mustache
+++ b/lib/templates/submitIssueDefaultBody.mustache
@@ -1,10 +1,15 @@
-*What's the problem?*
+*What's up?*
 ???
 
 
-*What other browser extensions are installed?*
+*Where does it happen?*
 ???
 
-*Did you read the known issues and search /r/RESissues?*
+
+*Screenshots or mock-ups*
+???
+
+
+*What browser extensions are installed?*
 ???
 

--- a/lib/templates/submitWizard.mustache
+++ b/lib/templates/submitWizard.mustache
@@ -1,44 +1,63 @@
-<h3>Let's talk about Reddit Enhancement Suite</h3>
-<div class="RESDialogContents">
-    <div id="RESSubmitOptions">
-        What's on your mind?<br>
+{{#foolin}}
+    <h2>Enjoy April Fool's</h2>
+    <p>RES can't turn off any of Reddit's shenanigans. However, <a href="/r/Enhancement/wiki/faq/srstyle" target="_blank" rel="noopener noreferer">you can turn off subreddit styles</a>.</p>
+{{/foolin}}
 
-		{{#foolin}}
-            <div id="RESSubmitAprilFools">
-                Enjoy April Fool's. RES can't turn off any of reddit's shenanigans. However, <a href="/r/Enhancement/wiki/faq/srstyle" target="_blank" rel="noopener noreferer">you can turn off subreddit styles</a>.
-            </div>
-		{{/foolin}}
+<h2>Something is broken in RES. How do I fix it?</h2>
 
-        <div id="RESSubmitBug" class="submittingToEnhancementButton" title="Post a problem to /r/RESissues">
-            I'm having issues or found a bug
-        </div><br>
-        <div id="RESSubmitFeatureRequest" class="submittingToEnhancementButton" title="Post a request to /r/Enhancement">I have an idea for a feature</div><br>
-        <div id="RESSubmitOther" class="submittingToEnhancementButton" title="Start a discussion on  /r/Enhancement">I'm not having any problems, but have a question</div>
-    </div>
-    <div id="RESBugReport">
-        Do you need help with RES or want to report a bug?
-        <br>
-        <ol>
-            <li>Try <a href="/r/RESissues/wiki/postanissue">troubleshooting it yourself</a>.</li>
-            <li>Have you <a target="_blank" rel="noopener noreferer" href="/r/RESissues/search?restrict_sr=on">searched /r/RESIssues</a> to see if someone else has reported it?</li>
-            <li>Check the <a target="_blank" rel="noopener noreferer" href="/r/Enhancement/wiki/faq">RES FAQ</a> </li>
-            <li>
-                This might already be a known issue:
-                <ul id="RESKnownBugs"><li style="color: red;">Loading...</li></ul>
-            </li>
-        </ol>
+<p>Take a minute to read through other posts. Someone might have already posted a solution.</p>
 
-        <span id="submittingBug" class="submittingToEnhancementButton">I've checked, double-checked, and still want to post an issue.</span>
-    </div>
-    <div id="RESFeatureRequest">
-        So you want to request a feature. Great! Please just consider the following first:<br>
-        <ol>
-            <li>Have you <a target="_blank" rel="noopener noreferer" href="/r/Enhancement/search?restrict_sr=on">searched /r/Enhancement</a> to see if someone else has requested it?</li>
-            <li>Would your idea appeal to many redditors? Personal or subreddit-specific requests usually aren't added to RES.</li>
-            <li>See if someone else has already requested this:
-                <ul id="RESKnownFeatureRequests"><li style="color: red;">Loading...</li></ul>
-            </li>
-        </ol>
-        <span id="submittingFeature" class="submittingToEnhancementButton">I still want to submit a feature request!</span>
-    </div>
-</div>
+<ol id="RESKnownBugs">
+    {{#bugs}}
+        <li>
+            <a target="_blank" rel="noopener noreferer" href="{{url}}">{{title}}</a>
+        </li>
+    {{/bugs}}
+</ol>
+
+<p><a href="/r/RESissues/submit/" class="blueButton">Ask how to fix RES</a></p>
+
+<p>Please write some text about:</p>
+<dl>
+
+    <dt>What makes this happen?</dt>
+    <dd>
+        clicking a button, opening an image preview, ...
+    </dd>
+
+
+    <dt>Where does this happen?</dt>
+    <dd>
+        in a particular subreddit, on comments pages, on frontpage (reddit.com), on /r/all, ...
+    </dd>
+
+    <dt>Screenshot/video of problem</dt>
+    <dd>
+        <a href="//www.take-a-screenshot.org/" target="_blank" rel="noreferer noopener">Take a screenshot</a>, <a href="//imgur.com/upload">upload it</a>, and copy-paste the link here.
+    </dd>
+</dl>
+
+
+<h2>How do I customize or use RES features?</h2>
+<p>If you want to disable certain features of RES, try searching in <a href="{{settings}}">RES settings</a>, your account's <a href="/prefs">reddit preferences</a>, or <a href="/r/Enhancement/search?q=restrict_sr=on">posts in r/Enhancement</a>.</p>
+
+<p><a href="/r/Enhancement/submit/" class="blueButton">Get guidance on using RES</a></p>
+
+
+<h2>I have a suggestion.</h2>
+
+<p>Look for similar ideas before posting:</p>
+<ol id="RESKnownFeatureRequests">
+    {{#requests}}
+        <li>
+            <a target="_blank" rel="noopener noreferer" href="{{url}}">{{title}}</a>
+        </li>
+    {{/requests}}
+</ol>
+<p><a href="/r/Enhancement/submit/" class="blueButton">Post a request</a></p>
+
+
+<h2>I found a security issue.</a></h2>
+<p>Please report security issues privately using modmail.</p>
+<p><a href="/message/compose/?to=/r/Enhancement" class="blueButton">Report a security issue</a></p>
+


### PR DESCRIPTION
* Standard post selftext template for all RES subreddits: "what's up" and follow-up questions
* Move pre-edit wizard to guider attached to self-post
* Refactor current known issues and feature requests into "fetch yaml" and "render link list in guider template"

<img width="1251" alt="screen shot 2017-02-20 at 7 53 52 pm" src="https://cloud.githubusercontent.com/assets/455632/23150177/60b64130-f7a6-11e6-81ce-b87771dbe6f7.png">

