### PR TITLE
Switch to targeted workaround for AMO API destructuring issue

### DIFF
--- a/lib/utils/keycode.js
+++ b/lib/utils/keycode.js
@@ -92,7 +92,9 @@ export function niceKeyCode(keyArray: number | string | KeyArray): string {
 	} else if (typeof keyArray === 'string') {
 		const split = keyArray.split(',');
 		const code = parseInt(split[0], 10);
-		const [alt, ctrl, shift, meta] = [...split.slice(1).map(s => s === 'true'), false, false, false, false];
+		// AMO API bug: validation crashes when `modifiers` is inlined
+		const modifiers = [...split.slice(1).map(s => s === 'true'), false, false, false, false];
+		const [alt, ctrl, shift, meta] = modifiers;
 		keyArray = [code, alt, ctrl, shift, meta];
 	}
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "babel-plugin-lodash": "3.2.11",
     "babel-plugin-transform-class-properties": "6.23.0",
     "babel-plugin-transform-dead-code-elimination": "2.2.2",
-    "babel-plugin-transform-es2015-destructuring": "6.23.0",
     "babel-plugin-transform-es2015-modules-commonjs": "6.23.0",
     "babel-plugin-transform-export-extensions": "6.22.0",
     "babel-plugin-transform-flow-strip-types": "6.22.0",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -8,8 +8,6 @@ import ProgressBarPlugin from 'progress-bar-webpack-plugin';
 import ZipPlugin from 'zip-webpack-plugin';
 import webpack from 'webpack';
 
