### PR TITLE
Remove explicit yarn installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,6 @@ addons:
     secure: hHF06xHY6pLdxscwYhUHdSRuUH2CPA61AUrvPiW54lnMwwkDvCQakR+aY5HbjptFIfOwkWsS4xoqXH4pZTfhMOji32S/+ELT+AqLdkIgnLYDfBj4RcsZoXyvuiLx29i4PVCnGMikctBp4dM6wORgfd1tu3uwhcoQrBjxCMW1qmY=
 cache:
   yarn: true
-before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
-  - export PATH=$HOME/.yarn/bin:$PATH
 install:
   - yarn install --pure-lockfile
   - yarn check --integrity


### PR DESCRIPTION
Closes #3624

It appears that Travis now installs yarn before the `install`/`beforeinstall` phases, so we aren't overwriting it anymore.