### PR TITLE
RESTips: Avoid concurrent daily- and feature tips

### DIFF
--- a/lib/modules/RESTips.js
+++ b/lib/modules/RESTips.js
@@ -63,7 +63,7 @@ let allowFeatureTips;
 const featureTipReadyPromise = new Promise(resolve => { allowFeatureTips = resolve; });
 
 module.afterLoad = async () => {
-	let showsDailyTip = module.options.dailyTip.value && await dailyTip();
+	const showsDailyTip = module.options.dailyTip.value && await dailyTip();
 	if (!showsDailyTip) allowFeatureTips();
 };
 
@@ -114,7 +114,7 @@ export const showFeatureTip = _.memoize(mutex(async (id: string, tip: Tip) => {
 	await showTip(guiderObj);
 }));
 
-async function dailyTip(): ?boolean { // `true` if daily tip is being shown
+async function dailyTip(): Promise<boolean> { // `true` if daily tip is being shown
 	const lastCheck = await lastTooltipStorage.get();
 	const now = Date.now();
 	const delay = PenaltyBox.penalizedDelay(module.moduleID, 'dailyTip', {
@@ -132,6 +132,7 @@ async function dailyTip(): ?boolean { // `true` if daily tip is being shown
 		}
 		return true;
 	}
+	return false;
 }
 
 function generateContent({ message, keyboard, options }: Tip) {

--- a/lib/modules/RESTips.js
+++ b/lib/modules/RESTips.js
@@ -63,11 +63,8 @@ let allowFeatureTips;
 const featureTipReadyPromise = new Promise(resolve => { allowFeatureTips = resolve; });
 
 module.afterLoad = async () => {
-	if (module.options.dailyTip.value) {
-		await dailyTip();
-	}
-
-	allowFeatureTips();
+	let showsDailyTip = module.options.dailyTip.value && await dailyTip();
+	if (!showsDailyTip) allowFeatureTips();
 };
 
 const newFeatureTipsCheckbox = _.once(() =>
@@ -117,7 +114,7 @@ export const showFeatureTip = _.memoize(mutex(async (id: string, tip: Tip) => {
 	await showTip(guiderObj);
 }));
 
-async function dailyTip() {
+async function dailyTip(): ?boolean { // `true` if daily tip is being shown
 	const lastCheck = await lastTooltipStorage.get();
 	const now = Date.now();
 	const delay = PenaltyBox.penalizedDelay(module.moduleID, 'dailyTip', {
@@ -133,6 +130,7 @@ async function dailyTip() {
 			PenaltyBox.alterFeaturePenalty(module.moduleID, 'dailyTip', _.clamp(PenaltyBox.MAX_PENALTY / tips.length, 3, 8));
 			await showOrdinaryTip('random');
 		}
+		return true;
 	}
 }
 


### PR DESCRIPTION
Allowing both causes a conflict on first run.