-import babelrc from './.babelrc.json';
-
 const browserConfig = {
 	chrome: {
 		target: 'chrome',
@@ -48,111 +46,99 @@ export default (env = {}) => {
 
 	const isProduction = process.env.NODE_ENV !== 'development';
 
-	const configs = browsers.map(b => browserConfig[b]).map(conf => {
-		const babelConfig = {
-			...babelrc,
-			babelrc: false,
-		};
-
-		if (conf.target === 'firefox') {
-			// The Firefox API can't deal with normal array destructuring
-			babelConfig.plugins.push('transform-es2015-destructuring');
-		}
-
-		return {
-			entry: `extricate-loader!interpolate-loader!./${conf.entry}`,
-			output: {
-				path: path.join(__dirname, 'dist', conf.output),
-				filename: conf.outputFilename || path.basename(conf.entry),
+	const configs = browsers.map(b => browserConfig[b]).map(conf => ({
+		entry: `extricate-loader!interpolate-loader!./${conf.entry}`,
+		output: {
+			path: path.join(__dirname, 'dist', conf.output),
+			filename: conf.outputFilename || path.basename(conf.entry),
+		},
+		devtool: isProduction ? 'source-map' : 'cheap-source-map',
+		bail: isProduction,
+		performance: false,
+		resolve: {
+			alias: {
+				browserEnvironment$: path.join(__dirname, conf.environment),
 			},
-			devtool: isProduction ? 'source-map' : 'cheap-source-map',
-			bail: isProduction,
-			performance: false,
-			resolve: {
-				alias: {
-					browserEnvironment$: path.join(__dirname, conf.environment),
-				},
-			},
-			module: {
-				rules: [{
-					test: /\.entry\.js$/,
-					use: [
-						{ loader: 'spawn-loader', options: { name: '[name].js' } },
-					],
-				}, {
-					test: /\.js$/,
-					exclude: path.join(__dirname, 'node_modules'),
-					use: [
-						{ loader: 'babel-loader', options: babelConfig },
-					],
-				}, {
-					test: /\.js$/,
-					include: path.join(__dirname, 'node_modules'),
-					use: [
-						{
-							loader: 'babel-loader',
-							options: {
-								plugins: ['transform-dead-code-elimination', 'transform-node-env-inline'],
-								compact: true,
-								babelrc: false,
-							},
-						},
-					],
-				}, {
-					test: /\.mustache$/,
-					use: [
-						{ loader: 'mustache-loader' },
-					],
-				}, {
-					test: /\.scss$/,
-					use: [
-						{ loader: 'file-loader', options: { name: '[name].css' } },
-						{ loader: 'extricate-loader', options: { resolve: '\\.js$' } },
-						{ loader: 'css-loader' },
-						{ loader: 'postcss-loader' },
-						{ loader: 'sass-loader' },
-					],
-				}, {
-					test: /\.html$/,
-					use: [
-						{ loader: 'file-loader', options: { name: '[name].[ext]' } },
-						{ loader: 'extricate-loader' },
-						{ loader: 'html-loader', options: { attrs: ['link:href', 'script:src'] } },
-					],
-				}, {
-					test: /\.(png|gif)$/,
-					exclude: path.join(__dirname, 'lib', 'images'),
-					use: [
-						{ loader: 'file-loader', options: { name: '[name].[ext]' } },
-					],
-				}, {
-					test: /\.(png|gif)$/,
-					include: path.join(__dirname, 'lib', 'images'),
-					use: [
-						{ loader: 'url-loader' },
-					],
-				}],
-				noParse: [
-					// to use `require` in Firefox
-					/nativeRequire\.js$/,
+		},
+		module: {
+			rules: [{
+				test: /\.entry\.js$/,
+				use: [
+					{ loader: 'spawn-loader', options: { name: '[name].js' } },
 				],
-			},
-			plugins: [
-				new ProgressBarPlugin(),
-				new webpack.DefinePlugin({
-					'process.env': {
-						BUILD_TARGET: JSON.stringify(conf.target),
+			}, {
+				test: /\.js$/,
+				exclude: path.join(__dirname, 'node_modules'),
+				use: [
+					{ loader: 'babel-loader' },
+				],
+			}, {
+				test: /\.js$/,
+				include: path.join(__dirname, 'node_modules'),
+				use: [
+					{
+						loader: 'babel-loader',
+						options: {
+							plugins: ['transform-dead-code-elimination', 'transform-node-env-inline'],
+							compact: true,
+							babelrc: false,
+						},
 					},
-				}),
-				new InertEntryPlugin(),
-				new LodashModuleReplacementPlugin(),
-				(env.zip && !conf.noZip && new ZipPlugin({
-					path: path.join('..', 'zip'),
-					filename: conf.output,
-				})),
-			].filter(x => x),
-		};
-	});
+				],
+			}, {
+				test: /\.mustache$/,
+				use: [
+					{ loader: 'mustache-loader' },
+				],
+			}, {
+				test: /\.scss$/,
+				use: [
+					{ loader: 'file-loader', options: { name: '[name].css' } },
+					{ loader: 'extricate-loader', options: { resolve: '\\.js$' } },
+					{ loader: 'css-loader' },
+					{ loader: 'postcss-loader' },
+					{ loader: 'sass-loader' },
+				],
+			}, {
+				test: /\.html$/,
+				use: [
+					{ loader: 'file-loader', options: { name: '[name].[ext]' } },
+					{ loader: 'extricate-loader' },
+					{ loader: 'html-loader', options: { attrs: ['link:href', 'script:src'] } },
+				],
+			}, {
+				test: /\.(png|gif)$/,
+				exclude: path.join(__dirname, 'lib', 'images'),
+				use: [
+					{ loader: 'file-loader', options: { name: '[name].[ext]' } },
+				],
+			}, {
+				test: /\.(png|gif)$/,
+				include: path.join(__dirname, 'lib', 'images'),
+				use: [
+					{ loader: 'url-loader' },
+				],
+			}],
+			noParse: [
+				// to use `require` in Firefox
+				/nativeRequire\.js$/,
+			],
+		},
+		plugins: [
+			new ProgressBarPlugin(),
+			new webpack.DefinePlugin({
+				'process.env': {
+					BUILD_TARGET: JSON.stringify(conf.target),
+				},
+			}),
+			new InertEntryPlugin(),
+			new LodashModuleReplacementPlugin(),
+			(env.zip && !conf.noZip && new ZipPlugin({
+				path: path.join('..', 'zip'),
+				filename: conf.output,
+			})),
+		].filter(x => x),
+	}));
 
 	return (configs.length === 1 ? configs[0] : configs);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1023,7 +1023,7 @@ babel-plugin-transform-es2015-computed-properties@^6.22.0:
     babel-runtime "^6.22.0"
     babel-template "^6.22.0"
 
-babel-plugin-transform-es2015-destructuring@6.23.0, babel-plugin-transform-es2015-destructuring@^6.19.0, babel-plugin-transform-es2015-destructuring@^6.22.0:
+babel-plugin-transform-es2015-destructuring@^6.19.0, babel-plugin-transform-es2015-destructuring@^6.22.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz#997bb1f1ab967f682d2b0876fe358d60e765c56d"
   dependencies:


### PR DESCRIPTION
It appears that this issue only occurs when an array containing a spread is immediately destructured.