### PR TITLE
deviantart: support "link" images

### DIFF
--- a/lib/modules/hosts/deviantart.js
+++ b/lib/modules/hosts/deviantart.js
@@ -18,8 +18,11 @@ export default new Host('deviantart', {
 
 		switch (info.type) {
 			case 'photo':
+			case 'link':
 				let src;
-				if ((/\.(jpg|jpeg|gif|png)/i).test(info.url)) {
+				if (info.fullsize_url) {
+					src = info.fullsize_url;
+				} else if ((/\.(jpg|jpeg|gif|png)/i).test(info.url)) {
 					src = info.url;
 				} else {
 					src = info.thumbnail_url;


### PR DESCRIPTION
Tested in browser: Chrome 60

e.g. http://ryanbullivant.deviantart.com/art/MLNCLY-676017093

...somehow these are different from normal images ¯\\\_(ツ)_/¯