### PR TITLE
Settings gear icon click action change for consistency

### DIFF
--- a/lib/core/migrate/migrate.js
+++ b/lib/core/migrate/migrate.js
@@ -524,6 +524,13 @@ const migrations = [
 			await Storage.setMultiple(remappedEntries);
 			await Storage.delete('RESmodules.newCommentCount.counts');
 		},
+	}, {
+		versionNumber: '5.7.3-commandLine-menu-opening',
+		async go() {
+			await Migrators.moveOption('commandLine', 'launchFromMenuButton', 'RESMenu', 'gearIconClickAction', launchFromMenu =>
+				launchFromMenu ? 'openCommandLine' : 'toggleMenuNoHover'
+			);
+		},
 	},
 
 ];  // ^^ Add new migrations ^^

--- a/lib/modules/commandLine.js
+++ b/lib/modules/commandLine.js
@@ -35,21 +35,11 @@ module.options = {
 		description: 'commandLineMenuItemDesc',
 		value: false,
 	},
-	launchFromMenuButton: {
-		title: 'commandLineLaunchFromMenuButtonTitle',
-		type: 'boolean',
-		description: 'commandLineLaunchFromMenuButtonDesc',
-		value: false,
-	},
 };
 
 module.go = () => {
 	if (module.options.menuItem.value) {
 		addMenuItem();
-	}
-
-	if (module.options.launchFromMenuButton.value) {
-		addMenuButtonHandler();
 	}
 };
 
@@ -60,16 +50,10 @@ function addMenuItem() {
 			text: '\uF060',
 		}));
 
