### PR TITLE
showImages: trigger permission dialog on keynav expansion

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -397,7 +397,12 @@ module.options = {
 		title: 'keyboardNavToggleExpandoTitle',
 		callback() {
 			const thing = SelectedEntry.selectedThing();
-			if (thing) ShowImages.toggleThingExpandos(thing, module.options.scrollOnExpando.value);
+			if (thing) {
+				ShowImages.toggleThingExpandos(thing, {
+					scrollOnExpando: module.options.scrollOnExpando.value,
+					isUserAction: true,
+				});
+			}
 		},
 	},
 	imageSizeUp: {

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -693,7 +693,7 @@ const updateRevealedImages = _.debounce(({ onlyOpen = false } = {}) => {
 
 const sortExpandosVertically = sortBy(v => v.button.getBoundingClientRect().top);
 
-export function toggleThingExpandos(thing: Thing, scrollOnExpando?: boolean): void {
+export function toggleThingExpandos(thing: Thing, { scrollOnExpando, isUserAction }: {| scrollOnExpando?: boolean, isUserAction?: boolean |} = {}): void {
 	const expandos = Expando.getAllExpandosFrom(thing);
 	if (!expandos.length) return;
 
@@ -711,6 +711,11 @@ export function toggleThingExpandos(thing: Thing, scrollOnExpando?: boolean): vo
 				!(expando instanceof Expando) ||
 				isExpandWanted(expando, { thing, autoExpandFirstVisibleNonMutedInThing: true, autoExpand: true, autoExpandTypes: ['any'], ignoreDuplicatesScope: thing.entry })
 			) {
+				const completeDeferred = deferredExpandos.get(expando);
+				if (completeDeferred) {
+					completeDeferred(isUserAction ? 'click' : undefined);
+				}
+
 				expando.expand();
 			}
 		}


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: `andytuba [8:21 PM] oh hmm keynav expando on a host which needs permissions doesn’t fire the permissions request dialog`
Tested in browser: chrome 59
