### PR TITLE
Move IntersectionObserver polyfill to firefox-only

### DIFF
--- a/firefox/firefox.entry.js
+++ b/firefox/firefox.entry.js
@@ -1,0 +1,3 @@
+/* Firefox-specific polyfills */
+
+import 'intersection-observer'; // eslint-disable-line import/no-extraneous-dependencies

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -23,6 +23,7 @@
 	},
 	"background": {
 		"scripts": [
+			"{{./firefox.entry.js}}",
 			"{{./background.entry.js}}"
 		]
 	},
@@ -31,6 +32,7 @@
 			"https://*.reddit.com/*"
 		],
 		"js": [
+			"{{./firefox.entry.js}}",
 			"{{../lib/main.entry.js}}"
 		],
 		"css": [

--- a/lib/vendor/index.js
+++ b/lib/vendor/index.js
@@ -5,8 +5,6 @@
  * to ease the future pain of migrating them to proper libraries (imported from npm).
  */
 
-import 'intersection-observer';
-
 export { $ } from './jquery';
 
 export { guiders } from './jqueryPlugins';


### PR DESCRIPTION
Tested in browser: Chrome 60, Firefox 54, Edge 15

...since Chrome and Edge support it.