### PR TITLE
Slight change to help speedup user tag loading

### DIFF
--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -819,7 +819,7 @@ export async function applyTagToAuthor(thisAuthorObj: HTMLAnchorElement, noEdit:
 	const tagObject = await getTagBatched(thisAuthor);
 
 	if (!_.isEmpty(tagObject)) {
-		if (tagElement && tagElement.parentElement) tagElement.parentElement.removeChild(tagElement);
+		if (tagElement) tagElement.remove();
 		addAuthorTag(thisAuthorObj, noEdit, thisAuthor, tagObject);
 	}
 

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -883,7 +883,7 @@ function addAuthorTag(thisAuthorObj: HTMLAnchorElement, noEdit: boolean, thisAut
 	}
 
 	if (noEdit) {
-		if (tag) addUserTag();
+		if (tag) return addUserTag();
 		return;
 	}
 

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -811,9 +811,15 @@ export async function applyTagToAuthor(thisAuthorObj: HTMLAnchorElement, noEdit:
 		);
 	}
 
+	let tagElement;
+	if (module.options.showTaggingIcon.value) {
+		tagElement = addAuthorTag(thisAuthorObj, noEdit, thisAuthor);
+	}
+
 	const tagObject = await getTagBatched(thisAuthor);
 
-	if (module.options.showTaggingIcon.value || !_.isEmpty(tagObject)) {
+	if (!_.isEmpty(tagObject)) {
+		if (tagElement && tagElement.parentElement) tagElement.parentElement.removeChild(tagElement);
 		addAuthorTag(thisAuthorObj, noEdit, thisAuthor, tagObject);
 	}
 
@@ -855,6 +861,7 @@ function addAuthorTag(thisAuthorObj: HTMLAnchorElement, noEdit: boolean, thisAut
 		userTag.appendChild(userTagLink);
 		userTag.classList.add('RESUserTag');
 		$(thisAuthorObj).after(userTag);
+		return userTag;
 	}
 
 	function addTrackVoteWeight() {
@@ -881,7 +888,7 @@ function addAuthorTag(thisAuthorObj: HTMLAnchorElement, noEdit: boolean, thisAut
 	}
 
 	if (module.options.trackVoteWeight.value) addTrackVoteWeight();
-	if (tag || module.options.showTaggingIcon.value) addUserTag();
+	if (tag || module.options.showTaggingIcon.value) return addUserTag();
 }
 
 // Ignore content from certain users.


### PR DESCRIPTION
The async operation is long and yields empty results far more often than not, so it makes more sense to load the user tag icon by default since adding them in often shifts around the whole page layout, then swapping it out for a tag if it exists.

The user tag icon appears anywhere between 500ms - 1500ms faster doing it this way from my tests. Makes the page feel fully loaded much more quickly.

Tested in Chrome 60