### PR TITLE
commentHidePersistor: Simplify logic, convert to watchForThing

### DIFF
--- a/lib/core/migrate/migrate.js
+++ b/lib/core/migrate/migrate.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 import { Storage } from '../../environment';
-import { forEachSeq } from '../../utils';
+import { forEachSeq, execRegexes } from '../../utils';
 import * as Modules from '../modules';
 import * as Options from '../options';
 import * as Migrators from './migrators';
@@ -530,6 +530,20 @@ const migrations = [
 			await Migrators.moveOption('commandLine', 'launchFromMenuButton', 'RESMenu', 'gearIconClickAction', launchFromMenu =>
 				launchFromMenu ? 'openCommandLine' : 'toggleMenuNoHover'
 			);
+		},
+	}, {
+		versionNumber: '5.7.4-shard-commentHidePersistor',
+		async go() {
+			const { hiddenThings } = await Storage.get('RESmodules.commentHidePersistor.hidePersistor') || {};
+			if (!hiddenThings) return;
+			const remappedEntries = Object.entries(hiddenThings).reduce((acc, [k, v]) => {
+				const page = (execRegexes.comments(k) || [])[2];
+				const collapsedThings = v.reduce((acc, k) => (acc[k] = true) && acc, {});
+				if (page && v.length) acc[`commentHidePersistor.${page}`] = { updateTime: Date.now(), collapsedThings };
+				return acc;
+			}, {});
+			await Storage.setMultiple(remappedEntries);
+			await Storage.delete('RESmodules.commentHidePersistor.hidePersistor');
 		},
 	},
 

--- a/lib/modules/commentHidePersistor.js
+++ b/lib/modules/commentHidePersistor.js
@@ -3,7 +3,7 @@
 import { $ } from '../vendor';
 import { Module } from '../core/module';
 import { Storage } from '../environment';
-import { click } from '../utils';
+import { DAY, click, execRegexes, watchForThings, Thing } from '../utils';
 
 export const module: Module<*> = new Module('commentHidePersistor');
 
@@ -16,115 +16,66 @@ module.include = [
 	'inbox',
 ];
 
-const hidePersistorStorage = Storage.wrap('RESmodules.commentHidePersistor.hidePersistor', {
-	hiddenThings: ({}: { [key: string]: string[] }),
-	hiddenKeys: ([]: string[]),
-});
+const expireAfterDays = 7;
+const currentId: string = (execRegexes.comments(location.pathname) || [])[2];
+const lastCleanStorage = Storage.wrap('RESmodules.commentHidePersistor.lastClean', (null: null | number));
+const entryStorage = Storage.wrapPrefix('commentHidePersistor.', (): {
+	updateTime: number,
+	collapsedThings?: { [fullName: string]: boolean },
+} => ({
+	updateTime: Date.now(),
+}));
 
