### PR TITLE
showImages: Don't apply elementResizeDetector when media is independent

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1793,15 +1793,18 @@ function makeMediaIndependentOnResize(media, element) {
 
 	const prevExpand = media.expand;
 	media.expand = () => {
-		// This is a slower method to listen to resizes, as it waits till the frame after the size is set to update.
-		// Using this is however necessary when it's not possible to determine size from media events.
-		elementResizeDetector().listenTo(element, () => {
-			if (element.clientHeight !== lastHeight) media.emitResizeEvent();
-		});
+		if (media.independent) {
+			media.emitResizeEvent();
+		} else {
+			// This is a slower method to listen to resizes, as it waits till the frame after the size is set to update.
+			// Using this is however necessary when it's not possible to determine size from media events.
+			elementResizeDetector().listenTo(element, () => {
+				if (element.clientHeight !== lastHeight) media.emitResizeEvent();
+			});
+		}
 
 		window.addEventListener('resize', debouncedResize);
 
-		if (media.independent) media.emitResizeEvent();
 		if (prevExpand) return prevExpand();
 	};
 


### PR DESCRIPTION
Fixes https://www.reddit.com/r/RESissues/comments/5x1z8v/bug_clickjack_warning_on_video_expandos/ and other no-script warnings since elementResizeDetector won't be applied on iframes.