### PR TITLE
Edge: emulate noninteractive auth with a background tab

### DIFF
--- a/edge/background.entry.js
+++ b/edge/background.entry.js
@@ -9,11 +9,7 @@ import { apiToPromise } from '../browser/utils/api';
 addListener('addURLToHistory', () => {});
 addListener('isURLVisited', () => false);
 
-addListener('authFlow', async ({ domain, clientId, scope, interactive }) => {
-	if (!interactive) {
-		throw new Error('Edge does not support noninteractive auth.');
-	}
-
+addListener('authFlow', async ({ domain, clientId, scope, interactive }, { index: currentIndex }) => {
 	const redirectUri = 'https://redditenhancementsuite.com/oauth';
 	const url = new URL(domain);
 	url.searchParams.set('client_id', clientId);
@@ -21,27 +17,42 @@ addListener('authFlow', async ({ domain, clientId, scope, interactive }) => {
 	url.searchParams.set('response_type', 'token');
 	url.searchParams.set('redirect_uri', redirectUri);
 
-	const { tabs: [{ id }] } = await apiToPromise(chrome.windows.create)({ url: url.href, type: 'popup' });
+	let id;
+	if (interactive) {
+		({ tabs: [{ id }] } = await apiToPromise(chrome.windows.create)({
+			url: url.href,
+			type: 'popup',
+		}));
+	} else {
+		({ id } = await apiToPromise(chrome.tabs.create)({
+			url: url.href,
+			index: currentIndex + 1,
+			active: false,
+		}));
+	}
 
 	return new Promise((resolve, reject) => {
-		function updateListener(tabId, { url }) {
-			if (tabId === id && url && url.startsWith(redirectUri)) {
+		function updateListener(tabId, updates) {
+			if (tabId !== id) return;
+
+			if (updates.url && updates.url.startsWith(redirectUri)) {
+				// we've reached the redirect URL
 				stopListening();
-				// Redirect arrived at the target, send back the URL...
-				resolve(url);
-				// ...and close the tab, since we have no forground script running on it.
-				// It's not feasible to use a foreground script to close the tab anyways,
-				// since Edge blocks it with a ridiculous
-				// "The site you're on is trying to close this window" warning.
+				resolve(updates.url);
+				apiToPromise(chrome.tabs.remove)(id);
+			} else if (!interactive && updates.status && updates.status === 'complete') {
+				// the page has loaded but we haven't redirected
+				stopListening();
+				reject(new Error('User interaction is required.'));
 				apiToPromise(chrome.tabs.remove)(id);
 			}
 		}
 
 		function removeListener(tabId) {
-			if (tabId === id) {
-				stopListening();
-				reject(new Error('User cancelled or denied access.'));
-			}
+			if (tabId !== id) return;
+			// tab closed
+			stopListening();
+			reject(new Error('User cancelled or denied access.'));
 		}
 
 		function stopListening() {


### PR DESCRIPTION
Tested in browser: Edge 15

This makes automatic backups feasible in Edge.

It's actually much less annoying than I thought it would be.