### PR TITLE
CI yarn install: switch to --frozen-lockfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,7 @@ addons:
 cache:
   yarn: true
 install:
-  - yarn install --pure-lockfile
-  - yarn check --integrity
+  - yarn install --frozen-lockfile
 matrix:
   exclude:
     - node_js: 7 # exclude default job https://github.com/travis-ci/travis-ci/issues/4681

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,7 @@ cache:
   - '%LOCALAPPDATA%\Yarn'
 install:
   - ps: Install-Product node $env:nodejs_version
-  - yarn install --pure-lockfile
-  - yarn check --integrity
+  - yarn install --frozen-lockfile
 test_script:
   - yarn test
   - yarn run build -- all


### PR DESCRIPTION
Yarn 0.23.x changes the way integrity checking works, which breaks our CI install, but it also adds `--frozen-lockfile`, which is the behaviour we were emulating with the integrity check.

(I'm not sure if it was added earlier, so I doubt this will work in appveyor, but if so we can continue to use integrity checking there)