### PR TITLE
streamable: use the API instead of iframe embed

### DIFF
--- a/lib/modules/hosts/streamable.js
+++ b/lib/modules/hosts/streamable.js
@@ -1,19 +1,34 @@
 /* @flow */
 
 import { Host } from '../../core/host';
+import { ajax } from '../../environment';
 
 export default new Host('streamable', {
 	name: 'streamable',
 	domains: ['streamable.com'],
 	logo: 'https://cdn-e2.streamable.com/static/14a98f7cb1ddc5213329c039dc39cac543ba410f/img/favicon.ico',
 	detect: ({ pathname }) => (/^\/(?:e\/)?(\w+)$/i).exec(pathname),
-	handleLink(href, [, hash]) {
+	async handleLink(href, [, hash]) {
+		const {
+			title,
+			files: { mp4: { url } },
+			thumbnail_url: thumbnail,
+			source,
+		} = await ajax({
+			url: `https://api.streamable.com/videos/${hash}`,
+			type: 'json',
+		});
+
 		return {
-			type: 'IFRAME',
-			embed: `https://streamable.com/res/${hash}`,
-			pause: '{"method":"pause"}',
-			play: '{"method":"play"}',
-			fixedRatio: true,
+			type: 'VIDEO',
+			title,
+			loop: true,
+			sources: [{
+				source: url,
+				type: 'video/mp4',
+			}],
+			poster: thumbnail,
+			source,
 		};
 	},
 });


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: https://www.reddit.com/r/RESissues/comments/66vgh3/bug_controls_are_invisible_in_streamable_videos/
Tested in browser: Chrome 60

A few people are complaining about invisible controls, which I can't reproduce, but regardless, we can sidestep the issue by using their API directly.

As a bonus, we get nicer initial sizing and resizing.