### PR TITLE
ajax: use separate `query` param for query params

### DIFF
--- a/lib/environment/ajax.js
+++ b/lib/environment/ajax.js
@@ -7,14 +7,15 @@ import { XhrCache } from './';
 type ResponseType = 'text' | 'json';
 type MethodType = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
-type AjaxOptions<Ty: ResponseType | void> = {
+type AjaxOptions<Ty: ResponseType | void> = {|
 	method?: MethodType,
 	url: string,
+	query?: { [key: string]: string | number | boolean },
 	headers?: { [key: string]: string },
-	data?: string | { [key: string]: string | number | boolean },
+	data?: string | { [key: string]: string },
 	type?: Ty,
 	cacheFor?: number,
-};
+|};
 
 class FetchError extends Error {
 	status: number;
@@ -34,11 +35,11 @@ declare function ajax(opt: AjaxOptions<'json'>): Promise<{ [key: string | number
  * Send a fetch request.
  *
  * `method`, `url`, and `headers` behave in the obvious way.
- * `data` objects will be appended as query parameters for GET-like requests.
- * `data` objects will be sent as application/x-www-form-urlencoded for non-GET-like requests.
- * `data` strings will be sent as-is for non-GET-like requests.
+ * `query` adds query params to `url`.
+ * `data` objects will be sent as application/x-www-form-urlencoded.
+ * `data` strings will be sent as-is.
  * `type` affects the return type, either 'text' or 'json'.
- * `cacheFor` is a TTL, in milliseconds, only for GET-like requests.
+ * `cacheFor` is a TTL, in milliseconds.
  */
 export async function ajax(options: AjaxOptions<*>) {
 	const { method, url, headers, data, type, cacheFor, sameOrigin } = buildRequestParams(options);
@@ -78,7 +79,7 @@ export async function ajax(options: AjaxOptions<*>) {
 ajax.invalidate = (options: AjaxOptions<*>) =>
 	XhrCache.delete(buildRequestParams(options).url);
 
-function buildRequestParams({ method = 'GET', url, headers: { ...headers } = {}, data, type = 'text', cacheFor = 0 }): {|
+function buildRequestParams({ method = 'GET', url, query = {}, headers: { ...headers } = {}, data, type = 'text', cacheFor = 0 }): {|
 	method: MethodType,
 	url: string,
 	headers: { [key: string]: string },
@@ -89,39 +90,29 @@ function buildRequestParams({ method = 'GET', url, headers: { ...headers } = {},
 |} {
 	// Expand relative URLs
 	const urlObj = new URL(url, location.href);
+	// Append query string to URL
+	for (const [key, val] of Object.entries(query)) {
+		urlObj.searchParams.set(key, String(val));
+	}
 
 	const sameOrigin = urlObj.hostname.includes(location.hostname.split('.').slice(-2).join('.'));
+	if (sameOrigin) {
+		// Add `app=res` to same-origin request URLs
+		urlObj.searchParams.set('app', 'res');
 
-	if (method === 'GET' || method === 'HEAD') {
-		// Append query string to URL for GET requests
-		if (typeof data === 'object') {
-			for (const [key, val] of Object.entries(data)) {
-				urlObj.searchParams.set(key, (val: any));
-			}
-			data = undefined;
-		}
-	} else {
-		// Convert plain data objects to application/x-www-form-urlencoded
-		if (typeof data === 'object') {
-			headers['Content-Type'] = 'application/x-www-form-urlencoded';
-			// this needs to be a string because Edge doesn't support sending URlSearchParams
-			// (the fetch polyfill passes it through to XHR, which is correct behaviour)
-			data = new URLSearchParams((data: any)).toString();
-		}
-
-		// Send modhash for same-origin non-GET requests
-		if (sameOrigin) {
+		if (method !== 'GET' && method !== 'HEAD') {
+			// Send modhash for same-origin non-GET requests
 			const hash = loggedInUserHash();
 			if (hash) headers['X-Modhash'] = hash;
 		}
-
-		// Never cache non-GET-like requests
-		cacheFor = 0;
 	}
 
-	// Add `app=res` to same-origin request URLs
-	if (sameOrigin) {
-		urlObj.searchParams.set('app', 'res');
+	// Convert plain data objects to application/x-www-form-urlencoded
+	if (typeof data === 'object') {
+		headers['Content-Type'] = 'application/x-www-form-urlencoded';
+		// this needs to be a string because Edge doesn't support sending URlSearchParams
+		// (the fetch polyfill passes it through to XHR, which is correct behaviour)
+		data = new URLSearchParams(data).toString();
 	}
 
 	return {

--- a/lib/modules/backupAndRestore/providers/GoogleDrive.js
+++ b/lib/modules/backupAndRestore/providers/GoogleDrive.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { ajax, launchAuthFlow, Permissions } from '../../../environment';
-import { Alert, string } from '../../../utils';
+import { Alert } from '../../../utils';
 import Provider from './Provider';
 
 const FILE = 'res-storage.json';
@@ -32,7 +32,8 @@ export default class GoogleDrive extends Provider {
 	async getExistingFile() {
 		const { files: [file] } = await ajax({
 			method: 'GET',
-			url: string.encode`https://content.googleapis.com/drive/v3/files?fields=files(id,modifiedTime)&q=${`name="${FILE}"`}&spaces=${FOLDER}`,
+			url: 'https://content.googleapis.com/drive/v3/files',
+			query: { fields: 'files(id,modifiedTime)', q: `name="${FILE}"`, spaces: FOLDER },
 			headers: { Authorization: `Bearer ${this.accessToken}` },
 			type: 'json',
 		});
@@ -46,7 +47,8 @@ export default class GoogleDrive extends Provider {
 		// create new file
 		return ajax({
 			method: 'POST',
-			url: 'https://content.googleapis.com/drive/v3/files?fields=id',
+			url: 'https://content.googleapis.com/drive/v3/files',
+			query: { fields: 'id' },
 			data: JSON.stringify({ name: FILE, parents: [FOLDER] }),
 			headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${this.accessToken}` },
 			type: 'json',
@@ -64,7 +66,8 @@ export default class GoogleDrive extends Provider {
 		if (!file) throw new Error('Could not find backup.');
 		const data = await ajax({
 			method: 'GET',
-			url: `https://content.googleapis.com/drive/v3/files/${file.id}?alt=media`,
+			url: `https://content.googleapis.com/drive/v3/files/${file.id}`,
+			query: { alt: 'media' },
 			headers: {
 				'x-goog-encode-response-if-executable': 'base64', // Download immediately (Edge 15 appears to not handle the 307s properly)
 				Authorization: `Bearer ${this.accessToken}`,
@@ -77,7 +80,8 @@ export default class GoogleDrive extends Provider {
 		const { id } = await this.getOrCreateFile();
 		const { modifiedTime } = await ajax({
 			method: 'PATCH',
-			url: `https://content.googleapis.com/upload/drive/v3/files/${id}?uploadType=media&fields=modifiedTime`,
+			url: `https://content.googleapis.com/upload/drive/v3/files/${id}`,
+			query: { uploadType: 'media', fields: 'modifiedTime' },
 			data,
 			headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${this.accessToken}` },
 			type: 'json',

--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -348,7 +348,7 @@ const getVideoInfo = batch(async videoIds => {
 
 	const { items } = await ajax({
 		url: 'https://www.googleapis.com/youtube/v3/videos',
-		data: {
+		query: {
 			id: videoIds.join(','),
 			part: parts.join(','),
 			key: 'AIzaSyB8ufxFN0GapU1hSzIbuOLfnFC0XzJousw',

--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -725,7 +725,7 @@ function WidgetObject(widgetOptions) {
 		ajax({
 			method: 'GET',
 			url: this.url,
-			data: {
+			query: {
 				limit: this.numPosts,
 			},
 		})

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -716,7 +716,7 @@ const reconcileNativeFilters = (() => {
 	const getTopScore = batch(async requests => {
 		const resp = (await ajax({
 			url: `/r/${requests.map(r => r.sub).join('+')}/top.json`,
-			data: { t: 'day', limit: 100 },
+			query: { t: 'day', limit: 100 },
 			type: 'json',
 		}): RedditListing<RedditLink>);
 

--- a/lib/modules/hosts/aarli.js
+++ b/lib/modules/hosts/aarli.js
@@ -12,7 +12,7 @@ export default new Host('aarli', {
 	async handleLink(href, [, aarId]) {
 		const info = await ajax({
 			url: 'https://aar.li/api.php',
-			data: { aarId },
+			query: { aarId },
 			type: 'json',
 		});
 

--- a/lib/modules/hosts/codepen.js
+++ b/lib/modules/hosts/codepen.js
@@ -13,7 +13,7 @@ export default new Host('codepen', {
 	async handleLink(href, [, user, hash]) {
 		const { html } = await ajax({
 			url: 'https://codepen.io/api/oembed',
-			data: {
+			query: {
 				url: `https://codepen.io/${user}/pen/${hash}`,
 				format: 'json',
 				height: 500,

--- a/lib/modules/hosts/derpibooru.js
+++ b/lib/modules/hosts/derpibooru.js
@@ -26,7 +26,7 @@ export default new Host('derpibooru', {
 
 			const { images } = await ajax({
 				url: 'https://derpibooru.org/api/v2/images/show.json',
-				data: { ids: requests.map(r => r.id).join(',') },
+				query: { ids: requests.map(r => r.id).join(',') },
 				type: 'json',
 			});
 

--- a/lib/modules/hosts/deviantart.js
+++ b/lib/modules/hosts/deviantart.js
@@ -12,7 +12,7 @@ export default new Host('deviantart', {
 	async handleLink(href) {
 		const info = await ajax({
 			url: 'https://backend.deviantart.com/oembed',
-			data: { url: href },
+			query: { url: href },
 			type: 'json',
 		});
 

--- a/lib/modules/hosts/flickr.js
+++ b/lib/modules/hosts/flickr.js
@@ -42,7 +42,7 @@ export default new Host('flickr', {
 	async handleLink(href, oembedTarget) {
 		const info = await ajax({
 			url: 'https://noembed.com/embed',
-			data: { url: oembedTarget },
+			query: { url: oembedTarget },
 			type: 'json',
 		});
 

--- a/lib/modules/hosts/futurism.js
+++ b/lib/modules/hosts/futurism.js
@@ -11,7 +11,7 @@ export default new Host('futurism', {
 	async handleLink(href) {
 		const { data, success, status } = await ajax({
 			url: 'https://www.futurism.com/wp-content/themes/futurism/res.php',
-			data: { url: href, reverse: href.includes('wp-content/uploads') },
+			query: { url: href, reverse: href.includes('wp-content/uploads') },
 			type: 'json',
 		});
 

--- a/lib/modules/hosts/giphy.js
+++ b/lib/modules/hosts/giphy.js
@@ -12,7 +12,7 @@ export default new Host('giphy', {
 	async handleLink(href, [, id]) {
 		const { data } = await ajax({
 			url: `https://api.giphy.com/v1/gifs/${id}`,
-			data: { api_key: 'dc6zaTOxFJmzC' },
+			query: { api_key: 'dc6zaTOxFJmzC' },
 			type: 'json',
 		});
 

--- a/lib/modules/hosts/graphiq.js
+++ b/lib/modules/hosts/graphiq.js
@@ -16,7 +16,7 @@ export default new Host('graphiq', {
 			height = '360',
 		} = await ajax({
 			url: 'https://oembed.graphiq.com/services/oembed',
-			data: { url },
+			query: { url },
 			type: 'json',
 			cacheFor: DAY,
 		});

--- a/lib/modules/hosts/gyazo.js
+++ b/lib/modules/hosts/gyazo.js
@@ -12,7 +12,7 @@ export default new Host('gyazo', {
 	async handleLink(href, [, id]) {
 		const info = await ajax({
 			url: 'https://api.gyazo.com/api/oembed',
-			data: { url: href },
+			query: { url: href },
 			type: 'json',
 		});
 

--- a/lib/modules/hosts/photobucket.js
+++ b/lib/modules/hosts/photobucket.js
@@ -15,7 +15,7 @@ export default new Host('photobucket', {
 		if (prefix !== 'i') {
 			const { imageUrl } = await ajax({
 				url: 'https://api.photobucket.com/v2/media/fromurl',
-				data: { url: src },
+				query: { url: src },
 				type: 'json',
 			});
 			src = imageUrl.replace('http:', 'https:');

--- a/lib/modules/hosts/pornbot.js
+++ b/lib/modules/hosts/pornbot.js
@@ -12,7 +12,7 @@ export default new Host('pornbot', {
 	async handleLink(href, [, hash]) {
 		const info = await ajax({
 			url: 'https://pornbot.net/ajax/info.php',
-			data: { v: hash },
+			query: { v: hash },
 			type: 'json',
 			cacheFor: DAY,
 		});

--- a/lib/modules/hosts/redditbooru.js
+++ b/lib/modules/hosts/redditbooru.js
@@ -16,7 +16,7 @@ export default new Host('redditbooru', {
 
 		const info = await ajax({
 			url: 'https://redditbooru.com/images/',
-			data: { postId: id },
+			query: { postId: id },
 			type: 'json',
 		});
 

--- a/lib/modules/hosts/steamcommunity.js
+++ b/lib/modules/hosts/steamcommunity.js
@@ -23,7 +23,7 @@ export default new Host('steamcommunity', {
 		} = await ajax({
 			method: 'POST',
 			url: 'https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/v0001/?format=json',
-			data: { itemcount: 1, 'publishedfileids[0]': id },
+			data: { itemcount: '1', 'publishedfileids[0]': id },
 			type: 'json',
 		});
 

--- a/lib/modules/hosts/supload.js
+++ b/lib/modules/hosts/supload.js
@@ -11,7 +11,8 @@ export default new Host('supload', {
 	detect: ({ pathname }) => (/^\/([A-Za-z0-9_-]+)/i).exec(pathname),
 	async handleLink(href, [, id]) {
 		const data = await ajax({
-			url: `https://www.supload.com/oembed?url=https://supload.com/${id}&format=json`,
+			url: 'https://www.supload.com/oembed',
+			query: { url: `https://supload.com/${id}`, format: 'json' },
 			type: 'json',
 			cacheFor: DAY,
 		});

--- a/lib/modules/hosts/tenor.js
+++ b/lib/modules/hosts/tenor.js
@@ -47,7 +47,7 @@ export default new Host('tenor', {
 
 		const { results: [gif] } = await ajax({
 			url: 'https://api.tenor.co/v1/gifs',
-			data: { key: 'JJHDC7UK73EH', ids: id },
+			query: { key: 'JJHDC7UK73EH', ids: id },
 			type: 'json',
 		});
 

--- a/lib/modules/hosts/tumblr.js
+++ b/lib/modules/hosts/tumblr.js
@@ -16,7 +16,7 @@ export default new Host('tumblr', {
 	async handleLink(href, [blog, id]) {
 		const { response } = await ajax({
 			url: `https://api.tumblr.com/v2/blog/${blog}/posts`,
-			data: {
+			query: {
 				api_key: 'WeJQquHCAasi5EzaN9jMtIZkYzGfESUtEvcYDeSMLICveo3XDq',
 				id,
 				filter: 'raw',

--- a/lib/modules/hosts/twitter.js
+++ b/lib/modules/hosts/twitter.js
@@ -16,7 +16,7 @@ export default new Host('twitter', {
 		// oEmbed like this...
 		const { html } = await ajax({
 			url: 'https://api.twitter.com/1/statuses/oembed.json',
-			data: { id, omit_script: process.env.BUILD_TARGET === 'firefox' },
+			query: { id, omit_script: process.env.BUILD_TARGET === 'firefox' },
 			type: 'json',
 		});
 

--- a/lib/modules/hosts/vidlit.js
+++ b/lib/modules/hosts/vidlit.js
@@ -11,7 +11,7 @@ export default new Host('vidlit', {
 	async handleLink(href, [, hash]) {
 		const oEmbed = await ajax({
 			url: 'https://vidl.it/oembed',
-			data: { url: href, maxwidth: 640, format: 'json' },
+			query: { url: href, maxwidth: 640, format: 'json' },
 			type: 'json',
 		});
 		return {

--- a/lib/modules/quickMessage.js
+++ b/lib/modules/quickMessage.js
@@ -245,7 +245,7 @@ async function getValidSendFrom() {
 	if (isModeratorAnywhere()) {
 		const { data } = (await ajax({
 			url: '/subreddits/mine/moderator.json',
-			data: {
+			query: {
 				limit: 1000,
 				show: 'all',
 				user: loggedInUser() || '', // for the cache

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -816,7 +816,7 @@ async function convertGifToVideo(options) {
 		const info = await ajax({
 			type: 'json',
 			url: 'https://upload.gfycat.com/transcodeRelease',
-			data: { fetchUrl: options.src },
+			query: { fetchUrl: options.src },
 			cacheFor: DAY,
 		});
 

--- a/lib/modules/sourceSnudown.js
+++ b/lib/modules/sourceSnudown.js
@@ -52,7 +52,7 @@ const viewSource = keyedMutex(async button => {
 
 		const response = await ajax({
 			url: `${path}.json`,
-			data: { raw_json: 1 },
+			query: { raw_json: 1 },
 			type: 'json',
 		});
 

--- a/lib/modules/submitHelper.js
+++ b/lib/modules/submitHelper.js
@@ -145,7 +145,7 @@ async function updateRepostWarning() {
 		try {
 			const { data } = (await ajax({
 				url: string.encode`/r/${subreddit}/search.json`,
-				data: {
+				query: {
 					restrict_sr: 'on',
 					sort: 'relevance',
 					limit: 1,

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -262,7 +262,7 @@ function manageSubreddits() {
 				// reset the last checked time for the subreddit list so that we refresh it anew no matter what.
 				ajax.invalidate({
 					url: '/subreddits/mine.json',
-					data: {
+					query: {
 						after: '',
 						limit: 100,
 						user: loggedInUser(),
@@ -1180,7 +1180,7 @@ async function getSubreddits(user) {
 	do {
 		const { data } = (await ajax({ // eslint-disable-line no-await-in-loop
 			url: '/subreddits/mine.json',
-			data: {
+			query: {
 				after,
 				limit: 100,
 				user, // for the cache

--- a/lib/utils/thingMetadata.js
+++ b/lib/utils/thingMetadata.js
@@ -12,7 +12,7 @@ export const getPostMetadata = batch(async (requests: { id: string }[]): Promise
 
 	const { data: { children } } = (await ajax({
 		url: `/by_id/${byId}.json`,
-		data: { limit: 100, raw_json: 1 },
+		query: { limit: 100, raw_json: 1 },
 		type: 'json',
 	}): RedditListing<RedditLink>);
 


### PR DESCRIPTION
...instead of overloading `data`, which prevents you from adding query params for non-GET requests.

It should also be a bit more intuitive that a param called `query`, rather than `data`, affects the URL.

Tested in browser: Chrome 60
