### PR TITLE
voteEnhancements: remove misleading post vote estimation

### DIFF
--- a/lib/modules/voteEnhancements.js
+++ b/lib/modules/voteEnhancements.js
@@ -1,17 +1,12 @@
 /* @flow */
 
 import _ from 'lodash';
-import { $ } from '../vendor';
 import { Module } from '../core/module';
-import { i18n } from '../environment';
 import {
 	addCSS,
 	colorFromArray,
 	colorToArray,
-	formatNumber,
-	isPageType,
 	projectInto,
-	string,
 	watchForThings,
 	zip,
 } from '../utils';
@@ -22,20 +17,6 @@ module.moduleName = 'voteEnhancementsName';
 module.category = 'appearanceCategory';
 module.description = 'voteEnhancementsDesc';
 module.options = {
-	estimatePostScore: {
-		title: 'voteEnhancementsEstimatePostScoreTitle',
-		type: 'boolean',
-		value: false,
-		description: 'voteEnhancementsEstimatePostScoreDesc',
-		bodyClass: true,
-	},
-	estimatePostVotes: {
-		title: 'voteEnhancementsEstimatePostVotesTitle',
-		type: 'boolean',
-		value: true,
-		description: 'voteEnhancementsEstimatePostVotesDesc',
-		bodyClass: true,
-	},
 	highlightScores: {
 		title: 'voteEnhancementsHighlightScoresTitle',
 		type: 'boolean',
@@ -179,48 +160,10 @@ module.beforeLoad = () => {
 };
 
 module.go = () => {
-	if (isPageType('comments')) {
-		if (module.options.estimatePostScore.value || module.options.estimatePostVotes.value) {
-			estimatePostScoreVotes();
-		}
-	}
 	if (module.options.highlightControversial.value) {
 		highlightControversial();
 	}
 };
-
-function estimatePostScoreVotes() {
-	const $linkinfoScore = $('.linkinfo .score');
-	if ($linkinfoScore.length) {
-		const points = parseInt($linkinfoScore.find('.number').text().replace(/[^0-9]/g, ''), 10);
-		const percentage = parseInt(($linkinfoScore.text().match(/([0-9]{1,3})\s?%/) || [0, 0])[1], 10);
-		if (points !== 0 && percentage !== 50) { // we can't estimate if percentage equal 50% (i.e. points equal zero) -- It's important to stop don't avoid divide by zero ! edit: if downvote>upvote we can't calculate too
-			const upvotes = Math.round(points * percentage / (2 * percentage - 100));
-			const downvotes = upvotes - points;
-			if (module.options.estimatePostScore.value) {
-				$linkinfoScore.after(string.escapeHTML`
-					<span class="upvotes">
-						<span class="number">${formatNumber(upvotes)}</span>
-						<span class="word">${upvotes === 1 ? i18n('voteEnhancementsUpvote') : i18n('voteEnhancementsUpvotes')}</span>
-					</span>
-					<span class="downvotes">
-						<span class="number">${formatNumber(downvotes)}</span>
-						<span class="word">${downvotes === 1 ? i18n('voteEnhancementsDownvote') : i18n('voteEnhancementsDownvotes')}</span
-					</span>
-				`);
-			}
-			if (module.options.estimatePostVotes.value) {
-				const totalVotes = upvotes + downvotes;
-				$linkinfoScore.after(string.escapeHTML`
-					<span class="totalvotes">
-						<span class="number">${formatNumber(totalVotes)}</span>
-						<span class="word">${totalVotes === 1 ? i18n('voteEnhancementsVote') : i18n('voteEnhancementsVotes')}</span>
-					</span>
-				`);
-			}
-		}
-	}
-}
 
 /**
  * @param {number} score

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -2420,24 +2420,6 @@
 		"message": "your votes for $1: $2",
 		"description": "As in `your votes for username: 42`"
 	},
-	"voteEnhancementsUpvote": {
-		"message": "upvote"
-	},
-	"voteEnhancementsUpvotes": {
-		"message": "upvotes"
-	},
-	"voteEnhancementsDownvote": {
-		"message": "downvote"
-	},
-	"voteEnhancementsDownvotes": {
-		"message": "downvotes"
-	},
-	"voteEnhancementsVote": {
-		"message": "vote"
-	},
-	"voteEnhancementsVotes": {
-		"message": "votes"
-	},
 	"xPostLinksXpostedFrom": {
 		"message": "x-posted from",
 		"description": "As in 'x-posted from /r/subreddit'"
@@ -3606,18 +3588,6 @@
 	},
 	"subredditManagerDisplayMultiCountsDesc": {
 		"message": "Show a badge on the subscribe button counting how many multireddits include this subreddit."
-	},
-	"voteEnhancementsEstimatePostScoreTitle": {
-		"message": "Estimate Post Score"
-	},
-	"voteEnhancementsEstimatePostScoreDesc": {
-		"message": "Calculate a post's score from its points and \"liked\" percentage."
-	},
-	"voteEnhancementsEstimatePostVotesTitle": {
-		"message": "Estimate Post Votes"
-	},
-	"voteEnhancementsEstimatePostVotesDesc": {
-		"message": "Calculate the total number of votes."
 	},
 	"voteEnhancementsHighlightScoresTitle": {
 		"message": "Highlight Scores"

--- a/tests/voteEnhancements.js
+++ b/tests/voteEnhancements.js
@@ -1,12 +1,4 @@
 module.exports = {
-	'total vote estimation': browser => {
-		browser
-			.url('https://www.reddit.com/r/RESIntegrationTests/comments/5jmvjf/vote_enhancements/')
-			.waitForElementVisible('.side', () => {
-				browser.expect.element('.side .totalvotes').text.match(/\d+ votes?/);
-			})
-			.end();
-	},
 	'color comment score': browser => {
 		const rootComment = '#thing_t1_dbkkubr';
 		const childComment = '#thing_t1_dbhdj53';


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/7673145/23597219/f125dd0e-01fe-11e7-9f5c-642f58a7bd9b.png)

~~Since the uncertainty becomes extreme as the upvote percentage approaches 50%.~~

Edit: Actually, that still appears to have an unwarranted amount of precision.

We know that the one post had ~12k points and 51% upvotes indicated, but only ~50k votes overall. This means either upvotes are weighted ~1.5x higher than downvotes or upvote percentage is skewed by ~10% (probably a combination of both).

Either way, trying to calculate vote totals could definitely be called "misleading", even for posts with a more usual vote percentage. (They're so far from the real vote counts that no remotely accurate conclusions can be drawn.)

So we're just going to remove them.