### PR TITLE
Add border to selected module in settings console

### DIFF
--- a/lib/css/res.scss
+++ b/lib/css/res.scss
@@ -668,6 +668,9 @@ div.usertext-edit {
 
 	&.active {
 		font-weight: bold;
+		-moz-box-shadow: inset 5px 0px 0px 0px rgb(171, 204, 227);
+		-webkit-box-shadow: inset 5px 0px 0px 0px rgb(171, 204, 227);
+		box-shadow: inset 5px 0px 0px 0px rgb(171, 204, 227);
 	}
 
 	small {

--- a/lib/css/res.scss
+++ b/lib/css/res.scss
@@ -668,9 +668,7 @@ div.usertext-edit {
 
 	&.active {
 		font-weight: bold;
-		-moz-box-shadow: inset 5px 0px 0px 0px rgb(171, 204, 227);
-		-webkit-box-shadow: inset 5px 0px 0px 0px rgb(171, 204, 227);
-		box-shadow: inset 5px 0px 0px 0px rgb(171, 204, 227);
+		box-shadow: inset 5px 0 0 0 rgb(171, 204, 227);
 	}
 
 	small {


### PR DESCRIPTION
Small CSS addition to make it more obvious which module is selected in the settings console. (attempting to fix #4048.

Also, first pull request on an open source project ever, so let me know if I'm doing something wrong!

![selected-border-res-console](https://cloud.githubusercontent.com/assets/9335202/23927816/78240818-08f2-11e7-91a0-751187f5aab3.PNG)
