### PR TITLE
Fix reversed ignore icons on dashboard tags page

### DIFF
--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -217,6 +217,11 @@ module.go = () => {
 
 export const usernameSelector = '.contents .author, .noncollapsed a.author, p.tagline a.author, #friend-table span.user a, .sidecontentbox .author, div.md a[href^="/u/"]:not([href*="/m/"]), div.md a[href*="reddit.com/u/"]:not([href*="/m/"]), .usertable a.author, .usertable span.user a, div.wiki-page-content .author';
 
+const ignoreIcons = {
+	IGNORED: '\uF038',
+	NORMAL: '\uF03B',
+};
+
 const $tagDialog = _.once(() => {
 	const colors = Object.entries(bgToTextColorMap)
 		.map(([color, textColor]) => ({
@@ -274,8 +279,7 @@ const $tagDialog = _.once(() => {
 		</div>
 	`);
 
-	const icons = ignoreIcons();
-	const ignoreToggleButton = CreateElement.toggleButton(undefined, 'userTaggerIgnore', false, icons.normal, icons.ignored, false, true);
+	const ignoreToggleButton = CreateElement.toggleButton(undefined, 'userTaggerIgnore', false, ignoreIcons.IGNORED, ignoreIcons.NORMAL, false, true);
 	ignoreToggleButton.classList.add('reverseToggleButton');
 	const ignoreSettingsLink = SettingsNavigation.makeUrlHashLink(module.moduleID, 'hardIgnore', ' configure ', 'gearIcon');
 	$tagger.find('.res-usertag-ignore').append(ignoreToggleButton, ignoreSettingsLink);
@@ -521,15 +525,13 @@ async function drawUserTagTable(sortMethod, descending) {
 		end = Math.min(count, tagsPerPage * page);
 	}
 
-	const icons = ignoreIcons();
-
 	taggedUsers
 		.slice(start, end)
 		.forEach((thisUser, userIndex) => {
 			const thisTag = (typeof tags[thisUser].tag === 'undefined') ? '' : tags[thisUser].tag;
 			const thisVotes = (typeof tags[thisUser].votes === 'undefined') ? 0 : tags[thisUser].votes;
 			const thisColor = (typeof tags[thisUser].color === 'undefined') ? '' : tags[thisUser].color;
-			const thisIgnore = (typeof tags[thisUser].ignore === 'undefined') ? icons.normal : icons.ignored;
+			const thisIgnore = (typeof tags[thisUser].ignore === 'undefined') ? ignoreIcons.NORMAL : ignoreIcons.IGNORED;
 
 			const userTagLink = document.createElement('a');
 			if (thisTag === '') {
@@ -575,13 +577,6 @@ async function drawUserTagTable(sortMethod, descending) {
 				$button.closest('tr').remove();
 			});
 	});
-}
-
-function ignoreIcons() {
-	return {
-		ignored: '\uF03B',
-		normal: '\uF038',
-	};
 }
 
 function saveTagForm() {


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: https://www.reddit.com/r/RESissues/comments/69v2x3/my_user_tags_dashboard_has_ignored_symbols/
Tested in browser: Chrome 60
