### PR TITLE
Replace protocol relative URLs with explicit https

### DIFF
--- a/examples/host.js
+++ b/examples/host.js
@@ -12,7 +12,7 @@ export default new Host('example', {
 	],
 
 	// Optional logo, for showing site attribution on the content
-	logo: '//example.com/favicon.ico',
+	logo: 'https://example.com/favicon.ico',
 	// OR, if the embed has its own attribution (watermark, etc.), disable RES' attribution
 	attribution: false,
 

--- a/lib/modules/hosts/bime.js
+++ b/lib/modules/hosts/bime.js
@@ -5,11 +5,11 @@ import { Host } from '../../core/host';
 export default new Host('bime', {
 	name: 'Bime Analytics Dashboards',
 	domains: ['bime.io'],
-	logo: '//a.bime.io/assets/favicons/favicon.ico',
+	logo: 'https://a.bime.io/assets/favicons/favicon.ico',
 	detect: ({ href }) => (/https?:\/\/([^.]+)\.bime\.io(?:\/([a-z0-9_-]+))+/i).exec(href),
 	handleLink: (href, [, user, dashboardId]) => ({
 		type: 'IFRAME',
-		embed: `//${user}.bime.io/dashboard/${dashboardId}`,
+		embed: `https://${user}.bime.io/dashboard/${dashboardId}`,
 		expandoClass: 'selftext',
 		width: '960px',
 		height: '540px',

--- a/lib/modules/hosts/clyp.js
+++ b/lib/modules/hosts/clyp.js
@@ -5,14 +5,12 @@ import { Host } from '../../core/host';
 export default new Host('clyp', {
 	name: 'clyp',
 	domains: ['clyp.it'],
-	logo: '//d2cjvbryygm0lr.cloudfront.net/favicon.ico',
+	logo: 'https://d2cjvbryygm0lr.cloudfront.net/favicon.ico',
 	detect: ({ pathname }) => (/^\/(playlist\/)?([A-Za-z0-9]+)/i).exec(pathname),
 	handleLink(href, [, playlist, id]) {
-		const urlBase = playlist ? '//clyp.it/playlist/' : '//clyp.it/';
-
 		return {
 			type: 'IFRAME',
-			embed: `${urlBase}${id}/widget`,
+			embed: `https://clyp.it/${playlist ? 'playlist/' : ''}${id}/widget`,
 			height: '160px',
 			width: '100%',
 		};

--- a/lib/modules/hosts/coub.js
+++ b/lib/modules/hosts/coub.js
@@ -12,8 +12,8 @@ export default new Host('coub', {
 
 	handleLink(href, [, hash, isGifv]) {
 		const src = isGifv ?
-			`//coub.com/view/${hash}.gifv?res=true` :
-			`//coub.com/embed/${hash}?autoplay=true&res=true`;
+			`https://coub.com/view/${hash}.gifv?res=true` :
+			`https://coub.com/embed/${hash}?autoplay=true&res=true`;
 
 		return {
 			type: 'IFRAME',

--- a/lib/modules/hosts/ctrlv.js
+++ b/lib/modules/hosts/ctrlv.js
@@ -4,7 +4,7 @@ import { Host } from '../../core/host';
 
 export default new Host('ctrlv', {
 	name: 'CtrlV.in',
-	logo: '//ctrlv.in/favicon.ico',
+	logo: 'https://ctrlv.in/favicon.ico',
 	domains: ['ctrlv.in'],
 	detect: ({ pathname }) => (/^\/([0-9]+)/i).exec(pathname),
 	handleLink(href, [, id]) {

--- a/lib/modules/hosts/dailymotion.js
+++ b/lib/modules/hosts/dailymotion.js
@@ -8,7 +8,7 @@ export default new Host('dailymotion', {
 	logo: 'https://static1.dmcdn.net/images/favicons/favicon-32x32.png.vb5b47df6329123929',
 	detect: ({ href }) => (/^https?:\/\/(?:(?:www|touch)\.)?dailymotion.com[\w\-\/:#]+video[\/=]([a-z0-9]+)/i).exec(href),
 	handleLink(href, [, hash]) {
-		const embed = `//www.dailymotion.com/embed/video/${hash}?api=postMessage`;
+		const embed = `https://www.dailymotion.com/embed/video/${hash}?api=postMessage`;
 
 		return {
 			type: 'IFRAME',

--- a/lib/modules/hosts/eroshare.js
+++ b/lib/modules/hosts/eroshare.js
@@ -5,12 +5,12 @@ import { Host } from '../../core/host';
 export default new Host('eroshare', {
 	name: 'eroshare',
 	domains: ['eroshare.com'],
-	logo: '//eroshare.com/favicon.ico',
+	logo: 'https://eroshare.com/favicon.ico',
 	detect: ({ hostname, pathname }) => hostname === 'eroshare.com' && (/^\/((?:i\/)?[a-z0-9]{8})/i).exec(pathname),
 	handleLink(href, [, hash]) {
 		return {
 			type: 'IFRAME',
-			embed: `//eroshare.com/embed/${hash}`,
+			embed: `https://eroshare.com/embed/${hash}`,
 			width: '550px',
 			height: '550px',
 			fixedRatio: true,

--- a/lib/modules/hosts/fiveHundredPx.js
+++ b/lib/modules/hosts/fiveHundredPx.js
@@ -14,7 +14,7 @@ import { Host } from '../../core/host';
 export default new Host('fiveHundredPx', {
 	name: 'fiveHundredPx',
 	domains: ['500px.org', '500px.net', '500px.com'],
-	logo: '//assetcdn.500px.org/assets/favicon-1e8257b93fb787f8ceb66b5522ee853c.ico',
+	logo: 'https://assetcdn.500px.org/assets/favicon-1e8257b93fb787f8ceb66b5522ee853c.ico',
 	detect: ({ href }) => (/^https?:\/\/\w*cdn\.500px\.(?:net|com|org)\/(?:photo\/)?([0-9]+)\//).exec(href),
 	handleLink(href, [, photoId]) {
 		return {

--- a/lib/modules/hosts/flickr.js
+++ b/lib/modules/hosts/flickr.js
@@ -6,7 +6,7 @@ import { ajax } from '../../environment';
 export default new Host('flickr', {
 	name: 'flickr',
 	domains: ['flickr.com', 'flic.kr', 'staticflickr.com'],
-	logo: '//s.yimg.com/pw/favicon.ico',
+	logo: 'https://s.yimg.com/pw/favicon.ico',
 	detect: (() => {
 		const alpha = '123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ';
 

--- a/lib/modules/hosts/gfycat.js
+++ b/lib/modules/hosts/gfycat.js
@@ -7,7 +7,7 @@ import { ajax } from '../../environment';
 export default new Host('gfycat', {
 	name: 'gfycat',
 	domains: ['gfycat.com'],
-	logo: '//gfycat.com/favicon2.ico',
+	logo: 'https://gfycat.com/favicon2.ico',
 	options: {
 		useMobileGfycat: {
 			title: 'gfycatUseMobileGfycatTitle',

--- a/lib/modules/hosts/gifyoutube.js
+++ b/lib/modules/hosts/gifyoutube.js
@@ -7,7 +7,7 @@ import { ajax } from '../../environment';
 export default new Host('gifs', {
 	name: 'gifs.com',
 	domains: ['gifs.com', 'gifyoutube.com', 'gifyt.com'],
-	logo: '//cdn.gifs.com/resources/favicon.png',
+	logo: 'https://cdn.gifs.com/resources/favicon.png',
 	detect: ({ href }) => (
 		(/^https?:\/\/(?:beta\.|www\.)?(?:gifyoutube|gifyt)\.com\/gif\/(\w+)\.?/i).exec(href) ||
 		(/^https?:\/\/share\.gifyoutube\.com\/(\w+)\.gif/i).exec(href)

--- a/lib/modules/hosts/github.js
+++ b/lib/modules/hosts/github.js
@@ -7,7 +7,7 @@ import { ajax } from '../../environment';
 
 export default new Host('github', {
 	domains: ['gist.github.com'],
-	logo: '//assets-cdn.github.com/favicon.ico',
+	logo: 'https://assets-cdn.github.com/favicon.ico',
 	name: 'github gists',
 	detect: ({ pathname }) => (/^\/(?:[\w-]+\/)?([a-z0-9]{20,}|\d+)/i).exec(pathname),
 	async handleLink(href, [, id]) {

--- a/lib/modules/hosts/graphiq.js
+++ b/lib/modules/hosts/graphiq.js
@@ -7,7 +7,7 @@ import { ajax } from '../../environment';
 export default new Host('graphiq', {
 	name: 'graphiq',
 	domains: ['graphiq.com'],
-	logo: '//www.graphiq.com/favicon.ico',
+	logo: 'https://www.graphiq.com/favicon.ico',
 	landingPage: 'https://www.graphiq.com/', // set menually as https url without www didn't work when i tried it
 	detect: ({ pathname }) => (/^\/(?:w|wlp|vlp)\/([A-z0-9]+)/i).exec(pathname),
 	async handleLink(href, [url, id]) {

--- a/lib/modules/hosts/iloopit.js
+++ b/lib/modules/hosts/iloopit.js
@@ -5,7 +5,7 @@ import { Host } from '../../core/host';
 export default new Host('iloopit', {
 	name: 'iLoopit - gif maker',
 	domains: ['iloopit.net'],
-	logo: '//iloopit.net/favicon.ico',
+	logo: 'https://iloopit.net/favicon.ico',
 	detect: ({ href }) => (
 		(/^https?:\/\/(\w+\.)?iloopit\.net\/.+?\/\?type=looplayer&loopid=(\d+)/i).exec(href) ||
 		(/^https?:\/\/(\w+\.)?iloopit\.net(\/tube)?\/(\d+)\/.+?\/(\?type=(looplayer)|(embed))?/i).exec(href)

--- a/lib/modules/hosts/imgflip.js
+++ b/lib/modules/hosts/imgflip.js
@@ -5,7 +5,7 @@ import { Host } from '../../core/host';
 export default new Host('imgflip', {
 	name: 'imgflip',
 	domains: ['imgflip.com'],
-	logo: '//imgflip.com/favicon02.png',
+	logo: 'https://imgflip.com/favicon02.png',
 	detect: ({ pathname }) => (/^\/(i|gif)\/([a-z0-9]+)/).exec(pathname),
 	handleLink(href, [, type, id]) {
 		return {

--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -7,7 +7,7 @@ import { string } from '../../utils';
 export default new Host('imgur', {
 	name: 'imgur',
 	domains: ['imgur.com'],
-	logo: '//i.imgur.com/favicon.ico',
+	logo: 'https://i.imgur.com/favicon.ico',
 	options: {
 		'prefer RES albums': {
 			title: 'imgurPreferResAlbumsTitle',
@@ -52,7 +52,7 @@ export default new Host('imgur', {
 		},
 	},
 	detect({ pathname, href }) {
-		const cdnUrl = '//i.imgur.com/';
+		const cdnUrl = 'https://i.imgur.com/';
 		const apiPrefix = 'https://api.imgur.com/3/';
 		const apiId = '1d8d9b36339e0e2';
 		const hashRe = /^https?:\/\/(?:i\.|m\.|edge\.|www\.)*imgur\.com\/(?:r\/\w+\/)*(?!gallery)(?!removalrequest)(?!random)(?!memegen)((?:\w{5}|\w{7})(?:[&,](?:\w{5}|\w{7}))*)(?:#\d+)?[a-z]?(\.(?:jpe?g|gifv?|png))?(\?.*)?$/i;

--- a/lib/modules/hosts/jsfiddle.js
+++ b/lib/modules/hosts/jsfiddle.js
@@ -12,7 +12,7 @@ export default new Host('jsfiddle', {
 			type: 'IFRAME',
 			expandoClass: 'selftext',
 			muted: true,
-			embed: `//jsfiddle.net${path}${categories || '/embedded/result,js,resources,html,css/'}`,
+			embed: `https://jsfiddle.net${path}${categories || '/embedded/result,js,resources,html,css/'}`,
 			width: '100%',
 			height: '500px',
 		};

--- a/lib/modules/hosts/livecap.js
+++ b/lib/modules/hosts/livecap.js
@@ -5,12 +5,12 @@ import { Host } from '../../core/host';
 export default new Host('livecap', {
 	name: 'LiveCap',
 	domains: ['livecap.tv'],
-	logo: '//www.livecap.tv/public/images/16x16.png',
+	logo: 'https://www.livecap.tv/public/images/16x16.png',
 
 	detect: ({ pathname }) => (/^\/[st]\/([a-zA-Z0-9_-]+\/[a-zA-Z0-9]+)/i).exec(pathname),
 
 	handleLink(href, [, path]) {
-		const embed = `//www.livecap.tv/s/embed/${path}`;
+		const embed = `https://www.livecap.tv/s/embed/${path}`;
 
 		return {
 			type: 'IFRAME',

--- a/lib/modules/hosts/livememe.js
+++ b/lib/modules/hosts/livememe.js
@@ -5,7 +5,7 @@ import { Host } from '../../core/host';
 export default new Host('livememe', {
 	name: 'livememe',
 	domains: ['livememe.com'],
-	logo: '//livememe.com/favicon.ico',
+	logo: 'https://livememe.com/favicon.ico',
 	detect: ({ pathname }) => (/^\/(?!edit)(\w{7})(?:\/|$)/i).exec(pathname),
 	handleLink(href, [, id]) {
 		return {

--- a/lib/modules/hosts/loophouse.js
+++ b/lib/modules/hosts/loophouse.js
@@ -5,7 +5,7 @@ import { Host } from '../../core/host';
 export default new Host('loophouse', {
 	name: 'loophouse',
 	domains: ['loophouse.tv'],
-	logo: '//loophouse.tv/favicon.ico',
+	logo: 'https://loophouse.tv/favicon.ico',
 	detect: ({ pathname }) => (/^\/l\/([\w-]+)(?:\/|$)/i).exec(pathname),
 	handleLink(href, [, hash]) {
 		const embed = `https://loophouse.tv/l/${hash}?playercard=1&muted=0&utm_source=reddit&utm_medium=res`;

--- a/lib/modules/hosts/memecrunch.js
+++ b/lib/modules/hosts/memecrunch.js
@@ -5,7 +5,7 @@ import { Host } from '../../core/host';
 export default new Host('memecrunch', {
 	name: 'memecrunch',
 	domains: ['memecrunch.com'],
-	logo: '//memecrunch.com/static/favicon.ico',
+	logo: 'https://memecrunch.com/static/favicon.ico',
 	detect: ({ pathname }) => (/^\/meme\/([0-9A-Z]+)\/([\w\-]+)(\/image\.(png|jpg))?/i).exec(pathname),
 	handleLink(href, [, id, format]) {
 		return {

--- a/lib/modules/hosts/memedad.js
+++ b/lib/modules/hosts/memedad.js
@@ -5,7 +5,7 @@ import { Host } from '../../core/host';
 export default new Host('memedad', {
 	name: 'memedad',
 	domains: ['memedad.com'],
-	logo: '//memedad.com/favicon.ico',
+	logo: 'https://memedad.com/favicon.ico',
 	detect: ({ pathname }) => (/^\/meme\/([0-9]+)/i).exec(pathname),
 	handleLink(href, [, id]) {
 		return {

--- a/lib/modules/hosts/oddshot.js
+++ b/lib/modules/hosts/oddshot.js
@@ -4,11 +4,11 @@ import { Host } from '../../core/host';
 
 export default new Host('oddshot', {
 	domains: ['oddshot.tv'],
-	logo: '//oddshot.tv/favicon.ico',
+	logo: 'https://oddshot.tv/favicon.ico',
 	name: 'Oddshot',
 	detect: ({ pathname }) => (/^\/shot\/([a-z0-9_-]+(?:\/[a-z0-9_-]+)?)/i).exec(pathname),
 	handleLink(href, [, hash]) {
-		const embed = `//oddshot.tv/shot/${hash}/embed`;
+		const embed = `https://oddshot.tv/shot/${hash}/embed`;
 
 		return {
 			type: 'IFRAME',

--- a/lib/modules/hosts/photobucket.js
+++ b/lib/modules/hosts/photobucket.js
@@ -6,7 +6,7 @@ import { ajax } from '../../environment';
 export default new Host('photobucket', {
 	name: 'photobucket',
 	domains: ['photobucket.com'],
-	logo: '//pic2.pbsrc.com/common/favicon.ico',
+	logo: 'https://pic2.pbsrc.com/common/favicon.ico',
 	detect: ({ href }) => (/([is]?)[0-9]+|media|smg|img(?=.photobucket.com)/i).exec(href),
 	async handleLink(href, [, prefix]) {
 		let src = href.replace('.html', '');

--- a/lib/modules/hosts/pixiv.js
+++ b/lib/modules/hosts/pixiv.js
@@ -7,7 +7,7 @@ import { getUrlParams } from '../../utils';
 export default new Host('pixiv', {
 	name: 'pixiv',
 	domains: ['pixiv.net'],
-	logo: '//www.pixiv.net/favicon.ico',
+	logo: 'https://www.pixiv.net/favicon.ico',
 	detect: ({ pathname, search }) => pathname === '/member_illust.php' && getUrlParams(search).illust_id,
 	permissions: ['https://app-api.pixiv.net/v1/illust/detail'],
 	async handleLink(href, id) {

--- a/lib/modules/hosts/pornbot.js
+++ b/lib/modules/hosts/pornbot.js
@@ -7,7 +7,7 @@ import { ajax } from '../../environment';
 export default new Host('pornbot', {
 	name: 'pornbot',
 	domains: ['pornbot.net'],
-	logo: '//pornbot.net/favicon.ico',
+	logo: 'https://pornbot.net/favicon.ico',
 	detect: ({ pathname }) => (/^\/([a-z0-9]{8,})/i).exec(pathname),
 	async handleLink(href, [, hash]) {
 		const info = await ajax({

--- a/lib/modules/hosts/qwipit.js
+++ b/lib/modules/hosts/qwipit.js
@@ -10,7 +10,7 @@ export default new Host('qwipit', {
 	handleLink(href, [, hash]) {
 		return {
 			type: 'IFRAME',
-			embed: `//qwip.it/reddit/${hash}`,
+			embed: `https://qwip.it/reddit/${hash}`,
 			height: '375px',
 			width: '485px',
 			fixedRatio: true,

--- a/lib/modules/hosts/raddit.js
+++ b/lib/modules/hosts/raddit.js
@@ -59,7 +59,7 @@ export default new Host('raddit', {
 			} else { // otherwise, create it.
 				const width = window.getComputedStyle(sb).width;
 
-				const src = `//radd.it${path}${path.includes('?') ? '&' : '?'}embed`;
+				const src = `https://radd.it${path}${path.includes('?') ? '&' : '?'}embed`;
 
 				listr = document.createElement('iframe');
 				listr.className = 'RES-raddit';

--- a/lib/modules/hosts/spotify.js
+++ b/lib/modules/hosts/spotify.js
@@ -5,7 +5,7 @@ import { Host } from '../../core/host';
 export default new Host('spotify', {
 	name: 'spotify',
 	domains: ['spotify.com'],
-	logo: '//spotify.com/favicon.ico',
+	logo: 'https://spotify.com/favicon.ico',
 	/*
 	* Match the following:
 	* https://open.spotify.com/track/id
@@ -18,7 +18,7 @@ export default new Host('spotify', {
 	handleLink(href, [, uri]) {
 		return {
 			type: 'IFRAME',
-			embed: `//embed.spotify.com/?uri=spotify:${uri.replace(/\//g, ':')}`,
+			embed: `https://embed.spotify.com/?uri=spotify:${uri.replace(/\//g, ':')}`,
 		};
 	},
 });

--- a/lib/modules/hosts/steampowered.js
+++ b/lib/modules/hosts/steampowered.js
@@ -4,7 +4,7 @@ import { Host } from '../../core/host';
 
 export default new Host('steampowered', {
 	name: 'steam',
-	logo: '//store.steampowered.com/favicon.ico',
+	logo: 'https://store.steampowered.com/favicon.ico',
 	domains: ['steampowered.com', 'steamusercontent.com'],
 	detect: ({ pathname }) => (/^\/ugc\/(\d{15,20}\/\w{40})(?:$|\/)/i).exec(pathname),
 	handleLink(href, [pathname]) {

--- a/lib/modules/hosts/strawpoll.js
+++ b/lib/modules/hosts/strawpoll.js
@@ -12,7 +12,7 @@ export default new Host('strawpoll', {
 			type: 'IFRAME',
 			expandoClass: 'selftext',
 			muted: true,
-			embed: `//www.strawpoll.me/embed_1/${uid}`,
+			embed: `https://www.strawpoll.me/embed_1/${uid}`,
 			height: '500px',
 			width: '700px',
 		};

--- a/lib/modules/hosts/streamable.js
+++ b/lib/modules/hosts/streamable.js
@@ -5,7 +5,7 @@ import { Host } from '../../core/host';
 export default new Host('streamable', {
 	name: 'streamable',
 	domains: ['streamable.com'],
-	logo: '//cdn-e2.streamable.com/static/14a98f7cb1ddc5213329c039dc39cac543ba410f/img/favicon.ico',
+	logo: 'https://cdn-e2.streamable.com/static/14a98f7cb1ddc5213329c039dc39cac543ba410f/img/favicon.ico',
 	detect: ({ pathname }) => (/^\/(?:e\/)?(\w+)$/i).exec(pathname),
 	handleLink(href, [, hash]) {
 		return {

--- a/lib/modules/hosts/supload.js
+++ b/lib/modules/hosts/supload.js
@@ -7,7 +7,7 @@ import { ajax } from '../../environment';
 export default new Host('supload', {
 	name: 'supload',
 	domains: ['supload.com'],
-	logo: '//supload.com/favicon.ico',
+	logo: 'https://supload.com/favicon.ico',
 	detect: ({ pathname }) => (/^\/([A-Za-z0-9_-]+)/i).exec(pathname),
 	async handleLink(href, [, id]) {
 		const data = await ajax({

--- a/lib/modules/hosts/tumblr.js
+++ b/lib/modules/hosts/tumblr.js
@@ -8,7 +8,7 @@ export default new Host('tumblr', {
 	name: 'tumblr',
 	domains: ['tumblr.com'],
 	permissions: ['https://api.tumblr.com/v2/blog/*/posts?api_key=*&id=*'],
-	logo: '//secure.assets.tumblr.com/images/favicons/favicon.ico',
+	logo: 'https://secure.assets.tumblr.com/images/favicons/favicon.ico',
 	detect({ hostname, pathname }) {
 		const pathMatch = (/^\/(?:post|image)\/(\d+)(?:\/|$)/i).exec(pathname);
 		return pathMatch && [hostname, pathMatch[1]];

--- a/lib/modules/hosts/uploadly.js
+++ b/lib/modules/hosts/uploadly.js
@@ -10,7 +10,7 @@ export default new Host('uploadly', {
 	handleLink(href, [, hash]) {
 		return {
 			type: 'IFRAME',
-			embed: `//uploadly.com/embed/${hash}`,
+			embed: `https://uploadly.com/embed/${hash}`,
 			width: '550px',
 			height: '550px',
 			fixedRatio: true,

--- a/lib/modules/hosts/vidble.js
+++ b/lib/modules/hosts/vidble.js
@@ -7,7 +7,7 @@ import { string } from '../../utils';
 export default new Host('vidble', {
 	name: 'vidble',
 	domains: ['vidble.com'],
-	logo: '//vidble.com/assets/ico/favicon.ico',
+	logo: 'https://vidble.com/assets/ico/favicon.ico',
 	detect: ({ pathname }) => (/^\/(show|album)\/([a-z0-9]+)/i).exec(pathname),
 	async handleLink(href, [, type, hash]) {
 		switch (type) {

--- a/lib/modules/hosts/xkcd.js
+++ b/lib/modules/hosts/xkcd.js
@@ -25,7 +25,7 @@ export default new Host('xkcd', {
 			title,
 			caption: escapeHTML(alt),
 			// Fix API always returning non-HTTPS URL
-			src: img.replace('http://', '//'),
+			src: img.replace('http://', 'https://'),
 		};
 	},
 });

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -793,7 +793,7 @@ async function convertGifToVideo(options) {
 	try {
 		const info = await ajax({
 			type: 'json',
-			url: '//upload.gfycat.com/transcodeRelease',
+			url: 'https://upload.gfycat.com/transcodeRelease',
 			data: { fetchUrl: options.src },
 			cacheFor: DAY,
 		});
@@ -1578,7 +1578,7 @@ function setMediaControls(media, lookupUrl, downloadUrl) {
 function addSiteAttribution(siteModule, media) {
 	const metadata = {
 		name: siteModule.name,
-		url: siteModule.landingPage || `//${siteModule.domains[0]}`,
+		url: siteModule.landingPage || `https://${siteModule.domains[0]}`,
 		logoUrl: siteModule.logo,
 		settingsLink: SettingsNavigation.makeUrlHash(module.moduleID, siteModuleOptionKey(siteModule)),
 	};

--- a/lib/templates/submitWizard.mustache
+++ b/lib/templates/submitWizard.mustache
@@ -33,7 +33,7 @@
 
     <dt>Screenshot/video of problem</dt>
     <dd>
-        <a href="//www.take-a-screenshot.org/" target="_blank" rel="noreferer noopener">Take a screenshot</a>, <a href="//imgur.com/upload">upload it</a>, and copy-paste the link here.
+        <a href="https://www.take-a-screenshot.org/" target="_blank" rel="noreferer noopener">Take a screenshot</a>, <a href="https://imgur.com/upload">upload it</a>, and copy-paste the link here.
     </dd>
 </dl>
 
@@ -57,7 +57,7 @@
 <p><a href="/r/Enhancement/submit/" class="blueButton">Post a request</a></p>
 
 
-<h2>I found a security issue.</a></h2>
+<h2>I found a security issue.</h2>
 <p>Please report security issues privately using modmail.</p>
 <p><a href="/message/compose/?to=/r/Enhancement" class="blueButton">Report a security issue</a></p>
 


### PR DESCRIPTION
I was going to do this for imgur to fix Chrome/Firefox differences for #4125, but figured we might as well do it for everything.

Reddit is https-only--and I highly doubt this will ever change--so protocol-relative links are always https.