### PR TITLE
Support r2-rendered post-to-profile comments page

### DIFF
--- a/lib/modules/commentDepth.js
+++ b/lib/modules/commentDepth.js
@@ -2,7 +2,7 @@
 
 import { $ } from '../vendor';
 import { Module } from '../core/module';
-import { insertParams, regexes, Thing } from '../utils';
+import { execRegexes, insertParams, regexes, Thing } from '../utils';
 
 export const module: Module<*> = new Module('commentDepth');
 

--- a/lib/modules/commentDepth.js
+++ b/lib/modules/commentDepth.js
@@ -70,12 +70,12 @@ module.go = () => {
 		// no need to proceed if depth already exists in the query string
 		if (search.match(/[?&]depth=/)) return;
 
-		if (pathname.match(regexes.commentPermalink)) {
+		if (regexes.commentPermalink.test(pathname)) {
 			if (!module.options.commentPermalinks.value) return;
 			if (!module.options.commentPermalinksContext.value && search.match(/[?&]context=/)) return;
 		}
 
-		const matches = pathname.match(regexes.comments);
+		const matches = execRegexes.comments(pathname);
 		if (!matches) return;
 
 		const subreddit = matches[1].toLowerCase();

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -8,6 +8,7 @@ import {
 	Alert,
 	Thing,
 	escapeHTML,
+	execRegexes,
 	filterMap,
 	formatDateDiff,
 	formatDateTime,
@@ -71,7 +72,7 @@ module.options = {
 	},
 };
 
-const currentCommentID: ?string = (regexes.comments.exec(location.pathname) || [])[2];
+const currentCommentID: ?string = (execRegexes.comments(location.pathname) || [])[2];
 const lastCleanStorage = Storage.wrap('RESmodules.newCommentCount.lastClean', (null: null | number));
 const commentCountStorage = Storage.wrap('RESmodules.newCommentCount.counts', ({}: { [key: string]: {
 	subscriptionDate?: number,

--- a/lib/utils/__tests__/location.js
+++ b/lib/utils/__tests__/location.js
@@ -6,6 +6,7 @@ import {
 	getUrlParams,
 	insertParams,
 	regexes,
+	execRegexes,
 } from '../location';
 
 test('getUrlParams', t => {
@@ -32,6 +33,14 @@ function regexMatches(t, regex, matches) {
 	}
 }
 
+function execRegexMatches(t, execRegex, matches) {
+	for (const m of matches) {
+		const [str, ...captureGroups] = [].concat(m);
+		// TODO: better error reporting when tests fail
+		t.deepEqual(execRegex(str).slice(1), captureGroups, str);
+	}
+}
+
 function regexDoesntMatch(t, regex, strings) {
 	for (const str of strings) {
 		t.false(regex.test(str));
@@ -48,8 +57,20 @@ test('frontpage', regexMatches, regexes.frontpage, [
 ]);
 
 test('comments regex', regexMatches, regexes.comments, [
+	['/r/aww/comments/4ooe2m/', 'aww', undefined, '4ooe2m'],
+	['/r/aww/comments/4ooe2m', 'aww', undefined, '4ooe2m'],
+	['/user/Shitty_Watercolour/comments/63tmon/', undefined, 'user/Shitty_Watercolour', '63tmon'],
+	['/user/Shitty_Watercolour/comments/63tmon', undefined, 'user/Shitty_Watercolour', '63tmon'],
+	['/comments/4ooe2m/', undefined, undefined, '4ooe2m'],
+	['/comments/4ooe2m', undefined, undefined, '4ooe2m'],
+	['/r/softwaregore/comments/5j23v3/handling_of_unicode_characters_ดดด/', 'softwaregore', undefined, '5j23v3'],
+]);
+
+test('comments execRegex', execRegexMatches, execRegexes.comments, [
 	['/r/aww/comments/4ooe2m/', 'aww', '4ooe2m'],
 	['/r/aww/comments/4ooe2m', 'aww', '4ooe2m'],
+	['/user/Shitty_Watercolour/comments/63tmon/', 'u_Shitty_Watercolour', '63tmon'],
+	['/user/Shitty_Watercolour/comments/63tmon', 'u_Shitty_Watercolour', '63tmon'],
 	['/comments/4ooe2m/', undefined, '4ooe2m'],
 	['/comments/4ooe2m', undefined, '4ooe2m'],
 	['/r/softwaregore/comments/5j23v3/handling_of_unicode_characters_ดดด/', 'softwaregore', '5j23v3'],
@@ -64,6 +85,8 @@ test('comments regex shouldn\'t match', regexDoesntMatch, regexes.comments, [
 test('commentsLinklist regex', regexMatches, regexes.commentsLinklist, [
 	'/r/aww/comments',
 	'/r/aww/comments/',
+	'/user/Shitty_Watercolour/comments/',
+	'/user/Shitty_Watercolour/comments',
 	'/r/enhancement+resissues/comments',
 	'/comments',
 ]);
@@ -71,6 +94,7 @@ test('commentsLinklist regex', regexMatches, regexes.commentsLinklist, [
 test('commentsLinklist regex shouldn\'t match', regexDoesntMatch, regexes.commentsLinklist, [
 	'/r/aww/comments/4ooe2m/',
 	'/comments/4ooe2m',
+	'/user/Shitty_Watercolour/comments/63tmon/',
 ]);
 
 test('inbox regex', regexMatches, regexes.inbox, [

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -93,6 +93,7 @@ export {
 	currentMultireddit,
 	currentSubreddit,
 	currentUserProfile,
+	execRegexes,
 	getUrlParams,
 	insertParams,
 	isCommentCode,

--- a/lib/utils/location.js
+++ b/lib/utils/location.js
@@ -67,7 +67,7 @@ export const regexes: { [key: string]: RegExp } = {
 };
 /* eslint-enable key-spacing */
 
-export const execRegexes: { [k: string]: (path: string) => undefined | string[] } = {
+export const execRegexes: { [k: string]: (path: string) => ?string[] } = {
 	comments: path => {
 		const match = regexes.comments.exec(path);
 		if (!match) return match;

--- a/lib/utils/location.js
+++ b/lib/utils/location.js
@@ -46,8 +46,8 @@ export function matchesPageLocation(includes?: OneOrMany<PageType | RegExp> = []
 /* eslint-disable key-spacing */
 export const regexes: { [key: string]: RegExp } = {
 	frontpage:        /^\/(?:hot|new|rising|controversial|top)?(?:\/|$)/i,
-	comments:         /^\/(?:r\/([\w\.]+)\/)?comments\/([a-z0-9]+)(?:\/|$)/i,
-	commentsLinklist: /^\/(?:r\/[\w\.\+]+\/)?comments\/?$/i,
+	comments:         /^\/(?:r\/([\w\.]+)\/|(u(?:ser)?\/[\w-]+)\/)?comments\/([a-z0-9]+)(?:\/|$)/i,
+	commentsLinklist: /^\/(?:r\/[\w\.\+]+\/|u(?:ser)?\/[\w-]+\/)?comments\/?$/i,
 	inbox:            /^\/(?:r\/([\w\.]+)\/)?message(?:\/|$)/i,
 	profile:          /^\/user\/([\w\-]+)(?:\/(?!m\/)|$)/i,
 	submit:           /^\/(?:r\/([\w\.\+]+)\/)?submit(?:\/|$)/i,
@@ -66,6 +66,15 @@ export const regexes: { [key: string]: RegExp } = {
 	liveThread:       /^\/live\/(?!create(?:\/|$))([a-z0-9]+)(?:\/|$)/i,
 };
 /* eslint-enable key-spacing */
+
+export const execRegexes: { [k: string]: (path: string) => undefined | string[] } = {
+	comments: path => {
+		const match = regexes.comments.exec(path);
+		if (!match) return match;
+		match.splice(1, 2, match[1] || match[2] && match[2].replace(/^u.*\//, 'u_'));
+		return match;
+	},
+};
 
 export type PageType = 'wiki' | 'search' | 'profile' | 'stylesheet' | 'modqueue' | 'subredditAbout' | 'comments' | 'commentsLinklist' | 'liveThread' | 'inbox' | 'submit' | 'account' | 'prefs' | 'linklist';
 

--- a/lib/utils/location.js
+++ b/lib/utils/location.js
@@ -80,7 +80,7 @@ export type PageType = 'wiki' | 'search' | 'profile' | 'stylesheet' | 'modqueue'
 
 export const pageType = _.once((): PageType => {
 	const defaultPageType = 'linklist';
-	const pageTypes = ['wiki', 'search', 'profile', 'stylesheet', 'modqueue', 'subredditAbout', 'comments', 'commentsLinklist', 'liveThread', 'inbox', 'submit', 'account', 'prefs'];
+	const pageTypes = ['wiki', 'search', 'stylesheet', 'modqueue', 'subredditAbout', 'comments', 'commentsLinklist', 'profile', 'liveThread', 'inbox', 'submit', 'account', 'prefs'];
 	return pageTypes.find(pageType => regexes[pageType].test(location.pathname)) || defaultPageType;
 });
 


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: #4128 
Tested in browser:  Chrome

Treats post-to-profile comments pages as regular comments pages, and some incidental cleanup.