### PR TITLE
Filterline: Add 'show help' button

### DIFF
--- a/lib/css/modules/_filteReddit.scss
+++ b/lib/css/modules/_filteReddit.scss
@@ -124,6 +124,7 @@ body.hideOver18 {
 			position: absolute;
 			width: 130px;
 			right: 0;
+			padding: 2px 0;
 			background-color: floralwhite;
 			border-radius: 0 2px 2px 2px;
 			box-shadow: darkgrey 1px 2px 4px;
@@ -189,7 +190,7 @@ body.hideOver18 {
 	}
 
 	&-option-toggle {
-		margin: 4px;
+		padding: 4px;
 		display: inline-flex;
 		align-items: center;
 
@@ -199,9 +200,17 @@ body.hideOver18 {
 		}
 	}
 
-	&-export-customfilters {
+	&-export-customfilters,
+	&-show-help {
 		text-align: center;
-		padding: 2px 0;
+		padding: 4px;
 		cursor: pointer;
+	}
+
+	&-show-help {
+		&::before {
+			content: '\2139';
+			margin-right: 3px;
+		}
 	}
 }

--- a/lib/modules/RESTips.js
+++ b/lib/modules/RESTips.js
@@ -103,6 +103,7 @@ export const showFeatureTip = mutex((id: string) => {
 
 	return showTip(tip, {
 		title: 'New feature',
+		classString: 'res-featureTip',
 		buttonCustomHTML: newFeatureTipsCheckbox(),
 		buttons: [],
 	});
@@ -340,6 +341,7 @@ function showOrdinaryTip(change?: 'random' | 'prev' | 'next') {
 			onclick: () => showOrdinaryTip('next'),
 		}],
 		onClose() { PenaltyBox.alterFeaturePenalty(module.moduleID, 'dailyTip', 4); },
+		classString: 'res-ordinaryTip',
 		buttonCustomHTML: dailyTipsCheckbox(),
 		title: 'RES Tips and Tricks',
 	});

--- a/lib/modules/RESTips.js
+++ b/lib/modules/RESTips.js
@@ -61,11 +61,11 @@ module.go = () => {
 
 let allowFeatureTips;
 const featureTips: Map<string, Tip> = new Map();
-const featureTipReadyPromise = new Promise(resolve => { allowFeatureTips = resolve; });
+const featureTipReadyPromise = new Promise(resolve => { allowFeatureTips = () => resolve(true); });
 
 module.afterLoad = async () => {
 	const showsDailyTip = module.options.dailyTip.value && await dailyTip();
-	if (!showsDailyTip) allowFeatureTips();
+	if (module.options.newFeatureTips.value && !showsDailyTip) allowFeatureTips();
 };
 
 const newFeatureTipsCheckbox = _.once(() =>
@@ -74,23 +74,26 @@ const newFeatureTipsCheckbox = _.once(() =>
 );
 
 // memoize: prevent the same tip from being added multiple times
-export const addFeatureTip = _.memoize((id: string, tip: Tip) => {
-	if (!Modules.isRunning(module)) return;
-
+export const addFeatureTip = _.memoize(async (id: string, tip: Tip) => {
 	tip.onHide = () => { featureTipsStorage.set(id, { enabled: false }); };
 
 	featureTips.set(id, tip);
 	// Make the tip accessible via daily tips / tips & tricks
 	tips.push(tip);
 
-	if (module.options.newFeatureTips.value) showFeatureTip(id, tip);
+	if (
+		await featureTipReadyPromise &&
+		await featureTipsStorage.get(id).then(({ enabled }) => enabled)
+	) showFeatureTip(id);
 });
 
-const showFeatureTip = mutex(async (id: string, tip: Tip) => {
-	await featureTipReadyPromise;
+export const showFeatureTip = mutex((id: string) => {
+	const tip = featureTips.get(id);
 
-	const { enabled } = await featureTipsStorage.get(id);
-	if (!enabled) return;
+	if (!tip) {
+		console.error('Feature tip is not added', id);
+		return;
+	}
 
 	if (tip.attachTo instanceof Element && !elementInViewport(tip.attachTo)) {
 		// Usually happens when subreddit CSS for some reason hides the element
@@ -98,7 +101,7 @@ const showFeatureTip = mutex(async (id: string, tip: Tip) => {
 		return;
 	}
 
-	await showTip(tip, {
+	return showTip(tip, {
 		title: 'New feature',
 		buttonCustomHTML: newFeatureTipsCheckbox(),
 		buttons: [],

--- a/lib/modules/filteReddit/Filterline.js
+++ b/lib/modules/filteReddit/Filterline.js
@@ -20,6 +20,7 @@ import * as SelectedEntry from '../selectedEntry';
 import * as SettingsNavigation from '../settingsNavigation';
 import * as ShowImages from '../showImages';
 import * as FilteReddit from '../filteReddit';
+import * as RESTips from '../RESTips';
 import ExternalFilter from './ExternalFilter';
 import Filter from './Filter';
 import browseContexts from './browseContexts';
@@ -61,6 +62,9 @@ export default class Filterline {
 								<input type="checkbox">
 								<span>Hide currently filtered</span>
 							</label>
+						</div>
+						<div class="res-filterline-show-help">
+							Usage information
 						</div>
 					</div>
 				</div>
@@ -106,6 +110,10 @@ export default class Filterline {
 			hideCheckbox.disabled = true;
 			await (hideCheckbox.checked ? this.hide() : this.unhide());
 			hideCheckbox.disabled = false;
+		});
+
+		downcast(this.dropdown.querySelector('.res-filterline-show-help'), HTMLElement).addEventListener('click', () => {
+			RESTips.showFeatureTip('filterlineVisible');
 		});
 	}
 

--- a/tests/RESTips.js
+++ b/tests/RESTips.js
@@ -1,0 +1,39 @@
+module.exports = {
+	'daily tips shows on first load, feature tips on second': browser => {
+		browser
+			.url('https://www.reddit.com/?limit=1')
+			.waitForElementVisible('.guider.res-ordinaryTip')
+			.assert.containsText('.guider', 'Welcome to RES')
+			.refresh()
+			.waitForElementVisible('.guider.res-featureTip')
+			.end();
+	},
+	'click through all tips': browser => {
+		let initialTextContent;
+
+		browser
+			.url('https://www.reddit.com/?limit=1')
+			.waitForElementVisible('.guider')
+			.perform(function checkNext(browser, done) {
+				browser
+					.execute(`
+						const last = Array.from(document.querySelectorAll('.guider')).slice(-1)[0];
+						return [last.id, last.textContent];
+					`, [], ({ value: [id, textContent] }) => {
+						if (!initialTextContent) {
+							initialTextContent = textContent;
+						} else if (initialTextContent === textContent) {
+							browser.end();
+							return;
+						}
+
+						browser
+							.click(`[id="${id}"] .guiders_button`)
+							.perform(checkNext);
+					});
+
+				done();
+			})
+		.end();
+	},
+};


### PR DESCRIPTION
Opens the `filterlineVisible` featureTip guider

Tested in browser: Chrome 58