### PR TITLE
Use common interface for hide/unhide

### DIFF
--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -10,6 +10,8 @@ import {
 	Thing,
 	addCSS,
 	batch,
+	hide,
+	unhide,
 	CreateElement,
 	downcast,
 	isPageType,
@@ -270,43 +272,26 @@ function hideLinkEventHandler(e) {
 
 const hideTimer = new Map();
 
-async function hideLink(clickedLink) {
+function hideLink(clickedLink, action = clickedLink.getAttribute('action')) {
 	const timeout = module.options.hideLinkInstant.value ?
 		null :
 		parseInt(module.options.hideLinkFadeDelay.value, 10);
 
-	let action = clickedLink.getAttribute('action');
+	const thing = Thing.checkedFrom(clickedLink);
 
-	const parentThing = Thing.checkedFrom(clickedLink);
-
-	if (action === 'unhide') {
-		$(clickedLink).text('unhiding...');
-	} else {
-		$(clickedLink).text('hiding...');
-		if (timeout === null) parentThing.$thing.hide();
+	if (action === 'hide') {
+		if (timeout === null) thing.$thing.hide();
+		else hideTimer.set(clickedLink, setTimeout(() => thing.$thing.fadeOut(300), timeout));
 	}
 
 	try {
-		await ajax({
-			method: 'POST',
-			url: `/api/${action}`,
-			data: { id: parentThing.getFullname() },
-		});
+		if (action === 'hide') hide(thing);
+		else unhide(thing);
 	} catch (e) {
 		Alert.open(`Sorry, there was an error trying to ${action} your submission. Try clicking again.`);
-		action = 'unhide';
-		throw e;
-	}
-
-	if (action === 'unhide') {
-		$(clickedLink).text('hide');
-		clickedLink.setAttribute('action', 'hide');
 		clearTimeout(hideTimer.get(clickedLink));
-		parentThing.$thing.show();
-	} else {
-		$(clickedLink).text('unhide');
-		clickedLink.setAttribute('action', 'unhide');
-		if (timeout !== null) hideTimer.set(clickedLink, setTimeout(() => parentThing.$thing.fadeOut(300), timeout));
+		thing.$thing.show();
+		throw e;
 	}
 }
 

--- a/lib/utils/thingHide.js
+++ b/lib/utils/thingHide.js
@@ -6,16 +6,32 @@ import { batch } from './async';
 
 const hideEndpoint = '/api/hide';
 const unhideEndpoint = '/api/unhide';
+const [HIDE, UNHIDE] = [false, true];
 
-const send = (endpoint: string, things: Thing[]) => {
+const send = (state, things: Thing[]) => {
+	function setState(newState) {
+		for (const thing of things) {
+			const hideElement = thing.getHideElement();
+			if (hideElement) {
+				hideElement.textContent = newState === HIDE ? 'unhide' : 'hide';
+				hideElement.setAttribute('action', newState === HIDE ? 'unhide' : 'hide');
+			}
+		}
+	}
+
+	for (const thing of things) {
+		const hideElement = thing.getHideElement();
+		if (hideElement) hideElement.textContent = state === HIDE ? 'hiding…' : 'unhiding…';
+	}
+
 	const fullnames = things.map(thing => thing.getFullname());
 
 	return ajax({
 		method: 'POST',
-		url: endpoint,
+		url: state === HIDE ? hideEndpoint : unhideEndpoint,
 		data: { id: fullnames.join(',') },
-	});
+	}).then(() => { setState(HIDE); }, () => { setState(UNHIDE); });
 };
 
-export const hide = batch(things => send(hideEndpoint, things), { size: 50 });
-export const unhide = batch(things => send(unhideEndpoint, things), { size: 50 });
+export const hide = batch(things => send(HIDE, things), { size: 50 });
+export const unhide = batch(things => send(UNHIDE, things), { size: 50 });


### PR DESCRIPTION
Moves rewriting the `hide` / `unhide` text to `thingHide.js` (which Filterline uses), so that the text always matches the current state.

From #4191

Tested in browser: Chrome 60