### PR TITLE
Fixed referenced object on reused hover element

### DIFF
--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -185,7 +185,7 @@ module.options = {
 	},
 };
 
-let shortCutsContainer, $subredditGroupDropdown, subredditGroupDropdownUL, $srList,
+let shortCutsContainer, $subredditGroupDropdown, subredditGroupDropdownUL, subredditGroupDropdownRefItem, $srList,
 	$editShortcutDialog, deleteButton, $sortMenu, gettingSubreddits,
 	subredditsLastViewed, sortShortcutsButton;
 
@@ -438,6 +438,8 @@ function showSubredditGroupDropdown(obj) {
 }
 
 function _showSubredditGroupDropdown(obj, subreddits, suffix) {
+	// Updates source object referenced on the 'click' events
+	subredditGroupDropdownRefItem = obj;
 	// Show dropdown after an appropriate delay
 	if (!$subredditGroupDropdown) {
 		$subredditGroupDropdown = $('<div>', { id: 'RESSubredditGroupDropdown' });
@@ -467,13 +469,13 @@ function _showSubredditGroupDropdown(obj, subreddits, suffix) {
 		$subredditGroupDropdown.on('click', '.edit', (e: MouseEvent) => {
 			e.preventDefault();
 			hideSubredditGroupDropdown();
-			editSubredditShortcut(obj, e);
+			editSubredditShortcut(subredditGroupDropdownRefItem, e);
 		});
 
 		$subredditGroupDropdown.on('click', '.delete', (e: MouseEvent) => {
 			e.preventDefault();
 			hideSubredditGroupDropdown();
-			editSubredditShortcut(obj, e);
+			editSubredditShortcut(subredditGroupDropdownRefItem, e);
 			deleteButton.click();
 		});
 	}


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
**Relevant issue:** The hover menu for the subreddit manager gets reused after it's first creation, but doesn't update it's 'click' action references to the edit and delete button which tells it which subreddit to modify. So if you are trying to edit or delete subreddits, it will always populate the Edit window with the first subreddit that was hovered. 
**Tested in browser:** Chrome 59
