### PR TITLE
Emulate auth flow in Chrome to fix logout after browser restart

### DIFF
--- a/browser/utils/auth.js
+++ b/browser/utils/auth.js
@@ -3,50 +3,85 @@
 
 import { apiToPromise } from './api';
 
-export async function emulateAuthFlow({
-	domain,
-	clientId,
-	scope,
-	interactive,
-	currentTabIndex,
-}: {|
-	domain: string,
-	clientId: string,
-	scope: string,
-	interactive: boolean,
-	currentTabIndex: number,
-|}) {
-	const redirectUri = 'https://redditenhancementsuite.com/oauth';
-	const url = new URL(domain);
-	url.searchParams.set('client_id', clientId);
-	url.searchParams.set('scope', scope);
-	url.searchParams.set('response_type', 'token');
-	url.searchParams.set('redirect_uri', redirectUri);
-
-	let id;
-	if (interactive) {
-		({ tabs: [{ id }] } = await apiToPromise(chrome.windows.create)({
-			url: url.href,
-			type: 'popup',
-		}));
-	} else {
-		({ id } = await apiToPromise(chrome.tabs.create)({
-			url: url.href,
-			index: currentTabIndex + 1,
-			active: false,
-		}));
-	}
+export async function emulateAuthFlowInNewWindow(url: string, redirectUri: string): Promise<string> {
+	// Emulate interactive auth.
+	// Open a popup window, then track its progress with chrome.tabs,
+	// succeeding if it navigates to our redirect URL, and failing if it's
+	// closed before then.
+	const { tabs: [{ id }] } = await apiToPromise(chrome.windows.create)({ url, type: 'popup' });
 
 	return new Promise((resolve, reject) => {
 		function updateListener(tabId, updates) {
 			if (tabId !== id) return;
 
 			if (updates.url && updates.url.startsWith(redirectUri)) {
-				// we've reached the redirect URL
 				stopListening();
 				resolve(updates.url);
 				apiToPromise(chrome.tabs.remove)(id);
-			} else if (!interactive && updates.status && updates.status === 'complete') {
+			}
+		}
+
+		function removeListener(tabId) {
+			if (tabId !== id) return;
+			stopListening();
+			reject(new Error('User cancelled or denied access.'));
+		}
+
+		function stopListening() {
+			chrome.tabs.onUpdated.removeListener(updateListener);
+			chrome.tabs.onRemoved.removeListener(removeListener);
+		}
+
+		chrome.tabs.onUpdated.addListener(updateListener);
+		chrome.tabs.onRemoved.addListener(removeListener);
+	});
+}
+
+export function emulateAuthFlowInBackground(url: string): Promise<string> {
+	// Emulate noninteractive auth.
+	// Fetch the auth page. If the user is preauthorized, we will 302
+	// to the redirect URL. However, because the token is passed in the hash,
+	// and fetch/XHR responses don't include the hash, we must use the
+	// webRequest API to read the redirect URL.
+	return new Promise((resolve, reject) => {
+		function headersListener({ redirectUrl }) {
+			stopListening();
+			resolve(redirectUrl);
+		}
+
+		function stopListening() {
+			chrome.webRequest.onBeforeRedirect.removeListener(headersListener);
+		}
+
+		chrome.webRequest.onBeforeRedirect.addListener(headersListener, { urls: [url] });
+
+		fetch(url, { credentials: 'include' })
+			.then(() => {
+				stopListening();
+				reject(new Error('User interaction is required.'));
+			}, e => {
+				stopListening();
+				reject(new Error(`Authorization page could not be loaded: ${e.message}`));
+				console.error(e);
+			});
+	});
+}
+
+export async function emulateAuthFlowInNewTab(url: string, redirectUri: string, currentTabIndex: number): Promise<string> {
+	// Emulate noninteractive auth.
+	// Open a background tab and track its progress with chrome.tabs,
+	// succeeding if it navigates to the redirect URL immediately.
+	const { id } = await apiToPromise(chrome.tabs.create)({ url, index: currentTabIndex + 1, active: false });
+
+	return new Promise((resolve, reject) => {
+		function updateListener(tabId, updates) {
+			if (tabId !== id) return;
+
+			if (updates.url && updates.url.startsWith(redirectUri)) {
+				stopListening();
+				resolve(updates.url);
+				apiToPromise(chrome.tabs.remove)(id);
+			} else if (updates.status && updates.status === 'complete') {
 				// the page has loaded but we haven't redirected
 				stopListening();
 				reject(new Error('User interaction is required.'));
@@ -56,7 +91,6 @@ export async function emulateAuthFlow({
 
 		function removeListener(tabId) {
 			if (tabId !== id) return;
-			// tab closed
 			stopListening();
 			reject(new Error('User cancelled or denied access.'));
 		}

--- a/chrome/beta/manifest.json
+++ b/chrome/beta/manifest.json
@@ -47,6 +47,7 @@
 		"history",
 		"storage",
 		"unlimitedStorage",
+		"webRequest",
 
 		"http://redditenhancementsuite.com/",
 		"http://reddit.com/*",
@@ -55,6 +56,7 @@
 		"https://*.reddit.com/*"
 	],
 	"optional_permissions": [
+		"https://redditenhancementsuite.com/oauth",
 		"https://api.twitter.com/*",
 		"https://onedrive.live.com/*",
 		"https://1drv.ms/*",
@@ -64,6 +66,9 @@
 		"https://api.tumblr.com/v2/blog/*/posts",
 		"https://xkcd.com/*/info.0.json",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
-		"https://content.googleapis.com/drive/v3/*"
+		"https://accounts.google.com/o/oauth2/v2/auth",
+		"https://content.googleapis.com/drive/v3/*",
+		"https://www.dropbox.com/oauth2/authorize",
+		"https://login.live.com/oauth20_authorize.srf"
 	]
 }

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -47,6 +47,7 @@
 		"history",
 		"storage",
 		"unlimitedStorage",
+		"webRequest",
 
 		"http://redditenhancementsuite.com/",
 		"http://reddit.com/*",
@@ -55,6 +56,7 @@
 		"https://*.reddit.com/*"
 	],
 	"optional_permissions": [
+		"https://redditenhancementsuite.com/oauth",
 		"https://api.twitter.com/*",
 		"https://onedrive.live.com/*",
 		"https://1drv.ms/*",
@@ -64,6 +66,9 @@
 		"https://api.tumblr.com/v2/blog/*/posts",
 		"https://xkcd.com/*/info.0.json",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
-		"https://content.googleapis.com/drive/v3/*"
+		"https://accounts.google.com/o/oauth2/v2/auth",
+		"https://content.googleapis.com/drive/v3/*",
+		"https://www.dropbox.com/oauth2/authorize",
+		"https://login.live.com/oauth20_authorize.srf"
 	]
 }

--- a/edge/background.entry.js
+++ b/edge/background.entry.js
@@ -3,15 +3,29 @@
 /* eslint-env webextensions */
 
 import { addListener } from '../browser/background';
-import { emulateAuthFlow } from '../browser/utils/auth';
+import { emulateAuthFlowInNewWindow, emulateAuthFlowInNewTab } from '../browser/utils/auth';
 
 // Edge doesn't have history.*
 addListener('addURLToHistory', () => {});
 addListener('isURLVisited', () => false);
 
-addListener('authFlow', ({ domain, clientId, scope, interactive }, { index }) =>
-	emulateAuthFlow({ domain, clientId, scope, interactive, currentTabIndex: index })
-);
+addListener('authFlow', ({ domain, clientId, scope, interactive }, { index: currentIndex }) => {
+	// Edge does not support chrome.identity.launchAuthFlow.
+	// Its chrome.webRequest API does not support requests made by extensions,
+	// so we can't emulate noninteractive auth without a new tab.
+	const redirectUri = 'https://redditenhancementsuite.com/oauth';
+	const url = new URL(domain);
+	url.searchParams.set('client_id', clientId);
+	url.searchParams.set('scope', scope);
+	url.searchParams.set('response_type', 'token');
+	url.searchParams.set('redirect_uri', redirectUri);
+
+	if (interactive) {
+		return emulateAuthFlowInNewWindow(url.href, redirectUri);
+	} else {
+		return emulateAuthFlowInNewTab(url.href, redirectUri, currentIndex);
+	}
+});
 
 // see chrome/background.entry.js
 addListener('download', ({ url, filename }) => {

--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -51,6 +51,7 @@
 		"http://*.reddit.com/*",
 		"https://*.reddit.com/*",
 
+		"https://redditenhancementsuite.com/oauth",
 		"https://api.twitter.com/*",
 		"https://onedrive.live.com/*",
 		"https://1drv.ms/*",
@@ -60,7 +61,10 @@
 		"https://api.tumblr.com/v2/blog/*/posts",
 		"https://xkcd.com/*/info.0.json",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
+		"https://accounts.google.com/o/oauth2/v2/auth",
 		"https://content.googleapis.com/drive/v3/*",
+		"https://www.dropbox.com/oauth2/authorize",
+		"https://login.live.com/oauth20_authorize.srf",
 
 		"https://api.photobucket.com/v2/media/fromurl",
 		"https://api.onedrive.com/*",

--- a/firefox/beta/manifest.json
+++ b/firefox/beta/manifest.json
@@ -59,6 +59,7 @@
 		"http://*.reddit.com/*",
 		"https://*.reddit.com/*",
 
+		"https://redditenhancementsuite.com/oauth",
 		"https://api.twitter.com/*",
 		"https://onedrive.live.com/*",
 		"https://1drv.ms/*",
@@ -68,6 +69,9 @@
 		"https://api.tumblr.com/v2/blog/*/posts",
 		"https://xkcd.com/*/info.0.json",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
-		"https://content.googleapis.com/drive/v3/*"
+		"https://accounts.google.com/o/oauth2/v2/auth",
+		"https://content.googleapis.com/drive/v3/*",
+		"https://www.dropbox.com/oauth2/authorize",
+		"https://login.live.com/oauth20_authorize.srf"
 	]
 }

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -59,6 +59,7 @@
 		"http://*.reddit.com/*",
 		"https://*.reddit.com/*",
 
+		"https://redditenhancementsuite.com/oauth",
 		"https://api.twitter.com/*",
 		"https://onedrive.live.com/*",
 		"https://1drv.ms/*",
@@ -68,6 +69,9 @@
 		"https://api.tumblr.com/v2/blog/*/posts",
 		"https://xkcd.com/*/info.0.json",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
-		"https://content.googleapis.com/drive/v3/*"
+		"https://accounts.google.com/o/oauth2/v2/auth",
+		"https://content.googleapis.com/drive/v3/*",
+		"https://www.dropbox.com/oauth2/authorize",
+		"https://login.live.com/oauth20_authorize.srf"
 	]
 }

--- a/lib/environment/auth.js
+++ b/lib/environment/auth.js
@@ -1,23 +1,23 @@
 /* @flow */
 
 import { sendMessage } from '../../browser';
+import { Permissions } from './';
 
 export async function launchAuthFlow(
-	{ domain, clientId, scope = '', allowChromiumRedirect = true }: {| domain: string, clientId: string, scope?: string, allowChromiumRedirect?: boolean |},
-	warnUserInteraction: (message: string) => Promise<void>,
+	{ domain, clientId, scope = '' }: {| domain: string, clientId: string, scope?: string |},
+	warnUserInteraction: () => Promise<void>,
 ): Promise<string> {
 	let responseUrl;
 	try {
-		responseUrl = await sendMessage('authFlow', { domain, clientId, scope, allowChromiumRedirect, interactive: false });
+		responseUrl = await sendMessage('authFlow', { domain, clientId, scope, interactive: false });
 	} catch (e) {
 		console.error('Noninteractive auth failed:', e);
 
-		await warnUserInteraction(`You may be redirected to ${(allowChromiumRedirect && process.env.BUILD_TARGET === 'chrome') ?
-			'chromiumapp.org (Google\'s special domain for Chrome extensions)' :
-			'redditenhancementsuite.com'
-		} to complete the login process.`);
+		await warnUserInteraction();
 
-		responseUrl = await sendMessage('authFlow', { domain, clientId, scope, allowChromiumRedirect, interactive: true });
+		await Permissions.request(['https://redditenhancementsuite.com/oauth']);
+
+		responseUrl = await sendMessage('authFlow', { domain, clientId, scope, interactive: true });
 	}
 
 	const hash = new URL(responseUrl).hash.slice(1);

--- a/lib/modules/backupAndRestore/providers/Dropbox.js
+++ b/lib/modules/backupAndRestore/providers/Dropbox.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { ajax, launchAuthFlow } from '../../../environment';
+import { ajax, launchAuthFlow, Permissions } from '../../../environment';
 import { Alert } from '../../../utils';
 import Provider from './Provider';
 
@@ -14,13 +14,12 @@ export default class Dropbox extends Provider {
 	accessToken: string;
 
 	async init(): Promise<this> {
+		await Permissions.request(['https://www.dropbox.com/oauth2/authorize']);
+
 		this.accessToken = await launchAuthFlow({
 			domain: 'https://www.dropbox.com/oauth2/authorize',
 			clientId: 'tdevom9o5xn0hnt',
-		}, message => Alert.open(`
-			<p>RES needs your permission to connect to Dropbox.</p>
-			<p><b>${message}</b></p>
-		`, { cancelable: true }));
+		}, () => Alert.open('RES needs your permission to connect to Dropbox.', { cancelable: true }));
 
 		return this;
 	}

--- a/lib/modules/backupAndRestore/providers/GoogleDrive.js
+++ b/lib/modules/backupAndRestore/providers/GoogleDrive.js
@@ -15,16 +15,13 @@ export default class GoogleDrive extends Provider {
 	accessToken: string;
 
 	async init(): Promise<this> {
-		await Permissions.request(['https://content.googleapis.com/drive/v3/*']);
+		await Permissions.request(['https://accounts.google.com/o/oauth2/v2/auth', 'https://content.googleapis.com/drive/v3/*']);
 
 		this.accessToken = await launchAuthFlow({
 			domain: 'https://accounts.google.com/o/oauth2/v2/auth',
 			clientId: '568759524377-nv0o2u4afuuulkfcjd7f6guf27qkevpt.apps.googleusercontent.com',
 			scope: 'https://www.googleapis.com/auth/drive.appdata',
-		}, message => Alert.open(`
-			<p>RES needs your permission to connect to Google Drive.</p>
-			<p><b>${message}</b></p>
-		`, { cancelable: true }));
+		}, () => Alert.open('RES needs your permission to connect to Google Drive.', { cancelable: true }));
 
 		return this;
 	}

--- a/lib/modules/backupAndRestore/providers/OneDrive.js
+++ b/lib/modules/backupAndRestore/providers/OneDrive.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { ajax, launchAuthFlow } from '../../../environment';
+import { ajax, launchAuthFlow, Permissions } from '../../../environment';
 import { Alert } from '../../../utils';
 import Provider from './Provider';
 
@@ -14,19 +14,13 @@ export default class OneDrive extends Provider {
 	accessToken: string;
 
 	async init(): Promise<this> {
+		await Permissions.request(['https://login.live.com/oauth20_authorize.srf']);
+
 		this.accessToken = await launchAuthFlow({
 			domain: 'https://login.live.com/oauth20_authorize.srf',
 			clientId: 'a1f95f80-0129-475b-9894-dfbb94f5ff1c',
 			scope: 'onedrive.appfolder',
-			// MS OAuth applications are limited to one root domain, so we must use redditenhancementsuite.com
-			// for everything.
-			// Using the builtin https://login.microsoftonline.com/common/oauth2/nativeclient is not viable
-			// because it doesn't allow implicit flow (immediate redirect with no user interaction).
-			allowChromiumRedirect: false,
-		}, message => Alert.open(`
-			<p>RES needs your permission to connect to OneDrive.</p>
-			<p><b>${message}</b></p>
-		`, { cancelable: true }));
+		}, () => Alert.open('RES needs your permission to connect to OneDrive.', { cancelable: true }));
 
 		return this;
 	}


### PR DESCRIPTION
Tested in browser: Chrome 60, Firefox 53, Edge 15

Part of a saga (#4280). This, more-or-less, is the solution I was looking for.

For some inexplicable reason, Chrome's implementation of `chrome.identity.launchWebAuthFlow` runs the flow in a separate context which doesn't preserve cookies across browser restarts. This makes noninteractive auth pretty much useless, because it's only noninteractive for the current session (so you might as well just store it in memory...).

Normally, you couldn't use `fetch` to resolve the redirect, since the hash is not exposed in the response. However, we're an extension, and we have access to `webRequest.onBeforeRedirect`, which _can_ read the hash from redirect URLs. So that's exactly what we do.

Doing it this way also allows us to use res.com for all redirects without sacrifice, which is nice.