### PR TITLE
userHighlight: change highlight color when collapsed

### DIFF
--- a/lib/modules/userHighlight.js
+++ b/lib/modules/userHighlight.js
@@ -288,7 +288,7 @@ function updateNewUsernames(thing) {
 
 	if (idClass) {
 		const color = colorGetter(idClass, element, thing.getAuthor());
-		doTextColor(`.${idClass}`, color);
+		doTextColor(idClass, color);
 	}
 }
 
@@ -328,7 +328,7 @@ const autoColorUsing = {
 
 		return {
 			color,
-			nightmodeColor: nightmodeColor,
+			nightmodeColor,
 		};
 	},
 	'hash-userid'(idClass) {
@@ -388,13 +388,13 @@ function doTextColor(selector, colorData) {
 	const color = colorData.color;
 	const nightmodeColor = colorData.nightmodeColor || colorData.color;
 	const css = `
-		.res-userHighlight .tagline .author${selector} {
+		.res-userHighlight .tagline .author.${selector} {
 			color: ${color} !important;
 		}
-		.res-userHighlight.res-nightmode .tagline .author${selector} {
+		.res-userHighlight.res-nightmode .tagline .author.${selector} {
 			color: ${nightmodeColor} !important;
 		}
-	`;	
+	`;
 	return addCSS(css);
 }
 

--- a/lib/modules/userHighlight.js
+++ b/lib/modules/userHighlight.js
@@ -292,15 +292,6 @@ function updateNewUsernames(thing) {
 	}
 }
 
-const autoColorTemplate = `
-	{{selector}} {
-		color: {{color}} !important;
-	}
-	.res-nightmode {{selector}} {
-		color: {{nightmodecolor}} !important;
-	}
-`;
-
 const autoColorUsing = {
 	'hash-userid-notbright'(idClass) {
 		const hash = hashCode(idClass);
@@ -336,9 +327,8 @@ const autoColorUsing = {
 		nightmodeColor = `rgb(${nightmodeColor.join(',')})`;
 
 		return {
-			template: autoColorTemplate,
 			color,
-			nightmodecolor: nightmodeColor,
+			nightmodeColor: nightmodeColor,
 		};
 	},
 	'hash-userid'(idClass) {
@@ -360,9 +350,8 @@ const autoColorUsing = {
 	},
 	monochrome() {
 		return {
-			template: autoColorTemplate,
 			color: 'black',
-			nightmodecolor: '#ccc',
+			nightmodeColor: '#ccc',
 		};
 	},
 };
@@ -372,22 +361,22 @@ export function highlightUser(userid: string) {
 	return highlight('user', name);
 }
 
-function highlight(name, selector = name, container = '.res-userHighlight .tagline') {
+function highlight(name, selector = name, container = '') {
 	const color = colorTable[name].color;
 	const hoverColor = colorTable[name].hoverColor;
 	const css = `
-		${container} .author.${selector} {
+		.res-userHighlight ${container} .tagline .author.${selector} {
 			color: ${module.options.fontColor.value} !important;
 			font-weight: bold;
 			padding: 0 2px 0 2px;
 			border-radius: 3px;
 			background-color: ${color} !important;
 		}
-		${container} .collapsed .author.${selector} {
+		.res-userHighlight ${container} .collapsed .tagline .author.${selector} {
 			color: white !important;
 			background-color: #AAA !important;
 		}
-		${container} .author.${selector}:hover {
+		.res-userHighlight ${container} .tagline .author.${selector}:hover {
 			background-color: ${hoverColor} !important;
 			text-decoration: none !important;
 		}
@@ -396,24 +385,16 @@ function highlight(name, selector = name, container = '.res-userHighlight .tagli
 }
 
 function doTextColor(selector, colorData) {
-	const template = colorData.template || '{{selector}} { color: {{color}} !important; }';
-
-	const placeholderValues = {
-		...colorData,
-		template: null,
-		selector: `.tagline .author${selector}`,
-	};
-
-	let css = template;
-
-	for (const [key, value] of Object.entries(placeholderValues)) {
-		const search = new RegExp(`{{${key}}}`, 'g');
-
-		if (value !== null && value !== undefined) {
-			css = css.replace(search, value);
+	const color = colorData.color;
+	const nightmodeColor = colorData.nightmodeColor || colorData.color;
+	const css = `
+		.res-userHighlight .tagline .author${selector} {
+			color: ${color} !important;
 		}
-	}
-
+		.res-userHighlight.res-nightmode .tagline .author${selector} {
+			color: ${nightmodeColor} !important;
+		}
+	`;	
 	return addCSS(css);
 }
 


### PR DESCRIPTION
This fixes a bug in userHighlight, where collapsed posts were still showing the highlighted color instead of gray. 
Originally, the selector used was `.tagline .collapsed`, when it should be `.collapsed .tagline`.

I also refactored a small part of the code.