### PR TITLE
remove environment/alert.js

### DIFF
--- a/lib/environment/alert.js
+++ b/lib/environment/alert.js
@@ -1,6 +1,0 @@
-/* @flow */
-
-import { addListener } from '../../browser';
-import { Alert } from '../utils';
-
-addListener('alert', text => { Alert.open(text); });

--- a/lib/environment/index.js
+++ b/lib/environment/index.js
@@ -1,7 +1,5 @@
 /* @flow */
 
-import './alert';
-
 export { addURLToHistory, isURLVisited } from './history';
 export { ajax } from './ajax';
 export { i18n } from './i18n';


### PR DESCRIPTION
Tested in browser: firefox 54.0a2

This was only used by the old Firefox backend, so is unnecessary after #4116