### PR TITLE
Update Beam to Mixer

### DIFF
--- a/lib/modules/hosts/mixer.js
+++ b/lib/modules/hosts/mixer.js
@@ -2,13 +2,13 @@
 
 import { Host } from '../../core/host';
 
-export default new Host('beam', {
-	name: 'Beam',
-	domains: ['beam.pro'],
-	logo: 'https://beam.pro/_latest/assets/favicons/favicon-32x32.png',
+export default new Host('mixer', {
+	name: 'Mixer',
+	domains: ['beam.pro', 'mixer.com'],
+	logo: 'https://mixer.com/_latest/assets/favicons/favicon-32x32.png',
 	detect: ({ pathname }) => (/^\/(\w+)$/).exec(pathname),
 	handleLink(href, [, clipId]) {
-		const embed = `https://beam.pro/embed/player/${clipId}`;
+		const embed = `https://mixer.com/embed/player/${clipId}`;
 
 		return {
 			type: 'IFRAME',


### PR DESCRIPTION
Beam is now called Mixer, Keep beam.pro domain for backwards compat.

Tested: Edge 15