### PR TITLE
Move translations to background page; cache on foreground in localStorage

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -12,7 +12,7 @@
 [options]
 module.use_strict=true
 
-module.name_mapper='^exec-loader!\(.+\)$'->'\1'
+module.name_mapper='^exec-loader\(\?cache\)?!\(.+\)$'->'\2'
 module.name_mapper.extension='mustache'->'<PROJECT_ROOT>/flow/stub/mustache.js'
 
 esproposal.export_star_as=enable

--- a/build/buildToken.js
+++ b/build/buildToken.js
@@ -1,0 +1,4 @@
+/* eslint-disable import/no-commonjs, import/no-nodejs-modules */
+
+// used for invalidating caches on each build (executed at build time)
+module.exports = String(Math.random()).slice(2);

--- a/chrome/environment.js
+++ b/chrome/environment.js
@@ -1,7 +1,8 @@
 /* eslint-env webextensions */
 
 import { createMessageHandler } from '../lib/environment/common/messaging';
-import { extendDeep, keyedMutex } from '../lib/utils';
+import { keyedMutex } from '../lib/utils/async';
+import { extendDeep } from '../lib/utils/object';
 import { apiToPromise } from './_helpers';
 
 const _sendMessage = apiToPromise(chrome.runtime.sendMessage);

--- a/firefox/beta/package.json
+++ b/firefox/beta/package.json
@@ -15,5 +15,5 @@
 		"private-browsing": true,
 		"multiprocess": true
 	},
-	"changes": "{{file-loader?name=CHANGES!extricate-loader!exec-loader!../../build/getChanges}}"
+	"changes": "{{file-loader?name=CHANGES!extricate-loader!exec-loader?cache!../../build/getChanges}}"
 }

--- a/firefox/package.json
+++ b/firefox/package.json
@@ -15,5 +15,5 @@
 		"private-browsing": true,
 		"multiprocess": true
 	},
-	"changes": "{{file-loader?name=CHANGES!extricate-loader!exec-loader!../build/getChanges}}"
+	"changes": "{{file-loader?name=CHANGES!extricate-loader!exec-loader?cache!../build/getChanges}}"
 }

--- a/lib/constants/localStorage.js
+++ b/lib/constants/localStorage.js
@@ -1,0 +1,5 @@
+/* @flow */
+
+export const CACHED_LANG_KEY = 'RES.i18nCachedLang';
+export const CACHED_MESSAGES_KEY = 'RES.i18nCachedMessages';
+export const CACHED_MESSAGES_TOKEN_KEY = 'RES.i18nCachedMessagesToken';

--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import { RES_DISABLED_KEY } from '../constants/sessionStorage';
+import { _loadI18n } from '../environment/i18n';
 import * as Modules from './modules';
 import { _loadModuleOptions } from './options/options';
 import { _loadModulePrefs } from './modules/modules';
@@ -79,9 +80,13 @@ export const loadComplete = contentLoaded
 
 // Module stages
 
-sourceLoaded.then(() => migrate());
+export const loadI18n = sourceLoaded
+	.then(() => _loadI18n());
 
-export const loadDynamicOptions = sourceLoaded
+export const runMigrations = loadI18n
+	.then(() => migrate());
+
+export const loadDynamicOptions = loadI18n
 	.then(() => allModules('loadDynamicOptions', { skipEnabledCheck: true }));
 
 export const loadOptions = loadDynamicOptions

--- a/lib/core/metadata/index.js
+++ b/lib/core/metadata/index.js
@@ -10,4 +10,4 @@ export {
 	isMajor,
 	updatedURL,
 	homepageURL,
-} from 'exec-loader!./packageInfo';
+} from 'exec-loader?cache!./packageInfo';

--- a/lib/environment/common/listeners.js
+++ b/lib/environment/common/listeners.js
@@ -1,9 +1,12 @@
 /* @flow */
 
