### PR TITLE
Cleanup permissions

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -47,7 +47,6 @@
 		"https://reddit.com/*",
 		"http://*.reddit.com/*",
 		"https://*.reddit.com/*",
-		"http://img.photobucket.com/*",
 		"http://noembed.com/embed?url=*"
 	],
 	"optional_permissions": [

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -46,8 +46,7 @@
 		"http://reddit.com/*",
 		"https://reddit.com/*",
 		"http://*.reddit.com/*",
-		"https://*.reddit.com/*",
-		"http://noembed.com/embed?url=*"
+		"https://*.reddit.com/*"
 	],
 	"optional_permissions": [
 		"https://api.twitter.com/*",

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -25,9 +25,6 @@
 	},
 	"content_scripts": [{
 		"matches": [
-			"http://reddit.com/*",
-			"https://reddit.com/*",
-			"http://*.reddit.com/*",
 			"https://*.reddit.com/*"
 		],
 		"js": [

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -53,7 +53,7 @@
 		"https://onedrive.live.com/*",
 		"https://1drv.ms/*",
 		"https://backend.deviantart.com/oembed",
-		"*://api.gyazo.com/api/oembed*",
+		"https://api.gyazo.com/api/oembed",
 		"*://codepen.io/api/oembed*",
 		"*://api.tumblr.com/v2/blog/*/posts?api_key=*&id=*",
 		"https://xkcd.com/*/info.0.json",

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -47,7 +47,6 @@
 		"https://reddit.com/*",
 		"http://*.reddit.com/*",
 		"https://*.reddit.com/*",
-		"http://*.flickr.com/photos/*",
 		"http://img.photobucket.com/*",
 		"http://noembed.com/embed?url=*"
 	],

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -54,7 +54,7 @@
 		"https://1drv.ms/*",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
-		"*://codepen.io/api/oembed*",
+		"https://codepen.io/api/oembed",
 		"*://api.tumblr.com/v2/blog/*/posts?api_key=*&id=*",
 		"https://xkcd.com/*/info.0.json",
 		"https://app-api.pixiv.net/v1/illust/detail",

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -51,7 +51,7 @@
 	"optional_permissions": [
 		"https://api.twitter.com/*",
 		"https://onedrive.live.com/*",
-		"*://1drv.ms/*",
+		"https://1drv.ms/*",
 		"*://backend.deviantart.com/oembed?url=*",
 		"*://api.gyazo.com/api/oembed*",
 		"*://codepen.io/api/oembed*",

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -55,7 +55,7 @@
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
 		"https://codepen.io/api/oembed",
-		"*://api.tumblr.com/v2/blog/*/posts?api_key=*&id=*",
+		"https://api.tumblr.com/v2/blog/*/posts",
 		"https://xkcd.com/*/info.0.json",
 		"https://app-api.pixiv.net/v1/illust/detail",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*"

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -25,7 +25,6 @@
 	},
 	"content_scripts": [{
 		"matches": [
-			"http://redditenhancementsuite.com/*",
 			"http://reddit.com/*",
 			"https://reddit.com/*",
 			"http://*.reddit.com/*",

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -52,7 +52,7 @@
 		"https://api.twitter.com/*",
 		"https://onedrive.live.com/*",
 		"https://1drv.ms/*",
-		"*://backend.deviantart.com/oembed?url=*",
+		"https://backend.deviantart.com/oembed",
 		"*://api.gyazo.com/api/oembed*",
 		"*://codepen.io/api/oembed*",
 		"*://api.tumblr.com/v2/blog/*/posts?api_key=*&id=*",

--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -26,7 +26,6 @@
 	},
 	"content_scripts": [{
 		"matches": [
-			"http://redditenhancementsuite.com/*",
 			"http://reddit.com/*",
 			"https://reddit.com/*",
 			"http://*.reddit.com/*",

--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -26,9 +26,6 @@
 	},
 	"content_scripts": [{
 		"matches": [
-			"http://reddit.com/*",
-			"https://reddit.com/*",
-			"http://*.reddit.com/*",
 			"https://*.reddit.com/*"
 		],
 		"js": [

--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -51,8 +51,7 @@
 
 		"https://api.twitter.com/*",
 		"https://onedrive.live.com/*",
-		"https://api.onedrive.com/*",
-		"*://1drv.ms/*",
+		"https://1drv.ms/*",
 		"*://backend.deviantart.com/oembed?url=*",
 		"*://api.gyazo.com/api/oembed*",
 		"*://codepen.io/api/oembed*",
@@ -62,6 +61,7 @@
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
 
 		"https://api.photobucket.com/v2/media/fromurl",
+		"https://api.onedrive.com/*",
 		"https://*.wikipedia.org/w/api.php",
 		"http://www.simplecove.com/resapi/*",
 		"https://www.googleapis.com/*"

--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -48,7 +48,6 @@
 		"https://reddit.com/*",
 		"http://*.reddit.com/*",
 		"https://*.reddit.com/*",
-		"http://img.photobucket.com/*",
 		"http://noembed.com/embed?url=*",
 
 		"https://api.twitter.com/*",

--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -48,7 +48,6 @@
 		"https://reddit.com/*",
 		"http://*.reddit.com/*",
 		"https://*.reddit.com/*",
-		"http://noembed.com/embed?url=*",
 
 		"https://api.twitter.com/*",
 		"https://onedrive.live.com/*",

--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -53,7 +53,7 @@
 		"https://onedrive.live.com/*",
 		"https://1drv.ms/*",
 		"https://backend.deviantart.com/oembed",
-		"*://api.gyazo.com/api/oembed*",
+		"https://api.gyazo.com/api/oembed",
 		"*://codepen.io/api/oembed*",
 		"*://api.tumblr.com/v2/blog/*/posts?api_key=*&id=*",
 		"https://xkcd.com/*/info.0.json",

--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -62,8 +62,8 @@
 		"https://app-api.pixiv.net/v1/illust/detail",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
 
-		"*://*.photobucket.com/*",
-		"*://*.wikipedia.org/*",
+		"https://api.photobucket.com/v2/media/fromurl",
+		"https://*.wikipedia.org/w/api.php",
 		"*://redditbooru.com/*",
 		"http://www.simplecove.com/resapi/*",
 		"https://www.googleapis.com/*"

--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -54,7 +54,7 @@
 		"https://1drv.ms/*",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
-		"*://codepen.io/api/oembed*",
+		"https://codepen.io/api/oembed",
 		"*://api.tumblr.com/v2/blog/*/posts?api_key=*&id=*",
 		"https://xkcd.com/*/info.0.json",
 		"https://app-api.pixiv.net/v1/illust/detail",

--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -48,7 +48,7 @@
 		"https://reddit.com/*",
 		"http://*.reddit.com/*",
 		"https://*.reddit.com/*",
-		"*://*.photobucket.com/*",
+		"http://img.photobucket.com/*",
 		"http://noembed.com/embed?url=*",
 
 		"https://api.twitter.com/*",
@@ -63,6 +63,7 @@
 		"https://app-api.pixiv.net/v1/illust/detail",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
 
+		"*://*.photobucket.com/*",
 		"*://*.wikipedia.org/*",
 		"*://redditbooru.com/*",
 		"http://www.simplecove.com/resapi/*",

--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -64,7 +64,6 @@
 
 		"https://api.photobucket.com/v2/media/fromurl",
 		"https://*.wikipedia.org/w/api.php",
-		"*://redditbooru.com/*",
 		"http://www.simplecove.com/resapi/*",
 		"https://www.googleapis.com/*"
 	]

--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -55,7 +55,7 @@
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
 		"https://codepen.io/api/oembed",
-		"*://api.tumblr.com/v2/blog/*/posts?api_key=*&id=*",
+		"https://api.tumblr.com/v2/blog/*/posts",
 		"https://xkcd.com/*/info.0.json",
 		"https://app-api.pixiv.net/v1/illust/detail",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",

--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -48,7 +48,6 @@
 		"https://reddit.com/*",
 		"http://*.reddit.com/*",
 		"https://*.reddit.com/*",
-		"http://*.flickr.com/photos/*",
 		"*://*.photobucket.com/*",
 		"http://noembed.com/embed?url=*",
 

--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -52,7 +52,7 @@
 		"https://api.twitter.com/*",
 		"https://onedrive.live.com/*",
 		"https://1drv.ms/*",
-		"*://backend.deviantart.com/oembed?url=*",
+		"https://backend.deviantart.com/oembed",
 		"*://api.gyazo.com/api/oembed*",
 		"*://codepen.io/api/oembed*",
 		"*://api.tumblr.com/v2/blog/*/posts?api_key=*&id=*",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -51,7 +51,6 @@
 		"https://reddit.com/*",
 		"http://*.reddit.com/*",
 		"https://*.reddit.com/*",
-		"http://noembed.com/embed?url=*",
 
 		"https://api.twitter.com/*",
 		"https://onedrive.live.com/*",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -55,7 +55,7 @@
 		"https://api.twitter.com/*",
 		"https://onedrive.live.com/*",
 		"https://1drv.ms/*",
-		"*://backend.deviantart.com/oembed?url=*",
+		"https://backend.deviantart.com/oembed",
 		"*://api.gyazo.com/api/oembed*",
 		"*://codepen.io/api/oembed*",
 		"*://api.tumblr.com/v2/blog/*/posts?api_key=*&id=*",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -28,7 +28,6 @@
 	},
 	"content_scripts": [{
 		"matches": [
-			"http://redditenhancementsuite.com/*",
 			"http://reddit.com/*",
 			"https://reddit.com/*",
 			"http://*.reddit.com/*",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -54,7 +54,7 @@
 
 		"https://api.twitter.com/*",
 		"https://onedrive.live.com/*",
-		"*://1drv.ms/*",
+		"https://1drv.ms/*",
 		"*://backend.deviantart.com/oembed?url=*",
 		"*://api.gyazo.com/api/oembed*",
 		"*://codepen.io/api/oembed*",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -57,7 +57,7 @@
 		"https://1drv.ms/*",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
-		"*://codepen.io/api/oembed*",
+		"https://codepen.io/api/oembed",
 		"*://api.tumblr.com/v2/blog/*/posts?api_key=*&id=*",
 		"https://xkcd.com/*/info.0.json",
 		"https://app-api.pixiv.net/v1/illust/detail",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -28,9 +28,6 @@
 	},
 	"content_scripts": [{
 		"matches": [
-			"http://reddit.com/*",
-			"https://reddit.com/*",
-			"http://*.reddit.com/*",
 			"https://*.reddit.com/*"
 		],
 		"js": [

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -51,7 +51,6 @@
 		"https://reddit.com/*",
 		"http://*.reddit.com/*",
 		"https://*.reddit.com/*",
-		"http://*.flickr.com/photos/*",
 		"http://img.photobucket.com/*",
 		"http://noembed.com/embed?url=*",
 

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -56,7 +56,7 @@
 		"https://onedrive.live.com/*",
 		"https://1drv.ms/*",
 		"https://backend.deviantart.com/oembed",
-		"*://api.gyazo.com/api/oembed*",
+		"https://api.gyazo.com/api/oembed",
 		"*://codepen.io/api/oembed*",
 		"*://api.tumblr.com/v2/blog/*/posts?api_key=*&id=*",
 		"https://xkcd.com/*/info.0.json",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -58,7 +58,7 @@
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
 		"https://codepen.io/api/oembed",
-		"*://api.tumblr.com/v2/blog/*/posts?api_key=*&id=*",
+		"https://api.tumblr.com/v2/blog/*/posts",
 		"https://xkcd.com/*/info.0.json",
 		"https://app-api.pixiv.net/v1/illust/detail",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*"

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -51,7 +51,6 @@
 		"https://reddit.com/*",
 		"http://*.reddit.com/*",
 		"https://*.reddit.com/*",
-		"http://img.photobucket.com/*",
 		"http://noembed.com/embed?url=*",
 
 		"https://api.twitter.com/*",

--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -21,8 +21,7 @@ let start;
 
 export function init() {
 	if (
-		!location.hostname.endsWith('.reddit.com') ||
-		(/^(?:i|m|static|thumbs|blog|code|mod|about|ads)\.reddit\.com$/i).test(location.hostname) ||
+		(/^(?:i|m|static|thumbs|blog|code|mod|about|ads)\./i).test(location.hostname) ||
 		(/^\/advertising/).test(location.pathname) ||
 		(/\.(?:compact|mobile|json|json-html)$/i).test(location.pathname)
 	) {

--- a/lib/modules/about.js
+++ b/lib/modules/about.js
@@ -95,6 +95,6 @@ module.options = {
 		description: 'aboutOptionsLicense',
 		title: 'aboutOptionsLicenseTitle',
 		text: CreateElement.icon('F0D3'),
-		callback: 'http://www.gnu.org/licenses/gpl-3.0.html',
+		callback: 'https://www.gnu.org/licenses/gpl-3.0.html',
 	},
 };

--- a/lib/modules/hosts/codepen.js
+++ b/lib/modules/hosts/codepen.js
@@ -7,7 +7,7 @@ import { ajax } from '../../environment';
 export default new Host('codepen', {
 	name: 'CodePen',
 	domains: ['codepen.io'],
-	permissions: ['https://codepen.io/api/oembed*'],
+	permissions: ['https://codepen.io/api/oembed'],
 	logo: 'https://codepen.io/favicon.ico',
 	detect: ({ pathname }) => (/^\/(?!anon)([a-z0-9_-]+)\/(?:pen|full|details|debug)\/([a-z]+)\b/i).exec(pathname),
 	async handleLink(href, [, user, hash]) {

--- a/lib/modules/hosts/deviantart.js
+++ b/lib/modules/hosts/deviantart.js
@@ -5,7 +5,7 @@ import { ajax } from '../../environment';
 
 export default new Host('deviantart', {
 	name: 'deviantART',
-	logo: 'http://i.deviantart.net/icons/da_favicon.ico',
+	logo: 'https://i.deviantart.net/icons/da_favicon.ico',
 	domains: ['deviantart.com', 'fav.me', 'sta.sh'],
 	permissions: ['https://backend.deviantart.com/oembed?url=*'],
 	detect: ({ href }) => (/^https?:\/\/(?:fav\.me\/.*|sta\.sh.*|(?:.+\.)?deviantart\.com\/(?:art\/.*|[^#]*#\/d.*))$/i).test(href),

--- a/lib/modules/hosts/deviantart.js
+++ b/lib/modules/hosts/deviantart.js
@@ -7,7 +7,7 @@ export default new Host('deviantart', {
 	name: 'deviantART',
 	logo: 'https://i.deviantart.net/icons/da_favicon.ico',
 	domains: ['deviantart.com', 'fav.me', 'sta.sh'],
-	permissions: ['https://backend.deviantart.com/oembed?url=*'],
+	permissions: ['https://backend.deviantart.com/oembed'],
 	detect: ({ href }) => (/^https?:\/\/(?:fav\.me\/.*|sta\.sh.*|(?:.+\.)?deviantart\.com\/(?:art\/.*|[^#]*#\/d.*))$/i).test(href),
 	async handleLink(href) {
 		const info = await ajax({

--- a/lib/modules/hosts/fiveHundredPx.js
+++ b/lib/modules/hosts/fiveHundredPx.js
@@ -20,7 +20,7 @@ export default new Host('fiveHundredPx', {
 		return {
 			type: 'IMAGE',
 			src: href.replace(/\/[0-9]+\.jpg$/, '/5.jpg'),
-			credits: `View original and details at: <a href="http://500px.com/photo/${photoId}">500px.com</a>`,
+			credits: `View original and details at: <a href="https://500px.com/photo/${photoId}">500px.com</a>`,
 		};
 	},
 });

--- a/lib/modules/hosts/gyazo.js
+++ b/lib/modules/hosts/gyazo.js
@@ -6,7 +6,7 @@ import { ajax } from '../../environment';
 export default new Host('gyazo', {
 	name: 'gyazo',
 	domains: ['gyazo.com'],
-	permissions: ['https://api.gyazo.com/api/oembed*'],
+	permissions: ['https://api.gyazo.com/api/oembed'],
 	logo: 'https://gyazo.com/favicon.ico',
 	detect: ({ pathname }) => (/^\/(\w{32})\b/i).exec(pathname),
 	async handleLink(href, [, id]) {

--- a/lib/modules/hosts/makeameme.js
+++ b/lib/modules/hosts/makeameme.js
@@ -5,12 +5,12 @@ import { Host } from '../../core/host';
 export default new Host('makeameme', {
 	name: 'makeameme',
 	domains: ['makeameme.org'],
-	logo: 'http://makeameme.org/images/favicons/favicon-32x32.png',
+	logo: 'https://makeameme.org/images/favicons/favicon-32x32.png',
 	detect: ({ pathname }) => (/^\/meme\/([\w\-]+)/i).exec(pathname),
 	handleLink(href, [, id]) {
 		return {
 			type: 'IMAGE',
-			src: `http://makeameme.org/media/created/${id}.jpg`,
+			src: `https://makeameme.org/media/created/${id}.jpg`,
 		};
 	},
 });

--- a/lib/modules/hosts/onedrive.js
+++ b/lib/modules/hosts/onedrive.js
@@ -6,13 +6,13 @@ import { ajax } from '../../environment';
 
 export default new Host('onedrive', {
 	domains: ['onedrive.live.com', '1drv.ms'],
-	permissions: ['*://1drv.ms/*', 'https://onedrive.live.com/*'],
+	permissions: ['https://1drv.ms/*', 'https://onedrive.live.com/*'],
 	name: 'Microsoft OneDrive',
 	detect: () => true,
 	async handleLink(href) {
 		if (href.includes('1drv.ms/')) {
 			href = await ajax({
-				url: href,
+				url: href.replace('http:', 'https:'),
 				type: 'redirect',
 				cacheFor: DAY,
 			});

--- a/lib/modules/hosts/ppy.js
+++ b/lib/modules/hosts/ppy.js
@@ -10,7 +10,7 @@ export default new Host('ppy.sh', {
 	handleLink(href, [, code]) {
 		return {
 			type: 'IMAGE',
-			src: `http://osu.ppy.sh/ss/${code}`,
+			src: `https://osu.ppy.sh/ss/${code}`,
 		};
 	},
 });

--- a/lib/modules/hosts/redditbooru.js
+++ b/lib/modules/hosts/redditbooru.js
@@ -15,7 +15,7 @@ export default new Host('redditbooru', {
 		}
 
 		const info = await ajax({
-			url: 'http://redditbooru.com/images/',
+			url: 'https://redditbooru.com/images/',
 			data: { postId: id },
 			type: 'json',
 		});

--- a/lib/modules/hosts/redditbooru.js
+++ b/lib/modules/hosts/redditbooru.js
@@ -6,7 +6,7 @@ import { ajax } from '../../environment';
 export default new Host('redditbooru', {
 	name: 'redditbooru',
 	domains: ['redditbooru.com'],
-	logo: 'http://redditbooru.com/favicon.ico',
+	logo: 'https://redditbooru.com/favicon.ico',
 	detect: ({ pathname }) => (/^\/gallery\/([\w]+)(\/[\w\-]+)?/i).exec(pathname),
 	async handleLink(href, [, id, base36]) {
 		// this will only be set for base36 IDs

--- a/lib/modules/hosts/snag.js
+++ b/lib/modules/hosts/snag.js
@@ -4,13 +4,13 @@ import { Host } from '../../core/host';
 
 export default new Host('snag', {
 	name: 'snag.gy',
-	logo: 'http://snag.gy/assets/images/favicon.ico',
+	logo: 'https://snaggys3static-snaggy.netdna-ssl.com/favicon.png',
 	domains: ['snag.gy'],
 	detect: ({ pathname }) => (/^\/(\w{5})(?:\.(\w+))?/i).exec(pathname),
 	handleLink(href, [, id, extension]) {
 		return {
 			type: 'IMAGE',
-			src: `http://i.snag.gy/${id}.${extension || 'jpg'}`,
+			src: `https://i.snag.gy/${id}.${extension || 'jpg'}`,
 		};
 	},
 });

--- a/lib/modules/hosts/tumblr.js
+++ b/lib/modules/hosts/tumblr.js
@@ -7,7 +7,7 @@ import { ajax } from '../../environment';
 export default new Host('tumblr', {
 	name: 'tumblr',
 	domains: ['tumblr.com'],
-	permissions: ['https://api.tumblr.com/v2/blog/*/posts?api_key=*&id=*'],
+	permissions: ['https://api.tumblr.com/v2/blog/*/posts'],
 	logo: 'https://secure.assets.tumblr.com/images/favicons/favicon.ico',
 	detect({ hostname, pathname }) {
 		const pathMatch = (/^\/(?:post|image)\/(\d+)(?:\/|$)/i).exec(pathname);

--- a/lib/modules/hosts/xkcd.js
+++ b/lib/modules/hosts/xkcd.js
@@ -24,8 +24,7 @@ export default new Host('xkcd', {
 			type: 'IMAGE',
 			title,
 			caption: escapeHTML(alt),
-			// Fix API always returning non-HTTPS URL
-			src: img.replace('http://', 'https://'),
+			src: img,
 		};
 	},
 });


### PR DESCRIPTION
Tested in browser: Chrome 59, Firefox 54

Many more details in commit messages, but basically:

- stop running on:
`http://redditenhancementsuite.com/*` (currently useless)
`http://reddit.com`, `http://*.reddit.com` (impossible)
`https://reddit.com` (redundant)
The mandatory permissions for these URLs are kept, so this is reversible.

- irreversibly remove some unused, http-only mandatory permissions:
`http://*.flickr.com/photos/*`
`http://img.photobucket.com/*`
`http://noembed.com/embed?url=*`
There's no reason we would use these in the future (over their https counterparts), especially now that adding optional permissions for hosts is trivial. Removing these means that users will only have to accept permissions for reddit.com and res.com when they install, which should placate some ~~tinfoil hat wearers~~privacy-conscious users. (at least in Chrome; the other browsers require all permissions to be accepted up front)

- cleanup/change a bunch of optional permissions
(these are optional, so changes don't really matter)

- cleanup a couple hosts (and fix a redditbooru issue related to an http->https upgrade redirect)