### PR TITLE
ner returnToPrevPage: Fix watchers not being invoked on restored page

### DIFF
--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -10,6 +10,7 @@ import {
 	Thing,
 	addCSS,
 	elementInViewport,
+	fastAsync,
 	newSitetable,
 } from '../utils';
 import * as Floater from './floater';
@@ -411,13 +412,13 @@ async function loadPage(url: string) {
 	if (nextPageURL) attachLoaderWidget(newLoaderWidget);
 }
 
-async function appendPage(newSiteTable, pageHTML = newSiteTable.outerHTML) {
+const appendPage = fastAsync(function*(newSiteTable, pageHTML = newSiteTable.outerHTML) {
 	const lastPageMarker = $('<div>', { class: 'NERPageMarker', text: `Page ${currPage + 1}` })
 		.append(SettingsNavigation.makeUrlHashLink(module.moduleID, undefined, ' ', 'gearIcon'))
 		.data({ currPage, nextPageURL, pageHTML })
 		.get(0);
 
-	await Init.bodyReady;
+	yield Init.bodyReady;
 
 	siteTable().appendChild(lastPageMarker);
 	siteTable().appendChild(newSiteTable);
@@ -433,7 +434,7 @@ async function appendPage(newSiteTable, pageHTML = newSiteTable.outerHTML) {
 	if (!nextPageURL) endNER('No more pages');
 
 	window.dispatchEvent(new Event('neverEndingLoad', { bubbles: true, cancelable: true }));
-}
+});
 
 function endNER(text) {
 	nextPageURL = null;


### PR DESCRIPTION
The `Init.go` handler executed before `await Init.bodyReady` in `appendPage` was resolved. Since `appendPage` doesn't itself invoke the watchers, but relies on `Init.go` for that, the page must be appended before the `Init.go` handler is invoked.

Tested in browser: Chrome 58
