### PR TITLE
Revenge of the Firefox Storage APIs 3: Tokyo Drift (tag sharding)

### DIFF
--- a/browser/foreground.js
+++ b/browser/foreground.js
@@ -59,6 +59,8 @@ addInterceptor('storage', keyedMutex(async ([operation, key, value]) => {
 			return _get(defaults);
 		case 'set':
 			return set(key, value);
+		case 'setMultiple':
+			return _set(value);
 		case 'patch':
 			const extended = extendDeep(await get(key) || {}, value);
 			return set(key, extended);

--- a/lib/core/migrate/migrate.js
+++ b/lib/core/migrate/migrate.js
@@ -499,6 +499,13 @@ const migrations = [
 		async go() {
 			await Migrators.updateOption('onboarding', 'updateNotification', 'releaseNotes', 'notification');
 		},
+	}, {
+		versionNumber: '5.6.1-shard-tags',
+		async go() {
+			const tags = await Storage.get('RESmodules.userTagger.tags') || {};
+			const remappedTags = _.mapKeys(tags, (v, k) => `RESmodules.userTagger.t.${k.toLowerCase()}`);
+			await Storage.setMultiple(remappedTags);
+		},
 	},
 
 ];  // ^^ Add new migrations ^^

--- a/lib/environment/storage.js
+++ b/lib/environment/storage.js
@@ -95,9 +95,9 @@ export function wrap<T>(key: string | () => string /* pure */, defaultValue: T):
 class PrefixWrapper<T> {
 	_prefix: string;
 	_keyMapper: (key: string) => string;
-	_default: T;
+	_default: () => T;
 
-	constructor(prefix: string, def: T, keyMapper: (key: string) => string) {
+	constructor(prefix: string, def: () => T, keyMapper: (key: string) => string) {
 		this._prefix = prefix;
 		this._default = def;
 		this._keyMapper = keyMapper;
@@ -108,7 +108,7 @@ class PrefixWrapper<T> {
 	}
 
 	get(key: string): Promise<T> {
-		return get(this._keyGen(key)).then(val => (val === null ? this._default : val));
+		return get(this._keyGen(key)).then(val => (val === null ? this._default() : val));
 	}
 
 	async getAll(): Promise<{ [key: string]: T }> {
@@ -141,6 +141,6 @@ class PrefixWrapper<T> {
 	}
 }
 
-export function wrapPrefix<T>(prefix: string, defaultValue: T, destructiveKeyMapper: (key: string) => string = x => x): PrefixWrapper<T> {
+export function wrapPrefix<T>(prefix: string, defaultValue: () => T, destructiveKeyMapper: (key: string) => string = x => x): PrefixWrapper<T> {
 	return new PrefixWrapper(prefix, defaultValue, destructiveKeyMapper);
 }

--- a/lib/environment/storage.js
+++ b/lib/environment/storage.js
@@ -120,6 +120,13 @@ class PrefixWrapper<T> {
 		}, {});
 	}
 
+	async batch(keys: string[]): Promise<{ [key: string]: T }> {
+		const rawValues = await batch(keys.map(k => this._keyGen(k)));
+		return _.transform(rawValues, (acc, v, k) => {
+			acc[k.slice(this._prefix.length)] = (v === null ? this._default() : v);
+		}, {});
+	}
+
 	set(key: string, value: T): Promise<void> {
 		return set(this._keyGen(key), value);
 	}

--- a/lib/environment/storage.js
+++ b/lib/environment/storage.js
@@ -19,6 +19,10 @@ export function set(key: string, value: mixed) {
 	return sendMessage('storage', ['set', key, value]);
 }
 
+export function setMultiple(valueMap: { [key: string]: mixed }) {
+	return sendMessage('storage', ['setMultiple', null, valueMap]);
+}
+
 /*
  * Deeply extends a value in storage.
  */

--- a/lib/environment/storage.js
+++ b/lib/environment/storage.js
@@ -7,6 +7,10 @@ export function get(key: string): Promise<any | null> {
 	return sendMessage('storage', ['get', key]);
 }
 
+export function getAll(): Promise<{ [key: string]: mixed }> {
+	return sendMessage('storage', ['getAll']);
+}
+
 export function batch<T: string>(keys: T[]): Promise<{ [key: T]: any | null }> {
 	return sendMessage('storage', ['batch', keys]);
 }
@@ -32,8 +36,8 @@ export function deletePath(key: string, ...path: string[]) {
 	return sendMessage('storage', ['deletePath', key, path.join(',')]);
 }
 
-function _delete(key: string) {
-	return sendMessage('storage', ['delete', key]);
+function _delete(keys: string | string[]) {
+	return sendMessage('storage', ['delete', keys]);
 }
 export { _delete as delete };
 
@@ -99,32 +103,41 @@ class PrefixWrapper<T> {
 		this._keyMapper = keyMapper;
 	}
 
-	_keyGen(k: string): string {
-		return this._prefix + this._keyMapper(k);
+	_keyGen(key: string): string {
+		return this._prefix + this._keyMapper(key);
 	}
 
-	get(k: K): Promise<T> {
-		return get(this._keyGen(k)).then(val => (val === null ? this._default : val));
+	get(key: string): Promise<T> {
+		return get(this._keyGen(key)).then(val => (val === null ? this._default : val));
 	}
 
-	set(k: K, value: T): Promise<void> {
-		return set(this._keyGen(k), value);
+	async getAll(): Promise<{ [key: string]: T }> {
+		const everything = await getAll();
+		return _.transform(everything, (acc, v, k) => {
+			if (k.startsWith(this._prefix)) {
+				acc[k.slice(this._prefix.length)] = v;
+			}
+		}, {});
 	}
 
-	patch(k: K, value: $Shape<T>): Promise<void> {
-		return patch(this._keyGen(k), (value: any));
+	set(key: string, value: T): Promise<void> {
+		return set(this._keyGen(key), value);
 	}
 
-	deletePath(k: K, ...path: string[]): Promise<void> {
-		return deletePath(this._keyGen(k), ...path);
+	patch(key: string, value: $Shape<T>): Promise<void> {
+		return patch(this._keyGen(key), (value: any));
 	}
 
-	delete(k: K): Promise<void> {
-		return _delete(this._keyGen(k));
+	deletePath(key: string, ...path: string[]): Promise<void> {
+		return deletePath(this._keyGen(key), ...path);
 	}
 
-	has(k: K): Promise<boolean> {
-		return has(this._keyGen(k));
+	delete(keys: string | string[]): Promise<void> {
+		return _delete([].concat(keys).map(k => this._keyGen(k)));
+	}
+
+	has(key: string): Promise<boolean> {
+		return has(this._keyGen(key));
 	}
 }
 

--- a/lib/environment/storage.js
+++ b/lib/environment/storage.js
@@ -88,13 +88,19 @@ export function wrap<T>(key: string | () => string /* pure */, defaultValue: T):
 	return new Wrapper(keyGenerator, defaultValue);
 }
 
-class DomainWrapper<K, T> {
-	_keyGen: (k: K) => string;
+class PrefixWrapper<T> {
+	_prefix: string;
+	_keyMapper: (key: string) => string;
 	_default: T;
 
-	constructor(keyGen: $PropertyType<this, '_keyGen'>, def: T) {
-		this._keyGen = keyGen;
+	constructor(prefix: string, def: T, keyMapper: (key: string) => string) {
+		this._prefix = prefix;
 		this._default = def;
+		this._keyMapper = keyMapper;
+	}
+
+	_keyGen(k: string): string {
+		return this._prefix + this._keyMapper(k);
 	}
 
 	get(k: K): Promise<T> {
@@ -122,6 +128,6 @@ class DomainWrapper<K, T> {
 	}
 }
 
-export function wrapDomain<K, T>(keyGenerator: (k: K) => string, defaultValue: T): DomainWrapper<K, T> {
-	return new DomainWrapper(keyGenerator, defaultValue);
+export function wrapPrefix<T>(prefix: string, defaultValue: T, destructiveKeyMapper: (key: string) => string = x => x): PrefixWrapper<T> {
+	return new PrefixWrapper(prefix, defaultValue, destructiveKeyMapper);
 }

--- a/lib/modules/RESTips.js
+++ b/lib/modules/RESTips.js
@@ -45,7 +45,7 @@ module.options = {
 	},
 };
 
-const featureTipsStorage = Storage.wrapPrefix('RESTips.featureTips.', { enabled: true });
+const featureTipsStorage = Storage.wrapPrefix('RESTips.featureTips.', () => ({ enabled: true }));
 const lastTooltipStorage = Storage.wrap('RESLastToolTip', 0);
 
 module.go = () => {

--- a/lib/modules/RESTips.js
+++ b/lib/modules/RESTips.js
@@ -45,7 +45,7 @@ module.options = {
 	},
 };
 
-const featureTipsStorage = Storage.wrapDomain(id => `RESTips.featureTips.${id}`, { enabled: true });
+const featureTipsStorage = Storage.wrapPrefix('RESTips.featureTips.', { enabled: true });
 const lastTooltipStorage = Storage.wrap('RESLastToolTip', 0);
 
 module.go = () => {

--- a/lib/modules/backupAndRestore.js
+++ b/lib/modules/backupAndRestore.js
@@ -32,7 +32,7 @@ module.options = {
 
 async function backup() {
 	// Generate copy of RES settings for download
-	const settings = await Storage.batch(await Storage.keys());
+	const settings = await Storage.getAll();
 	const blob = new Blob([serialize(settings)], { type: 'application/json' });
 	// Make nice-ish suggested filename RES-yyyy-mm-dd-timestamp.resbackup
 	const date = new Date();

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -1170,8 +1170,7 @@ async function getSubredditCompletions(query) {
 }
 
 async function getUserCompletions(query) {
-	const tags = await UserTagger.tagStorage.get();
-	const tagNames = Object.keys(tags);
+	const tagNames = Object.keys(await UserTagger.tagStorage.getAll());
 	const pageNames = Array.from(document.querySelectorAll('.author')).map(e => e.textContent);
 	return [...tagNames, ...pageNames]
 		.filter(e => e.toLowerCase().startsWith(query.toLowerCase()))

--- a/lib/modules/onboarding.js
+++ b/lib/modules/onboarding.js
@@ -63,7 +63,7 @@ module.options = {
 	},
 };
 
-const firstRunStorage = Storage.wrapPrefix('RES.firstRun.', (null: null | boolean));
+const firstRunStorage = Storage.wrapPrefix('RES.firstRun.', () => (null: null | boolean));
 
 module.go = async () => {
 	// if this is the first time this version has been run, pop open the what's new tab, background focused.

--- a/lib/modules/onboarding.js
+++ b/lib/modules/onboarding.js
@@ -63,7 +63,7 @@ module.options = {
 	},
 };
 
-const firstRunStorage = Storage.wrapDomain(version => `RES.firstRun.${version}`, (null: null | boolean));
+const firstRunStorage = Storage.wrapPrefix('RES.firstRun.', (null: null | boolean));
 
 module.go = async () => {
 	// if this is the first time this version has been run, pop open the what's new tab, background focused.

--- a/lib/modules/quickMessage.js
+++ b/lib/modules/quickMessage.js
@@ -80,7 +80,7 @@ module.options = {
 	},
 };
 
-const lastSentAsStorage = Storage.wrapPrefix('RESmodules.quickMessage.lastSentAs.', (null: null | string));
+const lastSentAsStorage = Storage.wrapPrefix('RESmodules.quickMessage.lastSentAs.', () => (null: null | string));
 
 module.go = () => {
 	CommandLine.registerCommand(

--- a/lib/modules/quickMessage.js
+++ b/lib/modules/quickMessage.js
@@ -80,7 +80,7 @@ module.options = {
 	},
 };
 
-const lastSentAsStorage = Storage.wrapDomain(user => `RESmodules.quickMessage.lastSentAs.${user}`, (null: null | string));
+const lastSentAsStorage = Storage.wrapPrefix('RESmodules.quickMessage.lastSentAs.', (null: null | string));
 
 module.go = () => {
 	CommandLine.registerCommand(

--- a/lib/modules/troubleshooter.js
+++ b/lib/modules/troubleshooter.js
@@ -97,18 +97,15 @@ function clearCache() {
 async function clearTags() {
 	const confirm = window.confirm(i18n('troubleshooterAreYouPositive'));
 	if (confirm) {
-		const tags = await UserTagger.tagStorage.get();
-		if (tags) {
-			let cnt = 0;
-			for (const i in tags) {
-				if ((tags[i].votes === 1 || tags[i].votes === 0 || tags[i].votes === -1) && !tags[i].hasOwnProperty('tag')) {
-					delete tags[i];
-					cnt += 1;
-				}
+		const tags = await UserTagger.tagStorage.getAll();
+		const keysToDelete = [];
+		for (const [key, { tag, votes }] of Object.entries(tags)) {
+			if ((votes === 1 || votes === 0 || votes === -1) && typeof tag !== 'string') {
+				keysToDelete.push(key);
 			}
-			UserTagger.tagStorage.set(tags);
-			Notifications.showNotification(i18n('troubleshooterEntriesRemoved', cnt), 2500);
 		}
+		UserTagger.tagStorage.delete(keysToDelete);
+		Notifications.showNotification(i18n('troubleshooterEntriesRemoved', keysToDelete.length), 2500);
 	} else {
 		Notifications.showNotification(i18n('troubleshooterNoActionTaken'), 2500);
 	}

--- a/lib/modules/troubleshooter.js
+++ b/lib/modules/troubleshooter.js
@@ -199,7 +199,7 @@ async function testEnvironment() {
 		rows.push(`wrapped.has(): ${(await wrapped.has(): any)}`, '');
 
 		rand = Math.random();
-		const domain = Storage.wrapPrefix(testKey, 'default');
+		const domain = Storage.wrapPrefix(testKey, () => 'default');
 		rows.push(`prefix.set(): ${rand}`);
 		domain.set('1', rand);
 		rows.push(`prefix.get(): ${(await domain.get('1', testKey): any)}`);

--- a/lib/modules/troubleshooter.js
+++ b/lib/modules/troubleshooter.js
@@ -199,15 +199,15 @@ async function testEnvironment() {
 		rows.push(`wrapped.has(): ${(await wrapped.has(): any)}`, '');
 
 		rand = Math.random();
-		const domain = Storage.wrapDomain(x => testKey + x, 'default');
-		rows.push(`domain.set(): ${rand}`);
-		domain.set(1, rand);
-		rows.push(`domain.get(): ${(await domain.get(1, testKey): any)}`);
-		rows.push(`domain.has(): ${(await domain.has(1, testKey): any)}`);
-		rows.push('domain.delete()');
-		domain.delete(1, testKey);
-		rows.push(`domain.get(): ${(await domain.get(1, testKey): any)}`);
-		rows.push(`domain.has(): ${(await domain.has(1, testKey): any)}`, '');
+		const domain = Storage.wrapPrefix(testKey, 'default');
+		rows.push(`prefix.set(): ${rand}`);
+		domain.set('1', rand);
+		rows.push(`prefix.get(): ${(await domain.get('1', testKey): any)}`);
+		rows.push(`prefix.has(): ${(await domain.has('1', testKey): any)}`);
+		rows.push('prefix.delete()');
+		domain.delete('1', testKey);
+		rows.push(`prefix.get(): ${(await domain.get('1', testKey): any)}`);
+		rows.push(`prefix.has(): ${(await domain.has('1', testKey): any)}`, '');
 	} catch (e) {
 		rows.push('', `Errored: ${e}`);
 		console.error(e);

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -195,8 +195,11 @@ async function showUserInfo(target, update) {
 
 	const nameLowercase = (data.name || '').toLowerCase();
 
-	if (UserTagger.tags && UserTagger.tags[nameLowercase] && UserTagger.tags[nameLowercase].link) {
-		const links = UserTagger.tags[nameLowercase].link.split(/\s/).reduce((acc, url) => acc + string.escape`<a target="_blank" rel="noopener noreferer" href="${url}">${url.replace(/^https?:\/\/(www\.)?/, '')}</a>`, '');
+	const userTaggerEnabled = Modules.isRunning(UserTagger);
+	const userTag = userTaggerEnabled && await UserTagger.tagStorage.get(nameLowercase);
+
+	if (userTag && userTag.link) {
+		const links = userTag.link.split(/\s/).reduce((acc, url) => acc + string.escape`<a target="_blank" rel="noopener noreferer" href="${url}">${url.replace(/^https?:\/\/(www\.)?/, '')}</a>`, '');
 		userHTML += `<div class="authorFieldPair"><div class="authorLabel">${i18n('userInfoLink')}</div> <div class="authorDetail">${links}</div></div>`;
 	}
 
@@ -217,9 +220,7 @@ async function showUserInfo(target, update) {
 		userHTML += string.escape`<div class="${isHighlight ? 'blueButton' : 'redButton'}" id="highlightUser" data-userid="${data.id}">${isHighlight ? i18n('userInfoHighlight') : i18n('userInfoUnhighlight')}</div>`;
 	}
 
-	const userTaggerEnabled = Modules.isRunning(UserTagger);
-
-	const isUnignore = userTaggerEnabled && UserTagger.tags && UserTagger.tags[nameLowercase] && UserTagger.tags[nameLowercase].ignore;
+	const isUnignore = userTag && userTag.ignore;
 	userHTML += string.escape`<div class="${isUnignore ? 'redButton' : 'blueButton'}" id="ignoreUser" user="${nameLowercase}">&empty; ${isUnignore ? i18n('userInfoUnignore') : i18n('userInfoIgnore')}</div>`;
 
 	userHTML += '<div class="clear"></div></div>'; // closes bottomButtons div

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -8,6 +8,7 @@ import {
 	Alert,
 	CreateElement,
 	Thing,
+	batch,
 	click,
 	downcast,
 	isCurrentSubreddit,
@@ -101,19 +102,15 @@ module.options = {
 
 export const usernameRE = /(?:u|user)\/([\w\-]+)/;
 
-export const tagStorage = Storage.wrap('RESmodules.userTagger.tags', ({}: { [user: string]: {|
+export const tagStorage = Storage.wrapPrefix('RESmodules.userTagger.t.', () => (({}: any): {|
 	tag?: string,
 	link?: string,
 	color?: string,
 	ignore?: boolean,
-	votes: number,
-|} }));
+	votes?: number,
+|}), user => user.toLowerCase());
 
-export let tags = {};
-
-module.beforeLoad = async () => {
-	tags = await tagStorage.get();
-
+module.beforeLoad = () => {
 	watchForElements(['siteTable', 'newComments'], usernameSelector, applyTagToAuthor);
 };
 
@@ -371,20 +368,15 @@ function attachVoteHandler() {
 	}, true);
 }
 
-function handleVoteClick($this) {
+async function handleVoteClick($this) {
 	const $otherArrow = $this.siblings('.arrow');
 	const thing = Thing.checkedFrom($this);
-	let thisAuthor = thing.getAuthor();
+	const thisAuthor = thing.getAuthor();
 
 	// Stop if the post is archived (unvotable) or you are voting on your own post/comment/etc.
 	if ($this.hasClass('archived') || !thisAuthor || thisAuthor === loggedInUser()) {
 		return;
 	}
-
-	thisAuthor = thisAuthor.toLowerCase();
-	const tagObject = tags[thisAuthor] = tags[thisAuthor] || { votes: 0 };
-
-	let votes = parseInt(tagObject.votes, 10) || 0;
 
 	// there are 6 possibilities here:
 	// 1) no vote yet, click upmod
@@ -395,30 +387,35 @@ function handleVoteClick($this) {
 	// 6) downmodded before, switching to upmod
 
 	// classes are changed AFTER this event is triggered
+	let voteDelta = 0;
 	if ($this.hasClass('up')) {
 		// adding an upvote
-		votes++;
+		voteDelta++;
 		if ($otherArrow.hasClass('downmod')) {
 			// also removing a downvote
-			votes++;
+			voteDelta++;
 		}
 	} else if ($this.hasClass('upmod')) {
 		// removing an upvote directly
-		votes--;
+		voteDelta--;
 	} else if ($this.hasClass('down')) {
 		// adding a downvote
-		votes--;
+		voteDelta--;
 		if ($otherArrow.hasClass('upmod')) {
 			// also removing an upvote
-			votes--;
+			voteDelta--;
 		}
 	} else if ($this.hasClass('downmod')) {
 		// removing a downvote directly
-		votes++;
+		voteDelta++;
 	}
 
+	// must load tag object _after_ checking the DOM, so that classes will not be changed
+	const tagObject = await tagStorage.get(thisAuthor);
+	const votes = (parseInt(tagObject.votes, 10) || 0) + voteDelta;
+
 	tagObject.votes = votes;
-	tagStorage.patch({ [thisAuthor]: { votes } });
+	tagStorage.patch(thisAuthor, { votes });
 
 	const thisAuthorObj = thing.getAuthorElement();
 	let thisVWobj = $(thisAuthorObj).nextAll('.voteWeight')[0];
@@ -432,11 +429,12 @@ function handleVoteClick($this) {
 
 let currentSortMethod, isDescending;
 
-function drawUserTagTable(sortMethod, descending) {
+async function drawUserTagTable(sortMethod, descending) {
 	currentSortMethod = sortMethod || currentSortMethod;
 	isDescending = (descending === undefined || descending === null) ? isDescending : descending;
 	const taggedUsers = [];
 	const filterType = $('#tagFilter').val();
+	const tags = await tagStorage.getAll();
 	for (const tagIndex in tags) {
 		if (filterType === 'tagged users') {
 			if (typeof tags[tagIndex].tag !== 'undefined') {
@@ -573,8 +571,7 @@ function drawUserTagTable(sortMethod, descending) {
 		const $button = $(this);
 		Alert.open(i18n('userTaggerAreYouSureYouWantToDeleteTag', thisUser), { cancelable: true })
 			.then(() => {
-				delete tags[thisUser];
-				tagStorage.deletePath(thisUser);
+				tagStorage.delete(thisUser);
 				$button.closest('tr').remove();
 			});
 	});
@@ -625,49 +622,39 @@ const bgToTextColorMap = {
 
 let clickedTag;
 
-function openUserTagPrompt(obj, username) {
-	username = username.toLowerCase();
+async function openUserTagPrompt(obj, username) {
 	clickedTag = obj;
 	$tagDialog().$usernameTitle.text(username);
 	$tagDialog().name.value = username;
-	if (typeof tags[username] !== 'undefined') {
-		if (typeof tags[username].link !== 'undefined') {
-			$tagDialog().link.value = tags[username].link;
-		} else {
-			$tagDialog().link.value = '';
-		}
-		if (typeof tags[username].tag !== 'undefined') {
-			$tagDialog().tag.value = tags[username].tag;
-		} else {
-			$tagDialog().tag.value = '';
-			if (typeof tags[username].link === 'undefined') {
-				// since we haven't yet set a tag or a link for this user, auto populate a link for the
-				// user based on where we are tagging from.
-				setLinkBasedOnTagLocation(obj);
-			}
-		}
-		const ignored = typeof tags[username].ignore !== 'undefined' ? tags[username].ignore : false;
-		$tagDialog().ignore.checked = ignored;
-		$tagDialog().ignoreContainer.classList.toggle('enabled', ignored);
-		if (typeof tags[username].votes !== 'undefined') {
-			$tagDialog().votes.value = String(tags[username].votes);
-		} else {
-			$tagDialog().votes.value = '';
-		}
-		if (typeof tags[username].color !== 'undefined') {
-			$($tagDialog().color).val(tags[username].color);
-		} else {
-			$tagDialog().color.selectedIndex = 0;
-		}
+
+	const tagObject = await tagStorage.get(username);
+
+	if (typeof tagObject.link !== 'undefined') {
+		$tagDialog().link.value = tagObject.link;
+	} else {
+		$tagDialog().link.value = '';
+	}
+	if (typeof tagObject.tag !== 'undefined') {
+		$tagDialog().tag.value = tagObject.tag;
 	} else {
 		$tagDialog().tag.value = '';
-		$tagDialog().ignore.checked = false;
-		$tagDialog().ignoreContainer.classList.remove('enabled');
-		$tagDialog().votes.value = '';
-		$tagDialog().link.value = '';
-		if (module.options.storeSourceLink.value) {
+		if (typeof tagObject.link === 'undefined') {
+			// since we haven't yet set a tag or a link for this user, auto populate a link for the
+			// user based on where we are tagging from.
 			setLinkBasedOnTagLocation(obj);
 		}
+	}
+	const ignored = !!tagObject.ignore;
+	$tagDialog().ignore.checked = ignored;
+	$tagDialog().ignoreContainer.classList.toggle('enabled', ignored);
+	if (typeof tagObject.votes !== 'undefined') {
+		$tagDialog().votes.value = String(tagObject.votes);
+	} else {
+		$tagDialog().votes.value = '';
+	}
+	if (typeof tagObject.color !== 'undefined') {
+		$($tagDialog().color).val(tagObject.color);
+	} else {
 		$tagDialog().color.selectedIndex = 0;
 	}
 
@@ -741,21 +728,18 @@ function closeUserTagPrompt() {
 	}
 }
 
-function setUserTag(username, tag, color, ignore, link, votes, noclick) {
-	username = username.toLowerCase();
-	if (((tag !== null) && (tag !== '')) || (ignore)) {
+async function setUserTag(username, tag, color, ignore, link, votes, noclick) {
+	const tagObject = await tagStorage.get(username);
+	if ((tag !== null && tag !== '') || ignore) {
 		if (tag === '') {
 			tag = 'ignored';
 		}
-		if (typeof tags[username] === 'undefined') {
-			tags[username] = { votes: 0 };
-		}
-		tags[username].tag = tag;
-		tags[username].link = link;
-		tags[username].color = color;
+		tagObject.tag = tag;
+		tagObject.link = link;
+		tagObject.color = color;
 		const bgColor = (color === 'none') ? 'transparent' : color;
 		if (ignore) {
-			tags[username].ignore = true;
+			tagObject.ignore = true;
 
 			Notifications.showNotification({
 				moduleID: module.moduleID,
@@ -770,7 +754,7 @@ function setUserTag(username, tag, color, ignore, link, votes, noclick) {
 				closeDelay: 5000,
 			});
 		} else {
-			delete tags[username].ignore;
+			delete tagObject.ignore;
 		}
 		if (!noclick) {
 			clickedTag.setAttribute('class', 'userTagLink hasTag');
@@ -778,15 +762,14 @@ function setUserTag(username, tag, color, ignore, link, votes, noclick) {
 			$(clickedTag).text(tag);
 		}
 	} else {
-		if (typeof tags[username] !== 'undefined') {
-			delete tags[username].tag;
-			delete tags[username].color;
-			delete tags[username].link;
-			if (tags[username].tag === 'ignored') {
-				delete tags[username].tag;
-			}
-			delete tags[username].ignore;
+		delete tagObject.tag;
+		delete tagObject.color;
+		delete tagObject.link;
+		if (tagObject.tag === 'ignored') {
+			delete tagObject.tag;
 		}
+		delete tagObject.ignore;
+
 		if (!noclick) {
 			clickedTag.setAttribute('style', 'background-color: transparent');
 			clickedTag.setAttribute('class', 'userTagLink RESUserTagImage');
@@ -794,28 +777,28 @@ function setUserTag(username, tag, color, ignore, link, votes, noclick) {
 		}
 	}
 
-	if (typeof tags[username] !== 'undefined') {
-		tags[username].votes = (isNaN(votes)) ? 0 : votes;
-	}
+	tagObject.votes = (isNaN(votes)) ? 0 : votes;
+
 	if (!noclick) {
 		const thisVW: ?HTMLAnchorElement = (clickedTag.parentNode: any).parentNode.querySelector('a.voteWeight');
 		if (thisVW) {
 			colorUser(thisVW, username, votes);
 		}
 	}
-	if (_.isEmpty(tags[username])) {
-		delete tags[username];
-		tagStorage.deletePath(username);
+	if (_.isEmpty(tagObject)) {
+		tagStorage.delete(username);
 	} else {
-		// Always need to delete the tag so deleted fields are removed
-		tagStorage.deletePath(username);
-		tagStorage.patch({ [username]: tags[username] });
+		tagStorage.set(username, tagObject);
 	}
 	closeUserTagPrompt();
 }
 
+const getTagBatched = batch(async users => {
+	const tags = await tagStorage.batch(users);
+	return users.map(user => tags[user.toLowerCase()]);
+}, { size: Infinity, delay: 0 });
 
-export function applyTagToAuthor(thisAuthorObj: HTMLAnchorElement, noEdit: boolean = false): void {
+export async function applyTagToAuthor(thisAuthorObj: HTMLAnchorElement, noEdit: boolean = false) {
 	let thisAuthor;
 	if (thisAuthorObj.href) {
 		const test = thisAuthorObj.href.match(usernameRE);
@@ -827,22 +810,20 @@ export function applyTagToAuthor(thisAuthorObj: HTMLAnchorElement, noEdit: boole
 		}
 	} else {
 		thisAuthor = (
-				thisAuthorObj.getAttribute('data-user') ||
-				thisAuthorObj.innerText ||
-				''
-			);
+			thisAuthorObj.getAttribute('data-user') ||
+			thisAuthorObj.innerText ||
+			''
+		);
 	}
 
-	thisAuthor = thisAuthor.toLowerCase();
+	const tagObject = await getTagBatched(thisAuthor);
 
-	const tagObject = tags[thisAuthor];
-
-	if (module.options.showTaggingIcon.value || tagObject) {
+	if (module.options.showTaggingIcon.value || !_.isEmpty(tagObject)) {
 		addAuthorTag(thisAuthorObj, noEdit, thisAuthor, tagObject);
 	}
 
 	if (
-		tagObject && tagObject.ignore && !noEdit &&
+		tagObject.ignore && !noEdit &&
 		thisAuthorObj.classList.contains('author') && !isPageType('profile')
 	) {
 		const thing = Thing.from(thisAuthorObj);
@@ -1008,15 +989,14 @@ function colorUser(obj, author, votes) {
 	}
 }
 
-export function ignoreUser(username: string, ignore: boolean) {
-	const thisName = username.toLowerCase();
+export async function ignoreUser(username: string, ignore: boolean) {
 	const thisIgnore = ignore !== false;
 	const {
 		color = 'none',
 		link = '',
 		votes = 0,
 		tag: oldTag = '',
-	} = tags && tags[thisName] || {};
+	} = await tagStorage.get(username);
 	let tag = oldTag;
 
 	if (thisIgnore && tag === '') {
@@ -1024,5 +1004,5 @@ export function ignoreUser(username: string, ignore: boolean) {
 	} else if (!thisIgnore && tag === 'ignored') {
 		tag = '';
 	}
-	setUserTag(thisName, tag, color, thisIgnore, link, votes, true /* noclick */);
+	setUserTag(username, tag, color, thisIgnore, link, votes, true /* noclick */);
 }


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: https://www.reddit.com/r/RESissues/comments/69ljqu/firefox_reddit_sluggish_and_unstable_since_res/
Tested in browser: Chrome 60, Firefox 54

`chrome.storage.local.set` is _absurdly_ slow in Firefox WebExtensions (the profile below would take just 30ms with `JSON.stringify`)

![image](https://cloud.githubusercontent.com/assets/7673145/25778294/c9c9e7e2-32c7-11e7-8aae-4ed13311c2d8.png)

To mitigate this, store tags under individual keys, so all tags don't need to be saved at once.

As a bonus, we also don't need to _load_ all tags at once, bringing init improvements to all browsers.