### PR TITLE
documentElement is always present at load

### DIFF
--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -39,20 +39,17 @@ export function init() {
 
 const sourceLoaded = new Promise(resolve => (start = resolve));
 
-export const documentReady = sourceLoaded
-	.then(() => waitFor(() => document && document.documentElement));
-
 // Edge sometimes has weird bugs with MutationObservers
 // so just make a best effort at divining when the head and body are ready
 
-export const headReady = documentReady
+export const headReady = sourceLoaded
 	.then(() => Promise.race([
 		waitForChild(document.documentElement, 'head'),
 		(waitFor(() => document.head, 100): Promise<any>),
 		contentLoaded,
 	]));
 
-export const bodyStart = documentReady
+export const bodyStart = sourceLoaded
 	.then(() => Promise.race([
 		waitForChild(document.documentElement, 'body'),
 		(waitFor(() => document.body, 100): Promise<any>),
@@ -65,7 +62,7 @@ export const bodyReady = bodyStart
 		contentLoaded, // in case reddit removes or changes .debuginfo
 	]));
 
-export const contentLoaded = documentReady
+export const contentLoaded = sourceLoaded
 	.then(() => Promise.race([
 		waitForEvent(window, 'DOMContentLoaded', 'load'),
 		waitFor(() => document.readyState === 'interactive' || document.readyState === 'complete', 500),
@@ -167,5 +164,5 @@ function _addModuleBodyClasses() {
 	}
 }
 
-documentReady.then(() => BodyClasses.add());
+headReady.then(() => BodyClasses.add());
 bodyStart.then(() => BodyClasses.add());


### PR DESCRIPTION
Tested in browser: Chrome 59, Firefox 54, Edge 15 (and this would totally break integration tests, so +1 each for Chrome and Firefox)