### PR TITLE
NER: avoid clobbering non-NER URL hashes

### DIFF
--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -237,7 +237,7 @@ function setReturnToPage(selected: ?Thing) {
 	history.replaceState(
 		{ ...history.state, resRestorePage, resRestoreURL, resRestoreHTML },
 		`${document.title}${resRestorePage ? `- page ${resRestorePage + 1}` : ''}`,
-		resRestorePage ? `#res:ner-page=${resRestorePage + 1}` : `${location.pathname}${location.search}`
+		resRestorePage ? `#res:ner-page=${resRestorePage + 1}` : `${location.pathname}${location.search}${isNerUrl() ? '' : location.hash}`
 	);
 }
 


### PR DESCRIPTION
...like RES or Toolbox settings links.

Tested in browser: Chrome 60
