### PR TITLE
Ignore npm5 package lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ $RECYCLE.BIN/
 ## Visual Studio ##
 .vscode
 .vs
+
+## NPM package lock ##
+package-lock.json


### PR DESCRIPTION
We aren't using it right now