### PR TITLE
keyboardNav: reduce coupling with showImages and selectedEntry

### DIFF
--- a/lib/core/migrate/migrate.js
+++ b/lib/core/migrate/migrate.js
@@ -511,6 +511,11 @@ const migrations = [
 		async go() {
 			await Storage.delete('RESmodules.userTagger.tags');
 		},
+	}, {
+		versionNumber: '5.7.0-keyboardNav-showImages-decoupling',
+		async go() {
+			await Migrators.moveOption('keyboardNav', 'mediaBrowseMode', 'showImages', 'mediaBrowse');
+		},
 	},
 
 ];  // ^^ Add new migrations ^^

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -921,7 +921,7 @@ function registerNsfwToggleCommand() {
 function registerSubredditFilterCommand() {
 	const getSubreddit = val => (
 		val ||
-		SelectedEntry.selectedThing() && SelectedEntry.selectedThing().getSubreddit() ||
+		SelectedEntry.selectedThing && SelectedEntry.selectedThing.getSubreddit() ||
 		currentSubreddit() ||
 		''
 	);

--- a/lib/modules/filteReddit/Filter.js
+++ b/lib/modules/filteReddit/Filter.js
@@ -145,7 +145,7 @@ export default class Filter<Parsed: { [key: any]: any }> {
 		try {
 			if (!this.fromSelected) throw new Error('Filter does not support selected entry data extraction.');
 
-			const selected = SelectedEntry.selectedThing();
+			const selected = SelectedEntry.selectedThing;
 			if (!selected) throw new Error('No entry is currently selected.');
 
 			if (!this.fromSelected) throw new Error('Cannot update without `fromSelected()` method');

--- a/lib/modules/filteReddit/Filterline.js
+++ b/lib/modules/filteReddit/Filterline.js
@@ -423,8 +423,8 @@ export default class Filterline {
 			this.updateThingFilterReason(thing, thing.filter, matchedFilter);
 			thing.element.classList.toggle('RESFiltered', !!matchedFilter);
 
-			if (matchedFilter && SelectedEntry.selectedThing() === thing) {
-				SelectedEntry.selectClosestVisible({ scrollStyle: 'none' });
+			if (matchedFilter && SelectedEntry.selectedThing === thing) {
+				SelectedEntry.move('closestVisible');
 			}
 
 			ShowImages.refresh();

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -45,19 +45,6 @@ module.moduleName = 'keyboardNavName';
 module.category = 'browsingCategory';
 module.description = 'keyboardNavDesc';
 module.options = {
-	mediaBrowseMode: {
-		type: 'boolean',
-		value: true,
-		description: 'keyboardNavMediaBrowseModeDesc',
-		title: 'keyboardNavMediaBrowseModeTitle',
-	},
-	scrollOnExpando: {
-		type: 'boolean',
-		value: true,
-		description: 'keyboardNavScrollOnExpandoDesc',
-		title: 'keyboardNavScrollOnExpandoTitle',
-		advanced: true,
-	},
 	linearScrollStyle: {
 		type: 'enum',
 		values: [{
@@ -211,22 +198,22 @@ module.options = {
 	},
 	moveUp: {
 		type: 'keycode',
-		include: ['linklist', 'commentsLinklist', 'modqueue', 'profile', 'search'],
+		include: ['linklist', 'modqueue', 'profile', 'search'],
 		value: [75, false, false, false, false], // k
 		description: 'keyboardNavMoveUpDesc',
 		title: 'keyboardNavMoveUpTitle',
 		callback() {
-			move(thing => thing.getNext({ direction: 'up' }), getLinearListMoveOptions(), SelectedEntry.autoSelect);
+			move(thing => thing.getNext({ direction: 'up' }), { allowMediaBrowse: true, scrollStyle: module.options.linearScrollStyle.value }, SelectedEntry.autoSelect);
 		},
 	},
 	moveDown: {
 		type: 'keycode',
-		include: ['linklist', 'commentsLinklist', 'modqueue', 'profile', 'search'],
+		include: ['linklist', 'modqueue', 'profile', 'search'],
 		value: [74, false, false, false, false], // j
 		description: 'keyboardNavMoveDownDesc',
 		title: 'keyboardNavMoveDownTitle',
 		callback() {
-			move(thing => thing.getNext({ direction: 'down' }), getLinearListMoveOptions(), () => {
+			move(thing => thing.getNext({ direction: 'down' }), { allowMediaBrowse: true, scrollStyle: module.options.linearScrollStyle.value }, () => {
 				const selected = SelectedEntry.selectedThing();
 				if (!selected) SelectedEntry.autoSelect();
 				else if (_.last(Thing.visibleThings()) === selected) nextPage();
@@ -235,7 +222,7 @@ module.options = {
 	},
 	moveUpComment: {
 		type: 'keycode',
-		include: ['comments', 'inbox'],
+		include: ['comments', 'commentsLinklist', 'inbox'],
 		value: [75, false, false, false, false], // k
 		description: 'keyboardNavMoveUpCommentDesc',
 		title: 'keyboardNavMoveUpCommentTitle',
@@ -248,7 +235,7 @@ module.options = {
 	},
 	moveDownComment: {
 		type: 'keycode',
-		include: ['comments', 'inbox'],
+		include: ['comments', 'commentsLinklist', 'inbox'],
 		value: [74, false, false, false, false], // j
 		description: 'keyboardNavMoveDownCommentDesc',
 		title: 'keyboardNavMoveDownCommentTitle',
@@ -400,11 +387,18 @@ module.options = {
 			const thing = SelectedEntry.selectedThing();
 			if (thing) {
 				ShowImages.toggleThingExpandos(thing, {
-					scrollOnExpando: module.options.scrollOnExpando.value,
+					scrollOnToggle: module.options.scrollOnExpando.value,
 					isUserAction: true,
 				});
 			}
 		},
+	},
+	scrollOnExpando: {
+		type: 'boolean',
+		value: true,
+		description: 'keyboardNavScrollOnExpandoDesc',
+		title: 'keyboardNavScrollOnExpandoTitle',
+		advanced: true,
 	},
 	imageSizeUp: {
 		type: 'keycode',
@@ -1002,7 +996,7 @@ function hideLink() {
 	}
 
 	if (module.options.onHideMoveDown.value) {
-		SelectedEntry.selectClosestVisible({ scrollStyle: 'none', mediaBrowse: module.options.mediaBrowseMode.value });
+		SelectedEntry.selectClosestVisible({ scrollStyle: 'none', allowMediaBrowse: true });
 	}
 }
 
@@ -1023,12 +1017,6 @@ function followSubreddit(newWindow) {
 		}
 	}
 }
-
-const getLinearListMoveOptions = () => ({
-	mediaBrowse: module.options.mediaBrowseMode.value,
-	scrollStyle: module.options.linearScrollStyle.value,
-	mediaBrowseScrollStyle: module.options.scrollOnExpando.value ? 'top' : undefined,
-});
 
 export let recentKeyMove = false;
 const refreshKeyMoveTimer = _.debounce(() => { recentKeyMove = false; }, 1000);

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -202,9 +202,7 @@ module.options = {
 		value: [75, false, false, false, false], // k
 		description: 'keyboardNavMoveUpDesc',
 		title: 'keyboardNavMoveUpTitle',
-		callback() {
-			move(thing => thing.getNext({ direction: 'up' }), { allowMediaBrowse: true, scrollStyle: module.options.linearScrollStyle.value }, SelectedEntry.autoSelect);
-		},
+		callback() { SelectedEntry.move('up', { allowMediaBrowse: true, scrollStyle: module.options.linearScrollStyle.value }); },
 	},
 	moveDown: {
 		type: 'keycode',
@@ -213,10 +211,9 @@ module.options = {
 		description: 'keyboardNavMoveDownDesc',
 		title: 'keyboardNavMoveDownTitle',
 		callback() {
-			move(thing => thing.getNext({ direction: 'down' }), { allowMediaBrowse: true, scrollStyle: module.options.linearScrollStyle.value }, () => {
-				const selected = SelectedEntry.selectedThing();
-				if (!selected) SelectedEntry.autoSelect();
-				else if (_.last(Thing.visibleThings()) === selected) nextPage();
+			SelectedEntry.move('down', { allowMediaBrowse: true, scrollStyle: module.options.linearScrollStyle.value }, () => {
+				const bump = Modules.isRunning(NeverEndingReddit) && _.last(Thing.visibleThings()) === SelectedEntry.selectedThing;
+				if (bump) NeverEndingReddit.loadNextPage(true);
 			});
 		},
 	},
@@ -226,12 +223,7 @@ module.options = {
 		value: [75, false, false, false, false], // k
 		description: 'keyboardNavMoveUpCommentDesc',
 		title: 'keyboardNavMoveUpCommentTitle',
-		callback() {
-			move(
-				thing => thing.getNext({ direction: 'up' }),
-				{ scrollStyle: module.options.linearScrollStyle.value }
-			);
-		},
+		callback() { SelectedEntry.move('up', { scrollStyle: module.options.linearScrollStyle.value }); },
 	},
 	moveDownComment: {
 		type: 'keycode',
@@ -239,12 +231,7 @@ module.options = {
 		value: [74, false, false, false, false], // j
 		description: 'keyboardNavMoveDownCommentDesc',
 		title: 'keyboardNavMoveDownCommentTitle',
-		callback() {
-			move(
-				thing => thing.getNext({ direction: 'down' }),
-				{ scrollStyle: module.options.linearScrollStyle.value }
-			);
-		},
+		callback() { SelectedEntry.move('down', { scrollStyle: module.options.linearScrollStyle.value }); },
 	},
 	moveTop: {
 		type: 'keycode',
@@ -252,7 +239,7 @@ module.options = {
 		value: [75, false, false, true, false], // shift-k
 		description: 'keyboardNavMoveTopDesc',
 		title: 'keyboardNavMoveTopTitle',
-		callback() { move(Thing.visibleThingElements()[0], { scrollStyle: 'top' }); },
+		callback() { SelectedEntry.move('top', { scrollStyle: module.options.nonLinearScrollStyle.value }); },
 	},
 	moveBottom: {
 		type: 'keycode',
@@ -260,7 +247,7 @@ module.options = {
 		value: [74, false, false, true, false], // shift-j
 		description: 'keyboardNavMoveBottomDesc',
 		title: 'keyboardNavMoveBottomTitle',
-		callback() { move(Thing.visibleThingElements().slice(-1)[0], { scrollStyle: 'top' }); },
+		callback() { SelectedEntry.move('bottom', { scrollStyle: module.options.nonLinearScrollStyle.value }); },
 	},
 	moveUpSibling: {
 		type: 'keycode',
@@ -268,12 +255,7 @@ module.options = {
 		value: [75, false, false, true, false], // shift-k
 		description: 'keyboardNavMoveUpSiblingDesc',
 		title: 'keyboardNavMoveUpSiblingTitle',
-		callback() {
-			move(
-				thing => thing.getNextSibling({ direction: 'up' }) || thing.getParent(),
-				{ scrollStyle: module.options.nonLinearScrollStyle.value }
-			);
-		},
+		callback() { SelectedEntry.move('upSibling', { scrollStyle: module.options.nonLinearScrollStyle.value }); },
 	},
 	moveDownSibling: {
 		type: 'keycode',
@@ -281,12 +263,7 @@ module.options = {
 		value: [74, false, false, true, false], // shift-j
 		description: 'keyboardNavMoveDownSiblingDesc',
 		title: 'keyboardNavMoveDownSiblingTitle',
-		callback() {
-			move(
-				thing => thing.getClosest(thing.getNextSibling, { direction: 'down' }),
-				{ scrollStyle: module.options.nonLinearScrollStyle.value }
-			);
-		},
+		callback() { SelectedEntry.move('downSibling', { scrollStyle: module.options.nonLinearScrollStyle.value }); },
 	},
 	moveDownParentSibling: {
 		type: 'keycode',
@@ -294,12 +271,7 @@ module.options = {
 		value: [74, true, false, false, false], // alt-j
 		description: 'keyboardNavMoveDownParentSiblingDesc',
 		title: 'keyboardNavMoveDownParentSiblingTitle',
-		callback() {
-			move(
-				thing => (thing.getParent() || thing).getClosest(thing.getNextSibling, { direction: 'down' }),
-				{ scrollStyle: module.options.nonLinearScrollStyle.value }
-			);
-		},
+		callback() { SelectedEntry.move('downParentSibling', { scrollStyle: module.options.nonLinearScrollStyle.value }); },
 	},
 	moveUpThread: {
 		type: 'keycode',
@@ -307,12 +279,7 @@ module.options = {
 		value: [75, true, false, true, false], // shift-alt-k
 		description: 'keyboardNavMoveUpThreadDesc',
 		title: 'keyboardNavMoveUpThreadTitle',
-		callback() {
-			move(
-				thing => thing.getThreadTop().getNextSibling({ direction: 'up' }) || thing.getThreadTop(),
-				{ scrollStyle: module.options.nonLinearScrollStyle.value }
-			);
-		},
+		callback() { SelectedEntry.move('upThread', { scrollStyle: module.options.nonLinearScrollStyle.value }); },
 	},
 	moveDownThread: {
 		type: 'keycode',
@@ -320,12 +287,7 @@ module.options = {
 		value: [74, true, false, true, false], // shift-alt-j
 		description: 'keyboardNavMoveDownThreadDesc',
 		title: 'keyboardNavMoveDownThreadTitle',
-		callback() {
-			move(
-				thing => thing.getThreadTop().getNextSibling({ direction: 'down' }),
-				{ scrollStyle: module.options.nonLinearScrollStyle.value }
-			);
-		},
+		callback() { SelectedEntry.move('downThread', { scrollStyle: module.options.nonLinearScrollStyle.value }); },
 	},
 	moveToTopComment: {
 		type: 'keycode',
@@ -333,12 +295,7 @@ module.options = {
 		value: [84, false, false, false, false], // t
 		description: 'keyboardNavMoveToTopCommentDesc',
 		title: 'keyboardNavMoveToTopCommentTitle',
-		callback() {
-			move(
-				thing => thing.getThreadTop(),
-				{ scrollStyle: module.options.nonLinearScrollStyle.value }
-			);
-		},
+		callback() { SelectedEntry.move('toTopComment', { scrollStyle: module.options.nonLinearScrollStyle.value }); },
 	},
 	moveToParent: {
 		type: 'keycode',
@@ -346,12 +303,7 @@ module.options = {
 		value: [80, false, false, false, false], // p
 		description: 'keyboardNavMoveToParentDesc',
 		title: 'keyboardNavMoveToParentTitle',
-		callback() {
-			move(
-				thing => thing.getParent(),
-				{ scrollStyle: module.options.nonLinearScrollStyle.value }
-			);
-		},
+		callback() { SelectedEntry.move('toParent', { scrollStyle: module.options.nonLinearScrollStyle.value }); },
 	},
 	showParents: {
 		type: 'keycode',
@@ -384,7 +336,7 @@ module.options = {
 		description: 'keyboardNavToggleExpandoDesc',
 		title: 'keyboardNavToggleExpandoTitle',
 		callback() {
-			const thing = SelectedEntry.selectedThing();
+			const thing = SelectedEntry.selectedThing;
 			if (thing) {
 				ShowImages.toggleThingExpandos(thing, {
 					scrollOnToggle: module.options.scrollOnExpando.value,
@@ -781,7 +733,7 @@ module.beforeLoad = () => {
 		SelectedEntry.addListener(updateLinkAnnotations, 'beforePaint');
 		watchForElements(['selfText'], null, element => {
 			const thing = Thing.from(element);
-			if (SelectedEntry.selectedThing() === thing) updateLinkAnnotations(thing);
+			if (SelectedEntry.selectedThing === thing) updateLinkAnnotations(thing);
 		});
 	}
 };
@@ -986,7 +938,7 @@ const promptUniqueShortcut = _.memoize(async (shortcut, options: any) => {
 });
 
 function hideLink() {
-	const selected = SelectedEntry.selectedThing();
+	const selected = SelectedEntry.selectedThing;
 	if (!selected) return;
 
 	// find the hide link and click it...
@@ -996,12 +948,12 @@ function hideLink() {
 	}
 
 	if (module.options.onHideMoveDown.value) {
-		SelectedEntry.selectClosestVisible({ scrollStyle: 'none', allowMediaBrowse: true });
+		SelectedEntry.move('closestVisible', { scrollStyle: 'none', allowMediaBrowse: true });
 	}
 }
 
 function followSubreddit(newWindow) {
-	const selected = SelectedEntry.selectedThing();
+	const selected = SelectedEntry.selectedThing;
 	if (!selected) return;
 
 	newWindow = typeof newWindow === 'boolean' ? newWindow : undefined;
@@ -1018,35 +970,8 @@ function followSubreddit(newWindow) {
 	}
 }
 
-export let recentKeyMove = false;
-const refreshKeyMoveTimer = _.debounce(() => { recentKeyMove = false; }, 1000);
-
-function move(target, options, fallback?: () => void) {
-	const selected = SelectedEntry.selectedThing();
-
-	if (typeof target === 'function') {
-		target = selected ? target(selected) : null;
-	}
-
-	if (target instanceof HTMLElement) {
-		target = Thing.from(target);
-	}
-
-	if (!target) {
-		if (fallback) fallback();
-		return null;
-	}
-
-	SelectedEntry.select(target, options);
-
-	recentKeyMove = true;
-	refreshKeyMoveTimer();
-
-	return target;
-}
-
 function showParents() {
-	const selected = SelectedEntry.selectedThing();
+	const selected = SelectedEntry.selectedThing;
 	if (!selected) return;
 
 	const button = selected.entry.querySelector('.buttons .bylink[href^="#"]');
@@ -1059,7 +984,7 @@ function showParents() {
 }
 
 function toggleChildren() {
-	const selected = SelectedEntry.selectedThing();
+	const selected = SelectedEntry.selectedThing;
 	if (!selected) return;
 
 	if (selected.thing.classList.contains('link')) return;
@@ -1082,7 +1007,7 @@ function toggleChildren() {
 	click(thisToggle);
 }
 
-function getMostVisibleElementInThingByQuery(query, thing = SelectedEntry.selectedThing()) {
+function getMostVisibleElementInThingByQuery(query, thing = SelectedEntry.selectedThing) {
 	if (!thing) return null;
 
 	const elements = Array.from(thing.entry.querySelectorAll(query));
@@ -1115,7 +1040,7 @@ function nextGalleryImage() {
 }
 
 function followLink(newWindow) {
-	const selected = SelectedEntry.selectedThing();
+	const selected = SelectedEntry.selectedThing;
 	if (!selected) return;
 
 	if (isPageType('comments') && !selected.thing.classList.contains('link')) return;
@@ -1138,7 +1063,7 @@ function followLinkByRank(num) {
 }
 
 function followPermalink(newWindow) {
-	const selected = SelectedEntry.selectedThing();
+	const selected = SelectedEntry.selectedThing;
 	if (!selected) return;
 	newWindow = typeof newWindow === 'boolean' ? newWindow : undefined;
 
@@ -1153,7 +1078,7 @@ function followPermalink(newWindow) {
 }
 
 function followComments(newWindow) {
-	const selected = SelectedEntry.selectedThing();
+	const selected = SelectedEntry.selectedThing;
 	if (!selected) return;
 
 	newWindow = typeof newWindow === 'boolean' ? newWindow : undefined;
@@ -1166,7 +1091,7 @@ function followComments(newWindow) {
 }
 
 function followLinkAndComments(background) {
-	const selected = SelectedEntry.selectedThing();
+	const selected = SelectedEntry.selectedThing;
 	if (!selected) return;
 	background = typeof background === 'boolean' ? background : undefined;
 
@@ -1175,7 +1100,7 @@ function followLinkAndComments(background) {
 
 function upVote(preventToggle) {
 	if (promptLogin()) return;
-	const selected = SelectedEntry.selectedThing();
+	const selected = SelectedEntry.selectedThing;
 	if (!selected) return;
 	preventToggle = typeof preventToggle === 'boolean' ? preventToggle : undefined;
 
@@ -1199,7 +1124,7 @@ function upVote(preventToggle) {
 
 function downVote(preventToggle) {
 	if (promptLogin()) return;
-	const selected = SelectedEntry.selectedThing();
+	const selected = SelectedEntry.selectedThing;
 	if (!selected) return;
 	preventToggle = typeof preventToggle === 'boolean' ? preventToggle : undefined;
 
@@ -1223,7 +1148,7 @@ function downVote(preventToggle) {
 
 function saveLink() {
 	if (promptLogin()) return;
-	const selected = SelectedEntry.selectedThing();
+	const selected = SelectedEntry.selectedThing;
 	if (!selected) return;
 
 	const link = selected.entry.querySelector('.link-save-button a, .link-unsave-button a');
@@ -1234,7 +1159,7 @@ function saveLink() {
 
 function saveComment() {
 	if (promptLogin()) return;
-	const selected = SelectedEntry.selectedThing();
+	const selected = SelectedEntry.selectedThing;
 	if (!selected) return;
 
 	const button = selected.entry.querySelector('.comment-save-button > a');
@@ -1244,7 +1169,7 @@ function saveComment() {
 }
 
 function saveCommentRES() {
-	const selected = SelectedEntry.selectedThing();
+	const selected = SelectedEntry.selectedThing;
 	if (!selected) return;
 
 	const saveComment = selected.entry.querySelector('.saveComments, .unsaveComments');
@@ -1257,7 +1182,7 @@ function saveCommentRES() {
 function reply() {
 	if (promptLogin()) return;
 
-	const selected = SelectedEntry.selectedThing();
+	const selected = SelectedEntry.selectedThing;
 	if (!selected) return;
 
 	if (selected.thing.classList.contains('link') && isPageType('comments')) {

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -166,9 +166,8 @@ export function handleClick(e: MouseEvent) {
 let selectedThing, selectedContainer;
 
 type SelectOptions = {
+	allowMediaBrowse?: boolean,
 	scrollStyle: ScrollStyle,
-	mediaBrowse?: boolean,
-	mediaBrowseScrollStyle?: ScrollStyle,
 	paintImmediate?: boolean, // Set `true` when `select` is invoked during the animation phase, in order for `beforePaint` not to be delayed to the next animation frame
 };
 

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -18,7 +18,6 @@ import {
 } from '../utils';
 import type { ScrollStyle } from '../utils/dom';
 import * as Hover from './hover';
-import * as KeyboardNav from './keyboardNav';
 
 export const module: Module<*> = new Module('selectedEntry');
 
@@ -126,7 +125,7 @@ module.go = () => {
 	watchForThings(['comment'], onNewComments);
 
 	if (module.options.autoSelectOnScroll.value) {
-		window.addEventListener('scroll', _.debounce(autoSelect, 300));
+		window.addEventListener('scroll', _.debounce(() => { if (!recentKeyMove) autoSelect(); }, 300));
 	}
 	if (module.options.selectOnClick.value) {
 		$(document.body).on('mouseup', Thing.bodyThingSelector, handleClick);
@@ -163,7 +162,8 @@ export function handleClick(e: MouseEvent) {
 	onClick(e);
 }
 
-let selectedThing, selectedContainer;
+export let selectedThing: ?Thing;
+let selectedContainer: ?HTMLElement;
 
 type SelectOptions = {
 	allowMediaBrowse?: boolean,
@@ -172,16 +172,6 @@ type SelectOptions = {
 };
 
 type SelectOptionsWithDirection = SelectOptions & { direction?: 'down' | 'up' };
-
-export const selectClosestVisible = _.debounce((options: SelectOptions) => {
-	const target = selectedThing.getClosestVisible(false);
-	if (target) select(target, options);
-});
-
-export { _selectedThing as selectedThing };
-function _selectedThing() {
-	return selectedThing;
-}
 
 const listeners = { beforeScroll: [], beforePaint: [], idle: [] };
 
@@ -222,7 +212,7 @@ const runCallbacks = (() => {
 })();
 
 export function select(newSelected: Thing, options: SelectOptions = { scrollStyle: 'none' }) {
-	if (newSelected.is(selectedThing)) return;
+	if (selectedThing && newSelected.is(selectedThing)) return;
 
 	const oldSelected = selectedThing;
 
@@ -260,8 +250,7 @@ function updateActiveElement(selected, last) {
 	}
 }
 
-export function autoSelect() {
-	if (KeyboardNav.recentKeyMove) return;
+function autoSelect() {
 	if (selectedThing && elementInViewport(selectedThing.element)) return;
 
 	for (const thing of Thing.visibleThings()) {
@@ -344,6 +333,47 @@ async function findLastSelectedThing() {
 	}
 }
 
+const movers = {
+	closestVisible: (thing: Thing) => thing.getClosestVisible(false),
+	up: (thing: Thing) => thing.getNext({ direction: 'up' }),
+	down: (thing: Thing) => thing.getNext({ direction: 'down' }),
+	top: () => Thing.visibleThings()[0],
+	bottom: () => Thing.visibleThings().slice(-1)[0],
+	upSibling: (thing: Thing) => thing.getNextSibling({ direction: 'up' }) || thing.getParent(),
+	downSibling: (thing: Thing) => thing.getClosest(thing.getNextSibling, { direction: 'down' }),
+	downParentSibling: (thing: Thing) => (thing.getParent() || thing).getClosest(thing.getNextSibling, { direction: 'down' }),
+	upThread: (thing: Thing) => thing.getThreadTop().getNextSibling({ direction: 'up' }) || thing.getThreadTop(),
+	downThread: (thing: Thing) => thing.getThreadTop().getNextSibling({ direction: 'down' }),
+	toTopComment: (thing: Thing) => thing.getThreadTop(),
+	toParent: (thing: Thing) => thing.getParent(),
+};
+
+let recentKeyMove = false;
+const refreshKeyMoveTimer = _.debounce(() => { recentKeyMove = false; }, 1000);
+
+export function move(direction: $Keys<typeof movers>, options?: SelectOptionsWithDirection, fallback?: () => void) {
+	if (!selectedThing) autoSelect();
+
+	const targetFn = movers[direction];
+
+	let thing;
+	if (!selectedThing && targetFn.length) throw new Error('Function only works when an entry is selected');
+	else thing = (selectedThing: any);
+
+	const target = targetFn(thing);
+
+	if (!target) {
+		if (fallback) fallback();
+		return;
+	} else if (selectedThing === target) {
+		return;
+	}
+
+	select(target, options);
+
+	recentKeyMove = true;
+	refreshKeyMoveTimer();
+}
 
 // old style: .RES-keyNav-activeElement { '+borderType+': '+focusBorder+'; background-color: '+focusBGColor+'; } \
 // this new pure CSS arrow will not work because to position it we must have .RES-keyNav-activeElement position relative, but that screws up image viewer's absolute positioning to

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -83,11 +83,18 @@ module.category = 'productivityCategory';
 module.description = 'showImagesDesc';
 module.bodyClass = true;
 module.options = {
+	mediaBrowse: {
+		title: 'showImagesMediaBrowseTitle',
+		type: 'boolean',
+		value: true,
+		description: 'showImagesMediaBrowseDesc',
+	},
 	browsePreloadCount: {
 		title: 'showImagesBrowsePreloadCountTitle',
 		type: 'text',
 		value: '1',
 		description: 'showImagesBrowsePreloadCountDesc',
+		dependsOn: options => options.mediaBrowse.value,
 	},
 	galleryPreloadCount: {
 		title: 'showImagesGalleryPreloadCountTitle',
@@ -494,7 +501,9 @@ module.go = () => {
 		}
 	}
 
-	SelectedEntry.addListener(mediaBrowse, 'beforeScroll');
+	if (module.options.mediaBrowse.value) {
+		SelectedEntry.addListener(mediaBrowse, 'beforeScroll');
+	}
 
 	// Handle spotlight next/prev hiding open expando's
 	const spotlight = document.querySelector('#siteTable_organic');
@@ -695,7 +704,7 @@ const updateRevealedImages = _.debounce(({ onlyOpen = false } = {}) => {
 
 const sortExpandosVertically = sortBy(v => v.button.getBoundingClientRect().top);
 
-export function toggleThingExpandos(thing: Thing, { scrollOnExpando, isUserAction }: {| scrollOnExpando?: boolean, isUserAction?: boolean |} = {}): void {
+export function toggleThingExpandos(thing: Thing, { scrollOnToggle, isUserAction }: {| scrollOnToggle?: boolean, isUserAction?: boolean |} = {}): void {
 	const expandos = Expando.getAllExpandosFrom(thing);
 	if (!expandos.length) return;
 
@@ -706,7 +715,7 @@ export function toggleThingExpandos(thing: Thing, { scrollOnExpando, isUserActio
 	if (openExpandos.length) {
 		for (const expando of openExpandos) expando.collapse();
 
-		if (scrollOnExpando) scrollToElement(thing.entry, { scrollStyle: 'directional' });
+		if (scrollOnToggle) scrollToElement(thing.entry, { scrollStyle: 'directional' });
 	} else {
 		for (const expando of expandos) {
 			if (
@@ -722,7 +731,7 @@ export function toggleThingExpandos(thing: Thing, { scrollOnExpando, isUserActio
 			}
 		}
 
-		if (scrollOnExpando) scrollToElement(thing.entry, { scrollStyle: 'top' });
+		if (scrollOnToggle) scrollToElement(thing.entry, { scrollStyle: 'top' });
 	}
 }
 
@@ -740,7 +749,7 @@ const preloadExpandos = idleThrottle((fromThing, direction, preloadCount = parse
 });
 
 function mediaBrowse(selected, unselected, options) {
-	if (!selected || !options.mediaBrowse || autoExpandActive) return;
+	if (!selected || !options.allowMediaBrowse || autoExpandActive) return;
 
 	const oldExpando = Expando.getEntryExpandoFrom(unselected);
 	const newExpando = Expando.getEntryExpandoFrom(selected);
@@ -752,7 +761,7 @@ function mediaBrowse(selected, unselected, options) {
 
 	if (mediaBrowseModeActive && newExpando) {
 		newExpando.expand();
-		if (options.mediaBrowseScrollStyle) options.scrollStyle = options.mediaBrowseScrollStyle;
+		options.scrollStyle = 'top';
 
 		preloadExpandos(selected, options.direction);
 	}

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -353,7 +353,7 @@ function registerCommandLine() {
 	);
 
 	function getAuthorTagLink() {
-		const selected = SelectedEntry.selectedThing();
+		const selected = SelectedEntry.selectedThing;
 		const searchArea = selected ? selected.entry : document.body;
 
 		return searchArea.querySelector('a.userTagLink');

--- a/lib/modules/wheelBrowse.js
+++ b/lib/modules/wheelBrowse.js
@@ -3,7 +3,6 @@
 import { $ } from '../vendor';
 import { Module } from '../core/module';
 import * as Floater from './floater';
-import * as KeyboardNav from './keyboardNav';
 import * as SelectedEntry from './selectedEntry';
 import * as SettingsNavigation from './settingsNavigation';
 import { Expando } from './showImages/expando';
@@ -18,52 +17,43 @@ module.include = [
 ];
 
 module.go = () => {
-	const wheelBrowseWidget = $('<div class="res-wheel-media-browse"></div>')
+	const wheelBrowseWidget = $('<div hidden class="res-wheel-media-browse"></div>')
 		.click(() => SettingsNavigation.loadSettingsPage(module.moduleID))
 		.hover(() => { updateGalleryPart(); })
 		.get(0);
 	const galleryPart = $('<div hidden class="res-wheel-media-browse-gallery"></div>')
 		.appendTo(wheelBrowseWidget)
 		.get(0);
+	let media;
 
-	function updateGalleryPart(selected = SelectedEntry.selectedThing(), scrollDirection = 'down') {
-		const expando = Expando.getEntryExpandoFrom(selected);
+	function updateGalleryPart(scrollDirection?: 'up' | 'down') {
+		const expando = Expando.getEntryExpandoFrom(SelectedEntry.selectedThing);
+		media = expando && expando.media;
 
 		galleryPart.hidden = !(
-			expando &&
-			expando.media &&
-			expando.media.classList.contains('res-gallery-slideshow') &&
-			(
-				!scrollDirection ||
-				( // Do not show the gallery scroll widget when at the end of the gallery
-					!(scrollDirection === 'down' && expando.media.querySelector('[last-piece=true]')) &&
-					!(scrollDirection === 'up' && expando.media.querySelector('[first-piece=true]'))
-				)
+			media &&
+			media.classList.contains('res-gallery-slideshow') &&
+			( // Do not show the gallery scroll widget when at the end of the gallery
+				!(scrollDirection === 'down' && media.querySelector('[last-piece=true]')) &&
+				!(scrollDirection === 'up' && media.querySelector('[first-piece=true]'))
 			)
 		);
 	}
 
-	let isSelectionCause = false;
-
 	function scrollWidget(target, scrollDirection) {
 		if (target === wheelBrowseWidget) {
-			isSelectionCause = true;
-			if (scrollDirection === 'down') KeyboardNav.module.options.moveDown.callback();
-			else KeyboardNav.module.options.moveUp.callback();
-			isSelectionCause = false;
+			SelectedEntry.move(scrollDirection, { allowMediaBrowse: true, scrollStyle: 'top' });
 		} else if (target === galleryPart) {
-			if (scrollDirection === 'down') KeyboardNav.module.options.nextGalleryImage.callback();
-			else KeyboardNav.module.options.previousGalleryImage.callback();
-			updateGalleryPart(undefined, scrollDirection);
+			const clicker = media && media.querySelector(scrollDirection === 'down' ? '.res-gallery-next' : '.res-gallery-previous');
+			if (clicker) clicker.click();
+			updateGalleryPart(scrollDirection);
 		}
 	}
 
-	SelectedEntry.addListener((selected, unselected, options) => {
-		// Avoid the floater disappearing when approaching the header, which may happen when using other scrollStyles
-		if (isSelectionCause) options.scrollStyle = 'top';
-
-		updateGalleryPart(selected);
-	}, 'beforeScroll');
+	SelectedEntry.addListener(selected => {
+		wheelBrowseWidget.hidden = !selected;
+		updateGalleryPart();
+	}, 'beforePaint');
 
 	wheelBrowseWidget.addEventListener('wheel', (e: WheelEvent) => {
 		e.stopImmediatePropagation();

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -384,10 +384,10 @@
 	"keyboardNavDesc": {
 		"message": "Keyboard navigation for reddit!"
 	},
-	"keyboardNavMediaBrowseModeTitle": {
-		"message": "Media Browse Mode"
+	"showImagesMediaBrowseTitle": {
+		"message": "Media Browse"
 	},
-	"keyboardNavMediaBrowseModeDesc": {
+	"showImagesMediaBrowseDesc": {
 		"message": "If media is open on the currently selected post when moving up/down one post, open media on the next post."
 	},
 	"keyboardNavScrollOnExpandoTitle": {


### PR DESCRIPTION
Moves `move` functions to selectedEntry
Moves mediaBrowse completely to showImages (as both wheelBrowse and keyboardNav invokes it)

Relevant issue: Closes #4246
Tested in browser:  Chrome 59