### PR TITLE
ajax: remove 'redirect' request type

### DIFF
--- a/browser/background.js
+++ b/browser/background.js
@@ -45,7 +45,6 @@ addListener('ajax', async ({ method, url, headers, data }) => {
 
 	return {
 		status: rawResponse.status,
-		url: rawResponse.url,
 		text: await rawResponse.text(),
 	};
 });

--- a/lib/environment/ajax.js
+++ b/lib/environment/ajax.js
@@ -5,7 +5,7 @@ import { sendMessage } from '../../browser';
 import { loggedInUserHash, string } from '../utils';
 import { XhrCache } from './';
 
-type ResponseType = 'text' | 'json' | 'redirect';
+type ResponseType = 'text' | 'json';
 
 type AjaxOptions<Ty: ResponseType | void> = {
 	method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
@@ -16,22 +16,14 @@ type AjaxOptions<Ty: ResponseType | void> = {
 	cacheFor?: number,
 };
 
-type RawResponse = {|
-	status: number,
-	url: string,
-	text: string,
-|};
-
 class AjaxError extends Error {
 	status: number;
 	text: string;
-	url: string;
 
-	constructor(message, { status, text, url }) {
+	constructor(message, { status, text }) {
 		super(message);
 		this.status = status;
 		this.text = text;
-		this.url = url;
 	}
 }
 
@@ -39,7 +31,6 @@ class AjaxError extends Error {
 declare function ajax(opt: AjaxOptions<void>): Promise<string>;
 declare function ajax(opt: AjaxOptions<'text'>): Promise<string>;
 declare function ajax(opt: AjaxOptions<'json'>): Promise<{ [key: string | number]: any }>;
-declare function ajax(opt: AjaxOptions<'redirect'>): Promise<string>;
 
 /**
  * Sends a same-origin or cross-origin XHR.
@@ -50,7 +41,7 @@ declare function ajax(opt: AjaxOptions<'redirect'>): Promise<string>;
  * The Content-Type header defaults to application/x-www-form-urlencoded for POST requests.
  * The X-Modhash header defaults to the current user's modhash for same-origin POST requests.
  * @param {object|string} [data] If passed an object, will be encoded and converted to a query string. Appended to the url for GET requests.
- * @param {string} [type='text'] Affects the return value. One of 'text', 'json', or 'redirect'.
+ * @param {string} [type='text'] Affects the return value. One of 'text' or 'json'.
  * Only the responseText and status fields are guaranteed to be present for cross-origin requests.
  * @param {boolean} [cacheFor=0] Time in milliseconds.
  * @returns {Promise} Resolves if a response with status 200 is recieved (and parsing succeeds, for 'json' requests).
@@ -91,7 +82,6 @@ export async function ajax({ method = 'GET', url: rawUrl, headers = {}, data: ra
 
 		response = {
 			status: rawResponse.status,
-			url: rawResponse.url,
 			text: await rawResponse.text(),
 		};
 	}
@@ -102,10 +92,10 @@ export async function ajax({ method = 'GET', url: rawUrl, headers = {}, data: ra
 	}
 
 	if (useCache) {
-		XhrCache.set(url, response);
+		XhrCache.set(url, response.text);
 	}
 
-	return processResponse(response, type);
+	return processResponse(response.text, type);
 }
 /* eslint-enable no-redeclare */
 
@@ -132,14 +122,12 @@ function buildRequestParams(method, url, data) {
 	return { url: urlObj.href, data, sameOrigin };
 }
 
-function processResponse(response: RawResponse, type: ResponseType) {
+function processResponse(text: string, type: ResponseType) {
 	switch (type) {
 		case 'text':
-			return response.text;
+			return text;
 		case 'json':
-			return JSON.parse(response.text);
-		case 'redirect':
-			return response.url;
+			return JSON.parse(text);
 		default:
 			throw new Error(`Invalid type: ${type}`);
 	}

--- a/lib/environment/xhrCache.js
+++ b/lib/environment/xhrCache.js
@@ -2,15 +2,15 @@
 
 import { sendMessage } from '../../browser';
 
-export function set(key: string, value: mixed) {
+export function set(key: string, value: string) {
 	return sendMessage('XHRCache', ['set', key, value]);
 }
 
-export function check(key: string, maxAge?: number /* milliseconds */): Promise<any | void> {
+export function check(key: string, maxAge?: number /* milliseconds */): Promise<string | void> {
 	return sendMessage('XHRCache', ['check', key, maxAge]);
 }
 
-export function _delete(key: string) {
+function _delete(key: string) {
 	return sendMessage('XHRCache', ['delete', key]);
 }
 export { _delete as delete };


### PR DESCRIPTION
Tested in browser: Chrome 60

This was only used before #4203 for onedrive, and it's a very strange thing to do. (Normally you don't care where the redirect is, as long as you get the content)