### PR TITLE
add "rel=0" to end of youtube embeds to get rid of related videos

### DIFF
--- a/lib/modules/hosts/youtube.js
+++ b/lib/modules/hosts/youtube.js
@@ -22,7 +22,7 @@ export default new Host('youtube', {
 			(/watch|embed|v/i).exec(split[0]) && split[1]; // watch/embed/v
 	},
 	handleLink(href, path) {
-		let src = insertParams(`https://www.youtube.com/embed/${path}`, { version: 3 });
+		let src = insertParams(`https://www.youtube.com/embed/${path}`, { version: 3, rel: 0 });
 
 		const params = getUrlParams(href);
 
@@ -53,7 +53,7 @@ export default new Host('youtube', {
 		return {
 			type: 'IFRAME',
 			embed: src,
-			embedAutoplay: insertParams(src, { autoplay: 1, rel: 0 }),
+			embedAutoplay: insertParams(src, { autoplay: 1 }),
 			fixedRatio: true,
 		};
 	},

--- a/lib/modules/hosts/youtube.js
+++ b/lib/modules/hosts/youtube.js
@@ -53,7 +53,7 @@ export default new Host('youtube', {
 		return {
 			type: 'IFRAME',
 			embed: src,
-			embedAutoplay: insertParams(src, { autoplay: 1 }),
+			embedAutoplay: insertParams(src, { autoplay: 1, rel: 0 }),
 			fixedRatio: true,
 		};
 	},


### PR DESCRIPTION
[https://redd.it/60jq6g](https://redd.it/60jq6g)

just appends "rel=0" to end of youtube embed links so the related videos bar doesn't come up when the video gets paused.