### PR TITLE
Fix mediaControls in Firefox

### DIFF
--- a/lib/utils/string.js
+++ b/lib/utils/string.js
@@ -51,16 +51,17 @@ export const html = flow(
 	htmlTagFunction,
 	markup => {
 		// <template> elements allow out-of-place elements e.g. <tr> without a <table>
-		const template: any = document.createElement('template');
+		// but they cause weird issues in Firefox (#4222), and it's unlikely that you'll need
+		// to use <tr>, except embedded in another template with string._html`<tr>...</tr>`,
+		// which doesn't have this limitation.
+		const template = document.createElement('div');
 		template.innerHTML = markup;
-		if (process.env.BUILD_TARGET === 'edge') {
-			// Edge does not support childELementCount or firstElementChild on DocumentFragment
-			return downcast(document.adoptNode(template.content.querySelector('*')), HTMLElement);
+		if (template.childElementCount !== 1) {
+			throw new Error(`Html template should have exactly one root node, but had ${template.childElementCount}`);
 		}
-		if (template.content.childElementCount !== 1) {
-			throw new Error(`Html template should have exactly one root node, but had ${template.content.childElementCount}`);
-		}
-		return downcast(document.adoptNode(template.content.firstElementChild), HTMLElement);
+		const child = downcast(template.firstElementChild, HTMLElement);
+		child.remove();
+		return child;
 	}
 );
 


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: fixes #4222, closes #4231
Tested in browser: Chrome 60, Firefox 54

I don't think it's likely that we'll need the extra functionality afforded by `<template>` (lone `<tr>`, etc.), since `<tr>` will generally be embedded in another template rather than rendered standalone.