-	Menu.addMenuItem($menuItem, _onClickMenu);
-}
-
-function addMenuButtonHandler() {
-	Menu.onClickMenuButton(_onClickMenu, true);
-}
-
-function _onClickMenu() {
-	Menu.hidePrefsDropdown();
-	toggleCmdLine(true);
+	Menu.addMenuItem($menuItem, () => {
+		Menu.hidePrefsDropdown();
+		toggleCmdLine(true);
+	});
 }
 
 const commandLine = _.once(() => {

--- a/lib/modules/menu.js
+++ b/lib/modules/menu.js
@@ -29,7 +29,7 @@ module.options = {
 			name: 'Toggle menu (hover action disabled)',
 			value: 'toggleMenuNoHover',
 		}],
-		value: 'openCommandLine',
+		value: 'toggleMenuNoHover',
 		description: 'gearIconClickActionDesc',
 		bodyClass: true,
 		advanced: true,

--- a/lib/modules/menu.js
+++ b/lib/modules/menu.js
@@ -28,10 +28,9 @@ let RESPrefsLink;
 let $menuItems = $();
 
 function renderConsoleLink() {
-	RESPrefsLink = $('<span id="openRESPrefs"><span id="RESSettingsButton" title="RES Settings" class="gearIcon"></span>')
+	RESPrefsLink = $('<span id="openRESPrefs"><a href="#res:settings/about"><span id="RESSettingsButton" title="RES Settings" class="gearIcon"></a></span>')
 		.mouseenter(() => showPrefsDropdown())
 		.get(0);
-	onClickMenuButton(() => showPrefsDropdown(0));
 }
 
 function addConsoleLink() {

--- a/lib/modules/menu.js
+++ b/lib/modules/menu.js
@@ -3,6 +3,8 @@
 import { $ } from '../vendor';
 import { Module } from '../core/module';
 import * as Hover from './hover';
+import * as SettingsConsole from './settingsConsole';
+import * as CommandLine from './commandLine';
 
 export const module: Module<*> = new Module('RESMenu');
 
@@ -10,7 +12,29 @@ module.moduleName = 'menuName';
 module.category = 'coreCategory';
 module.description = 'The <span class="gearIcon"></span> dropdown menu to manage RES settings and quick options';
 module.alwaysEnabled = true;
-module.hidden = true;
+module.options = {
+	gearIconClickAction: {
+		title: 'gearIconClickActionTitle',
+		type: 'enum',
+		values: [{
+			name: 'Open settings console',
+			value: 'openSettings',
+		}, {
+			name: 'Open command line',
+			value: 'openCommandLine',
+		}, {
+			name: 'Toggle menu',
+			value: 'toggleMenu',
+		}, {
+			name: 'Toggle menu (hover action disabled)',
+			value: 'toggleMenuNoHover',
+		}],
+		value: 'openCommandLine',
+		description: 'gearIconClickActionDesc',
+		bodyClass: true,
+		advanced: true,
+	},
+};
 
 module.beforeLoad = () => {
 	renderConsoleLink();
@@ -28,9 +52,20 @@ let RESPrefsLink;
 let $menuItems = $();
 
 function renderConsoleLink() {
-	RESPrefsLink = $('<span id="openRESPrefs"><a href="#res:settings/about"><span id="RESSettingsButton" title="RES Settings" class="gearIcon"></a></span>')
-		.mouseenter(() => showPrefsDropdown())
+	RESPrefsLink = $('<span id="openRESPrefs"><span id="RESSettingsButton" title="RES Settings" class="gearIcon"></span>')
+		.mouseenter(() => {
+			if(module.options.gearIconClickAction.value !== 'toggleMenuNoHover')
+				showPrefsDropdown();
+		})
 		.get(0);
+	onClickMenuButton(() => {
+		if(module.options.gearIconClickAction.value === 'openCommandLine')
+			CommandLine.toggleCmdLine();
+		else if(module.options.gearIconClickAction.value === 'openSettings')
+			SettingsConsole.open();
+		else
+			showPrefsDropdown();
+	});
 }
 
 function addConsoleLink() {

--- a/lib/modules/menu.js
+++ b/lib/modules/menu.js
@@ -54,17 +54,19 @@ let $menuItems = $();
 function renderConsoleLink() {
 	RESPrefsLink = $('<span id="openRESPrefs"><span id="RESSettingsButton" title="RES Settings" class="gearIcon"></span>')
 		.mouseenter(() => {
-			if(module.options.gearIconClickAction.value !== 'toggleMenuNoHover')
+			if (module.options.gearIconClickAction.value !== 'toggleMenuNoHover') {
 				showPrefsDropdown();
+			}
 		})
 		.get(0);
 	onClickMenuButton(() => {
-		if(module.options.gearIconClickAction.value === 'openCommandLine')
+		if (module.options.gearIconClickAction.value === 'openCommandLine') {
 			CommandLine.toggleCmdLine();
-		else if(module.options.gearIconClickAction.value === 'openSettings')
+		} else if (module.options.gearIconClickAction.value === 'openSettings') {
 			SettingsConsole.open();
-		else
+		} else {
 			showPrefsDropdown();
+		}
 	});
 }
 

--- a/lib/modules/menu.js
+++ b/lib/modules/menu.js
@@ -14,23 +14,23 @@ module.description = 'The <span class="gearIcon"></span> dropdown menu to manage
 module.alwaysEnabled = true;
 module.options = {
 	gearIconClickAction: {
-		title: 'gearIconClickActionTitle',
+		title: 'menuGearIconClickActionTitle',
 		type: 'enum',
 		values: [{
-			name: 'Open settings console',
+			name: 'menuGearIconClickActionOpenSettings',
 			value: 'openSettings',
 		}, {
-			name: 'Open command line',
+			name: 'menuGearIconClickActionOpenCommandLine',
 			value: 'openCommandLine',
 		}, {
-			name: 'Toggle menu',
+			name: 'menuGearIconClickActionToggleMenu',
 			value: 'toggleMenu',
 		}, {
-			name: 'Toggle menu (hover action disabled)',
+			name: 'menuGearIconClickActionToggleMenuNoHover',
 			value: 'toggleMenuNoHover',
 		}],
 		value: 'toggleMenuNoHover',
-		description: 'gearIconClickActionDesc',
+		description: 'menuGearIconClickActionDesc',
 		bodyClass: true,
 		advanced: true,
 	},
@@ -55,19 +55,19 @@ function renderConsoleLink() {
 	RESPrefsLink = $('<span id="openRESPrefs"><span id="RESSettingsButton" title="RES Settings" class="gearIcon"></span>')
 		.mouseenter(() => {
 			if (module.options.gearIconClickAction.value !== 'toggleMenuNoHover') {
-				showPrefsDropdown();
+				showPrefsDropdown(200);
 			}
 		})
+		.find('.gearIcon').click(() => {
+			if (module.options.gearIconClickAction.value === 'openCommandLine') {
+				CommandLine.toggleCmdLine();
+			} else if (module.options.gearIconClickAction.value === 'openSettings') {
+				SettingsConsole.open();
+			} else {
+				showPrefsDropdown(0);
+			}
+		}).end()
 		.get(0);
-	onClickMenuButton(() => {
-		if (module.options.gearIconClickAction.value === 'openCommandLine') {
-			CommandLine.toggleCmdLine();
-		} else if (module.options.gearIconClickAction.value === 'openSettings') {
-			SettingsConsole.open();
-		} else {
-			showPrefsDropdown();
-		}
-	});
 }
 
 function addConsoleLink() {
@@ -77,7 +77,7 @@ function addConsoleLink() {
 		.after('<span class="separator">|</span>');
 }
 
-function showPrefsDropdown(openDelay = 200) {
+function showPrefsDropdown(openDelay: number) {
 	Hover.dropdownList(module.moduleID, Hover.HIDDEN_FROM_SETTINGS)
 		.options({
 			openDelay,
@@ -106,27 +106,6 @@ export function addMenuItem(ele: JQuery | HTMLElement | string, onClick?: (e: Ev
 	} else {
 		$menuItems = $menuItems.add($menuItem);
 	}
-}
-
-function getMenuButton() {
-	return $(RESPrefsLink).find('.gearIcon');
-}
-
-let _onClickMenuButton;
-let _isImportant = false;
-
-export function onClickMenuButton(callback: () => void, isImportant?: boolean = false) {
-	const menuButton = getMenuButton();
-	if (!_onClickMenuButton || (isImportant && !_isImportant)) {
-		_onClickMenuButton = $.Callbacks();
-		_isImportant = isImportant;
-		_onClickMenuButton.add(hidePrefsDropdown);
-	}
-	if (isImportant || !_onClickMenuButton.isImportant) {
-		_onClickMenuButton.add(callback);
-	}
-
-	menuButton.on('click', _onClickMenuButton.fire);
 }
 
 function addLegacyStyling() {

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -4003,5 +4003,11 @@
 	},
 	"iredditPreferRedditMediaDesc": {
 		"message": "Try to load images and video from Reddit's media servers."
+	},
+	"gearIconClickActionTitle": {
+		"message": "Gear Icon Click Action"
+	},
+	"gearIconClickActionDesc": {
+		"message": "Change what action occurs when you chick the settings gear icon."
 	}
 }

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -2816,12 +2816,6 @@
 	"commandLineMenuItemDesc": {
 		"message": "Add a \"launch command line\" item to the RES dropdown menu"
 	},
-	"commandLineLaunchFromMenuButtonTitle": {
-		"message": "Launch From Menu Button"
-	},
-	"commandLineLaunchFromMenuButtonDesc": {
-		"message": "Launch the command line by clicking the RES menu gear button"
-	},
 	"presetsLiteTitle": {
 		"message": "Lite"
 	},
@@ -4004,10 +3998,22 @@
 	"iredditPreferRedditMediaDesc": {
 		"message": "Try to load images and video from Reddit's media servers."
 	},
-	"gearIconClickActionTitle": {
+	"menuGearIconClickActionTitle": {
 		"message": "Gear Icon Click Action"
 	},
-	"gearIconClickActionDesc": {
-		"message": "Change what action occurs when you chick the settings gear icon."
+	"menuGearIconClickActionDesc": {
+		"message": "What should happen when you click on the gear icon? Unless specified, hovering will open the menu."
+	},
+	"menuGearIconClickActionOpenSettings": {
+		"message": "Open settings console"
+	},
+	"menuGearIconClickActionOpenCommandLine": {
+		"message": "Open command line"
+	},
+	"menuGearIconClickActionToggleMenu": {
+		"message": "Open menu"
+	},
+	"menuGearIconClickActionToggleMenuNoHover": {
+		"message": "Open menu (no hover)"
 	}
 }

--- a/tests/menu.js
+++ b/tests/menu.js
@@ -19,7 +19,7 @@ module.exports = {
 			.waitForElementVisible('#header')
 			.waitForElementVisible('#RESSettingsButton')
 			.moveToElement('#RESSettingsButton', 0, 0)
-			.pause(1000)
+			.click('#RESSettingsButton')
 			.click('#SettingsConsole')
 			.waitForElementVisible('#RESConsoleContainer')
 			.end();


### PR DESCRIPTION
Changed the Settings gear icon's click action to open the settings panel, not toggle the hover state of the menu. No other hover menu appears to have this behavior and I find it unintuitive and find myself accidentally closing the hover menu trying to click the cog.

<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: UX consistency 
Tested in browser: Chrome
