### PR TITLE
Allows userTagger to be used within userInfo popup

### DIFF
--- a/lib/css/_zindex.scss
+++ b/lib/css/_zindex.scss
@@ -9,15 +9,16 @@ $zindex-autocomplete-dropdown: _(0);
 $zindex-go-mode-panel:         _(1);
 $zindex-key-help:              _(2);
 $zindex-res-hover:             _(3);
-$zindex-show-link-title:       _(4);
+$zindex-user-tagger:           _(4);
+$zindex-show-link-title:       _(5);
 
 // Dialogs
-$zindex-big-editor:            _(5);
-$zindex-ner-content:           _(6);
-$zindex-quick-message-dialog:  _(7);
-$zindex-console-container:     _(8);
-$zindex-command-line-widget:   _(9);
-$zindex-notifications:         _(10);
-$zindex-alert-message:         _(11);
+$zindex-big-editor:            _(6);
+$zindex-ner-content:           _(7);
+$zindex-quick-message-dialog:  _(8);
+$zindex-console-container:     _(9);
+$zindex-command-line-widget:   _(10);
+$zindex-notifications:         _(11);
+$zindex-alert-message:         _(12);
 
-$zindex-baconbit:              _(12);
+$zindex-baconbit:              _(13);

--- a/lib/css/modules/_userTagger.scss
+++ b/lib/css/modules/_userTagger.scss
@@ -3,7 +3,7 @@
 	position: absolute;
 	width: 336px;
 	box-sizing: border-box;
