### PR TITLE
Fix mediaControls not showing on Firefox

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1321,11 +1321,11 @@ function generateImage(options: ImageMedia, context) {
 		title: options.title,
 		caption: options.caption,
 		credits: options.credits,
-		src: options.src,
 		href: options.href || context.href,
 		openInNewWindow: module.options.openInNewWindow.value,
 	}): any);
 	const image: HTMLImageElement = (element.querySelector('img.res-image-media'): any);
+	image.src = options.src; // Set here instead of in template as workaround for Firefox `<template>` bug which causes `<img>` to an emit error event; #4222
 	const anchor = element.querySelector('a.res-expando-link');
 
 	const transparentGif = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';

--- a/lib/modules/showImages/templates.js
+++ b/lib/modules/showImages/templates.js
@@ -40,7 +40,7 @@ export const galleryTemplate = /*:: <T> */({ title, caption, credits, src }: {| 
 	</div>
 `;
 
-export const imageTemplate = ({ title, caption, credits, src, href, openInNewWindow }: {| title?: string, caption?: string, credits?: string, src: string, href: string, openInNewWindow: boolean |}) => string.html`
+export const imageTemplate = ({ title, caption, credits, href, openInNewWindow }: {| title?: string, caption?: string, credits?: string, href: string, openInNewWindow: boolean |}) => string.html`
 	<div class="res-image">
 		${title && string._html`
 		<h4 class="res-title">${title}</h4>
@@ -52,7 +52,7 @@ export const imageTemplate = ({ title, caption, credits, src, href, openInNewWin
 		<div class="res-credits">${string.safe(credits)}</div>
 		`}
 		<a class="res-expando-link noKeyNav" href="${href}" ${openInNewWindow && string._html`target="_blank" rel="noopener noreferrer"`}>
-			<img class="res-image-media" src="${src}">
+			<img class="res-image-media">
 		</a>
 	</div>
 `;


### PR DESCRIPTION
Fixes #4222 

Tested in browser: Firefox 55
