### PR TITLE
newCommentCount: Clean-up and concurrency fix

### DIFF
--- a/lib/core/migrate/migrate.js
+++ b/lib/core/migrate/migrate.js
@@ -516,6 +516,14 @@ const migrations = [
 		async go() {
 			await Migrators.moveOption('keyboardNav', 'mediaBrowseMode', 'showImages', 'mediaBrowse');
 		},
+	}, {
+		versionNumber: '5.7.1-shard-newCommentCount',
+		async go() {
+			const entries = await Storage.get('RESmodules.newCommentCount.counts') || {};
+			const remappedEntries = _.mapKeys(entries, (v, k) => `newCommentCount.${k}`);
+			await Storage.setMultiple(remappedEntries);
+			await Storage.delete('RESmodules.newCommentCount.counts');
+		},
 	},
 
 ];  // ^^ Add new migrations ^^

--- a/lib/css/modules/_newCommentCount.scss
+++ b/lib/css/modules/_newCommentCount.scss
@@ -5,7 +5,6 @@
 
 .RESSubscriptionButton {
 	float: right;
-	margin-left: 8px;
 	cursor: pointer;
 	color: #369;
 	font-size: 12px;

--- a/lib/environment/storage.js
+++ b/lib/environment/storage.js
@@ -115,6 +115,10 @@ class PrefixWrapper<T> {
 		return get(this._keyGen(key)).then(val => (val === null ? this._default() : val));
 	}
 
+	getNullable(key: string): Promise<?T> {
+		return get(this._keyGen(key));
+	}
+
 	async getAll(): Promise<{ [key: string]: T }> {
 		const everything = await getAll();
 		return _.transform(everything, (acc, v, k) => {

--- a/lib/environment/storage.js
+++ b/lib/environment/storage.js
@@ -135,6 +135,13 @@ class PrefixWrapper<T> {
 		}, {});
 	}
 
+	async batchNullable(keys: string[]): Promise<{ [key: string]: ?T }> {
+		const rawValues = await batch(keys.map(k => this._keyGen(k)));
+		return _.transform(rawValues, (acc, v, k) => {
+			acc[k.slice(this._prefix.length)] = v;
+		}, {});
+	}
+
 	set(key: string, value: T): Promise<void> {
 		return set(this._keyGen(key), value);
 	}

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -20,6 +20,7 @@ import {
 	watchForThings,
 	mutex,
 	waitForEvent,
+	batch,
 } from '../utils';
 import { Storage, isPrivateBrowsing } from '../environment';
 import * as Dashboard from './dashboard';
@@ -89,7 +90,8 @@ const entryStorage = Storage.wrapPrefix('newCommentCount.', (): {
 module.beforeLoad = () => {
 	updateToggleSubscriptionButton();
 
-	watchForThings(['post'], displayNewCommentCount);
+	// Immediate in order to avoid many entry lookups
+	watchForThings(['post'], displayNewCommentCount, { immediate: true });
 };
 
 module.go = () => {
@@ -117,6 +119,11 @@ module.afterLoad = async () => {
 	}
 };
 
+const getEntryBatched = batch(async ids => {
+	const entries = await entryStorage.batchNullable(ids);
+	return ids.map(id => entries[id]);
+}, { size: Infinity, delay: 0 });
+
 function setEntry(id: string, newCommentCount, newEditedTime) {
 	if (!module.options.monitorPostsVisited.value) return false;
 	if (!module.options.monitorPostsVisitedIncognito.value && isPrivateBrowsing()) return false;
@@ -133,13 +140,13 @@ function setEntry(id: string, newCommentCount, newEditedTime) {
 }
 
 export async function hasEntry(thing: Thing): Promise<boolean> {
-	return !!(await entryStorage.getNullable(thing.getFullname().split('_').slice(-1)[0]));
+	return !!(await getEntryBatched(thing.getFullname().split('_').slice(-1)[0]));
 }
 
 export async function getNewCount(thing: Thing): Promise<?number> {
 	const currentCount = thing.getCommentCount();
 
-	const countObj = await entryStorage.getNullable(thing.getFullname().split('_').slice(-1)[0]);
+	const countObj = await getEntryBatched(thing.getFullname().split('_').slice(-1)[0]);
 	const lastOpenedCount = countObj && countObj.count;
 
 	if (typeof currentCount !== 'number' || typeof lastOpenedCount !== 'number') return;

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -18,6 +18,8 @@ import {
 	loggedInUser,
 	regexes,
 	watchForThings,
+	mutex,
+	waitForEvent,
 } from '../utils';
 import { Storage, isPrivateBrowsing } from '../environment';
 import * as Dashboard from './dashboard';
@@ -74,7 +76,7 @@ module.options = {
 
 const currentId: ?string = (execRegexes.comments(location.pathname) || [])[2];
 const lastCleanStorage = Storage.wrap('RESmodules.newCommentCount.lastClean', (null: null | number));
-const commentCountStorage = Storage.wrap('RESmodules.newCommentCount.counts', ({}: { [key: string]: {
+const commentCountStorage = Storage.wrapPrefix('commentCount.', (): {
 	subscriptionDate?: number,
 	count: number,
 	editedTime: number,
@@ -82,13 +84,10 @@ const commentCountStorage = Storage.wrap('RESmodules.newCommentCount.counts', ({
 	title: string,
 	updateTime: number,
 	lastCheck?: number,
-} }));
-let commentCounts = {};
+} => { throw new Error('Default value should never be retrieved'); });
 
-module.beforeLoad = async () => {
-	commentCounts = await commentCountStorage.get();
-
-	handleToggleButton(); // Initialize subscription button
+module.beforeLoad = () => {
+	createToggleSubscriptionButton();
 
 	watchForThings(['post'], displayNewCommentCount);
 };
@@ -97,11 +96,12 @@ module.go = () => {
 	if (isPageType('comments')) {
 		watchForThings(['comment'], updateCommentCountFromMyComment);
 		if (module.options.showSubscribeButton.value) {
-			getToggleButton().appendTo('.commentarea .panestack-title');
+			getToggleSubscriptionButton().appendTo('.commentarea .panestack-title');
 		}
 	} else if (isCurrentSubreddit('dashboard')) {
 		addDashboardFunctionality();
 	}
+
 	checkSubscriptions();
 };
 
@@ -117,16 +117,19 @@ module.afterLoad = async () => {
 	}
 };
 
-function displayNewCommentCount(thing) {
+export async function getNewCount(thing: Thing): Promise<?number> {
 	const currentCount = thing.getCommentCount();
 
-	const countObj = commentCounts[thing.getFullname().split('_').slice(-1)[0]];
+	const countObj = await commentCountStorage.getNullable(thing.getFullname().split('_').slice(-1)[0]);
 	const lastOpenedCount = countObj && countObj.count;
 
-	if (!Number.isInteger(currentCount) || !Number.isInteger(lastOpenedCount)) return;
+	if (typeof currentCount !== 'number' || typeof lastOpenedCount !== 'number') return;
 
-	const newCount = Math.max(currentCount - lastOpenedCount, 0);
+	return Math.max(currentCount - lastOpenedCount, 0);
+}
 
+async function displayNewCommentCount(thing) {
+	const newCount = await getNewCount(thing);
 	if (!newCount) return;
 
 	thing.element.classList.add('res-hasNewComments');
@@ -135,14 +138,15 @@ function displayNewCommentCount(thing) {
 		.append(`<span class="newComments">&nbsp;(${newCount} new)</span>`);
 }
 
-function updateCommentCountFromMyComment(thing) {
+async function updateCommentCountFromMyComment(thing) {
 	if (!currentId) return;
 
 	const timestamp = thing.getTimestamp();
 	const isRecent = timestamp && (Date.now() - timestamp.getTime()) < 10000;
 	const isMine = loggedInUser() === thing.getAuthor();
 	if (isRecent && isMine) {
-		saveCommentCount(currentId, commentCounts[currentId].count + 1, commentCounts[currentId].editedTime);
+		const { count, editedTime } = await commentCountStorage.get(thing.getFullname().split('_').slice(-1)[0]);
+		saveCommentCount(currentId, count + 1, editedTime);
 	}
 }
 
@@ -158,8 +162,7 @@ function saveCommentCount(id: string, newCommentCount, newEditedTime) {
 		editedTime: newEditedTime,
 	};
 
-	commentCounts[id] = Object.assign(commentCounts[id] || {}, patch);
-	commentCountStorage.patch({ [id]: patch });
+	commentCountStorage.patch(id, patch);
 }
 
 /**
@@ -173,112 +176,109 @@ function updateCommentCount() {
 	}
 }
 
-function cleanOldCounts() {
+async function cleanOldCounts() {
 	const now = Date.now();
 	lastCleanStorage.set(now);
 	const keepTrackPeriod = DAY * parseInt(module.options.cleanComments.value, 10);
-	for (const i in commentCounts) {
+	for (const [id, data] of Object.entries(await commentCountStorage.getAll())) {
 		// Do not automatically delete comments belonging to actively subscribed threads
-		if (commentCounts[i] && commentCounts[i].subscriptionDate) {
+		if (data.subscriptionDate) {
 			continue;
-		} else if (!commentCounts[i] || ((now - commentCounts[i].updateTime) > keepTrackPeriod)) {
-			delete commentCounts[i];
-			commentCountStorage.deletePath(i);
+		} else if ((now - data.updateTime) > keepTrackPeriod) {
+			stopTracking(id);
 		}
 	}
 }
 
-const getToggleButton = _.once(() =>
+const getToggleSubscriptionButton = _.once(() =>
 	$('<span>', {
 		id: 'REScommentSubToggle',
 		class: 'RESSubscriptionButton',
-		click: toggleSubscription,
+		click: createToggleSubscriptionButton,
 	})
 );
 
-function handleToggleButton() {
-	if (!currentId) return;
-	const $toggleButton = getToggleButton();
-	if (commentCounts[currentId] && commentCounts[currentId].subscriptionDate !== undefined) {
+const createToggleSubscriptionButton = mutex(async () => {
+	if (!currentId) throw new Error('No currentId');
+
+	const $button = getToggleSubscriptionButton();
+	const data = await commentCountStorage.getNullable(currentId);
+	if (data && data.subscriptionDate) {
 		// Unsubscribe.
-		$toggleButton
+		$button
 			.html('<span class="res-icon">&#xF038;</span> unsubscribe')
 			.attr('title', 'stop receiving notifications')
 			.addClass('unsubscribe');
+		return waitForEvent($button.get(0), 'click').then(async () => {
+			await unsubscribe(currentId);
+			Notifications.showNotification({
+				notificationID: 'newCommentCountUnsubscribe',
+				moduleID: 'newCommentCount',
+				message: 'You are now unsubscribed from this thread.',
+			}, 3000);
+		});
 	} else {
 		// Subscribe.
-		$toggleButton
+		$button
 			.html('<span class="res-icon">&#xF03B;</span> subscribe')
 			.attr('title', 'notify me of new comments')
 			.removeClass('unsubscribe');
+		return waitForEvent($button.get(0), 'click').then(async () => {
+			await subscribe(currentId);
+			Notifications.showNotification({
+				notificationID: 'newCommentCountSubscribe',
+				moduleID: 'newCommentCount',
+				optionKey: 'subscriptionLength',
+				message: `
+					<p>
+						You are now subscribed to this thread for ${module.options.subscriptionLength.value} days.
+						When new comments are posted you'll receive a notification.
+					</p>
+					<p><a href="/r/Dashboard#newCommentsContents">Manage subscriptions</a></p>
+				`,
+			}, 5000);
+		});
 	}
-}
+});
 
-function toggleSubscription() {
-	if (!currentId) return;
-	if (typeof commentCounts[currentId].subscriptionDate !== 'undefined') {
-		unsubscribeFromThread(currentId);
-	} else {
-		subscribeToThread(currentId);
-	}
-	handleToggleButton();
-}
-
-function subscribeToThread(id) {
+function subscribe(id) {
 	const now = Date.now();
-	commentCounts[id].subscriptionDate = now;
-	commentCountStorage.patch({ [id]: { subscriptionDate: now } });
-	Notifications.showNotification({
-		notificationID: 'newCommentCountSubscribe',
-		moduleID: 'newCommentCount',
-		optionKey: 'subscriptionLength',
-		message: `
-			<p>
-				You are now subscribed to this thread for ${module.options.subscriptionLength.value} days.
-				When new comments are posted you'll receive a notification.
-			</p>
-			<p><a href="/r/Dashboard#newCommentsContents">Manage subscriptions</a></p>
-		`,
-	}, 5000);
+	return commentCountStorage.patch(id, { subscriptionDate: now });
 }
 
-function unsubscribeFromThread(id) {
-	delete commentCounts[id].subscriptionDate;
-	commentCountStorage.deletePath(id, 'subscriptionDate');
-	Notifications.showNotification({
-		notificationID: 'newCommentCountUnsubscribe',
-		moduleID: 'newCommentCount',
-		message: 'You are now unsubscribed from this thread.',
-	}, 3000);
+function unsubscribe(id) {
+	return commentCountStorage.deletePath(id, 'subscriptionDate');
 }
 
-function checkSubscriptions() {
-	for (const [id, subscription] of Object.entries(commentCounts)) {
-		if (subscription && typeof subscription.subscriptionDate !== 'undefined') {
+function stopTracking(id) {
+	return commentCountStorage.deletePath(id);
+}
+
+async function checkSubscriptions() {
+	for (const [id, subscription] of Object.entries(await commentCountStorage.getAll())) {
+		const { subscriptionDate } = subscription;
+		if (subscriptionDate) {
 			const lastCheck = parseInt(subscription.lastCheck, 10) || 0;
-			const subscriptionDate = parseInt(subscription.subscriptionDate, 10);
 			// If it's been subscriptionLength days since we've subscribed, we're going to delete this subscription...
 			const now = Date.now();
 			if ((now - subscriptionDate) > (DAY * parseInt(module.options.subscriptionLength.value, 10))) {
-				delete subscription.subscriptionDate;
+				unsubscribe(id);
 			}
 			// if we haven't checked this subscription in 5 minutes, try it again...
 			if ((now - lastCheck) > 300000) {
-				subscription.lastCheck = now;
-				checkThread(id);
+				commentCountStorage.patch(id, { lastCheck: now });
+				checkThread(id, subscription);
 			}
 		}
 	}
-	commentCountStorage.set(commentCounts);
 }
 
-async function checkThread(id) {
-	const { count, editedTime, url, title } = commentCounts[id];
+async function checkThread(id, subscription) {
 	const { num_comments: newCount, edited: newEditedTime } = await getPostMetadata({ id });
+	const { count, editedTime, url, title } = subscription;
 
 	if (newCount > count) {
-		commentCounts[id].count = newCount;
-		commentCountStorage.patch({ [id]: { count: newCount } });
+		commentCountStorage.patch(id, { count: newCount });
 
 		const notification = await Notifications.showNotification({
 			header: 'New comments',
@@ -289,13 +289,12 @@ async function checkThread(id) {
 		}, 10000);
 
 		// add button to unsubscribe from within notification.
-		const unsubscribeButton = handleButton(id, 'unsubscribe');
-		unsubscribeButton.addEventListener('click', notification.close);
-		$(notification.element).find('.RESNotificationContent').append(unsubscribeButton);
+		const { button, promise } = createButton(id, 'unsubscribe');
+		promise.then(notification.close);
+		$(notification.element).find('.RESNotificationContent').append(button);
 	}
 	if (module.options.notifyEditedPosts.value && newEditedTime && newEditedTime > editedTime) {
-		commentCounts[id].editedTime = newEditedTime;
-		commentCountStorage.patch({ [id]: { editedTime: newEditedTime } });
+		commentCountStorage.patch(id, { editedTime: newEditedTime });
 
 		const notification = await Notifications.showNotification({
 			header: 'Post edited',
@@ -307,101 +306,55 @@ async function checkThread(id) {
 		}, 10000);
 
 		// add button to unsubscribe from within notification.
-		const unsubscribeButton = handleButton(id, 'unsubscribe');
-		unsubscribeButton.addEventListener('click', notification.close);
-		$(notification.element).find('.RESNotificationContent').append(unsubscribeButton);
+		const { button, promise } = createButton(id, 'unsubscribe');
+		promise.then(notification.close);
+		$(notification.element).find('.RESNotificationContent').append(button);
 	}
 }
 
-function handleButton(id, action) {
-	const $button = $('<span>', {
-		class: 'RESSubscriptionButton',
-		'data-id': id,
-	});
+function createButton(id, type) {
+	const $button = $('<span class="RESSubscriptionButton">');
+	let action;
 
-	switch (action) {
+	switch (type) {
 		case 'unsubscribe':
 			$button
 				.html('<span class="res-icon">&#xF038;</span> unsubscribe')
 				.attr('title', 'stop receiving notifications')
-				.addClass('unsubscribe')
-				.click(unsubscribeButton);
-			break;
-		case 'subscribe':
-			$button
-				.html('<span class="res-icon">&#xF03B;</span> subscribe')
-				.attr('title', 'notify me of new comments')
-				.click(subscribeButton);
+				.addClass('unsubscribe');
+			action = () => unsubscribe(id);
 			break;
 		case 'renew':
 			$button
 				.html('<span class="res-icon">&#xF03B;</span> renew')
-				.attr('title', `renew for ${module.options.subscriptionLength.value} days`)
-				.click(renewSubscriptionButton);
+				.attr('title', `renew for ${module.options.subscriptionLength.value} days`);
+			action = async () => {
+				await subscribe(id);
+
+				Notifications.showNotification({
+					notificationID: 'newCommentCountRenew',
+					moduleID: 'newCommentCount',
+					optionKey: 'subscriptionLength',
+					message: `Subscription renewed for ${module.options.subscriptionLength.value} days.`,
+				});
+			};
 			break;
 		case 'delete':
 			$button
 				.html('<span class="res-icon">&#xF155;</span>')
 				.attr('title', 'delete from list')
-				.addClass('deleteIcon')
-				.click(stopTracking);
+				.addClass('deleteIcon');
+			action = async () => {
+				const { title } = await commentCountStorage.get(id);
+				return Alert.open(`Are you sure you want to stop tracking new comments on post: "${title}"?`, { cancelable: true })
+					.then(() => stopTracking(id));
+			};
 			break;
 		default:
 			break;
 	}
-	return $button.get(0);
-}
 
-function renewSubscriptionButton(e) {
-	const thisURL = $(e.currentTarget).attr('data-id');
-	renewSubscription(thisURL);
-	Notifications.showNotification({
-		notificationID: 'newCommentCountRenew',
-		moduleID: 'newCommentCount',
-		optionKey: 'subscriptionLength',
-		message: `Subscription renewed for ${module.options.subscriptionLength.value} days.`,
-	});
-}
-
-function renewSubscription(id) {
-	const now = Date.now();
-	commentCounts[id].subscriptionDate = now;
-	commentCountStorage.patch({ [id]: { subscriptionDate: now } });
-	drawSubscriptionsTable();
-}
-
-function unsubscribeButton(e) {
-	const thisURL = $(e.currentTarget).attr('data-id');
-	unsubscribe(thisURL);
-}
-
-function stopTracking(e) {
-	const id = $(e.currentTarget).attr('data-id');
-	const $button = $(e.currentTarget);
-	Alert.open(`Are you sure you want to stop tracking new comments on post: "${commentCounts[id].title}"?`, { cancelable: true })
-		.then(() => {
-			delete commentCounts[id];
-			commentCountStorage.deletePath(id);
-			$button.closest('tr').remove();
-		});
-}
-
-function unsubscribe(id) {
-	delete commentCounts[id].subscriptionDate;
-	commentCountStorage.deletePath(id, 'subscriptionDate');
-	drawSubscriptionsTable();
-}
-
-function subscribeButton(e) {
-	const thisURL = $(e.currentTarget).attr('data-id');
-	subscribe(thisURL);
-}
-
-function subscribe(id) {
-	const now = Date.now();
-	commentCounts[id].subscriptionDate = now;
-	commentCountStorage.patch({ [id]: { subscriptionDate: now } });
-	drawSubscriptionsTable();
+	return { button: $button.get(0), promise: waitForEvent($button.get(0), 'click').then(action) };
 }
 
 function addDashboardFunctionality() {
@@ -412,7 +365,7 @@ function addDashboardFunctionality() {
 	$openOnReddit.click(event => {
 		event.preventDefault();
 		let url = 't3_';
-		const $threads = $('#newCommentsTable tr td:last-of-type > span:first-of-type');
+		const $threads = $('#newCommentsTable tbody > tr');
 		const ids = $threads.get().map(ele => ele.getAttribute('data-id'));
 		const concatIds = ids.join(',t3_');
 		url += concatIds;
@@ -445,10 +398,11 @@ function addDashboardFunctionality() {
 
 let currentSortMethod, isDescending;
 
-function drawSubscriptionsTable(sortMethod, descending) {
+async function drawSubscriptionsTable(sortMethod, descending) {
 	currentSortMethod = sortMethod || currentSortMethod;
 	isDescending = (descending === undefined) ? isDescending : !!descending;
-	const thisCounts = filterMap(Object.entries(commentCounts), ([id, commentCount]) => {
+	$('#newCommentsTable tbody').html('');
+	const thisCounts = filterMap(Object.entries(await commentCountStorage.getAll()), ([id, commentCount]) => {
 		const match = new URL(commentCount.url).pathname.match(regexes.subreddit);
 		if (match) {
 			return [{
@@ -458,7 +412,6 @@ function drawSubscriptionsTable(sortMethod, descending) {
 			}];
 		}
 	});
-	$('#newCommentsTable tbody').html('');
 	switch (currentSortMethod) {
 		case 'subscriptionDate':
 			thisCounts.sort((a, b) =>
@@ -493,10 +446,14 @@ function drawSubscriptionsTable(sortMethod, descending) {
 			const now = new Date();
 
 			// set up buttons.
-			const thisTrash = handleButton(id, 'delete');
-			const thisRenewButton = handleButton(id, 'renew');
-			const thisUnsubButton = handleButton(id, 'unsubscribe');
-			const thisSubscribeButton = handleButton(id, 'subscribe');
+			const { button: thisTrashButton, promise: thisTrashPromise } = createButton(id, 'delete');
+			thisTrashPromise.then(drawSubscriptionsTable);
+			const { button: thisRenewButton, promise: thisRenewPromise } = createButton(id, 'renew');
+			thisRenewPromise.then(drawSubscriptionsTable);
+			const { button: thisUnsubButton, promise: thisUnsubPromise } = createButton(id, 'unsubscribe');
+			thisUnsubPromise.then(drawSubscriptionsTable);
+			const { button: thisSubscribeButton, promise: thisSubscribePromise } = createButton(id, 'subscribe');
+			thisSubscribePromise.then(drawSubscriptionsTable);
 
 			let thisExpiresContent;
 			if (isSubscribed) {
@@ -508,7 +465,7 @@ function drawSubscriptionsTable(sortMethod, descending) {
 
 			// populate table row.
 			const thisROW = `
-				<tr><td><a href="${url}">${escapeHTML(title)}</a></td>
+				<tr data-id="${id}"><td><a href="${url}">${escapeHTML(title)}</a></td>
 				<td><a href="/r/${subreddit}">/r/${subreddit}</a></td>
 				<td><abbr title="${formatDateTime(thisUpdateTime)}">${formatDateDiff(thisUpdateTime)} ago</abbr></td>
 				<td>${thisExpiresContent}</td><td></td></tr>
@@ -516,8 +473,8 @@ function drawSubscriptionsTable(sortMethod, descending) {
 
 			const $thisROW = $(thisROW);
 
+			$thisROW.find('td:last-of-type').append(thisTrashButton);
 			// add buttons.
-			$thisROW.find('td:first-of-type').append(thisTrash);
 			if (isSubscribed) {
 				$thisROW.find('td:last-of-type').append(thisRenewButton).append(' ');
 				$thisROW.find('td:last-of-type').append(thisUnsubButton);

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -72,7 +72,7 @@ module.options = {
 	},
 };
 
-const currentCommentID: ?string = (execRegexes.comments(location.pathname) || [])[2];
+const currentId: ?string = (execRegexes.comments(location.pathname) || [])[2];
 const lastCleanStorage = Storage.wrap('RESmodules.newCommentCount.lastClean', (null: null | number));
 const commentCountStorage = Storage.wrap('RESmodules.newCommentCount.counts', ({}: { [key: string]: {
 	subscriptionDate?: number,
@@ -134,23 +134,17 @@ function displayNewCommentCount(thing) {
 }
 
 function updateCommentCountFromMyComment(thing) {
-	if (!currentCommentID) return;
+	if (!currentId) return;
 
 	const timestamp = thing.getTimestamp();
 	const isRecent = timestamp && (Date.now() - timestamp.getTime()) < 10000;
 	const isMine = loggedInUser() === thing.getAuthor();
 	if (isRecent && isMine) {
-		saveCommentCount(currentCommentID, commentCounts[currentCommentID].count + 1, commentCounts[currentCommentID].editedTime);
+		saveCommentCount(currentId, commentCounts[currentId].count + 1, commentCounts[currentId].editedTime);
 	}
 }
 
-/**
- * save an updated CommentCount
- *
- * @param {string} commentID - ID of comment to store new count against
- * @param {int} newCommentCount - new number of comments to save
- */
-function saveCommentCount(commentID: string, newCommentCount, newEditedTime) {
+function saveCommentCount(id: string, newCommentCount, newEditedTime) {
 	if (!module.options.monitorPostsVisited.value) return false;
 	if (!module.options.monitorPostsVisitedIncognito.value && isPrivateBrowsing()) return false;
 
@@ -162,8 +156,8 @@ function saveCommentCount(commentID: string, newCommentCount, newEditedTime) {
 		editedTime: newEditedTime,
 	};
 
-	commentCounts[commentID] = Object.assign(commentCounts[commentID] || {}, patch);
-	commentCountStorage.patch({ [commentID]: patch });
+	commentCounts[id] = Object.assign(commentCounts[id] || {}, patch);
+	commentCountStorage.patch({ [id]: patch });
 }
 
 /**
@@ -172,8 +166,8 @@ function saveCommentCount(commentID: string, newCommentCount, newEditedTime) {
 function updateCommentCount() {
 	const listingThing = Thing.from(document.querySelector('#siteTable a.comments'));
 
-	if (currentCommentID && listingThing) {
-		saveCommentCount(currentCommentID, listingThing.getCommentCount(), listingThing.getPostEditTimestamp());
+	if (currentId && listingThing) {
+		saveCommentCount(currentId, listingThing.getCommentCount(), listingThing.getPostEditTimestamp());
 	}
 }
 
@@ -201,9 +195,9 @@ const _toggleButton = _.once(() =>
 );
 
 function handleToggleButton() {
-	if (!currentCommentID) return;
+	if (!currentId) return;
 	const $toggleButton = _toggleButton();
-	if (commentCounts[currentCommentID] && commentCounts[currentCommentID].subscriptionDate !== undefined) {
+	if (commentCounts[currentId] && commentCounts[currentId].subscriptionDate !== undefined) {
 		// Unsubscribe.
 		$toggleButton
 			.html('<span class="res-icon">&#xF038;</span> unsubscribe')
@@ -219,19 +213,19 @@ function handleToggleButton() {
 }
 
 function toggleSubscription() {
-	if (!currentCommentID) return;
-	if (typeof commentCounts[currentCommentID].subscriptionDate !== 'undefined') {
-		unsubscribeFromThread(currentCommentID);
+	if (!currentId) return;
+	if (typeof commentCounts[currentId].subscriptionDate !== 'undefined') {
+		unsubscribeFromThread(currentId);
 	} else {
-		subscribeToThread(currentCommentID);
+		subscribeToThread(currentId);
 	}
 	handleToggleButton();
 }
 
-function subscribeToThread(commentID) {
+function subscribeToThread(id) {
 	const now = Date.now();
-	commentCounts[commentID].subscriptionDate = now;
-	commentCountStorage.patch({ [commentID]: { subscriptionDate: now } });
+	commentCounts[id].subscriptionDate = now;
+	commentCountStorage.patch({ [id]: { subscriptionDate: now } });
 	Notifications.showNotification({
 		notificationID: 'newCommentCountSubscribe',
 		moduleID: 'newCommentCount',
@@ -246,9 +240,9 @@ function subscribeToThread(commentID) {
 	}, 5000);
 }
 
-function unsubscribeFromThread(commentID) {
-	delete commentCounts[commentID].subscriptionDate;
-	commentCountStorage.deletePath(commentID, 'subscriptionDate');
+function unsubscribeFromThread(id) {
+	delete commentCounts[id].subscriptionDate;
+	commentCountStorage.deletePath(id, 'subscriptionDate');
 	Notifications.showNotification({
 		notificationID: 'newCommentCountUnsubscribe',
 		moduleID: 'newCommentCount',
@@ -317,10 +311,10 @@ async function checkThread(id) {
 	}
 }
 
-function handleButton(threadid, action) {
+function handleButton(id, action) {
 	const $button = $('<span>', {
 		class: 'RESSubscriptionButton',
-		'data-threadid': threadid,
+		'data-id': id,
 	});
 
 	switch (action) {
@@ -357,7 +351,7 @@ function handleButton(threadid, action) {
 }
 
 function renewSubscriptionButton(e) {
-	const thisURL = $(e.currentTarget).attr('data-threadid');
+	const thisURL = $(e.currentTarget).attr('data-id');
 	renewSubscription(thisURL);
 	Notifications.showNotification({
 		notificationID: 'newCommentCountRenew',
@@ -367,44 +361,44 @@ function renewSubscriptionButton(e) {
 	});
 }
 
-function renewSubscription(threadid) {
+function renewSubscription(id) {
 	const now = Date.now();
-	commentCounts[threadid].subscriptionDate = now;
-	commentCountStorage.patch({ [threadid]: { subscriptionDate: now } });
+	commentCounts[id].subscriptionDate = now;
+	commentCountStorage.patch({ [id]: { subscriptionDate: now } });
 	drawSubscriptionsTable();
 }
 
 function unsubscribeButton(e) {
-	const thisURL = $(e.currentTarget).attr('data-threadid');
+	const thisURL = $(e.currentTarget).attr('data-id');
 	unsubscribe(thisURL);
 }
 
 function stopTracking(e) {
-	const threadId = $(e.currentTarget).attr('data-threadid');
+	const id = $(e.currentTarget).attr('data-id');
 	const $button = $(e.currentTarget);
-	Alert.open(`Are you sure you want to stop tracking new comments on post: "${commentCounts[threadId].title}"?`, { cancelable: true })
+	Alert.open(`Are you sure you want to stop tracking new comments on post: "${commentCounts[id].title}"?`, { cancelable: true })
 		.then(() => {
-			delete commentCounts[threadId];
-			commentCountStorage.deletePath(threadId);
+			delete commentCounts[id];
+			commentCountStorage.deletePath(id);
 			$button.closest('tr').remove();
 		});
 }
 
-function unsubscribe(threadid) {
-	delete commentCounts[threadid].subscriptionDate;
-	commentCountStorage.deletePath(threadid, 'subscriptionDate');
+function unsubscribe(id) {
+	delete commentCounts[id].subscriptionDate;
+	commentCountStorage.deletePath(id, 'subscriptionDate');
 	drawSubscriptionsTable();
 }
 
 function subscribeButton(e) {
-	const thisURL = $(e.currentTarget).attr('data-threadid');
+	const thisURL = $(e.currentTarget).attr('data-id');
 	subscribe(thisURL);
 }
 
-function subscribe(threadid) {
+function subscribe(id) {
 	const now = Date.now();
-	commentCounts[threadid].subscriptionDate = now;
-	commentCountStorage.patch({ [threadid]: { subscriptionDate: now } });
+	commentCounts[id].subscriptionDate = now;
+	commentCountStorage.patch({ [id]: { subscriptionDate: now } });
 	drawSubscriptionsTable();
 }
 
@@ -417,7 +411,7 @@ function addDashboardFunctionality() {
 		event.preventDefault();
 		let url = 't3_';
 		const $threads = $('#newCommentsTable tr td:last-of-type > span:first-of-type');
-		const ids = $threads.get().map(ele => ele.getAttribute('data-threadid'));
+		const ids = $threads.get().map(ele => ele.getAttribute('data-id'));
 		const concatIds = ids.join(',t3_');
 		url += concatIds;
 		location.href = `/by_id/${url}`;

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -440,8 +440,7 @@ async function drawSubscriptionsTable(sortMethod, descending) {
 	}
 	let rows = 0;
 	for (const { subscriptionDate, updateTime, id, url, title, subreddit } of thisCounts) {
-		const isSubscribed = typeof subscriptionDate !== 'undefined';
-		if (isSubscribed) {
+		if (subscriptionDate) {
 			const thisUpdateTime = new Date(updateTime);
 			const now = new Date();
 
@@ -452,16 +451,9 @@ async function drawSubscriptionsTable(sortMethod, descending) {
 			thisRenewPromise.then(drawSubscriptionsTable);
 			const { button: thisUnsubButton, promise: thisUnsubPromise } = createButton(id, 'unsubscribe');
 			thisUnsubPromise.then(drawSubscriptionsTable);
-			const { button: thisSubscribeButton, promise: thisSubscribePromise } = createButton(id, 'subscribe');
-			thisSubscribePromise.then(drawSubscriptionsTable);
 
-			let thisExpiresContent;
-			if (isSubscribed) {
-				const thisExpires = new Date(subscriptionDate + (DAY * parseInt(module.options.subscriptionLength.value, 10)));
-				thisExpiresContent = `<abbr title="${formatDateTime(thisExpires)}">${formatDateDiff(now, thisExpires)}</abbr>`;
-			} else {
-				thisExpiresContent = '';
-			}
+			const thisExpires = new Date(subscriptionDate + (DAY * parseInt(module.options.subscriptionLength.value, 10)));
+			const thisExpiresContent = `<abbr title="${formatDateTime(thisExpires)}">${formatDateDiff(now, thisExpires)}</abbr>`;
 
 			// populate table row.
 			const thisROW = `
@@ -473,14 +465,10 @@ async function drawSubscriptionsTable(sortMethod, descending) {
 
 			const $thisROW = $(thisROW);
 
-			$thisROW.find('td:last-of-type').append(thisTrashButton);
 			// add buttons.
-			if (isSubscribed) {
-				$thisROW.find('td:last-of-type').append(thisRenewButton).append(' ');
-				$thisROW.find('td:last-of-type').append(thisUnsubButton);
-			} else {
-				$thisROW.find('td:last-of-type').append(thisSubscribeButton);
-			}
+			$thisROW.find('td:last-of-type').append(thisTrashButton);
+			$thisROW.find('td:last-of-type').append(thisRenewButton).append(' ');
+			$thisROW.find('td:last-of-type').append(thisUnsubButton);
 
 			$('#newCommentsTable tbody').append($thisROW);
 			rows++;

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -76,7 +76,7 @@ module.options = {
 
 const currentId: ?string = (execRegexes.comments(location.pathname) || [])[2];
 const lastCleanStorage = Storage.wrap('RESmodules.newCommentCount.lastClean', (null: null | number));
-const commentCountStorage = Storage.wrapPrefix('commentCount.', (): {
+const entryStorage = Storage.wrapPrefix('newCommentCount.', (): {
 	subscriptionDate?: number,
 	count: number,
 	editedTime: number,
@@ -87,14 +87,14 @@ const commentCountStorage = Storage.wrapPrefix('commentCount.', (): {
 } => { throw new Error('Default value should never be retrieved'); });
 
 module.beforeLoad = () => {
-	createToggleSubscriptionButton();
+	updateToggleSubscriptionButton();
 
 	watchForThings(['post'], displayNewCommentCount);
 };
 
 module.go = () => {
 	if (isPageType('comments')) {
-		watchForThings(['comment'], updateCommentCountFromMyComment);
+		watchForThings(['comment'], updateCurrentCommentCountFromMyComment);
 		if (module.options.showSubscribeButton.value) {
 			getToggleSubscriptionButton().appendTo('.commentarea .panestack-title');
 		}
@@ -109,22 +109,37 @@ module.afterLoad = async () => {
 	// Clean counts every six hours
 	const lastClean = await lastCleanStorage.get() || 0;
 	if ((Date.now() - lastClean) > 0.25 * DAY) {
-		cleanOldCounts();
+		pruneOldEntries();
 	}
 
 	if (isPageType('comments')) {
-		updateCommentCount();
+		updateCurrentEntry();
 	}
 };
 
-export async function beenOpened(thing: Thing): Promise<boolean> {
-	return !!(await commentCountStorage.getNullable(thing.getFullname().split('_').slice(-1)[0]));
+function setEntry(id: string, newCommentCount, newEditedTime) {
+	if (!module.options.monitorPostsVisited.value) return false;
+	if (!module.options.monitorPostsVisitedIncognito.value && isPrivateBrowsing()) return false;
+
+	const patch = {
+		count: newCommentCount,
+		url: location.href.replace(location.hash, ''),
+		title: document.title,
+		updateTime: Date.now(),
+		editedTime: newEditedTime,
+	};
+
+	entryStorage.patch(id, patch);
+}
+
+export async function hasEntry(thing: Thing): Promise<boolean> {
+	return !!(await entryStorage.getNullable(thing.getFullname().split('_').slice(-1)[0]));
 }
 
 export async function getNewCount(thing: Thing): Promise<?number> {
 	const currentCount = thing.getCommentCount();
 
-	const countObj = await commentCountStorage.getNullable(thing.getFullname().split('_').slice(-1)[0]);
+	const countObj = await entryStorage.getNullable(thing.getFullname().split('_').slice(-1)[0]);
 	const lastOpenedCount = countObj && countObj.count;
 
 	if (typeof currentCount !== 'number' || typeof lastOpenedCount !== 'number') return;
@@ -142,49 +157,34 @@ async function displayNewCommentCount(thing) {
 		.append(`<span class="newComments">&nbsp;(${newCount} new)</span>`);
 }
 
-async function updateCommentCountFromMyComment(thing) {
+/**
+ * Handle updating page's comment counts
+ */
+function updateCurrentEntry() {
+	const listingThing = Thing.from(document.querySelector('#siteTable a.comments'));
+
+	if (currentId && listingThing) {
+		setEntry(currentId, listingThing.getCommentCount(), listingThing.getPostEditTimestamp());
+	}
+}
+
+async function updateCurrentCommentCountFromMyComment(thing) {
 	if (!currentId) return;
 
 	const timestamp = thing.getTimestamp();
 	const isRecent = timestamp && (Date.now() - timestamp.getTime()) < 10000;
 	const isMine = loggedInUser() === thing.getAuthor();
 	if (isRecent && isMine) {
-		const { count, editedTime } = await commentCountStorage.get(thing.getFullname().split('_').slice(-1)[0]);
-		saveCommentCount(currentId, count + 1, editedTime);
+		const { count, editedTime } = await entryStorage.get(currentId);
+		setEntry(currentId, count + 1, editedTime);
 	}
 }
 
-function saveCommentCount(id: string, newCommentCount, newEditedTime) {
-	if (!module.options.monitorPostsVisited.value) return false;
-	if (!module.options.monitorPostsVisitedIncognito.value && isPrivateBrowsing()) return false;
-
-	const patch = {
-		count: newCommentCount,
-		url: location.href.replace(location.hash, ''),
-		title: document.title,
-		updateTime: Date.now(),
-		editedTime: newEditedTime,
-	};
-
-	commentCountStorage.patch(id, patch);
-}
-
-/**
- * Handle updating page's comment counts
- */
-function updateCommentCount() {
-	const listingThing = Thing.from(document.querySelector('#siteTable a.comments'));
-
-	if (currentId && listingThing) {
-		saveCommentCount(currentId, listingThing.getCommentCount(), listingThing.getPostEditTimestamp());
-	}
-}
-
-async function cleanOldCounts() {
+async function pruneOldEntries() {
 	const now = Date.now();
 	lastCleanStorage.set(now);
 	const keepTrackPeriod = DAY * parseInt(module.options.cleanComments.value, 10);
-	for (const [id, data] of Object.entries(await commentCountStorage.getAll())) {
+	for (const [id, data] of Object.entries(await entryStorage.getAll())) {
 		// Do not automatically delete comments belonging to actively subscribed threads
 		if (data.subscriptionDate) {
 			continue;
@@ -198,15 +198,15 @@ const getToggleSubscriptionButton = _.once(() =>
 	$('<span>', {
 		id: 'REScommentSubToggle',
 		class: 'RESSubscriptionButton',
-		click: createToggleSubscriptionButton,
+		click: updateToggleSubscriptionButton,
 	})
 );
 
-const createToggleSubscriptionButton = mutex(async () => {
+const updateToggleSubscriptionButton = mutex(async () => {
 	if (!currentId) throw new Error('No currentId');
 
 	const $button = getToggleSubscriptionButton();
-	const data = await commentCountStorage.getNullable(currentId);
+	const data = await entryStorage.getNullable(currentId);
 	if (data && data.subscriptionDate) {
 		// Unsubscribe.
 		$button
@@ -247,19 +247,19 @@ const createToggleSubscriptionButton = mutex(async () => {
 
 function subscribe(id) {
 	const now = Date.now();
-	return commentCountStorage.patch(id, { subscriptionDate: now });
+	return entryStorage.patch(id, { subscriptionDate: now });
 }
 
 function unsubscribe(id) {
-	return commentCountStorage.deletePath(id, 'subscriptionDate');
+	return entryStorage.deletePath(id, 'subscriptionDate');
 }
 
 function stopTracking(id) {
-	return commentCountStorage.deletePath(id);
+	return entryStorage.deletePath(id);
 }
 
 async function checkSubscriptions() {
-	for (const [id, subscription] of Object.entries(await commentCountStorage.getAll())) {
+	for (const [id, subscription] of Object.entries(await entryStorage.getAll())) {
 		const { subscriptionDate } = subscription;
 		if (subscriptionDate) {
 			const lastCheck = parseInt(subscription.lastCheck, 10) || 0;
@@ -270,7 +270,7 @@ async function checkSubscriptions() {
 			}
 			// if we haven't checked this subscription in 5 minutes, try it again...
 			if ((now - lastCheck) > 300000) {
-				commentCountStorage.patch(id, { lastCheck: now });
+				entryStorage.patch(id, { lastCheck: now });
 				checkThread(id, subscription);
 			}
 		}
@@ -282,7 +282,7 @@ async function checkThread(id, subscription) {
 	const { count, editedTime, url, title } = subscription;
 
 	if (newCount > count) {
-		commentCountStorage.patch(id, { count: newCount });
+		entryStorage.patch(id, { count: newCount });
 
 		const notification = await Notifications.showNotification({
 			header: 'New comments',
@@ -298,7 +298,7 @@ async function checkThread(id, subscription) {
 		$(notification.element).find('.RESNotificationContent').append(button);
 	}
 	if (module.options.notifyEditedPosts.value && newEditedTime && newEditedTime > editedTime) {
-		commentCountStorage.patch(id, { editedTime: newEditedTime });
+		entryStorage.patch(id, { editedTime: newEditedTime });
 
 		const notification = await Notifications.showNotification({
 			header: 'Post edited',
@@ -349,7 +349,7 @@ function createButton(id, type) {
 				.attr('title', 'delete from list')
 				.addClass('deleteIcon');
 			action = async () => {
-				const { title } = await commentCountStorage.get(id);
+				const { title } = await entryStorage.get(id);
 				return Alert.open(`Are you sure you want to stop tracking new comments on post: "${title}"?`, { cancelable: true })
 					.then(() => stopTracking(id));
 			};
@@ -406,7 +406,7 @@ async function drawSubscriptionsTable(sortMethod, descending) {
 	currentSortMethod = sortMethod || currentSortMethod;
 	isDescending = (descending === undefined) ? isDescending : !!descending;
 	$('#newCommentsTable tbody').html('');
-	const thisCounts = filterMap(Object.entries(await commentCountStorage.getAll()), ([id, commentCount]) => {
+	const thisCounts = filterMap(Object.entries(await entryStorage.getAll()), ([id, commentCount]) => {
 		const match = new URL(commentCount.url).pathname.match(regexes.subreddit);
 		if (match) {
 			return [{

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -117,6 +117,10 @@ module.afterLoad = async () => {
 	}
 };
 
+export async function beenOpened(thing: Thing): Promise<boolean> {
+	return !!(await commentCountStorage.getNullable(thing.getFullname().split('_').slice(-1)[0]));
+}
+
 export async function getNewCount(thing: Thing): Promise<?number> {
 	const currentCount = thing.getCommentCount();
 

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -98,43 +98,7 @@ module.go = () => {
 			handleToggleButton();
 		}
 	} else if (isCurrentSubreddit('dashboard')) {
-		// If we're on the dashboard, add a tab to it...
-		// add tab to dashboard
-		const $tabPage = Dashboard.addTab('newCommentsContents', 'My Subscriptions', module.moduleID);
-		// populate the contents of the tab
-		const $openOnReddit = $('<a href="#" id="openOnReddit">as reddit link listing</a>');
-		$openOnReddit.click(event => {
-			event.preventDefault();
-			let url = 't3_';
-			const $threads = $('#newCommentsTable tr td:last-of-type > span:first-of-type');
-			const ids = $threads.get().map(ele => ele.getAttribute('data-threadid'));
-			const concatIds = ids.join(',t3_');
-			url += concatIds;
-			location.href = `/by_id/${url}`;
-		});
-		$tabPage.append($openOnReddit);
-		const $thisTable = $('<table id="newCommentsTable" />');
-		$thisTable.append('<thead><tr><th sort="" class="active">Submission</th><th sort="subreddit">Subreddit</th><th sort="updateTime">Last viewed</th><th sort="subscriptionDate">Expires in</th><th class="actions">Actions</th></tr></thead><tbody></tbody>');
-		$tabPage.append($thisTable);
-		$('#newCommentsTable thead th').click(function(e) {
-			e.preventDefault();
-			if ($(this).hasClass('actions')) {
-				return false;
-			}
-			if ($(this).hasClass('active')) {
-				$(this).toggleClass('descending');
-			}
-			$(this).addClass('active');
-			$(this).siblings().removeClass('active').find('SPAN').remove();
-			$(this).find('.sortAsc, .sortDesc').remove();
-			if ($(e.target).hasClass('descending')) {
-				$(this).append('<span class="sortDesc" />');
-			} else {
-				$(this).append('<span class="sortAsc" />');
-			}
-			drawSubscriptionsTable($(e.target).attr('sort'), $(e.target).hasClass('descending'));
-		});
-		drawSubscriptionsTable();
+		addDashboardFunctionality();
 	}
 	checkSubscriptions();
 };
@@ -150,152 +114,6 @@ module.afterLoad = async () => {
 		updateCommentCount();
 	}
 };
-
-let currentSortMethod, isDescending;
-
-function drawSubscriptionsTable(sortMethod, descending) {
-	currentSortMethod = sortMethod || currentSortMethod;
-	isDescending = (descending === undefined) ? isDescending : !!descending;
-	const thisCounts = filterMap(Object.entries(commentCounts), ([id, commentCount]) => {
-		const match = new URL(commentCount.url).pathname.match(regexes.subreddit);
-		if (match) {
-			return [{
-				id,
-				subreddit: match[1].toLowerCase(),
-				...commentCount,
-			}];
-		}
-	});
-	$('#newCommentsTable tbody').html('');
-	switch (currentSortMethod) {
-		case 'subscriptionDate':
-			thisCounts.sort((a, b) =>
-				(a.subscriptionDate > b.subscriptionDate) ? 1 : (b.subscriptionDate > a.subscriptionDate) ? -1 : 0
-			);
-			if (isDescending) thisCounts.reverse();
-			break;
-		case 'updateTime':
-			thisCounts.sort((a, b) =>
-				(a.updateTime > b.updateTime) ? 1 : (b.updateTime > a.updateTime) ? -1 : 0
-			);
-			if (isDescending) thisCounts.reverse();
-			break;
-		case 'subreddit':
-			thisCounts.sort((a, b) =>
-				(a.subreddit > b.subreddit) ? 1 : (b.subreddit > a.subreddit) ? -1 : 0
-			);
-			if (isDescending) thisCounts.reverse();
-			break;
-		default:
-			thisCounts.sort((a, b) =>
-				(a.title > b.title) ? 1 : (b.title > a.title) ? -1 : 0
-			);
-			if (isDescending) thisCounts.reverse();
-			break;
-	}
-	let rows = 0;
-	for (const { subscriptionDate, updateTime, id, url, title, subreddit } of thisCounts) {
-		const isSubscribed = typeof subscriptionDate !== 'undefined';
-		if (isSubscribed) {
-			const thisUpdateTime = new Date(updateTime);
-			const now = new Date();
-
-			// set up buttons.
-			const thisTrash = handleButton(id, 'delete');
-			const thisRenewButton = handleButton(id, 'renew');
-			const thisUnsubButton = handleButton(id, 'unsubscribe');
-			const thisSubscribeButton = handleButton(id, 'subscribe');
-
-			let thisExpiresContent;
-			if (isSubscribed) {
-				const thisExpires = new Date(subscriptionDate + (DAY * parseInt(module.options.subscriptionLength.value, 10)));
-				thisExpiresContent = `<abbr title="${formatDateTime(thisExpires)}">${formatDateDiff(now, thisExpires)}</abbr>`;
-			} else {
-				thisExpiresContent = '';
-			}
-
-			// populate table row.
-			const thisROW = `
-				<tr><td><a href="${url}">${escapeHTML(title)}</a></td>
-				<td><a href="/r/${subreddit}">/r/${subreddit}</a></td>
-				<td><abbr title="${formatDateTime(thisUpdateTime)}">${formatDateDiff(thisUpdateTime)} ago</abbr></td>
-				<td>${thisExpiresContent}</td><td></td></tr>
-			`;
-
-			const $thisROW = $(thisROW);
-
-			// add buttons.
-			$thisROW.find('td:first-of-type').append(thisTrash);
-			if (isSubscribed) {
-				$thisROW.find('td:last-of-type').append(thisRenewButton).append(' ');
-				$thisROW.find('td:last-of-type').append(thisUnsubButton);
-			} else {
-				$thisROW.find('td:last-of-type').append(thisSubscribeButton);
-			}
-
-			$('#newCommentsTable tbody').append($thisROW);
-			rows++;
-		}
-	}
-	if (rows === 0) {
-		$('#newCommentsTable tbody').append('<td colspan="5">You are currently not subscribed to any threads. To subscribe to a thread, click the "subscribe" button found near the top of the comments page.</td>');
-		$('#openOnReddit').hide();
-	} else {
-		$('#openOnReddit').show();
-	}
-}
-
-function renewSubscriptionButton(e) {
-	const thisURL = $(e.currentTarget).attr('data-threadid');
-	renewSubscription(thisURL);
-	Notifications.showNotification({
-		notificationID: 'newCommentCountRenew',
-		moduleID: 'newCommentCount',
-		optionKey: 'subscriptionLength',
-		message: `Subscription renewed for ${module.options.subscriptionLength.value} days.`,
-	});
-}
-
-function renewSubscription(threadid) {
-	const now = Date.now();
-	commentCounts[threadid].subscriptionDate = now;
-	commentCountStorage.patch({ [threadid]: { subscriptionDate: now } });
-	drawSubscriptionsTable();
-}
-
-function unsubscribeButton(e) {
-	const thisURL = $(e.currentTarget).attr('data-threadid');
-	unsubscribe(thisURL);
-}
-
-function stopTracking(e) {
-	const threadId = $(e.currentTarget).attr('data-threadid');
-	const $button = $(e.currentTarget);
-	Alert.open(`Are you sure you want to stop tracking new comments on post: "${commentCounts[threadId].title}"?`, { cancelable: true })
-		.then(() => {
-			delete commentCounts[threadId];
-			commentCountStorage.deletePath(threadId);
-			$button.closest('tr').remove();
-		});
-}
-
-function unsubscribe(threadid) {
-	delete commentCounts[threadid].subscriptionDate;
-	commentCountStorage.deletePath(threadid, 'subscriptionDate');
-	drawSubscriptionsTable();
-}
-
-function subscribeButton(e) {
-	const thisURL = $(e.currentTarget).attr('data-threadid');
-	subscribe(thisURL);
-}
-
-function subscribe(threadid) {
-	const now = Date.now();
-	commentCounts[threadid].subscriptionDate = now;
-	commentCountStorage.patch({ [threadid]: { subscriptionDate: now } });
-	drawSubscriptionsTable();
-}
 
 function displayNewCommentCount(thing) {
 	const currentCount = thing.getCommentCount();
@@ -372,45 +190,6 @@ function cleanOldCounts() {
 			commentCountStorage.deletePath(i);
 		}
 	}
-}
-
-function handleButton(threadid, action) {
-	const $button = $('<span>', {
-		class: 'RESSubscriptionButton',
-		'data-threadid': threadid,
-	});
-
-	switch (action) {
-		case 'unsubscribe':
-			$button
-				.html('<span class="res-icon">&#xF038;</span> unsubscribe')
-				.attr('title', 'stop receiving notifications')
-				.addClass('unsubscribe')
-				.click(unsubscribeButton);
-			break;
-		case 'subscribe':
-			$button
-				.html('<span class="res-icon">&#xF03B;</span> subscribe')
-				.attr('title', 'notify me of new comments')
-				.click(subscribeButton);
-			break;
-		case 'renew':
-			$button
-				.html('<span class="res-icon">&#xF03B;</span> renew')
-				.attr('title', `renew for ${module.options.subscriptionLength.value} days`)
-				.click(renewSubscriptionButton);
-			break;
-		case 'delete':
-			$button
-				.html('<span class="res-icon">&#xF155;</span>')
-				.attr('title', 'delete from list')
-				.addClass('deleteIcon')
-				.click(stopTracking);
-			break;
-		default:
-			break;
-	}
-	return $button.get(0);
 }
 
 const _toggleButton = _.once(() =>
@@ -535,5 +314,229 @@ async function checkThread(id) {
 		const unsubscribeButton = handleButton(id, 'unsubscribe');
 		unsubscribeButton.addEventListener('click', notification.close);
 		$(notification.element).find('.RESNotificationContent').append(unsubscribeButton);
+	}
+}
+
+function handleButton(threadid, action) {
+	const $button = $('<span>', {
+		class: 'RESSubscriptionButton',
+		'data-threadid': threadid,
+	});
+
+	switch (action) {
+		case 'unsubscribe':
+			$button
+				.html('<span class="res-icon">&#xF038;</span> unsubscribe')
+				.attr('title', 'stop receiving notifications')
+				.addClass('unsubscribe')
+				.click(unsubscribeButton);
+			break;
+		case 'subscribe':
+			$button
+				.html('<span class="res-icon">&#xF03B;</span> subscribe')
+				.attr('title', 'notify me of new comments')
+				.click(subscribeButton);
+			break;
+		case 'renew':
+			$button
+				.html('<span class="res-icon">&#xF03B;</span> renew')
+				.attr('title', `renew for ${module.options.subscriptionLength.value} days`)
+				.click(renewSubscriptionButton);
+			break;
+		case 'delete':
+			$button
+				.html('<span class="res-icon">&#xF155;</span>')
+				.attr('title', 'delete from list')
+				.addClass('deleteIcon')
+				.click(stopTracking);
+			break;
+		default:
+			break;
+	}
+	return $button.get(0);
+}
+
+function renewSubscriptionButton(e) {
+	const thisURL = $(e.currentTarget).attr('data-threadid');
+	renewSubscription(thisURL);
+	Notifications.showNotification({
+		notificationID: 'newCommentCountRenew',
+		moduleID: 'newCommentCount',
+		optionKey: 'subscriptionLength',
+		message: `Subscription renewed for ${module.options.subscriptionLength.value} days.`,
+	});
+}
+
+function renewSubscription(threadid) {
+	const now = Date.now();
+	commentCounts[threadid].subscriptionDate = now;
+	commentCountStorage.patch({ [threadid]: { subscriptionDate: now } });
+	drawSubscriptionsTable();
+}
+
+function unsubscribeButton(e) {
+	const thisURL = $(e.currentTarget).attr('data-threadid');
+	unsubscribe(thisURL);
+}
+
+function stopTracking(e) {
+	const threadId = $(e.currentTarget).attr('data-threadid');
+	const $button = $(e.currentTarget);
+	Alert.open(`Are you sure you want to stop tracking new comments on post: "${commentCounts[threadId].title}"?`, { cancelable: true })
+		.then(() => {
+			delete commentCounts[threadId];
+			commentCountStorage.deletePath(threadId);
+			$button.closest('tr').remove();
+		});
+}
+
+function unsubscribe(threadid) {
+	delete commentCounts[threadid].subscriptionDate;
+	commentCountStorage.deletePath(threadid, 'subscriptionDate');
+	drawSubscriptionsTable();
+}
+
+function subscribeButton(e) {
+	const thisURL = $(e.currentTarget).attr('data-threadid');
+	subscribe(thisURL);
+}
+
+function subscribe(threadid) {
+	const now = Date.now();
+	commentCounts[threadid].subscriptionDate = now;
+	commentCountStorage.patch({ [threadid]: { subscriptionDate: now } });
+	drawSubscriptionsTable();
+}
+
+function addDashboardFunctionality() {
+	// add tab to dashboard
+	const $tabPage = Dashboard.addTab('newCommentsContents', 'My Subscriptions', module.moduleID);
+	// populate the contents of the tab
+	const $openOnReddit = $('<a href="#" id="openOnReddit">as reddit link listing</a>');
+	$openOnReddit.click(event => {
+		event.preventDefault();
+		let url = 't3_';
+		const $threads = $('#newCommentsTable tr td:last-of-type > span:first-of-type');
+		const ids = $threads.get().map(ele => ele.getAttribute('data-threadid'));
+		const concatIds = ids.join(',t3_');
+		url += concatIds;
+		location.href = `/by_id/${url}`;
+	});
+	$tabPage.append($openOnReddit);
+	const $thisTable = $('<table id="newCommentsTable" />');
+	$thisTable.append('<thead><tr><th sort="" class="active">Submission</th><th sort="subreddit">Subreddit</th><th sort="updateTime">Last viewed</th><th sort="subscriptionDate">Expires in</th><th class="actions">Actions</th></tr></thead><tbody></tbody>');
+	$tabPage.append($thisTable);
+	$('#newCommentsTable thead th').click(function(e) {
+		e.preventDefault();
+		if ($(this).hasClass('actions')) {
+			return false;
+		}
+		if ($(this).hasClass('active')) {
+			$(this).toggleClass('descending');
+		}
+		$(this).addClass('active');
+		$(this).siblings().removeClass('active').find('SPAN').remove();
+		$(this).find('.sortAsc, .sortDesc').remove();
+		if ($(e.target).hasClass('descending')) {
+			$(this).append('<span class="sortDesc" />');
+		} else {
+			$(this).append('<span class="sortAsc" />');
+		}
+		drawSubscriptionsTable($(e.target).attr('sort'), $(e.target).hasClass('descending'));
+	});
+	drawSubscriptionsTable();
+}
+
+let currentSortMethod, isDescending;
+
+function drawSubscriptionsTable(sortMethod, descending) {
+	currentSortMethod = sortMethod || currentSortMethod;
+	isDescending = (descending === undefined) ? isDescending : !!descending;
+	const thisCounts = filterMap(Object.entries(commentCounts), ([id, commentCount]) => {
+		const match = new URL(commentCount.url).pathname.match(regexes.subreddit);
+		if (match) {
+			return [{
+				id,
+				subreddit: match[1].toLowerCase(),
+				...commentCount,
+			}];
+		}
+	});
+	$('#newCommentsTable tbody').html('');
+	switch (currentSortMethod) {
+		case 'subscriptionDate':
+			thisCounts.sort((a, b) =>
+				(a.subscriptionDate > b.subscriptionDate) ? 1 : (b.subscriptionDate > a.subscriptionDate) ? -1 : 0
+			);
+			if (isDescending) thisCounts.reverse();
+			break;
+		case 'updateTime':
+			thisCounts.sort((a, b) =>
+				(a.updateTime > b.updateTime) ? 1 : (b.updateTime > a.updateTime) ? -1 : 0
+			);
+			if (isDescending) thisCounts.reverse();
+			break;
+		case 'subreddit':
+			thisCounts.sort((a, b) =>
+				(a.subreddit > b.subreddit) ? 1 : (b.subreddit > a.subreddit) ? -1 : 0
+			);
+			if (isDescending) thisCounts.reverse();
+			break;
+		default:
+			thisCounts.sort((a, b) =>
+				(a.title > b.title) ? 1 : (b.title > a.title) ? -1 : 0
+			);
+			if (isDescending) thisCounts.reverse();
+			break;
+	}
+	let rows = 0;
+	for (const { subscriptionDate, updateTime, id, url, title, subreddit } of thisCounts) {
+		const isSubscribed = typeof subscriptionDate !== 'undefined';
+		if (isSubscribed) {
+			const thisUpdateTime = new Date(updateTime);
+			const now = new Date();
+
+			// set up buttons.
+			const thisTrash = handleButton(id, 'delete');
+			const thisRenewButton = handleButton(id, 'renew');
+			const thisUnsubButton = handleButton(id, 'unsubscribe');
+			const thisSubscribeButton = handleButton(id, 'subscribe');
+
+			let thisExpiresContent;
+			if (isSubscribed) {
+				const thisExpires = new Date(subscriptionDate + (DAY * parseInt(module.options.subscriptionLength.value, 10)));
+				thisExpiresContent = `<abbr title="${formatDateTime(thisExpires)}">${formatDateDiff(now, thisExpires)}</abbr>`;
+			} else {
+				thisExpiresContent = '';
+			}
+
+			// populate table row.
+			const thisROW = `
+				<tr><td><a href="${url}">${escapeHTML(title)}</a></td>
+				<td><a href="/r/${subreddit}">/r/${subreddit}</a></td>
+				<td><abbr title="${formatDateTime(thisUpdateTime)}">${formatDateDiff(thisUpdateTime)} ago</abbr></td>
+				<td>${thisExpiresContent}</td><td></td></tr>
+			`;
+
+			const $thisROW = $(thisROW);
+
+			// add buttons.
+			$thisROW.find('td:first-of-type').append(thisTrash);
+			if (isSubscribed) {
+				$thisROW.find('td:last-of-type').append(thisRenewButton).append(' ');
+				$thisROW.find('td:last-of-type').append(thisUnsubButton);
+			} else {
+				$thisROW.find('td:last-of-type').append(thisSubscribeButton);
+			}
+
+			$('#newCommentsTable tbody').append($thisROW);
+			rows++;
+		}
+	}
+	if (rows === 0) {
+		$('#newCommentsTable tbody').append('<td colspan="5">You are currently not subscribed to any threads. To subscribe to a thread, click the "subscribe" button found near the top of the comments page.</td>');
+		$('#openOnReddit').hide();
+	} else {
+		$('#openOnReddit').show();
 	}
 }

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -88,14 +88,16 @@ let commentCounts = {};
 module.beforeLoad = async () => {
 	commentCounts = await commentCountStorage.get();
 
+	handleToggleButton(); // Initialize subscription button
+
 	watchForThings(['post'], displayNewCommentCount);
 };
 
 module.go = () => {
 	if (isPageType('comments')) {
 		watchForThings(['comment'], updateCommentCountFromMyComment);
-		if (module.options.showSubscribeButton.value && document.querySelector('.commentarea .panestack-title')) {
-			handleToggleButton();
+		if (module.options.showSubscribeButton.value) {
+			getToggleButton().appendTo('.commentarea .panestack-title');
 		}
 	} else if (isCurrentSubreddit('dashboard')) {
 		addDashboardFunctionality();
@@ -186,17 +188,17 @@ function cleanOldCounts() {
 	}
 }
 
-const _toggleButton = _.once(() =>
+const getToggleButton = _.once(() =>
 	$('<span>', {
 		id: 'REScommentSubToggle',
 		class: 'RESSubscriptionButton',
 		click: toggleSubscription,
-	}).appendTo('.commentarea .panestack-title')
+	})
 );
 
 function handleToggleButton() {
 	if (!currentId) return;
-	const $toggleButton = _toggleButton();
+	const $toggleButton = getToggleButton();
 	if (commentCounts[currentId] && commentCounts[currentId].subscriptionDate !== undefined) {
 		// Unsubscribe.
 		$toggleButton


### PR DESCRIPTION
This should prevent that one instance overwrites another, as sometimes can be seen by `updateCommentCountFromMyComment` sometimes being ineffective.