-	z-index: $zindex-res-hover;
+	z-index: $zindex-show-link-title;
 
 	form > div {
 		clear: both;

--- a/lib/css/modules/_userTagger.scss
+++ b/lib/css/modules/_userTagger.scss
@@ -3,7 +3,7 @@
 	position: absolute;
 	width: 336px;
 	box-sizing: border-box;
-	z-index: $zindex-show-link-title;
+	z-index: $zindex-user-tagger;
 
 	form > div {
 		clear: both;

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -146,7 +146,7 @@ async function showUserInfo(target, update) {
 
 	const $header = $(string.html`
 		<div>
-			<a href="/user/${data.name}">/u/${data.name}</a>
+			<a href="/user/${data.name}">/u/${data.name} </a>
 		 	(<a href="/user/${data.name}/submitted/">${i18n('userInfoLinks')}</a>)
 		 	(<a href="/user/${data.name}/comments/">${i18n('userInfoComments')}</a>)
 		</div>
@@ -230,6 +230,7 @@ async function showUserInfo(target, update) {
 	if (userTaggerEnabled) {
 		const ignoreButton = body.find('#ignoreUser');
 		ignoreButton.on('click', ignoreUser);
+		UserTagger.applyTagToAuthor($header.find("a")[0], false);
 	}
 	if (module.options.highlightButton.value) {
 		body.find('#highlightUser').on('click', ({ target }: Event) => {

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -233,7 +233,8 @@ async function showUserInfo(target, update) {
 	if (userTaggerEnabled) {
 		const ignoreButton = body.find('#ignoreUser');
 		ignoreButton.on('click', ignoreUser);
-		UserTagger.applyTagToAuthor(body[0].querySelector('a[href*="/u/"]'): HTMLAnchorElement, false, true);
+		const tagAnchorPoint = downcast(body[0].querySelector('a[href*="/u/"]'), HTMLAnchorElement);
+		UserTagger.applyTagToAuthor(tagAnchorPoint, false, true);
 	}
 	if (module.options.highlightButton.value) {
 		body.find('#highlightUser').on('click', ({ target }: Event) => {

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -146,7 +146,7 @@ async function showUserInfo(target, update) {
 
 	const $header = $(string.html`
 		<div>
-			<a href="/user/${data.name}">/u/${data.name} </a>
+			<a href="/user/${data.name}">/u/${data.name}</a>
 		 	(<a href="/user/${data.name}/submitted/">${i18n('userInfoLinks')}</a>)
 		 	(<a href="/user/${data.name}/comments/">${i18n('userInfoComments')}</a>)
 		</div>
@@ -198,6 +198,9 @@ async function showUserInfo(target, update) {
 	const userTaggerEnabled = Modules.isRunning(UserTagger);
 	const userTag = userTaggerEnabled && await UserTagger.tagStorage.get(nameLowercase);
 
+	if (userTaggerEnabled) {		
+		userHTML += `<div class="authorFieldPair"><div class="authorLabel">${i18n('userInfoUserTag')}</div> <div class="authorDetail" style="display:flex"><a href="/u/${data.name}"/></div></div>`;
+	}
 	if (userTag && userTag.link) {
 		const links = userTag.link.split(/\s/).reduce((acc, url) => acc + string.escape`<a target="_blank" rel="noopener noreferer" href="${url}">${url.replace(/^https?:\/\/(www\.)?/, '')}</a>`, '');
 		userHTML += `<div class="authorFieldPair"><div class="authorLabel">${i18n('userInfoLink')}</div> <div class="authorDetail">${links}</div></div>`;
@@ -230,7 +233,7 @@ async function showUserInfo(target, update) {
 	if (userTaggerEnabled) {
 		const ignoreButton = body.find('#ignoreUser');
 		ignoreButton.on('click', ignoreUser);
-		UserTagger.applyTagToAuthor($header.find("a")[0], false, true);
+		UserTagger.applyTagToAuthor(body.find('a[href*="/u/"]')[0], false, true);
 	}
 	if (module.options.highlightButton.value) {
 		body.find('#highlightUser').on('click', ({ target }: Event) => {

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -233,7 +233,7 @@ async function showUserInfo(target, update) {
 	if (userTaggerEnabled) {
 		const ignoreButton = body.find('#ignoreUser');
 		ignoreButton.on('click', ignoreUser);
-		UserTagger.applyTagToAuthor(body.find('a[href*="/u/"]')[0], false, true);
+		UserTagger.applyTagToAuthor(body[0].querySelector('a[href*="/u/"]'), false, true);
 	}
 	if (module.options.highlightButton.value) {
 		body.find('#highlightUser').on('click', ({ target }: Event) => {

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -230,7 +230,7 @@ async function showUserInfo(target, update) {
 	if (userTaggerEnabled) {
 		const ignoreButton = body.find('#ignoreUser');
 		ignoreButton.on('click', ignoreUser);
-		UserTagger.applyTagToAuthor($header.find("a")[0], false);
+		UserTagger.applyTagToAuthor($header.find("a")[0], false, true);
 	}
 	if (module.options.highlightButton.value) {
 		body.find('#highlightUser').on('click', ({ target }: Event) => {

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -198,7 +198,7 @@ async function showUserInfo(target, update) {
 	const userTaggerEnabled = Modules.isRunning(UserTagger);
 	const userTag = userTaggerEnabled && await UserTagger.tagStorage.get(nameLowercase);
 
-	if (userTaggerEnabled) {		
+	if (userTaggerEnabled) {
 		userHTML += `<div class="authorFieldPair"><div class="authorLabel">${i18n('userInfoUserTag')}</div> <div class="authorDetail" style="display:flex"><a href="/u/${data.name}"/></div></div>`;
 	}
 	if (userTag && userTag.link) {

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -233,7 +233,7 @@ async function showUserInfo(target, update) {
 	if (userTaggerEnabled) {
 		const ignoreButton = body.find('#ignoreUser');
 		ignoreButton.on('click', ignoreUser);
-		UserTagger.applyTagToAuthor(body[0].querySelector('a[href*="/u/"]'), false, true);
+		UserTagger.applyTagToAuthor(body[0].querySelector('a[href*="/u/"]'): HTMLAnchorElement, false, true);
 	}
 	if (module.options.highlightButton.value) {
 		body.find('#highlightUser').on('click', ({ target }: Event) => {

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -793,7 +793,7 @@ const getTagBatched = batch(async users => {
 	return users.map(user => tags[user.toLowerCase()]);
 }, { size: Infinity, delay: 0 });
 
-export async function applyTagToAuthor(thisAuthorObj: HTMLAnchorElement, noEdit: boolean = false) {
+export async function applyTagToAuthor(thisAuthorObj: HTMLAnchorElement, noEdit: boolean = false, alwaysShow: boolean = false) {
 	let thisAuthor;
 	if (thisAuthorObj.href) {
 		const test = thisAuthorObj.href.match(usernameRE);
@@ -812,15 +812,15 @@ export async function applyTagToAuthor(thisAuthorObj: HTMLAnchorElement, noEdit:
 	}
 
 	let tagElement;
-	if (module.options.showTaggingIcon.value) {
-		tagElement = addAuthorTag(thisAuthorObj, noEdit, thisAuthor);
+	if (module.options.showTaggingIcon.value || alwaysShow) {
+		tagElement = addAuthorTag(thisAuthorObj, noEdit, thisAuthor, {alwaysShow: alwaysShow});
 	}
 
 	const tagObject = await getTagBatched(thisAuthor);
 
 	if (!_.isEmpty(tagObject)) {
 		if (tagElement) tagElement.remove();
-		addAuthorTag(thisAuthorObj, noEdit, thisAuthor, tagObject);
+		addAuthorTag(thisAuthorObj, noEdit, thisAuthor, tagObject, {alwaysShow: alwaysShow});
 	}
 
 	if (
@@ -832,7 +832,7 @@ export async function applyTagToAuthor(thisAuthorObj: HTMLAnchorElement, noEdit:
 	}
 }
 
-function addAuthorTag(thisAuthorObj: HTMLAnchorElement, noEdit: boolean, thisAuthor, { votes = 0, color, tag } = {}) {
+function addAuthorTag(thisAuthorObj: HTMLAnchorElement, noEdit: boolean, thisAuthor, { votes = 0, color, tag, alwaysShow } = {}) {
 	let userTagLink;
 
 	function addUserTag() {
@@ -888,7 +888,7 @@ function addAuthorTag(thisAuthorObj: HTMLAnchorElement, noEdit: boolean, thisAut
 	}
 
 	if (module.options.trackVoteWeight.value) addTrackVoteWeight();
-	if (tag || module.options.showTaggingIcon.value) return addUserTag();
+	if (tag || module.options.showTaggingIcon.value || alwaysShow) return addUserTag();
 }
 
 // Ignore content from certain users.

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -813,14 +813,14 @@ export async function applyTagToAuthor(thisAuthorObj: HTMLAnchorElement, noEdit:
 
 	let tagElement;
 	if (module.options.showTaggingIcon.value || alwaysShow) {
-		tagElement = addAuthorTag(thisAuthorObj, noEdit, thisAuthor, {alwaysShow: alwaysShow});
+		tagElement = addAuthorTag(thisAuthorObj, noEdit, thisAuthor, undefined, alwaysShow);
 	}
 
 	const tagObject = await getTagBatched(thisAuthor);
 
 	if (!_.isEmpty(tagObject)) {
 		if (tagElement) tagElement.remove();
-		addAuthorTag(thisAuthorObj, noEdit, thisAuthor, tagObject, {alwaysShow: alwaysShow});
+		addAuthorTag(thisAuthorObj, noEdit, thisAuthor, tagObject, alwaysShow);
 	}
 
 	if (
@@ -832,7 +832,7 @@ export async function applyTagToAuthor(thisAuthorObj: HTMLAnchorElement, noEdit:
 	}
 }
 
-function addAuthorTag(thisAuthorObj: HTMLAnchorElement, noEdit: boolean, thisAuthor, { votes = 0, color, tag, alwaysShow } = {}) {
+function addAuthorTag(thisAuthorObj: HTMLAnchorElement, noEdit: boolean, thisAuthor, { votes = 0, color, tag } = {}, alwaysShow: boolean = false) {
 	let userTagLink;
 
 	function addUserTag() {

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -4003,5 +4003,8 @@
 	},
 	"iredditPreferRedditMediaDesc": {
 		"message": "Try to load images and video from Reddit's media servers."
+	},
+	"userInfoUserTag": {
+		"message": "User Tag:"
 	}
 }


### PR DESCRIPTION
This is particularly useful for anyone that wants to disable `showTaggingIcon`, but still wants to be able to easily tag someone. With this change, the _Tagging_ icon will appear on the _User Info_ popup, even if `showTaggingIcon` is disabled.

Required a little _z-space_ adjustment of the popups to prevent the _Tagging_ popup appearing below the _User Info_ popup.