### PR TITLE
keyboardNav move(Down|Up): Fix handling when nothing is selected / no target

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1029,7 +1029,7 @@ const getLinearListMoveOptions = () => ({
 export let recentKeyMove = false;
 const refreshKeyMoveTimer = _.debounce(() => { recentKeyMove = false; }, 1000);
 
-function move(target, options) {
+function move(target, options, fallback?: () => void) {
 	const selected = SelectedEntry.selectedThing();
 
 	if (typeof target === 'function') {
@@ -1040,7 +1040,10 @@ function move(target, options) {
 		target = Thing.from(target);
 	}
 
-	if (!target) return null;
+	if (!target) {
+		if (fallback) fallback();
+		return null;
+	}
 
 	SelectedEntry.select(target, options);
 

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -216,7 +216,7 @@ module.options = {
 		description: 'keyboardNavMoveUpDesc',
 		title: 'keyboardNavMoveUpTitle',
 		callback() {
-			move(thing => thing.getNext({ direction: 'up' }), getLinearListMoveOptions());
+			move(thing => thing.getNext({ direction: 'up' }), getLinearListMoveOptions(), SelectedEntry.autoSelect);
 		},
 	},
 	moveDown: {
@@ -226,7 +226,11 @@ module.options = {
 		description: 'keyboardNavMoveDownDesc',
 		title: 'keyboardNavMoveDownTitle',
 		callback() {
-			move(thing => thing.getNext({ direction: 'down' }), getLinearListMoveOptions());
+			move(thing => thing.getNext({ direction: 'down' }), getLinearListMoveOptions(), () => {
+				const selected = SelectedEntry.selectedThing();
+				if (!selected) SelectedEntry.autoSelect();
+				else if (_.last(Thing.visibleThings()) === selected) nextPage();
+			});
 		},
 	},
 	moveUpComment: {
@@ -1347,9 +1351,8 @@ function handleGoModeEscapeKey(event: KeyboardEvent) {
 
 function nextPage() {
 	// if Never Ending Reddit is enabled, just scroll to the bottom.  Otherwise, click the 'next' link.
-	if (Modules.isRunning(NeverEndingReddit) && NeverEndingReddit.loaderWidget) {
-		click(NeverEndingReddit.loaderWidget);
-		move(Thing.visibleThingElements().slice(-1)[0]);
+	if (Modules.isRunning(NeverEndingReddit)) {
+		NeverEndingReddit.loadNextPage(true);
 	} else {
 		// get the first link to the next page of reddit...
 		const nextPrevLinks = NeverEndingReddit.getNextPrevLinks();

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -99,7 +99,7 @@ let nextPageURL;
 let $NREPause, isPaused, pauseReason, pauseAfterPages, nextPausePage;
 let scrollListenerAttached = false;
 
-export let loaderWidget;
+let loaderWidget;
 export let loadPromise;
 
 const isPausedStorage = Storage.wrap('RESmodules.neverEndingReddit.isPaused', false);

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -10,6 +10,7 @@ import {
 	Thing,
 	addCSS,
 	elementInViewport,
+	scrollToElement,
 	fastAsync,
 	newSitetable,
 } from '../utils';
@@ -316,7 +317,7 @@ function buildLoaderWidget() {
 	widget.id = 'progressIndicator';
 	widget.className = 'neverEndingReddit';
 
-	widget.addEventListener('click', (e: Event) => { if (e.target.tagName !== 'A') loadNextPage(); });
+	widget.addEventListener('click', (e: Event) => { if (e.target.tagName !== 'A') loadNextPage(true); });
 
 	return widget;
 }
@@ -355,10 +356,16 @@ function setLoaderWidgetActionText(widget) {
 		.appendTo(widget);
 }
 
-function loadNextPage() {
-	if (loadPromise || !nextPageURL) return;
-	loadPromise = loadPage(nextPageURL);
-	loadPromise.then(() => { loadPromise = null; });
+export function loadNextPage(scrollToLoadWidget: boolean = false) {
+	if (!nextPageURL) return;
+
+	if (!loadPromise) {
+		loadPromise = loadPage(nextPageURL).then(() => { loadPromise = null; });
+	}
+
+	if (scrollToLoadWidget) scrollToElement(loaderWidget, { scrollStyle: 'middle', direction: 'down' });
+
+	return loadPromise;
 }
 
 async function loadPage(url: string) {

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -261,7 +261,7 @@ function updateActiveElement(selected, last) {
 	}
 }
 
-function autoSelect() {
+export function autoSelect() {
 	if (KeyboardNav.recentKeyMove) return;
 	if (selectedThing && elementInViewport(selectedThing.element)) return;
 


### PR DESCRIPTION
When nothing is currently selected, auto select the top-most visible thing. When something is selected, and there are no further entries, load the next page.