-module.go = async () => {
-	bindToHideLinks();
-	await hideHiddenThings();
+module.beforeLoad = async () => {
+	if (!currentId) throw new Error('Could not find comment page id');
+
+	await restoreCommentCollapse();
 };
 
-let allHiddenThings = {};
-let hiddenKeys = [];
-let hiddenThings = [];
-const hiddenThingsKey = location.pathname;
-const maxKeys = 100;
-const pruneKeysTo = 50;
+module.go = () => {
+	listenToCommentCollapse();
+};
 
-function bindToHideLinks() {
-	/**
-	 * For every expand/collapse link, add a click listener that will
-	 * store or remove the comment ID from our list of hidden comments.
-	 **/
-	$('body').on('click', 'a.expand', function() {
-		const $thing = $(this).parents('.thing:eq(0)');
-		const thingId = $thing.attr('data-fullname');
-		const collapsing = $thing.is('.collapsed') || $(this).parent().parent().hasClass('noncollapsed');
+module.afterLoad = async () => {
+	// Clean counts every six hours
+	const lastClean = await lastCleanStorage.get() || 0;
+	if ((Date.now() - lastClean) > 0.25 * DAY) {
+		pruneOldEntries();
+	}
+};
 
-		/* Add our key to pages interacted with, for potential pruning later */
-		if (!hiddenKeys.includes(hiddenThingsKey)) {
-			hiddenKeys.push(hiddenThingsKey);
+async function pruneOldEntries() {
+	const now = Date.now();
+	lastCleanStorage.set(now);
+	const keepTrackPeriod = DAY * parseInt(expireAfterDays, 10);
+	for (const [id, data] of Object.entries(await entryStorage.getAll())) {
+		if ((now - data.updateTime) > keepTrackPeriod) {
+			entryStorage.delete(id);
 		}
+	}
+}
 
-		if (collapsing) {
-			addHiddenThing(thingId);
-		} else {
-			removeHiddenThing(thingId);
-		}
+async function restoreCommentCollapse() {
+	const { collapsedThings } = await entryStorage.get(currentId);
+	if (collapsedThings) {
+		watchForThings(['comment'], thing => {
+			if (thing.getFullname() in collapsedThings) {
+				const toggle = thing.getCommentToggleElement();
+				if (toggle) click(toggle);
+			}
+		}, { immediate: true });
+	}
+}
+
+function listenToCommentCollapse() {
+	$(document.body).on('click', 'a.expand', function() {
+		const thing = Thing.from(this);
+		if (!thing) return;
+
+		const collapsed = thing.isCollapsed();
+		const thingId = thing.getFullname();
+
+		if (collapsed) entryStorage.patch(currentId, { collapsedThings: { [thingId]: true }, updateTime: Date.now() });
+		else entryStorage.deletePath(currentId, 'collapsedThings', thingId);
 	});
-}
-
-async function loadHiddenThings() {
-	const hidePersistorData = await hidePersistorStorage.get();
-
-	if (hidePersistorData) {
-		allHiddenThings = hidePersistorData.hiddenThings;
-		hiddenKeys = hidePersistorData.hiddenKeys;
-
-		/**
-		 * Prune allHiddenThings of old content so it doesn't get
-		 * huge.
-		 **/
-		if (hiddenKeys.length > maxKeys) {
-			const pruneStart = maxKeys - pruneKeysTo;
-			const newHiddenThings = {};
-			/* Recreate our object as a subset of the original */
-			const newHiddenKeys = hiddenKeys.slice(pruneStart);
-
-			for (const hiddenKey of newHiddenKeys) {
-				newHiddenThings[hiddenKey] = allHiddenThings[hiddenKey];
-			}
-
-			allHiddenThings = newHiddenThings;
-			hiddenKeys = newHiddenKeys;
-			syncHiddenThings();
-		}
-
-		if (allHiddenThings[hiddenThingsKey]) {
-			hiddenThings = allHiddenThings[hiddenThingsKey];
-		}
-	}
-}
-
-function addHiddenThing(thingId) {
-	if (!hiddenThings.includes(thingId)) {
-		hiddenThings.push(thingId);
-	}
-	syncHiddenThings();
-}
-
-function removeHiddenThing(thingId) {
-	const i = hiddenThings.indexOf(thingId);
-	if (i !== -1) {
-		hiddenThings.splice(i, 1);
-	}
-	syncHiddenThings();
-}
-
-function syncHiddenThings() {
-	allHiddenThings[hiddenThingsKey] = hiddenThings;
-	const hidePersistorData = {
-		hiddenThings: allHiddenThings,
-		hiddenKeys,
-	};
-	hidePersistorStorage.set(hidePersistorData);
-}
-
-async function hideHiddenThings() {
-	await loadHiddenThings();
-
-	const query = hiddenThings
-		.filter(v => v)
-		.map(id => `[data-fullname=${id}].noncollapsed > div.entry a.expand`)
-		.join(', ');
-
-	if (query) {
-		for (const collapseButton of document.querySelectorAll(query)) {
-			if (collapseButton.offsetParent) {
-				click(collapseButton);
-			}
-		}
-	}
 }

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -506,9 +506,13 @@ export default class Thing {
 		return this.thing.classList.contains('RESFiltered');
 	}
 
+	isCollapsed(): boolean {
+		return this.thing.classList.contains('collapsed');
+	}
+
 	isInCollapsed(): boolean {
 		const parent_ = this.getParent();
-		return !!(parent_ && parent_.getClosest(function() { return this.thing.classList.contains('collapsed'); }));
+		return !!(parent_ && parent_.getClosest(function() { this.isCollapsed(); }));
 	}
 
 	isVisible(): boolean {


### PR DESCRIPTION
Like in #4298, fixes multiple instances overwriting each other.