### PR TITLE
Thing.getNumberOfChildren: support languages where the number of comments comes after the word

### DIFF
--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -235,7 +235,7 @@ export default class Thing {
 
 	getNumberOfChildren(): number {
 		const numChildrenElem = this.element.querySelector('.numchildren');
-		return numChildrenElem && parseInt((/\((\d+)/).exec(numChildrenElem.textContent)[1], 10) || 0;
+		return numChildrenElem && parseInt((/(\d+)/).exec(numChildrenElem.textContent)[1], 10) || 0;
 	}
 
 	static _parseScore(scoreEle: HTMLElement): number {

--- a/tests/hideChildComments.js
+++ b/tests/hideChildComments.js
@@ -32,6 +32,14 @@ module.exports = {
 
 			.end();
 	},
+	'works for non-english languages (korean)': browser => {
+		browser
+			.url('https://ko.reddit.com/r/RESIntegrationTests/comments/5sq835/hide_child_comments/')
+			.waitForElementVisible(toggleChildren(parent))
+			.click(toggleChildren(parent))
+			.waitForElementNotVisible(child)
+			.end();
+	},
 	'hide all': browser => {
 		browser
 			// when clicking "hide all"


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: https://www.reddit.com/r/RESissues/comments/69soho/res_561_hide_child_comments_button_gone_after/
Tested in browser: Chrome 60, integration tests