### PR TITLE
Disable RES if not running on r2

### DIFF
--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -21,7 +21,7 @@ let start;
 
 export function init() {
 	if (
-		document.documentElement && !document.documentElement.getAttribute('xmlns') || // Only run on r2
+		!document.documentElement.getAttribute('xmlns') || // Only run on r2
 		(/^(?:i|m|static|thumbs|blog|code|mod|about|ads)\./i).test(location.hostname) ||
 		(/^\/advertising/).test(location.pathname) ||
 		(/\.(?:compact|mobile|json|json-html)$/i).test(location.pathname)

--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -21,6 +21,7 @@ let start;
 
 export function init() {
 	if (
+		document.documentElement && !document.documentElement.getAttribute('xmlns') || // Only run on r2
 		(/^(?:i|m|static|thumbs|blog|code|mod|about|ads)\./i).test(location.hostname) ||
 		(/^\/advertising/).test(location.pathname) ||
 		(/\.(?:compact|mobile|json|json-html)$/i).test(location.pathname)


### PR DESCRIPTION
Short-term hack until real compatibility is built.

Related to #4128 