### PR TITLE
Migrator to remove old tag object

### DIFF
--- a/lib/core/migrate/migrate.js
+++ b/lib/core/migrate/migrate.js
@@ -506,6 +506,11 @@ const migrations = [
 			const remappedTags = _.mapKeys(tags, (v, k) => `tag.${k.toLowerCase()}`);
 			await Storage.setMultiple(remappedTags);
 		},
+	}, {
+		versionNumber: '5.6.2-remove-old-tags',
+		async go() {
+			await Storage.delete('RESmodules.userTagger.tags');
+		},
 	},
 
 ];  // ^^ Add new migrations ^^


### PR DESCRIPTION
Split off from #4221 so that the latter is non-destructive (in case something goes wrong with migration).