### PR TITLE
notifications: Fix manual close being disregarded

### DIFF
--- a/lib/modules/notifications.js
+++ b/lib/modules/notifications.js
@@ -305,23 +305,29 @@ function setCloseNotificationTimer({ currentTarget: thisNotification }: Event | 
 	thisNotification.setAttribute('style', `-webkit-animation-delay: ${delay / 1000}s; -webkit-animation-duration: ${duration / 1000}s; animation-delay: ${delay / 1000}s; animation-duration: ${duration / 1000}s`);
 	// Total delay including fade out duration.
 	delay += duration;
-	clearTimeout(notificationTimers[thisNotificationID]);
+	clearAsyncTasks(thisNotification);
 	const thisTimer = setTimeout(() => closeNotification(thisNotification), delay);
 	notificationTimers[thisNotificationID] = thisTimer;
 	thisNotification.addEventListener('mouseenter', cancelCloseNotificationTimer);
-	thisNotification.removeEventListener('mouseleave', setCloseNotificationTimer);
 }
 
 function cancelCloseNotificationTimer({ currentTarget: thisNotification }: Event) {
-	const thisNotificationID = +thisNotification.getAttribute('id').split('-')[1];
 	thisNotification.classList.remove('timerOn');
 	thisNotification.removeAttribute('style');
-	clearTimeout(notificationTimers[thisNotificationID]);
-	thisNotification.removeEventListener('mouseenter', cancelCloseNotificationTimer);
+	clearAsyncTasks(thisNotification);
 	thisNotification.addEventListener('mouseleave', setCloseNotificationTimer);
 }
 
+function clearAsyncTasks(thisNotification) {
+	thisNotification.removeEventListener('mouseleave', setCloseNotificationTimer);
+	thisNotification.removeEventListener('mouseenter', cancelCloseNotificationTimer);
+	const thisNotificationID = +thisNotification.getAttribute('id').split('-')[1];
+	clearTimeout(notificationTimers[thisNotificationID]);
+}
+
 function closeNotification(thisNotification) {
+	clearAsyncTasks(thisNotification);
+
 	// When closing with timerOn, don't hesitate at end of animation. Otherwise do a quick fade.
 	$(thisNotification)
 		.fadeOut(thisNotification.classList.contains('timerOn') ? 0 : 200)


### PR DESCRIPTION
The fade was canceled when moving the cursor from the notification.

Fixes https://www.reddit.com/r/RESissues/comments/5j612x/notification_close_bug/

Tested in browser: Chrome 58