+import { getLocaleDictionary } from '../../../locales';
 import Cache from '../../utils/Cache';
 import type { AddListener } from './messaging';
 
 export function addCommonBackgroundListeners(addListener: AddListener<void>) {
+	addListener('i18n', locale => getLocaleDictionary(locale));
+
 	const session = new Map();
 
 	addListener('session', ([operation, key, value]) => {

--- a/lib/environment/i18n.js
+++ b/lib/environment/i18n.js
@@ -1,10 +1,58 @@
 /* @flow */
 
-import { getMessage } from '../../locales';
+import { CACHED_LANG_KEY, CACHED_MESSAGES_KEY, CACHED_MESSAGES_TOKEN_KEY } from '../constants/localStorage';
 import { rawLocale } from '../utils/localization';
+import buildToken from 'exec-loader!../../build/buildToken';
+import { sendMessage } from 'browserEnvironment';
 
+let messages;
+
+export async function _loadI18n(): Promise<void> {
+	// fast path: i18n dictionary is cached
+	// should be hit almost every time
+	if (
+		localStorage.getItem(CACHED_LANG_KEY) === rawLocale() &&
+		localStorage.getItem(CACHED_MESSAGES_TOKEN_KEY) === buildToken
+	) {
+		try {
+			messages = JSON.parse(localStorage.getItem(CACHED_MESSAGES_KEY) || '');
+			return;
+		} catch (e) {
+			console.error('Failed to parse cached i18n', e);
+		}
+	}
+
+	// slow path: wait for background page to send new locales
+	// will be hit the first (ever) pageload on a new domain
+	// or after clearing localStorage
+	messages = await sendMessage('i18n', rawLocale());
+	localStorage.setItem(CACHED_MESSAGES_KEY, JSON.stringify(messages));
+	localStorage.setItem(CACHED_LANG_KEY, rawLocale());
+	localStorage.setItem(CACHED_MESSAGES_TOKEN_KEY, buildToken);
+}
+
+// Behaves like https://developer.chrome.com/extensions/i18n#method-getMessage
 export function i18n(messageName: string, ...substitutions: Array<string | number>): string {
 	if (!messageName) return '';
-	// implementation should return the empty string if it cannot find a translation
-	return getMessage(rawLocale(), messageName, substitutions) || messageName;
+
+	if (!messages) {
+		if (process.env.NODE_ENV === 'development') {
+			throw new Error(`i18n called too early! key: ${messageName}`);
+		} else {
+			console.error('i18n called too early! key:', messageName);
+			return messageName;
+		}
+	}
+
+	const message = messages[messageName];
+
+	if (!message) return messageName;
+
+	// Replace direct references to substitutions, e.g. `First substitution: $1`
+	// Maximum of 9 substitutions allowed, i.e. only one number after the `$`
+	return message.replace(/\$(\d)\b(?!\$)/g, (match, number) => substitutions[number - 1]);
+
+	// Chrome also supports named placeholders, e.g. `Error: $error_message$`
+	// but Transifex does not create the `placeholders` field in exported JSON
+	// https://developer.chrome.com/extensions/i18n#examples-getMessage
 }

--- a/lib/modules/troubleshooter.js
+++ b/lib/modules/troubleshooter.js
@@ -2,6 +2,7 @@
 
 import testTemplate from '../templates/test.mustache';
 import { MODULE_PROFILING_KEY, PERF_PROFILING_KEY, RES_DISABLED_KEY } from '../constants/sessionStorage';
+import { CACHED_LANG_KEY, CACHED_MESSAGES_KEY, CACHED_MESSAGES_TOKEN_KEY } from '../constants/localStorage';
 import { Module } from '../core/module';
 import { Alert } from '../utils';
 import { Session, Storage, XhrCache, i18n, isPrivateBrowsing, multicast } from '../environment';
@@ -88,6 +89,9 @@ module.options = {
 function clearCache() {
 	XhrCache.clear();
 	Session.clear();
+	localStorage.removeItem(CACHED_LANG_KEY);
+	localStorage.removeItem(CACHED_MESSAGES_TOKEN_KEY);
+	localStorage.removeItem(CACHED_MESSAGES_KEY);
 	Notifications.showNotification(i18n('troubleshooterCachesCleared'), 2500);
 }
 

--- a/locales/index.js
+++ b/locales/index.js
@@ -40,40 +40,17 @@ const getLocale = _.memoize(localeName => {
 	}
 });
 
-const getLookupFunction = _.memoize(localeName => {
+export const getLocaleDictionary = _.memoize((localeName: string): { [key: string]: string } => {
 	const transifexLocale = redditLocaleToTransifexLocale(localeName);
-	const locales = _.compact([
-		// 1. Exact match (en_CA -> en_CA)
-		getLocale(transifexLocale),
-		// 2. Match without region (en_CA -> en)
-		getLocale(transifexLocale.slice(0, transifexLocale.indexOf('_'))),
+
+	const mergedLocales = {
 		// 3. Default (en)
-		getLocale(DEFAULT_TRANSIFEX_LOCALE),
-	]);
-
-	return messageName => {
-		for (let i = 0; i < locales.length; ++i) { // eslint-disable-line no-restricted-syntax
-			const entry = locales[i][messageName];
-			if (entry) {
-				return entry.message;
-			}
-		}
+		...getLocale(DEFAULT_TRANSIFEX_LOCALE),
+		// 2. Match without region (en_CA -> en)
+		...getLocale(transifexLocale.slice(0, transifexLocale.indexOf('_'))),
+		// 1. Exact match (en_CA -> en_CA)
+		...getLocale(transifexLocale),
 	};
+
+	return _.mapValues(mergedLocales, x => x.message);
 });
-
-// Behaves like https://developer.chrome.com/extensions/i18n#method-getMessage
-// if it accepted a locale name
-export function getMessage(localeName: string, messageName: string, substitutions: Array<string | number>): string {
-	// Transifex will fill in missing translations from partially-translated languages
-	// with strings from the base locale (en).
-	// So we don't need to do multiple checks here.
-	const message = getLookupFunction(localeName)(messageName) || '';
-
-	// Replace direct references to substitutions, e.g. `First substitution: $1`
-	// Maximum of 9 substitutions allowed, i.e. only one number after the `$`
-	return message.replace(/\$(\d)\b(?!\$)/g, (match, number) => substitutions[number - 1]);
-
-	// Chrome also supports named placeholders, e.g. `Error: $error_message$`
-	// but Transifex does not create the `placeholders` field in exported JSON
-	// https://developer.chrome.com/extensions/i18n#examples-getMessage
-}

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -3137,7 +3137,7 @@
 		"message": "Clear Cache"
 	},
 	"troubleshooterClearCacheDesc": {
-		"message": "Clear your RES cache and session. This includes the \"My Subreddits\" dropdown and cached user or subreddit info."
+		"message": "Clear your RES cache and session. This includes the \"My Subreddits\" dropdown, user/subreddit info, i18n dictionary, etc."
 	},
 	"troubleshooterClearTagsTitle": {
 		"message": "Clear Tags"

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-no-useless-assign": "1.0.2",
     "eslint-plugin-prefer-spread": "1.0.3",
-    "exec-loader": "2.0.0",
+    "exec-loader": "2.1.0",
     "extricate-loader": "1.0.0",
     "file-loader": "0.10.1",
     "firefox-extension-deploy": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,7 +152,7 @@ ansi-escapes@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
-ansi-regex@*, ansi-regex@^2.0.0:
+ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
 
@@ -3323,7 +3323,7 @@ esprima-fb@~15001.1001.0-dev-harmony-fb:
   version "15001.1001.0-dev-harmony-fb"
   resolved "https://registry.yarnpkg.com/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz#43beb57ec26e8cf237d3dd8b33e42533577f2659"
 
-esprima@3.x.x, esprima@^3.1.1, esprima@~3.1.0:
+esprima@3.x.x, esprima@~3.1.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
@@ -3385,9 +3385,11 @@ evp_bytestokey@^1.0.0:
   dependencies:
     create-hash "^1.1.1"
 
-exec-loader@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/exec-loader/-/exec-loader-2.0.0.tgz#64bd845a31562cc797a745e238f06c65bc593cf5"
+exec-loader@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/exec-loader/-/exec-loader-2.1.0.tgz#cee9d54a5319ac480ec0d5d703a798198f153d14"
+  dependencies:
+    loader-utils "^1.0.2"
 
 execa@^0.5.0:
   version "0.5.1"
@@ -4330,7 +4332,7 @@ ignore@^3.1.2, ignore@^3.2.0:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.4.tgz#4055e03596729a8fabe45a43c100ad5ed815c4e8"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
@@ -4934,19 +4936,12 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
-js-yaml@3.6.1:
+js-yaml@3.6.1, js-yaml@^3.4.3, js-yaml@^3.4.6, js-yaml@^3.5.1, js-yaml@^3.5.4:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
   dependencies:
     argparse "^1.0.7"
     esprima "^2.6.0"
-
-js-yaml@^3.4.3, js-yaml@^3.4.6, js-yaml@^3.5.1, js-yaml@^3.5.4:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.1.tgz#782ba50200be7b9e5a8537001b7804db3ad02628"
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^3.1.1"
 
 js-yaml@~3.7.0:
   version "3.7.0"


### PR DESCRIPTION
This eliminates the effect of translations on bundle size (and hence parse/compile performance), at the cost of slow init on the first (ever) pageload on each domain or when switching languages.

Each dictionary is 64-100k, so we have quite a bit of localStorage headroom.