### PR TITLE
Subreddit manager features

### DIFF
--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -551,7 +551,7 @@ function editSubredditShortcut(ele, event) {
 					<input type="text" name="subreddit" value="${subreddit}" id="shortcut-subreddit" class="${unsortable ? 'unsortable' : ''}"><!-- no whitespace
 					--><button type="submit" id="sortButton" title="Sort subreddits">A-Z</button>
 
-					<div class="RESDescription">Put a + between subreddits to make a drop-down menu.</div>
+					<div class="RESDescription">Put a + between subreddits to make a drop-down menu.<br/>Put ?+ to make subreddits after it only show in dropdown.</div>
 				</div>
 			</div>
 			<div class="RESFormItem">

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -345,8 +345,8 @@ function redrawShortcuts() {
 
 		if (shortcut.subreddit.includes('+')) {
 			// Reddit seems to redirect to randomly reorder multi links, so need to sort and compare
-			let currentSub = (currentSubreddit() || '').toLowerCase().split('+').sort().join('+');
-			let sortedSubs = shortcut.subreddit.toLowerCase().replace(/\?\+/g, '+').split('+').sort();
+			const currentSub = (currentSubreddit() || '').toLowerCase().split('+').sort().join('+');
+			const sortedSubs = shortcut.subreddit.toLowerCase().replace(/\?\+/g, '+').split('+').sort();
 			if (module.options.showMultiAsCurrentIfAtChild.value) {
 				for (const sub of sortedSubs) {
 					if (isCurrentSubreddit(sub)) {

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -344,8 +344,9 @@ function redrawShortcuts() {
 		thisShortCut.classList.add('subbarlink');
 
 		if(shortcut.subreddit.includes('+')) {
-			var sortedSubs = shortcut.subreddit.toLowerCase().replace(/\?\+/g, '+').split('+').sort();
+			// Reddit seems to redirect to randomly reorder multi links, so need to sort and compare
 			var currentSub = (currentSubreddit() || '').toLowerCase().split('+').sort().join('+');
+			var sortedSubs = shortcut.subreddit.toLowerCase().replace(/\?\+/g, '+').split('+').sort();
 			if (module.options.showMultiAsCurrentIfAtChild.value) {
 				for (var i in sortedSubs) {
 					if (isCurrentSubreddit(sortedSubs[i])) {

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -344,7 +344,8 @@ function redrawShortcuts() {
 		thisShortCut.classList.add('subbarlink');
 
 		if(shortcut.subreddit.includes('+')) {
-			var sortedSubs = shortcut.subreddit.replace(/\?\+/g, '+').split('+').sort();
+			var sortedSubs = shortcut.subreddit.toLowerCase().replace(/\?\+/g, '+').split('+').sort();
+			var currentSub = (currentSubreddit() || '').toLowerCase().split('+').sort().join('+');
 			if (module.options.showMultiAsCurrentIfAtChild.value) {
 				for (var i in sortedSubs) {
 					if (isCurrentSubreddit(sortedSubs[i])) {
@@ -352,7 +353,7 @@ function redrawShortcuts() {
 					}
 				}
 			}
-			if (isCurrentSubreddit(sortedSubs.join('+'))) {
+			if (currentSub === sortedSubs.join('+')) {
 				thisShortCut.classList.add('RESShortcutsCurrentSub');
 			}
 		}

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -343,10 +343,10 @@ function redrawShortcuts() {
 		thisShortCut.setAttribute('data-subreddit', shortcut.subreddit);
 		thisShortCut.classList.add('subbarlink');
 
-		if(shortcut.subreddit.includes('+')) {
+		if (shortcut.subreddit.includes('+')) {
 			// Reddit seems to redirect to randomly reorder multi links, so need to sort and compare
-			var currentSub = (currentSubreddit() || '').toLowerCase().split('+').sort().join('+');
-			var sortedSubs = shortcut.subreddit.toLowerCase().replace(/\?\+/g, '+').split('+').sort();
+			let currentSub = (currentSubreddit() || '').toLowerCase().split('+').sort().join('+');
+			let sortedSubs = shortcut.subreddit.toLowerCase().replace(/\?\+/g, '+').split('+').sort();
 			if (module.options.showMultiAsCurrentIfAtChild.value) {
 				for (const sub of sortedSubs) {
 					if (isCurrentSubreddit(sub)) {
@@ -357,8 +357,7 @@ function redrawShortcuts() {
 			if (currentSub === sortedSubs.join('+')) {
 				thisShortCut.classList.add('RESShortcutsCurrentSub');
 			}
-		}
-		else if (isCurrentSubreddit(shortcut.subreddit)) {
+		} else if (isCurrentSubreddit(shortcut.subreddit)) {
 			thisShortCut.classList.add('RESShortcutsCurrentSub');
 		}
 

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -348,8 +348,8 @@ function redrawShortcuts() {
 			var currentSub = (currentSubreddit() || '').toLowerCase().split('+').sort().join('+');
 			var sortedSubs = shortcut.subreddit.toLowerCase().replace(/\?\+/g, '+').split('+').sort();
 			if (module.options.showMultiAsCurrentIfAtChild.value) {
-				for (var i in sortedSubs) {
-					if (isCurrentSubreddit(sortedSubs[i])) {
+				for (const sub of sortedSubs) {
+					if (isCurrentSubreddit(sub)) {
 						thisShortCut.classList.add('RESShortcutsCurrentSub');
 					}
 				}

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -183,12 +183,6 @@ module.options = {
 		value: true,
 		description: 'subredditManagerDisplayMultiCountsDesc',
 	},
-	showMultiAsCurrentIfAtChild: {
-		title: 'showMultiAsCurrentIfAtChildTitle',
-		type: 'boolean',
-		value: false,
-		description: 'showMultiAsCurrentIfAtChildDesc',
-	},
 };
 
 let shortCutsContainer, $subredditGroupDropdown, subredditGroupDropdownUL, subredditGroupDropdownRefItem, $srList,
@@ -347,11 +341,9 @@ function redrawShortcuts() {
 			// Reddit seems to redirect to randomly reorder multi links, so need to sort and compare
 			const currentSub = (currentSubreddit() || '').toLowerCase().split('+').sort().join('+');
 			const sortedSubs = shortcut.subreddit.toLowerCase().replace(/\?\+/g, '+').split('+').sort();
-			if (module.options.showMultiAsCurrentIfAtChild.value) {
-				for (const sub of sortedSubs) {
-					if (isCurrentSubreddit(sub)) {
-						thisShortCut.classList.add('RESShortcutsCurrentSub');
-					}
+			for (const sub of sortedSubs) {
+				if (isCurrentSubreddit(sub)) {
+					thisShortCut.classList.add('RESShortcutsCurrentSub');
 				}
 			}
 			if (currentSub === sortedSubs.join('+')) {

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -183,6 +183,12 @@ module.options = {
 		value: true,
 		description: 'subredditManagerDisplayMultiCountsDesc',
 	},
+	showMultiAsCurrentIfAtChild: {
+		title: 'showMultiAsCurrentIfAtChildTitle',
+		type: 'boolean',
+		value: false,
+		description: 'showMultiAsCurrentIfAtChildDesc',
+	},
 };
 
 let shortCutsContainer, $subredditGroupDropdown, subredditGroupDropdownUL, subredditGroupDropdownRefItem, $srList,
@@ -337,11 +343,24 @@ function redrawShortcuts() {
 		thisShortCut.setAttribute('data-subreddit', shortcut.subreddit);
 		thisShortCut.classList.add('subbarlink');
 
-		if (isCurrentSubreddit(shortcut.subreddit)) {
+		if(shortcut.subreddit.includes('+')) {
+			var sortedSubs = shortcut.subreddit.replace(/\?\+/g, '+').split('+').sort();
+			if (module.options.showMultiAsCurrentIfAtChild.value) {
+				for (var i in sortedSubs) {
+					if (isCurrentSubreddit(sortedSubs[i])) {
+						thisShortCut.classList.add('RESShortcutsCurrentSub');
+					}
+				}
+			}
+			if (isCurrentSubreddit(sortedSubs.join('+'))) {
+				thisShortCut.classList.add('RESShortcutsCurrentSub');
+			}
+		}
+		else if (isCurrentSubreddit(shortcut.subreddit)) {
 			thisShortCut.classList.add('RESShortcutsCurrentSub');
 		}
 
-		thisShortCut.setAttribute('href', `/r/${shortcut.subreddit}`);
+		thisShortCut.setAttribute('href', `/r/${shortcut.subreddit.replace(/(?:\?\+.*|\?$)/, '')}`);
 		thisShortCut.textContent = shortcut.displayName;
 		thisShortCut.addEventListener('click', (e: MouseEvent) => {
 			if (e.button !== 0 || e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) {
@@ -399,8 +418,8 @@ function showSubredditGroupDropdown(obj) {
 	let subreddits = [];
 	let suffix = '';
 
-	if (obj.getAttribute && obj.getAttribute('href').includes('+')) {
-		let cleanSubreddits = obj.getAttribute('href').replace('/r/', '');
+	if (obj.getAttribute && obj.getAttribute('data-subreddit').includes('+')) {
+		let cleanSubreddits = obj.getAttribute('data-subreddit');
 
 		if (cleanSubreddits.indexOf('/') > cleanSubreddits.lastIndexOf('+') || module.options.alwaysApplySuffixToMulti.value) {
 			// for shortcuts like a+b/x, use subreddits=a+b ; suffix = x
@@ -415,7 +434,7 @@ function showSubredditGroupDropdown(obj) {
 				cleanSubreddits = cleanSubreddits.substr(0, pos);
 			}
 		}
-		subreddits = cleanSubreddits.split('+');
+		subreddits = cleanSubreddits.replace(/\?\+/g, '+').split('+');
 	}
 
 	if (!(subreddits.length || module.options.dropdownEditButton.value)) {
@@ -509,7 +528,7 @@ function hideSubredditGroupDropdown() {
 }
 
 function editSubredditShortcut(ele, event) {
-	const subreddit = ele.getAttribute('href').slice(3);
+	const subreddit = ele.getAttribute('data-subreddit');
 
 	const idx = mySubredditShortcuts.findIndex(shortcut => shortcut.subreddit === subreddit);
 

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -3967,5 +3967,11 @@
 	},
 	"iredditPreferRedditMediaDesc": {
 		"message": "Try to load images and video from Reddit's media servers."
+	},
+	"showMultiAsCurrentIfAtChildTitle": {
+		"message": "Highlighted multi if at any"
+	},
+	"showMultiAsCurrentIfAtChildDesc": {
+		"message": "Highlighted multi if at any of the multi's subreddits."
 	}
 }

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -3967,11 +3967,5 @@
 	},
 	"iredditPreferRedditMediaDesc": {
 		"message": "Try to load images and video from Reddit's media servers."
-	},
-	"showMultiAsCurrentIfAtChildTitle": {
-		"message": "Highlighted multi if at any"
-	},
-	"showMultiAsCurrentIfAtChildDesc": {
-		"message": "Highlighted multi if at any of the multi's subreddits."
 	}
 }


### PR DESCRIPTION
So this does three things; two feature additions, of which I've been doing for a while with a hack and a stylesheet tweak, and one bug fix. 

1. Option to highlight a multi on the subreddit manager bar if at any of it's nested subreddits. So if I have a `Gaming` multi the target of `overwatch+leagueoflegends+dota2+heroesofthestorm`, if I'm on any of those subreddits, `Gaming` will get highlighted as if it were the current sub. For people that utilize the multi's mainly for the dropdown, this should make it more intuitive for them if they want to enable it. Also makes the next thing more useful. Example: https://gfycat.com/HatefulFalseFlicker

2. Allows for an alternative use of the dropdown to act as a normal, single subreddit with "related subs" in the dropdown. In use, it looks like this: 
 
    **Subreddit:** `leagueoflegends?+leagueoflegends/new+leagueofmeta+loleventvods`
    **Display Name:** `leagueoflegends ▼`
    **Results:** https://gfycat.com/MenacingWastefulCorydorascatfish 
 
The inclusion of the `?` on the first subreddit is all you need. This is how I made it work before because the URL would ignore everything after that point. Shouldn't negatively affect anything else, can be used along side normal multi links, and is pretty simplistic in how to make use of it.

3. Also fixes a bug where reddit redirects url multi's to the ~~alphabetized~~ *randomized* version of the same link. So `/r/c+b+a` ~~would~~ *might* navigate to `/r/a+b+c` *or `/r/b+a+c`*, which is fine, but if it's on your subreddit bar, it wouldn't show as highlighted.