### PR TITLE
iframe: Use absolute width

### DIFF
--- a/lib/modules/hosts/clyp.js
+++ b/lib/modules/hosts/clyp.js
@@ -12,7 +12,7 @@ export default new Host('clyp', {
 			type: 'IFRAME',
 			embed: `https://clyp.it/${playlist ? 'playlist/' : ''}${id}/widget`,
 			height: '160px',
-			width: '100%',
+			width: '600px',
 		};
 	},
 });

--- a/lib/modules/hosts/hastebin.js
+++ b/lib/modules/hosts/hastebin.js
@@ -14,7 +14,7 @@ export default new Host('hastebin', {
 			muted: true,
 			embed: `https://hastebin.com/${filename}`,
 			height: '500px',
-			width: '100%',
+			width: '1000px',
 		};
 	},
 });

--- a/lib/modules/hosts/hastebin.js
+++ b/lib/modules/hosts/hastebin.js
@@ -14,7 +14,7 @@ export default new Host('hastebin', {
 			muted: true,
 			embed: `https://hastebin.com/${filename}`,
 			height: '500px',
-			width: '1000px',
+			width: '800px',
 		};
 	},
 });

--- a/lib/modules/hosts/jsfiddle.js
+++ b/lib/modules/hosts/jsfiddle.js
@@ -13,7 +13,7 @@ export default new Host('jsfiddle', {
 			expandoClass: 'selftext',
 			muted: true,
 			embed: `https://jsfiddle.net${path}${categories || '/embedded/result,js,resources,html,css/'}`,
-			width: '100%',
+			width: '800px',
 			height: '500px',
 		};
 	},

--- a/lib/modules/hosts/pastebin.js
+++ b/lib/modules/hosts/pastebin.js
@@ -14,7 +14,7 @@ export default new Host('pastebin', {
 			muted: true,
 			embed: `https://pastebin.com/embed_iframe.php?i=${id}`,
 			height: '500px',
-			width: '100%',
+			width: '700px',
 		};
 	},
 });

--- a/lib/modules/hosts/soundcloud.js
+++ b/lib/modules/hosts/soundcloud.js
@@ -13,7 +13,7 @@ export default new Host('soundcloud', {
 			type: 'IFRAME',
 			embed: string.encode`https://w.soundcloud.com/player/?url=${href}`,
 			height: '166px',
-			width: '100%',
+			width: '700px',
 			pause: '{"method":"pause"}',
 			play: '{"method":"play"}',
 		};


### PR DESCRIPTION
Relative sizes stopped working back when iframe media was changed to `position: absolute`.

Tested in browser: Chrome 58
