### PR TITLE
keyboardNav: Set followLinkTabFocus as unadvanced option

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -178,7 +178,6 @@ module.options = {
 		value: true,
 		description: 'keyboardNavFollowLinkNewTabFocusDesc',
 		title: 'keyboardNavFollowLinkNewTabFocusTitle',
-		advanced: true,
 	},
 	toggleHelp: {
 		type: 'keycode',


### PR DESCRIPTION
Since it is an useful option.
