### PR TITLE
Swap OneDrive API

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -99,6 +99,7 @@
 		"no-confusing-arrow": 0,
 		"no-console": 0,
 		"no-continue": 0,
+		"no-div-regex": 0,
 		"no-duplicate-imports": 0, // see import/no-duplicates (ESLint's rule doesn't handle Flow `import type`)
 		"no-else-return": 0,
 		"no-empty-function": [2, { "allow": ["arrowFunctions", "methods"] }],

--- a/lib/modules/hosts/onedrive.js
+++ b/lib/modules/hosts/onedrive.js
@@ -10,14 +10,6 @@ export default new Host('onedrive', {
 	name: 'Microsoft OneDrive',
 	detect: () => true,
 	async handleLink(href) {
-		if (href.includes('1drv.ms/')) {
-			href = await ajax({
-				url: href.replace('http:', 'https:'),
-				type: 'redirect',
-				cacheFor: DAY,
-			});
-		}
-
 		// Encode the URL in base64 then convert it to unpadded base64url format
 		// https://dev.onedrive.com/shares/shares.htm
 		const encodedUrl = `u!${btoa(href)}`

--- a/lib/modules/hosts/onedrive.js
+++ b/lib/modules/hosts/onedrive.js
@@ -49,27 +49,16 @@ export default new Host('onedrive', {
 
 			if (!gallery.length) throw new Error('No images in gallery.');
 
-			if (gallery.length > 1) {
-				const src = gallery.map(img => ({
+			return {
+				type: 'GALLERY',
+				src: gallery.map(img => ({
 					type: 'IMAGE',
 					title: img.name,
 					caption: img.description,
 					src: img['@content.downloadUrl'],
 					href: img.webUrl,
-				}));
-
-				return {
-					type: 'GALLERY',
-					src,
-				};
-			} else {
-				return {
-					type: 'IMAGE',
-					title: gallery[0].name,
-					caption: gallery[0].description,
-					src: gallery[0]['@content.downloadUrl'],
-				};
-			}
+				})),
+			};
 		} else {
 			const type = json.file.mimeType.substring(0, json.file.mimeType.indexOf('/'));
 

--- a/lib/modules/hosts/onedrive.js
+++ b/lib/modules/hosts/onedrive.js
@@ -18,12 +18,15 @@ export default new Host('onedrive', {
 			});
 		}
 
-		// We have to encode the URL in base64 then convert it to unpadded base64url format
-		const siteURL = btoa(href);
-		const encodedURL = `u!${siteURL.replace(/\=/g, '').replace(/\//g, '_').replace(/\+/g, '-')}`;
+		// Encode the URL in base64 then convert it to unpadded base64url format
+		// https://dev.onedrive.com/shares/shares.htm
+		const encodedUrl = `u!${btoa(href)}`
+			.replace(/=+$/g, '')
+			.replace(/\//g, '_')
+			.replace(/\+/g, '-');
 
 		const json = await ajax({
-			url: `https://api.onedrive.com/v1.0/shares/${encodedURL}/root?expand=children`,
+			url: `https://api.onedrive.com/v1.0/shares/${encodedUrl}/root?expand=children`,
 			type: 'json',
 			cacheFor: DAY,
 		});
@@ -33,7 +36,7 @@ export default new Host('onedrive', {
 		// The link is a folder, get its content instead.
 		if (json.folder) {
 			const { value: files, error } = await ajax({
-				url: `https://api.onedrive.com/v1.0/shares/${encodedURL}/root?expand=children`,
+				url: `https://api.onedrive.com/v1.0/shares/${encodedUrl}/root?expand=children`,
 				type: 'json',
 				cacheFor: DAY,
 			});

--- a/lib/modules/hosts/onedrive.js
+++ b/lib/modules/hosts/onedrive.js
@@ -18,16 +18,12 @@ export default new Host('onedrive', {
 			});
 		}
 
-		const hashRe = /(?:resid=|&id=)([a-z0-9!%]+)(?:.*&authkey=([a-z0-9%!_-]+)|)/i;
-		const groups = hashRe.exec(href);
-
-		if (!groups) throw new Error('No URL match found');
-
-		const resId = decodeURIComponent(groups[1]);
-		const authKey = decodeURIComponent(groups[2]);
+		// We have to encode the URL in base64 then convert it to unpadded base64url format
+		const siteURL = btoa(href);
+		const encodedURL = `u!${siteURL.replace(/\=/g, '').replace(/\//g, '_').replace(/\+/g, '-')}`;
 
 		const json = await ajax({
-			url: `https://api.onedrive.com/v1.0/drive/items/${resId}${authKey ? `?authKey=${authKey}` : ''}`,
+			url: `https://api.onedrive.com/v1.0/shares/${encodedURL}/root?expand=children`,
 			type: 'json',
 			cacheFor: DAY,
 		});
@@ -37,7 +33,7 @@ export default new Host('onedrive', {
 		// The link is a folder, get its content instead.
 		if (json.folder) {
 			const { value: files, error } = await ajax({
-				url: `https://api.onedrive.com/v1.0/drive/items/${resId}/children${authKey ? `?authKey=${authKey}` : ''}`,
+				url: `https://api.onedrive.com/v1.0/shares/${encodedURL}/root?expand=children`,
 				type: 'json',
 				cacheFor: DAY,
 			});

--- a/lib/modules/hosts/onedrive.js
+++ b/lib/modules/hosts/onedrive.js
@@ -23,50 +23,42 @@ export default new Host('onedrive', {
 			cacheFor: DAY,
 		});
 
-		if (json.error) throw new Error(`Onedrive request error: ${json.error}`);
-
-		// The link is a folder, get its content instead.
-		if (json.folder) {
-			const { value: files, error } = await ajax({
-				url: `https://api.onedrive.com/v1.0/shares/${encodedUrl}/root?expand=children`,
-				type: 'json',
-				cacheFor: DAY,
-			});
-
-			if (error) throw new Error(`Onedrive request error: ${error}`);
-
-			// Gallery
-
-			const gallery = files.filter(({ file }) => file && file.mimeType.includes('image'));
-
-			if (!gallery.length) throw new Error('No images in gallery.');
-
+		if (json.children.length) {
 			return {
 				type: 'GALLERY',
-				src: gallery.map(img => ({
-					type: 'IMAGE',
-					title: img.name,
-					caption: img.description,
-					src: img['@content.downloadUrl'],
-					href: img.webUrl,
-				})),
+				src: json.children.map(processFile),
 			};
 		} else {
-			const type = json.file.mimeType.substring(0, json.file.mimeType.indexOf('/'));
+			return processFile(json);
+		}
+
+		function processFile({
+			name,
+			description,
+			webUrl,
+			'@content.downloadUrl': src,
+			file: { mimeType },
+		}) {
+			const type = mimeType.slice(0, mimeType.indexOf('/'));
 
 			switch (type) {
 				case 'image':
 					return {
 						type: 'IMAGE',
-						src: json['@content.downloadUrl'],
+						title: name,
+						caption: description,
+						src,
+						href: webUrl,
 					};
 				case 'video':
 					return {
 						type: 'VIDEO',
+						title: name,
+						caption: description,
 						loop: false,
 						sources: [{
-							source: json['@content.downloadUrl'],
-							type: json.file.mimeType,
+							source: src,
+							type: mimeType,
 						}],
 					};
 				case 'audio':
@@ -74,8 +66,8 @@ export default new Host('onedrive', {
 						type: 'AUDIO',
 						loop: false,
 						sources: [{
-							file: json['@content.downloadUrl'],
-							type: json.file.mimeType,
+							file: src,
+							type: mimeType,
 						}],
 					};
 				default:


### PR DESCRIPTION
Fixes #4180.

Change OneDrive API to [Shares API](https://dev.onedrive.com/shares/shares.htm), makes us resilient to URL changes and auth issues.

Tested on Edge 15.
(@erikdesjardins: and Chrome 60)