### PR TITLE
Fix expando preloading

### DIFF
--- a/lib/utils/string.js
+++ b/lib/utils/string.js
@@ -55,12 +55,12 @@ export const html = flow(
 		template.innerHTML = markup;
 		if (process.env.BUILD_TARGET === 'edge') {
 			// Edge does not support childELementCount or firstElementChild on DocumentFragment
-			return downcast(template.content.querySelector('*'), HTMLElement);
+			return downcast(document.adoptNode(template.content.querySelector('*')), HTMLElement);
 		}
 		if (template.content.childElementCount !== 1) {
 			throw new Error(`Html template should have exactly one root node, but had ${template.content.childElementCount}`);
 		}
-		return downcast(template.content.firstElementChild, HTMLElement);
+		return downcast(document.adoptNode(template.content.firstElementChild), HTMLElement);
 	}
 );
 


### PR DESCRIPTION
Elements must be owned by the current document for images to be preloaded.

Tested in browser: chrome 59, firefox 54, edge 15