### PR TITLE
Pixiv: switch back to iframe embed

### DIFF
--- a/chrome/beta/manifest.json
+++ b/chrome/beta/manifest.json
@@ -57,7 +57,6 @@
 		"https://codepen.io/api/oembed",
 		"https://api.tumblr.com/v2/blog/*/posts",
 		"https://xkcd.com/*/info.0.json",
-		"https://app-api.pixiv.net/v1/illust/detail",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*"
 	]
 }

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -57,7 +57,6 @@
 		"https://codepen.io/api/oembed",
 		"https://api.tumblr.com/v2/blog/*/posts",
 		"https://xkcd.com/*/info.0.json",
-		"https://app-api.pixiv.net/v1/illust/detail",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*"
 	]
 }

--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -57,7 +57,6 @@
 		"https://codepen.io/api/oembed",
 		"https://api.tumblr.com/v2/blog/*/posts",
 		"https://xkcd.com/*/info.0.json",
-		"https://app-api.pixiv.net/v1/illust/detail",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
 
 		"https://api.photobucket.com/v2/media/fromurl",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -60,7 +60,6 @@
 		"https://codepen.io/api/oembed",
 		"https://api.tumblr.com/v2/blog/*/posts",
 		"https://xkcd.com/*/info.0.json",
-		"https://app-api.pixiv.net/v1/illust/detail",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*"
 	]
 }

--- a/lib/modules/hosts/pixiv.js
+++ b/lib/modules/hosts/pixiv.js
@@ -1,7 +1,6 @@
 /* @flow */
 
 import { Host } from '../../core/host';
-import { ajax } from '../../environment';
 import { getUrlParams } from '../../utils';
 
 export default new Host('pixiv', {
@@ -9,25 +8,14 @@ export default new Host('pixiv', {
 	domains: ['pixiv.net'],
 	logo: 'https://www.pixiv.net/favicon.ico',
 	detect: ({ pathname, search }) => pathname === '/member_illust.php' && getUrlParams(search).illust_id,
-	permissions: ['https://app-api.pixiv.net/v1/illust/detail'],
-	async handleLink(href, id) {
-		const {
-			illust: {
-				title,
-				caption,
-				meta_single_page: { original_image_url: src },
-			},
-		} = await ajax({
-			url: 'https://app-api.pixiv.net/v1/illust/detail',
-			data: { illust_id: id },
-			type: 'json',
-		});
-
+	handleLink(href, id) {
 		return {
-			type: 'IMAGE',
-			title,
-			caption,
-			src,
+			type: 'IFRAME',
+			expandoClass: 'image',
+			muted: true,
+			embed: `https://embed.pixiv.net/embed_mk2.php?id=${id}&size=large`,
+			width: '700px',
+			height: '700px',
 		};
 	},
 });


### PR DESCRIPTION
...since loading an image 403s if it doesn't have a pixiv referer, which we can't easily spoof (and which wouldn't be particularly nice to do).

I suspect that this was always the case, and I fooled myself since the images were cached. Interestingly, even with a hard refresh + disabling the cache in the console, loading a cached image doesn't 403--it takes a full browser restart.