### PR TITLE
neverEndingReddit: check rank width before appending new sitetable

### DIFF
--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -420,14 +420,14 @@ const appendPage = fastAsync(function*(newSiteTable, pageHTML = newSiteTable.out
 
 	yield Init.bodyReady;
 
-	siteTable().appendChild(lastPageMarker);
-	siteTable().appendChild(newSiteTable);
-
 	const firstLen = $(siteTable()).find('.link:last .rank').text().length;
 	const lastLen = $(newSiteTable).find('.link:last .rank').text().length;
 	if (lastLen > firstLen) {
 		addCSS(`body.res > .content .link .rank { width: ${(lastLen * 1.1).toFixed(1)}ex; }`);
 	}
+
+	siteTable().appendChild(lastPageMarker);
+	siteTable().appendChild(newSiteTable);
 
 	currPage++;
 


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: Fixes #4200
Tested in browser: Chrome 60

Otherwise, both `firstLen` and `lastLen` would be from the same post, so we'd never add the CSS.