### PR TITLE
new location: duplicates

### DIFF
--- a/lib/utils/__tests__/location.js
+++ b/lib/utils/__tests__/location.js
@@ -157,6 +157,10 @@ test('comment permalink regex doesn\'t match', regexDoesntMatch, regexes.comment
 	'/comments/4ooe2m',
 ]);
 
+test('duplicate regex', regexMatches, regexes.duplicates, [
+	['/r/aww/duplicates/400e2m', '400e2m'],
+]);
+
 test('subreddit regex', regexMatches, regexes.subreddit, [
 	['/r/Enhancement', 'Enhancement'],
 	['/r/Enhancement/', 'Enhancement'],

--- a/lib/utils/location.js
+++ b/lib/utils/location.js
@@ -28,6 +28,7 @@ export const regexes: { [key: string]: RegExp } = {
 	stylesheet:       /^\/(?:r\/([\w\.]+)\/)about\/stylesheet(?:\/|$)/i,
 	search:           /^\/(?:r\/[\w\.\+]+\/|(?:me|user\/[\w\-]+)\/[mf]\/[\w\.\+]+\/|domain\/[^\/]+\/)?search(?:\/|$)/i,
 	commentPermalink: /^\/(?:r\/([\w\.]+)\/)?comments\/([a-z0-9]+)\/[^\/]*\/([a-z0-9]+)(?:\/|$)/i,
+	duplicates:       /^\/r\/[\w\.\+]+\/duplicates\/([a-z0-9]+)/i,
 	subreddit:        /^\/r\/([\w\.\+]+)(?:\/|$)/i,
 	subredditAbout:   /^\/r\/([\w\.]+)\/about(?:\/(?!modqueue|reports|spam|unmoderated|edited)|$)/i,
 	modqueue:         /^\/r\/([\w\.\+]+)\/about\/(?:modqueue|reports|spam|unmoderated|edited)(?:\/|$)/i,


### PR DESCRIPTION
Since filteReddit naively uses the first matching regex, which for duplicates pages was `subreddit`, that subreddit's filterline was applied — which I've found in most cases is undesirable
