### PR TITLE
Avoid concurrent installs warning for updates in Firefox

### DIFF
--- a/browser/foreground.js
+++ b/browser/foreground.js
@@ -32,6 +32,8 @@ export {
 	addInterceptor,
 };
 
+addInterceptor('extensionId', () => chrome.runtime.id);
+
 addInterceptor('isPrivateBrowsing', () => chrome.extension.inIncognitoContext);
 
 const _set = apiToPromise((items, callback) => chrome.storage.local.set(items, callback));

--- a/lib/environment/id.js
+++ b/lib/environment/id.js
@@ -1,0 +1,7 @@
+/* @flow */
+
+import { sendSynchronous } from '../../browser';
+
+export function getExtensionId(): string {
+	return sendSynchronous('extensionId');
+}

--- a/lib/environment/index.js
+++ b/lib/environment/index.js
@@ -3,6 +3,7 @@
 export { addURLToHistory, isURLVisited } from './history';
 export { ajax } from './ajax';
 export { download } from './download';
+export { getExtensionId } from './id';
 export { i18n } from './i18n';
 export { isPrivateBrowsing } from './privateBrowsing';
 export { launchAuthFlow } from './auth';

--- a/lib/modules/version.js
+++ b/lib/modules/version.js
@@ -1,8 +1,10 @@
 /* @flow */
 
+import _ from 'lodash';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
 import * as Metadata from '../core/metadata';
+import { getExtensionId } from '../environment';
 import {
 	BodyClasses,
 	range,
@@ -31,7 +33,6 @@ module.afterLoad = () => {
 	avoidConcurrentInstalls();
 };
 
-
 function addVersionClasses() {
 	BodyClasses.add('res');
 	const versionComponents = Metadata.version.split('.');
@@ -40,19 +41,20 @@ function addVersionClasses() {
 	}
 }
 
-
 function reportVersion() {
 	// report the version of RES to reddit's advisory checker.
 	$('<div>', {
 		id: 'RESConsoleVersion',
 		style: 'display: none;',
 		text: Metadata.version,
+		'data-id': getExtensionId(),
 	}).appendTo(document.body);
 }
 
 function avoidConcurrentInstalls() {
-	const concurrentInstalls = $('[id=RESConsoleVersion]')
-		.toArray()
+	const installs = Array.from(document.querySelectorAll('#RESConsoleVersion'));
+	// versions before 5.6.2 will not report their id, so assume they are unique
+	const concurrentInstalls = _.uniqBy(installs, e => e.getAttribute('data-id') || Math.random())
 		.map(e => e.textContent);
 
 	if (concurrentInstalls.length > 1) {


### PR DESCRIPTION
Tested in browser: Chrome 60, Firefox 54
