### PR TITLE
Messaging: stop wrapping errors

### DIFF
--- a/browser/utils/__tests__/messaging.js
+++ b/browser/utils/__tests__/messaging.js
@@ -126,8 +126,8 @@ test('erroring backend handler', async t => {
 	addListener('throwError', () => { throw new Error('foo'); });
 	addListener('rejectPromise', () => Promise.reject(new Error('bar')));
 
-	await t.throws(sendMessage('throwError'), 'Error in target\'s "throwError" handler: foo');
-	await t.throws(sendMessage('rejectPromise'), 'Error in target\'s "rejectPromise" handler: bar');
+	await t.throws(sendMessage('throwError'), 'foo');
+	await t.throws(sendMessage('rejectPromise'), 'bar');
 });
 
 test('erroring interceptor', async t => {
@@ -143,7 +143,7 @@ test('erroring synchronous interceptor', t => {
 	const { a: { addInterceptor, sendSynchronous } } = createPair();
 	addInterceptor('throwError', () => { throw new Error('foo'); });
 
-	t.throws(() => sendSynchronous('throwError'), 'Error in "throwError" interceptor: foo');
+	t.throws(() => sendSynchronous('throwError'), 'foo');
 });
 
 test('backend listener invalid type', async t => {

--- a/browser/utils/__tests__/messaging.js
+++ b/browser/utils/__tests__/messaging.js
@@ -66,48 +66,6 @@ test('backend handler with context', async t => {
 	t.is(await sendMessage('addOnePlusContext', 3, 5), 9);
 });
 
-test('interceptor', async t => {
-	const { a: { addInterceptor, sendMessage } } = createPair();
-	addInterceptor('addTwo', x => x + 2);
-
-	const response = sendMessage('addTwo', 3);
-	t.true(typeof response.then === 'function', 'response is a promise');
-	t.is(await response, 5);
-});
-
-test('interceptor returning a promise', async t => {
-	const { a: { addInterceptor, sendMessage } } = createPair();
-	addInterceptor('addTwo', x => Promise.resolve(x + 2));
-
-	const response = sendMessage('addTwo', 3);
-	t.true(typeof response.then === 'function', 'response is a promise');
-	t.is(await response, 5);
-});
-
-test('interceptor with context', async t => {
-	const { a: { addInterceptor, sendMessage } } = createPair();
-	addInterceptor('addOnePlusContext', (x, context) => x + 1 + context);
-
-	t.is(await sendMessage('addOnePlusContext', 3, 5), 9);
-});
-
-test('mixed backend handler and interceptors', async t => {
-	const { a: { addInterceptor, sendMessage }, b: { addListener } } = createPair();
-	addListener('addOne', x => x + 1);
-	addInterceptor('addTwo', x => x + 2);
-
-	t.is(await sendMessage('addOne', 3), 4);
-	t.is(await sendMessage('addTwo', 3), 5);
-});
-
-test('interceptor preempts backend listener', t => {
-	t.plan(1);
-	const { a: { addInterceptor, sendMessage }, b: { addListener } } = createPair();
-	addListener('foo', () => t.fail());
-	addInterceptor('foo', () => t.pass());
-	sendMessage('foo');
-});
-
 test('synchronous interceptor', t => {
 	const { a: { addInterceptor, sendSynchronous } } = createPair();
 	addInterceptor('addThree', x => x + 3);
@@ -128,15 +86,6 @@ test('erroring backend handler', async t => {
 
 	await t.throws(sendMessage('throwError'), 'foo');
 	await t.throws(sendMessage('rejectPromise'), 'bar');
-});
-
-test('erroring interceptor', async t => {
-	const { a: { addInterceptor, sendMessage } } = createPair();
-	addInterceptor('throwError', () => { throw new Error('foo'); });
-	addInterceptor('rejectPromise', () => Promise.reject(new Error('bar')));
-
-	await t.throws(sendMessage('throwError'), 'Error in "throwError" interceptor: foo');
-	await t.throws(sendMessage('rejectPromise'), 'Error in "rejectPromise" interceptor: bar');
 });
 
 test('erroring synchronous interceptor', t => {

--- a/browser/utils/messaging.js
+++ b/browser/utils/messaging.js
@@ -59,23 +59,6 @@ export function createMessageHandler<MsgCtx, ListenerCtx>(_sendMessage: Internal
 	}
 
 	function sendMessage(type, data, context) {
-		const interceptor = interceptors.get(type);
-		if (interceptor) {
-			try {
-				const response = interceptor(data, context);
-				if (isPromise(response) /*:: && response instanceof Promise */) {
-					return response.catch(e => {
-						console.error(e);
-						return Promise.reject(new Error(`Error in "${type}" interceptor: ${e.message || e}`));
-					});
-				}
-				return Promise.resolve(response);
-			} catch (e) {
-				console.error(e);
-				return Promise.reject(new Error(`Error in "${type}" interceptor: ${e.message || e}`));
-			}
-		}
-
 		return _sendMessage({ type, data }, context).then(({ data, error }) => {
 			if (error) {
 				throw new MessageHandlerError(error.message, `${error.stack}\n    at target's "${type}" handler`);

--- a/lib/environment/storage.js
+++ b/lib/environment/storage.js
@@ -1,33 +1,33 @@
 /* @flow */
 
 import _ from 'lodash';
-import { sendMessage } from '../../browser';
+import { sendSynchronous } from '../../browser';
 
 export function get(key: string): Promise<any | null> {
-	return sendMessage('storage', ['get', key]);
+	return sendSynchronous('storage', ['get', key]);
 }
 
 export function getAll(): Promise<{ [key: string]: mixed }> {
-	return sendMessage('storage', ['getAll']);
+	return sendSynchronous('storage', ['getAll']);
 }
 
 export function batch<T: string>(keys: T[]): Promise<{ [key: T]: any | null }> {
-	return sendMessage('storage', ['batch', keys]);
+	return sendSynchronous('storage', ['batch', keys]);
 }
 
 export function set(key: string, value: mixed) {
-	return sendMessage('storage', ['set', key, value]);
+	return sendSynchronous('storage', ['set', key, value]);
 }
 
 export function setMultiple(valueMap: { [key: string]: mixed }) {
-	return sendMessage('storage', ['setMultiple', null, valueMap]);
+	return sendSynchronous('storage', ['setMultiple', null, valueMap]);
 }
 
 /*
  * Deeply extends a value in storage.
  */
 export function patch(key: string, value: { [key: string]: mixed }) {
-	return sendMessage('storage', ['patch', key, value]);
+	return sendSynchronous('storage', ['patch', key, value]);
 }
 
 /*
@@ -37,24 +37,24 @@ export function patch(key: string, value: { [key: string]: mixed }) {
  * will `delete userTaggerStoredValue.username.tag`
  */
 export function deletePath(key: string, ...path: string[]) {
-	return sendMessage('storage', ['deletePath', key, path.join(',')]);
+	return sendSynchronous('storage', ['deletePath', key, path.join(',')]);
 }
 
 function _delete(keys: string | string[]) {
-	return sendMessage('storage', ['delete', keys]);
+	return sendSynchronous('storage', ['delete', keys]);
 }
 export { _delete as delete };
 
 export function has(key: string): Promise<boolean> {
-	return sendMessage('storage', ['has', key]);
+	return sendSynchronous('storage', ['has', key]);
 }
 
 export function keys(): Promise<string[]> {
-	return sendMessage('storage', ['keys']);
+	return sendSynchronous('storage', ['keys']);
 }
 
 export function clear() {
-	return sendMessage('storage', ['clear']);
+	return sendSynchronous('storage', ['clear']);
 }
 
 class Wrapper<T> {


### PR DESCRIPTION
Tested in browser: Chrome 60, Firefox 53, Edge 15

So now we get (somewhat) proper stack traces from the background page. Every browser has a fun nonstandard `Error` implementation, but this works in all of them (at least, it's no worse than it was before).

Before:
![image](https://user-images.githubusercontent.com/7673145/27097504-6c01521a-5042-11e7-9ecb-341cc85d797d.png)
After (stack):
![image](https://user-images.githubusercontent.com/7673145/27108743-febd5d72-506c-11e7-9653-439f08a39db5.png)
After (no stack):
![image](https://user-images.githubusercontent.com/7673145/27108768-263ba3cc-506d-11e7-96a8-c9024dd67324.png)