### PR TITLE
Fix shortcut bar left scrolling by using integer value

### DIFF
--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -978,14 +978,9 @@ function redrawSubredditBar() {
 		shortCutsLeft.textContent = '<';
 		shortCutsLeft.addEventListener('click', () => {
 			const firstChild: HTMLElement = (shortCutsContainer.firstChild: any);
-			let marginLeft = firstChild.style.marginLeft;
-			marginLeft = parseInt(marginLeft.replace('px', ''), 10);
-
-			if (isNaN(marginLeft)) marginLeft = 0;
-
-			const shiftWidth = $('#RESShortcutsViewport').width() - 80;
-			marginLeft += shiftWidth;
-			marginLeft = Math.floor(marginLeft);
+			const containerMargin = parseInt(firstChild.style.marginLeft, 10) || 0;
+			const shiftWidth = Math.floor($('#RESShortcutsViewport').width()) - 80;
+			const marginLeft = containerMargin + shiftWidth;
 			if (marginLeft <= 0) {
 				firstChild.style.marginLeft = `${marginLeft}px`;
 			}

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -985,6 +985,7 @@ function redrawSubredditBar() {
 
 			const shiftWidth = $('#RESShortcutsViewport').width() - 80;
 			marginLeft += shiftWidth;
+			marginLeft = Math.floor(marginLeft);
 			if (marginLeft <= 0) {
 				firstChild.style.marginLeft = `${marginLeft}px`;
 			}


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: With long shortcut bars, the left scroll button appeared to be unresponsive. The math being done to find the shift distance could create a possible fractional value (0 < marginLeft < 1). Since marginLeft would have to be <= 0 to trigger the shift, it would fail in this case.

Tested in browser: Chrome 57.0.2987.110 (Arch Linux)
