### PR TITLE
Use chrome.downloads for downloading in Firefox

### DIFF
--- a/chrome/background.entry.js
+++ b/chrome/background.entry.js
@@ -11,6 +11,15 @@ addListener('isURLVisited', async url =>
 	(await apiToPromise(chrome.history.getVisits)({ url })).length > 0
 );
 
+// Adding `download` permission to Chrome would require a permissions dialog,
+// and would provide no benefit, since Chrome properly supports <a download>
+addListener('download', ({ url, filename }) => {
+	const a = document.createElement('a');
+	a.href = url;
+	a.download = filename || '';
+	a.click();
+});
+
 addListener('openNewTabs', ({ urls, focusIndex }, { id: tabId, index: currentIndex }) => {
 	urls.forEach((url, i) => {
 		chrome.tabs.create({

--- a/edge/background.entry.js
+++ b/edge/background.entry.js
@@ -6,6 +6,14 @@ import { addListener } from '../browser/background';
 addListener('addURLToHistory', () => {});
 addListener('isURLVisited', () => false);
 
+// see chrome/background.entry.js
+addListener('download', ({ url, filename }) => {
+	const a = document.createElement('a');
+	a.href = url;
+	a.download = filename || '';
+	a.click();
+});
+
 // Edge doesn't support openerTabId
 addListener('openNewTabs', ({ urls, focusIndex }, { index: currentIndex }) => {
 	urls.forEach((url, i) => {

--- a/firefox/background.entry.js
+++ b/firefox/background.entry.js
@@ -11,6 +11,11 @@ addListener('isURLVisited', async url =>
 	(await apiToPromise(chrome.history.getVisits)({ url })).length > 0
 );
 
+// Firefox <a download> is same-origin only
+addListener('download', ({ url, filename }) => {
+	chrome.downloads.download({ url, filename });
+});
+
 // Firefox doesn't support openerTabId
 addListener('openNewTabs', ({ urls, focusIndex }, { index: currentIndex }) => {
 	urls.forEach((url, i) => {

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -48,6 +48,7 @@
 		"history",
 		"storage",
 		"unlimitedStorage",
+		"downloads",
 
 		"http://redditenhancementsuite.com/",
 		"http://reddit.com/*",

--- a/lib/environment/download.js
+++ b/lib/environment/download.js
@@ -1,0 +1,11 @@
+/* @flow */
+
+import { sendMessage } from '../../browser';
+
+export function download(url: string, filename?: string) {
+	return sendMessage('download', {
+		// resolve relative URLs
+		url: new URL(url, location.href).href,
+		filename,
+	});
+}

--- a/lib/environment/index.js
+++ b/lib/environment/index.js
@@ -4,6 +4,7 @@ import './alert';
 
 export { addURLToHistory, isURLVisited } from './history';
 export { ajax } from './ajax';
+export { download } from './download';
 export { i18n } from './i18n';
 export { isPrivateBrowsing } from './privateBrowsing';
 export { launchAuthFlow } from './auth';

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -31,7 +31,6 @@ import {
 	Thing,
 	addCSS,
 	batch,
-	click,
 	CreateElement,
 	elementInViewport,
 	scrollToElement,
@@ -47,7 +46,14 @@ import {
 	getPercentageVisibleYAxis,
 	getViewportSize,
 } from '../utils';
-import { addURLToHistory, ajax, isPrivateBrowsing, openNewTab, Permissions } from '../environment';
+import {
+	addURLToHistory,
+	ajax,
+	download,
+	isPrivateBrowsing,
+	openNewTab,
+	Permissions,
+} from '../environment';
 import * as Options from '../core/options';
 import * as NeverEndingReddit from './neverEndingReddit';
 import * as SelectedEntry from './selectedEntry';
@@ -1530,13 +1536,7 @@ function setMediaControls(media, lookupUrl, downloadUrl) {
 				rotateMedia(media, ++rotationState);
 				break;
 			case 'download':
-				downloadUrl = new URL(downloadUrl, location.href).href;
-
-				// Create element to trigger download
-				const link = document.createElement('a');
-				link.href = downloadUrl;
-				link.download = '';
-				click(link);
+				download(downloadUrl);
 				break;
 			case 'imageLookup':
 				// Google doesn't like image url's without a protacol


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: fixes #3527
Tested in browser: chrome 59, firefox 54

This can't be used for the backup file download, because it doesn't work for blobs in Firefox. Ugh.