### PR TITLE
showImages: Don't resize when child element is fullscreen

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1787,7 +1787,9 @@ function makeMediaIndependentOnResize(media, element) {
 	media.addEventListener('mediaResize', e => {
 		media.independent = true;
 
-		if (!media.offsetParent) {
+		// $FlowIssue `mozFullScreenElement` not recognized
+		const fullscreenElement = (document.fullscreenElement || document.webkitFullscreenElement || document.mozFullScreenElement: any);
+		if (!media.offsetParent || independent.contains(fullscreenElement)) {
 			// Allowing propagation when non-visible may cause unwanted side-effects,
 			// so cancel and instead emit a new signal when expanded
 			e.stopImmediatePropagation();


### PR DESCRIPTION
Unnecessary to resize when hidden, and `clientHeight` seemingly becomes unreliable.

Should fix https://www.reddit.com/r/RESissues/comments/69jdn8/expando_collapsed_after_fullscreen_youtube_with/
Tested in browser: Chrome 59, Firefox 55
