### PR TITLE
[WIP] Anonymizer button

### DIFF
--- a/lib/modules/anonymizer.js
+++ b/lib/modules/anonymizer.js
@@ -2,20 +2,17 @@
 
 import { $ } from '../vendor';
 import { Module } from '../core/module';
-import * as Init from '../core/init';
-import * as Modules from '../core/modules';
-import * as Options from '../core/options';
 import {
-	Alert,
-	addCSS,	
+	addCSS,
 	BodyClasses,
 	CreateElement,
 	currentSubreddit,
 	hashCode,
-	watchForThings,	
+	watchForThings,
 	Thing,
 } from '../utils';
 import * as Menu from './menu';
+import * as StyleTweaks from './styleTweaks';
 
 export const module: Module<*> = new Module('anonymizer');
 
@@ -27,6 +24,20 @@ module.options = {
 
 module.beforeLoad = () => {
 	BodyClasses.remove('res-anonymizer');
+	addCSS(`
+		.res-anonymizer .side,
+		.res-anonymizer .pagename,
+		.res-anonymizer .domain,
+		.res-anonymizer .commentingAsUser,
+		.res-anonymizer .user,
+		.res-anonymizer .flair,
+		.res-anonymizer .RESUserTag,
+		.res-anonymizer .userattrs,
+		.res-anonymizer #sr-header-area {
+			opacity: 0 !important;
+		}
+	`);
+	setUserColor('', '', '#3399cc');
 };
 
 module.go = () => {
@@ -36,6 +47,7 @@ module.go = () => {
 let $anonymizerSwitch;
 let anonymizerOn = false;
 let isInitialized = false;
+let subredditStyle;
 const visitedUsers = new Map();
 const roles = ['submitter', 'admin', 'moderator'];
 
@@ -68,19 +80,17 @@ function userToggledAnonymizer(e) {
 	if (e) {
 		e.preventDefault();
 	}
-	console.log(`anonymizerOn: ${anonymizerOn} isInitialized: ${isInitialized}`);
 	if (anonymizerOn) {
-		BodyClasses.remove('res-anonymizer');
+		undoAnonymize();
 	} else {
-		BodyClasses.add('res-anonymizer');
 		doAnonymize();
 	}
 	anonymizerOn = !anonymizerOn;
-	console.log(`anonymizerOn: ${anonymizerOn} isInitialized: ${isInitialized}`);
 	updateAnonymizerSwitch(anonymizerOn);
 }
 
-function doAnonymize() {
+async function doAnonymize() {
+	BodyClasses.add('res-anonymizer');
 	if (!isInitialized) {
 		for (const thing of Thing.things()) {
 			if (thing.isPost() || thing.isComment() || thing.isMessage()) {
@@ -89,6 +99,19 @@ function doAnonymize() {
 		}
 		watchForThings(['post', 'comment', 'message'], updateNewUsernames, { immediate: true });
 		isInitialized = true;
+	}
+	if (currentSubreddit()) {
+		subredditStyle = await StyleTweaks.getSubredditStyleToggle();
+		if (!subredditStyle) {
+			StyleTweaks.toggleSubredditStyle(false);
+		}
+	}
+}
+
+function undoAnonymize() {
+	BodyClasses.remove('res-anonymizer');
+	if (!subredditStyle) {
+		StyleTweaks.toggleSubredditStyle(true);
 	}
 }
 
@@ -101,7 +124,7 @@ function updateNewUsernames(thing) {
 	if (idClass) {
 		const role = roles.filter(r => element.classList.contains(r))[0];
 		if (visitedUsers.has(idClass)) {
-			if (role && visitedUsers.get(idClass).role != role) {				
+			if (role && visitedUsers.get(idClass).role !== role) {
 				visitedUsers.get(idClass).css.forEach(css => { css.remove(); });
 				visitedUsers.delete(idClass);
 			} else {
@@ -111,31 +134,37 @@ function updateNewUsernames(thing) {
 		const colorData = colorMap(idClass, role);
 		console.log(`${idClass} => ${thing.getAuthor()} | ${colorData.color}`);
 		const css = [];
-		css.push(setUserColor(idClass, colorData.color));
+		if (colorData.color) {
+			css.push(setUserColor(`.${idClass}`, thing.getAuthor(), colorData.color));
+		}
 		if (colorData.nightmodeColor) {
-			css.push(setUserColor(idClass, colorData.nightmodeColor, '.res-nightmode'));
+			css.push(setUserColor(`.${idClass}`, thing.getAuthor(), colorData.nightmodeColor, '.res-nightmode'));
 		}
 		visitedUsers.set(idClass, { role, css });
 	}
 }
 
-function setUserColor(selector, color, container = '') {
+function setUserColor(idClass, username, color, container = '') {
 	const css = `
-		.res-anonymizer${container} .tagline .author.${selector} {
+		.res-anonymizer${container} .tagline .author${idClass},
+		.res-anonymizer${container} a[href*="/user/${username}"],
+		.res-anonymizer${container} a[href*="/u/${username}"] {
 			color: ${color} !important;				
 			padding: 0 2px 0 2px;
 			border-radius: 3px;				
 			background-color: ${color} !important;
 		}
-		.res-anonymizer${container} .collapsed .tagline .author.${selector} {
+		.res-anonymizer${container} .collapsed .tagline .author${idClass} {
 			color: #AAA !important;
 			background-color: #AAA !important;				
 		}	
-		.res-anonymizer${container} .tagline .author.${selector}:hover {
+		.res-anonymizer${container} .tagline .author${idClass}:hover,
+		.res-anonymizer${container} a[href*="/user/${username}"]:hover,
+		.res-anonymizer${container} a[href*="/u/${username}"]:hover {
 			color: white !important;
 			background-color: ${generateHoverColor(color)} !important;
 			text-decoration: none !important;
-		}
+		}	
 	`;
 	return addCSS(css);
 }
@@ -159,7 +188,7 @@ function colorMap(idClass, role) {
 		case 'submitter':
 			return {
 				color: '#0055DF',
-			};	
+			};
 		case 'admin':
 			return {
 				color: '#FF0011',
@@ -204,6 +233,6 @@ function colorMap(idClass, role) {
 			return {
 				color,
 				nightmodeColor,
-			};			
+			};
 	}
 }

--- a/lib/modules/anonymizer.js
+++ b/lib/modules/anonymizer.js
@@ -1,0 +1,209 @@
+/* @flow */
+
+import { $ } from '../vendor';
+import { Module } from '../core/module';
+import * as Init from '../core/init';
+import * as Modules from '../core/modules';
+import * as Options from '../core/options';
+import {
+	Alert,
+	addCSS,	
+	BodyClasses,
+	CreateElement,
+	currentSubreddit,
+	hashCode,
+	watchForThings,	
+	Thing,
+} from '../utils';
+import * as Menu from './menu';
+
+export const module: Module<*> = new Module('anonymizer');
+
+module.moduleName = 'anonymizerName';
+module.category = 'appearanceCategory';
+module.description = 'anonymizerDesc';
+module.options = {
+};
+
+module.beforeLoad = () => {
+	BodyClasses.remove('res-anonymizer');
+};
+
+module.go = () => {
+	createAnonymizerSwitch();
+};
+
+let $anonymizerSwitch;
+let anonymizerOn = false;
+let isInitialized = false;
+const visitedUsers = new Map();
+const roles = ['submitter', 'admin', 'moderator'];
+
+function createAnonymizerSwitch() {
+	$anonymizerSwitch = $('<div>', {
+		text: 'anonymize',
+		title: 'Anonymize current page',
+	});
+
+	const toggle = CreateElement.toggleButton(
+		undefined,
+		'anonymizerToggle',
+		anonymizerOn,
+		'\uF09A',
+		'\uF09B',
+		false,
+		true
+	);
+	$(toggle).appendTo($anonymizerSwitch);
+
+	Menu.addMenuItem($anonymizerSwitch, userToggledAnonymizer);
+}
+
+function updateAnonymizerSwitch(toggle) {
+	if (!$anonymizerSwitch) return;
+	$anonymizerSwitch.find('.toggleButton').toggleClass('enabled', toggle);
+}
+
+function userToggledAnonymizer(e) {
+	if (e) {
+		e.preventDefault();
+	}
+	console.log(`anonymizerOn: ${anonymizerOn} isInitialized: ${isInitialized}`);
+	if (anonymizerOn) {
+		BodyClasses.remove('res-anonymizer');
+	} else {
+		BodyClasses.add('res-anonymizer');
+		doAnonymize();
+	}
+	anonymizerOn = !anonymizerOn;
+	console.log(`anonymizerOn: ${anonymizerOn} isInitialized: ${isInitialized}`);
+	updateAnonymizerSwitch(anonymizerOn);
+}
+
+function doAnonymize() {
+	if (!isInitialized) {
+		for (const thing of Thing.things()) {
+			if (thing.isPost() || thing.isComment() || thing.isMessage()) {
+				updateNewUsernames(thing);
+			}
+		}
+		watchForThings(['post', 'comment', 'message'], updateNewUsernames, { immediate: true });
+		isInitialized = true;
+	}
+}
+
+function updateNewUsernames(thing) {
+	const element = thing.getAuthorElement();
+	if (!element) return;
+
+	const idClass = Array.from(element.classList).find(cls => cls.startsWith('id-t2_'));
+
+	if (idClass) {
+		const role = roles.filter(r => element.classList.contains(r))[0];
+		if (visitedUsers.has(idClass)) {
+			if (role && visitedUsers.get(idClass).role != role) {				
+				visitedUsers.get(idClass).css.forEach(css => { css.remove(); });
+				visitedUsers.delete(idClass);
+			} else {
+				return;
+			}
+		}
+		const colorData = colorMap(idClass, role);
+		console.log(`${idClass} => ${thing.getAuthor()} | ${colorData.color}`);
+		const css = [];
+		css.push(setUserColor(idClass, colorData.color));
+		if (colorData.nightmodeColor) {
+			css.push(setUserColor(idClass, colorData.nightmodeColor, '.res-nightmode'));
+		}
+		visitedUsers.set(idClass, { role, css });
+	}
+}
+
+function setUserColor(selector, color, container = '') {
+	const css = `
+		.res-anonymizer${container} .tagline .author.${selector} {
+			color: ${color} !important;				
+			padding: 0 2px 0 2px;
+			border-radius: 3px;				
+			background-color: ${color} !important;
+		}
+		.res-anonymizer${container} .collapsed .tagline .author.${selector} {
+			color: #AAA !important;
+			background-color: #AAA !important;				
+		}	
+		.res-anonymizer${container} .tagline .author.${selector}:hover {
+			color: white !important;
+			background-color: ${generateHoverColor(color)} !important;
+			text-decoration: none !important;
+		}
+	`;
+	return addCSS(css);
+}
+
+function generateHoverColor(color) { // generate a darker color
+	if (!(/^#[0-9A-F]{6}$/i).test(color)) {
+		return false;
+	}
+	let R = parseInt(color.substr(1, 2), 16);
+	let G = parseInt(color.substr(3, 2), 16);
+	let B = parseInt(color.substr(5, 2), 16);
+	// R = R + 0.25 *(255-R); // 25% lighter
+	R = Math.round(0.75 * R) + 256; // we add 256 to add a 1 before the color in the hex format
+	G = Math.round(0.75 * G) + 256; // then we remove the 1, this have for effect to
+	B = Math.round(0.75 * B) + 256; // add a 0 before one char color in hex format (i.e. 0xA -> 0x10A -> 0x0A)
+	return `#${R.toString(16).substr(1)}${G.toString(16).substr(1)}${B.toString(16).substr(1)}`;
+}
+
+function colorMap(idClass, role) {
+	switch (role) {
+		case 'submitter':
+			return {
+				color: '#0055DF',
+			};	
+		case 'admin':
+			return {
+				color: '#FF0011',
+			};
+		case 'moderator':
+			return {
+				color: '#228822',
+			};
+		default:
+			const hash = hashCode(idClass);
+
+			// With help from /u/Rangi42
+
+			const r = (hash & 0xFF0000) >> 16;
+			const g = (hash & 0x00FF00) >> 8;
+			const b = hash & 0x0000FF;
+			// Luminance formula: http://stackoverflow.com/a/596243/70175
+			const lum = Math.round(r * 0.299 + g * 0.587 + b * 0.114);
+			const minLum = 0x66; // Night mode background is #191919 or #222222
+			const maxLum = 0xAA; // Regular background is #FFFFFF or #F7F7F8
+
+			let color = [r, g, b];
+			let nightmodeColor = [r, g, b];
+			if (lum < minLum) {
+				const scale = minLum / lum;
+				nightmodeColor = [
+					Math.round(r * scale),
+					Math.round(g * scale),
+					Math.round(b * scale),
+				];
+			} else if (lum > maxLum) {
+				const scale = maxLum / lum;
+				color = [
+					Math.round(r * scale),
+					Math.round(g * scale),
+					Math.round(b * scale),
+				];
+			}
+			color = `rgb(${color.join(',')})`;
+			nightmodeColor = `rgb(${nightmodeColor.join(',')})`;
+
+			return {
+				color,
+				nightmodeColor,
+			};			
+	}
+}

--- a/lib/modules/anonymizer.js
+++ b/lib/modules/anonymizer.js
@@ -20,24 +20,172 @@ module.moduleName = 'anonymizerName';
 module.category = 'appearanceCategory';
 module.description = 'anonymizerDesc';
 module.options = {
+	hideUsernames: {
+		title: 'anonymizerHideUsernamesTitle',
+		type: 'boolean',
+		value: true,
+		selectors: ['.commentingAsUser', '.user'],
+		description: 'anonymizerHideUsernamesDesc',
+	},
+	defaultColor: {
+		title: 'anonymizerDefaultColorTitle',
+		type: 'color',
+		value: '#3399cc',
+		description: 'anonymizerDefaultColorDesc',
+		dependsOn: options => options.hideUsernames.value && !options.autoColorUsernames.value,
+	},
+	autoColorUsernames: {
+		title: 'anonymizerAutoColorUsernamesTitle',
+		type: 'boolean',
+		value: true,
+		description: 'anonymizerAutoColorUsernamesDesc',
+		dependsOn: options => options.hideUsernames.value,
+	},
+	highlightOP: {
+		title: 'anonymizerHighlightOPTitle',
+		type: 'boolean',
+		value: true,
+		description: 'anonymizerHighlightOPDesc',
+		dependsOn: options => options.hideUsernames.value,
+	},
+	OPColor: {
+		title: 'anonymizerOPColorTitle',
+		type: 'color',
+		value: '#0055DF',
+		description: 'anonymizerOPColorDesc',
+		dependsOn: options => options.hideUsernames.value && options.highlightOP.value,
+	},
+	highlightModerator: {
+		title: 'anonymizerHighlightModeratorTitle',
+		type: 'boolean',
+		value: true,
+		description: 'anonymizerHighlightModeratorDesc',
+		dependsOn: options => options.hideUsernames.value,
+	},
+	moderatorColor: {
+		title: 'anonymizerModeratorColorTitle',
+		type: 'color',
+		value: '#228822',
+		description: 'anonymizerModeratorColorDesc',
+		dependsOn: options => options.hideUsernames.value && options.highlightModerator.value,
+	},
+	highlightAdmin: {
+		title: 'anonymizerHighlightAdminTitle',
+		type: 'boolean',
+		value: true,
+		description: 'anonymizerHighlightAdminDesc',
+		dependsOn: options => options.hideUsernames.value,
+	},
+	adminColor: {
+		title: 'anonymizerAdminColorTitle',
+		type: 'color',
+		value: '#FF0011',
+		description: 'anonymizerAdminColorDesc',
+		dependsOn: options => options.hideUsernames.value && options.highlightAdmin.value,
+	},
+	disableSubredditStyle: {
+		title: 'anonymizerDisableSubredditStyleTitle',
+		type: 'boolean',
+		value: true,
+		description: 'anonymizerDisableSubredditStyleDesc',
+	},
+	hideSidebar: {
+		title: 'anonymizerHideSidebarTitle',
+		type: 'boolean',
+		value: true,
+		selectors: ['.side'],
+		description: 'anonymizerHideSidebarDesc',
+	},
+	hideSubredditNames: {
+		title: 'anonymizerHideSubredditNamesTitle',
+		type: 'boolean',
+		value: true,
+		selectors: ['.pagename', '.domain'],
+		description: 'anonymizerHideSubredditNamesDesc',
+	},
+	hideSubredditMentions: {
+		title: 'anonymizerHideSubredditMentionsTitle',
+		type: 'boolean',
+		value: true,
+		description: 'anonymizerHideSubredditMentionsDesc',
+	},
+	subredditMentionColor: {
+		title: 'anonymizerSubredditMentionColorTitle',
+		type: 'color',
+		value: '#0079d3',
+		description: 'anonymizerSubredditMentionColorDesc',
+		dependsOn: options => options.hideSubredditMentions.value,
+	},
+	hideFlairs: {
+		title: 'anonymizerHideFlairsTitle',
+		type: 'boolean',
+		value: true,
+		selectors: ['.flair'],
+		description: 'anonymizerHideFlairsDesc',
+	},
+	hideTags: {
+		title: 'anonymizerHideTagsTitle',
+		type: 'boolean',
+		value: true,
+		selectors: ['.RESUserTag', '.userattrs'],
+		description: 'anonymizerHideTagsDesc',
+	},
+	hideTopBar: {
+		title: 'anonymizerHideTopBarTitle',
+		type: 'boolean',
+		value: true,
+		selectors: ['#sr-header-area'],
+		description: 'anonymizerHideTopBarDesc',
+	},
+	hideTime: {
+		title: 'anonymizerHideTimeTitle',
+		type: 'boolean',
+		value: false,
+		selectors: ['.tagline time'],
+		description: 'anonymizerHideTimeDesc',
+	},
 };
 
 module.beforeLoad = () => {
 	BodyClasses.remove('res-anonymizer');
-	addCSS(`
-		.res-anonymizer .side,
-		.res-anonymizer .pagename,
-		.res-anonymizer .domain,
-		.res-anonymizer .commentingAsUser,
-		.res-anonymizer .user,
-		.res-anonymizer .flair,
-		.res-anonymizer .RESUserTag,
-		.res-anonymizer .userattrs,
-		.res-anonymizer #sr-header-area {
-			opacity: 0 !important;
+	const selectors = [];
+	for (const option of Object.keys(module.options)) {
+		if (module.options[option].selectors && module.options[option].value) {
+			selectors.push(...module.options[option].selectors);
 		}
-	`);
-	setUserColor('', '', '#3399cc');
+	}
+	console.log(`selectors: ${selectors}`);
+	if (selectors.length > 0) {
+		addCSS(`
+			${selectors.map(s => `.res-anonymizer ${s}`).join(',\n')} {
+				opacity: 0 !important;
+			}
+		`);
+	}
+	if (module.options.hideSubredditMentions.value) {
+		const color = module.options.subredditMentionColor.value;
+		const selector = '.res-anonymizer .usertext-body';
+		addCSS(`
+			${selector} a[href^="/r/"],
+			${selector} a[href*="reddit.com/r/"],
+			${selector} a[href*="redd.it/"] {
+				color: ${color} !important;				
+				padding: 0 2px 0 2px;
+				border-radius: 3px;				
+				background-color: ${color} !important;
+			}
+			${selector} a[href^="/r/"]:hover,
+			${selector} a[href*="reddit.com/r/"]:hover,
+			${selector} a[href*="redd.it/"]:hover {
+				color: white !important;
+				background-color: ${generateHoverColor(color)} !important;
+				text-decoration: none !important;
+			}				
+		`);
+	}
+	if (module.options.hideUsernames.value && !module.options.autoColorUsernames.value) {
+		setUserColor('', '', module.options.defaultColor.value);
+	}
 };
 
 module.go = () => {
@@ -92,15 +240,17 @@ function userToggledAnonymizer(e) {
 async function doAnonymize() {
 	BodyClasses.add('res-anonymizer');
 	if (!isInitialized) {
-		for (const thing of Thing.things()) {
-			if (thing.isPost() || thing.isComment() || thing.isMessage()) {
-				updateNewUsernames(thing);
+		if (module.options.hideUsernames) {
+			for (const thing of Thing.things()) {
+				if (thing.isPost() || thing.isComment() || thing.isMessage()) {
+					updateNewUsernames(thing);
+				}
 			}
+			watchForThings(['post', 'comment', 'message'], updateNewUsernames, { immediate: true });
 		}
-		watchForThings(['post', 'comment', 'message'], updateNewUsernames, { immediate: true });
 		isInitialized = true;
 	}
-	if (currentSubreddit()) {
+	if (module.options.disableSubredditStyle.value && currentSubreddit()) {
 		subredditStyle = await StyleTweaks.getSubredditStyleToggle();
 		if (!subredditStyle) {
 			StyleTweaks.toggleSubredditStyle(false);
@@ -110,7 +260,7 @@ async function doAnonymize() {
 
 function undoAnonymize() {
 	BodyClasses.remove('res-anonymizer');
-	if (!subredditStyle) {
+	if (module.options.disableSubredditStyle.value && !subredditStyle) {
 		StyleTweaks.toggleSubredditStyle(true);
 	}
 }
@@ -132,7 +282,7 @@ function updateNewUsernames(thing) {
 			}
 		}
 		const colorData = colorMap(idClass, role);
-		console.log(`${idClass} => ${thing.getAuthor()} | ${colorData.color}`);
+		console.log(`${idClass} => ${thing.getAuthor()} | ${role} | ${colorData.color}`);
 		const css = [];
 		if (colorData.color) {
 			css.push(setUserColor(`.${idClass}`, thing.getAuthor(), colorData.color));
@@ -170,6 +320,7 @@ function setUserColor(idClass, username, color, container = '') {
 }
 
 function generateHoverColor(color) { // generate a darker color
+	// from userHighlight module (TODO: remove code duplication)
 	if (!(/^#[0-9A-F]{6}$/i).test(color)) {
 		return false;
 	}
@@ -184,55 +335,64 @@ function generateHoverColor(color) { // generate a darker color
 }
 
 function colorMap(idClass, role) {
-	switch (role) {
-		case 'submitter':
-			return {
-				color: '#0055DF',
-			};
-		case 'admin':
-			return {
-				color: '#FF0011',
-			};
-		case 'moderator':
-			return {
-				color: '#228822',
-			};
-		default:
-			const hash = hashCode(idClass);
+	if (role === 'submitter' && module.options.highlightOP.value) {
+		return {
+			color: module.options.OPColor.value,
+		};
+	}
+	if (role === 'moderator' && module.options.highlightModerator.value) {
+		return {
+			color: module.options.moderatorColor.value,
+		};
+	}
+	if (role === 'admin' && module.options.highlightAdmin.value) {
+		return {
+			color: module.options.adminColor.value,
+		};
+	}
 
-			// With help from /u/Rangi42
+	if (!module.options.autoColorUsernames.value) {
+		return {
+			color: module.options.defaultColor.value,
+		};
+	} else {
+		// from userHighlight module (TODO: remove code duplication)
 
-			const r = (hash & 0xFF0000) >> 16;
-			const g = (hash & 0x00FF00) >> 8;
-			const b = hash & 0x0000FF;
-			// Luminance formula: http://stackoverflow.com/a/596243/70175
-			const lum = Math.round(r * 0.299 + g * 0.587 + b * 0.114);
-			const minLum = 0x66; // Night mode background is #191919 or #222222
-			const maxLum = 0xAA; // Regular background is #FFFFFF or #F7F7F8
+		const hash = hashCode(idClass);
 
-			let color = [r, g, b];
-			let nightmodeColor = [r, g, b];
-			if (lum < minLum) {
-				const scale = minLum / lum;
-				nightmodeColor = [
-					Math.round(r * scale),
-					Math.round(g * scale),
-					Math.round(b * scale),
-				];
-			} else if (lum > maxLum) {
-				const scale = maxLum / lum;
-				color = [
-					Math.round(r * scale),
-					Math.round(g * scale),
-					Math.round(b * scale),
-				];
-			}
-			color = `rgb(${color.join(',')})`;
-			nightmodeColor = `rgb(${nightmodeColor.join(',')})`;
+		// With help from /u/Rangi42
 
-			return {
-				color,
-				nightmodeColor,
-			};
+		const r = (hash & 0xFF0000) >> 16;
+		const g = (hash & 0x00FF00) >> 8;
+		const b = hash & 0x0000FF;
+		// Luminance formula: http://stackoverflow.com/a/596243/70175
+		const lum = Math.round(r * 0.299 + g * 0.587 + b * 0.114);
+		const minLum = 0x66; // Night mode background is #191919 or #222222
+		const maxLum = 0xAA; // Regular background is #FFFFFF or #F7F7F8
+
+		let color = [r, g, b];
+		let nightmodeColor = [r, g, b];
+		if (lum < minLum) {
+			const scale = minLum / lum;
+			nightmodeColor = [
+				Math.round(r * scale),
+				Math.round(g * scale),
+				Math.round(b * scale),
+			];
+		} else if (lum > maxLum) {
+			const scale = maxLum / lum;
+			color = [
+				Math.round(r * scale),
+				Math.round(g * scale),
+				Math.round(b * scale),
+			];
+		}
+		color = `rgb(${color.join(',')})`;
+		nightmodeColor = `rgb(${nightmodeColor.join(',')})`;
+
+		return {
+			color,
+			nightmodeColor,
+		};
 	}
 }

--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -305,7 +305,15 @@ export async function toggleSubredditStyleIfNecessary() {
 	toggleSubredditStyle(!toggleOff);
 }
 
-async function toggleSubredditStyle(toggle, subreddit = currentSubreddit()) {
+export async function getSubredditStyleToggle() {
+	const subreddit = currentSubreddit();
+	if (!subreddit) {
+		return;
+	}
+	return (await ignoredSubredditStyleStorage.get()).includes(subreddit.toLowerCase());
+}
+
+export async function toggleSubredditStyle(toggle, subreddit = currentSubreddit()) {
 	subreddit = (subreddit || '').toLowerCase();
 
 	if (isCurrentSubreddit(subreddit)) {

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -3915,5 +3915,119 @@
 	},
 	"iredditPreferRedditMediaDesc": {
 		"message": "Try to load images and video from Reddit's media servers."
-	}
+	},
+	"anonymizerName": {
+		"message": "Anonymizer"
+	},
+	"anonymizerDesc": {
+		"message": "Adds a switch to the RES gear menu that anonymizes the current page."
+	},	
+	"anonymizerHideUsernamesTitle": {
+		"message": "Hide Usernames"
+	},
+	"anonymizerHideUsernamesDesc": {
+		"message": "Temporarily hide all usernames and mentions"
+	},
+	"anonymizerDefaultColorTitle": {
+		"message": "Default Username Color"
+	},
+	"anonymizerDefaultColorDesc": {
+		"message": "Default color for hiding usernames"
+	},
+	"anonymizerAutoColorUsernamesTitle": {
+		"message": "Auto Color Usernames"
+	},
+	"anonymizerAutoColorUsernamesDesc": {
+		"message": "Automatically set a special color for each username"
+	},
+	"anonymizerHighlightOPTitle": {
+		"message": "Highlight OP"
+	},
+	"anonymizerHighlightOPDesc": {
+		"message": "Assign a special color for OP"
+	},
+	"anonymizerOPColorTitle": {
+		"message": "OP Color"
+	},
+	"anonymizerOPColorDesc": {
+		"message": "Color to use for OP"
+	},
+	"anonymizerHighlightModeratorTitle": {
+		"message": "Highlight Moderators"
+	},
+	"anonymizerHighlightModeratorDesc": {
+		"message": "Assign a special color for moderators"
+	},
+	"anonymizerModeratorColorTitle": {
+		"message": "Moderator Color"
+	},
+	"anonymizerModeratorColorDesc": {
+		"message": "Color to use for moderators"
+	},
+	"anonymizerHighlightAdminTitle": {
+		"message": "Highlight Admins"
+	},
+	"anonymizerHighlightAdminDesc": {
+		"message": "Assign a special color for administrators"
+	},
+	"anonymizerAdminColorTitle": {
+		"message": "Admin Color"
+	},
+	"anonymizerAdminColorDesc": {
+		"message": "Color to use for administrators"
+	},
+	"anonymizerDisableSubredditStyleTitle": {
+		"message": "Disable Subreddit Style"
+	},
+	"anonymizerDisableSubredditStyleDesc": {
+		"message": "Temporarily disable subreddit style"
+	},	
+	"anonymizerHideSidebarTitle": {
+		"message": "Hide Sidebar"
+	},
+	"anonymizerHideSidebarDesc": {
+		"message": "Temporarily hide sidebar"
+	},
+	"anonymizerHideSubredditNamesTitle": {
+		"message": "Hide Subreddit Names"
+	},
+	"anonymizerHideSubredditNamesDesc": {
+		"message": "Temporarily hide subreddit title"
+	},
+	"anonymizerHideSubredditMentionsTitle": {
+		"message": "Hide Subreddit Mentions"
+	},
+	"anonymizerHideSubredditMentionsDesc": {
+		"message": "Temporarily hide subreddit mentions"
+	},	
+	"anonymizerSubredditMentionColorTitle": {
+		"message": "Subreddit Mention Color"
+	},
+	"anonymizerSubredditMentionColorDesc": {
+		"message": "Color to use for subreddit mentions"
+	},	
+	"anonymizerHideFlairsTitle": {
+		"message": "Hide Flairs"
+	},
+	"anonymizerHideFlairsDesc": {
+		"message": "Temporarily hide flairs"
+	},
+	"anonymizerHideTagsTitle": {
+		"message": "Hide Tags"
+	},
+	"anonymizerHideTagsDesc": {
+		"message": "Temporarily hide user tags"
+	},
+	"anonymizerHideTopBarTitle": {
+		"message": "Hide Top Bar"
+	},
+	"anonymizerHideTopBarDesc": {
+		"message": "Temporarily hide top bar"
+	},
+	"anonymizerHideTimeTitle": {
+		"message": "Hide Time"
+	},
+	"anonymizerHideTimeDesc": {
+		"message": "Temporarily hide post time"
+	}	
 }


### PR DESCRIPTION
This adds a switch to the gear menu that anonymizes usernames and subreddit information.
It is a implementation of the [RedditUsernameHider](https://github.com/mjkersey/RedditUsernameHider/), see also the [reddit thread](https://www.reddit.com/r/Enhancement/comments/5rpqc9/feature_request_anonymizer_buttonlinkwidget_for/) and issue #3967.

I'm still working on this and any feedback or suggestions are welcome.

Currently implemented:

- Hide usernames and mentions
  - option to automatically assign colors for each user and specify colors for OP, mods, admins
- Hide subreddit names and mentions
- Disable subreddit style
- Hide the side/top bar, flairs, tags and post time

Current issues:

- Username colors replicates behavior from the userHighlight module and some code is copy&pasted from there
- Communication with the styleTweaks module could be done better
  - as of now styleTweaks remembers that a subreddit style was turned off when the user leaves the page without turning the anonymizer off

closes #3967 