### PR TITLE
Update imgur.js

### DIFF
--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -137,7 +137,7 @@ export default new Host('imgur', {
 		function _handleImage(hash, url) {
 			const [,, extension] = hashRe.exec(url) || [];
 
-			if (['.png', '.jpg'].includes(extension)) {
+			if (['.png', '.jpg', '.jpeg'].includes(extension)) {
 				// Extension is given and hopefully correct, so we can intuit the mimetype
 				// removed caption API calls as they don't seem to exist/matter for single images, only albums...
 				// If we don't show captions and know the mimetype, then we can skip the API call.


### PR DESCRIPTION
Added '.jpeg' inside the _handleimage function; previously expanding ".jpeg" file types would also show the original filename above the image

![before](https://cloud.githubusercontent.com/assets/11085692/23151180/20d5e308-f7b6-11e6-8bde-38966cce07de.png)
![after](https://cloud.githubusercontent.com/assets/11085692/23151181/22dc34e0-f7b6-11e6-83ff-c375519a6898.png)
