### PR TITLE
RESTips: Increase z-index so that dropdowns are above guider

### DIFF
--- a/lib/modules/RESTips.js
+++ b/lib/modules/RESTips.js
@@ -355,6 +355,11 @@ function showTip(tip: Tip, guiderObj) {
 		guiderObj.buttons = [...guiderObj.buttons, { name: 'More', onclick }];
 	}
 
+	const attachTo: ?HTMLElement = tip.attachTo && $(tip.attachTo).get(0) || null;
+
+	// Make the attachTo element navigatable even when e.g. dropdowns intersect the guider
+	const toggleIncreasedZIndex = state => { if (attachTo) attachTo.classList.toggle('restips-increased-z-index', state); };
+
 	return new Promise(resolve => {
 		guiders.hideAll();
 		guiders.createGuider({
@@ -366,9 +371,12 @@ function showTip(tip: Tip, guiderObj) {
 			...tip,
 			onHide() {
 				if (tip.onHide) tip.onHide();
+				toggleIncreasedZIndex(false);
 				resolve();
 			},
+			attachTo,
 		});
+		toggleIncreasedZIndex(true);
 		guiders.show();
 	});
 }

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -531,7 +531,7 @@ const createFilterline = _.once(() => {
 			if (newVisibilityState) {
 				completeFilterline();
 				filterlineTab.removeAttribute('aftercontent');
-				RESTips.addFeatureTip('filterlineVisible', { ...featureTips.filterlineVisible, attachTo: filterline.filterContainer });
+				RESTips.addFeatureTip('filterlineVisible', { ...featureTips.filterlineVisible, attachTo: filterline.element });
 			} else if (filterline.getActiveFilters().find(v => !(v instanceof ExternalFilter))) {
 				filterlineTab.setAttribute('aftercontent', ' (active)');
 			}

--- a/lib/modules/filteReddit/Filterline.js
+++ b/lib/modules/filteReddit/Filterline.js
@@ -33,6 +33,7 @@ export default class Filterline {
 	hiddenThings: Thing[] = [];
 	showFilterReason: boolean = false;
 
+	element: HTMLElement;
 	dropdown: HTMLElement;
 	filterContainer: HTMLElement;
 	otherContainer: HTMLElement;
@@ -70,7 +71,7 @@ export default class Filterline {
 				</div>
 			</div>
 		`);
-		const element = $element[0];
+		const element = this.element = $element[0];
 		this.filterContainer = element.querySelector('.res-filterline-filters');
 		this.externalContainer = element.querySelector('.res-filterline-external');
 		this.otherContainer = element.querySelector('.res-filterline-other');

--- a/lib/vendor/guiders.css
+++ b/lib/vendor/guiders.css
@@ -168,3 +168,14 @@
 .guiders_buttons_container label input[type=checkbox] {
 	margin-right: 5px;
 }
+.guiders_content ul {
+	list-style-type: circle;
+	margin-left: 12px;
+}
+.guiders_content strong {
+	font-style: initial;
+	font-weight: bold;
+}
+.restips-increased-z-index {
+	z-index: 900003 !important;
+}


### PR DESCRIPTION
The guider refers to functionality in the dropdown, so it is nice being able use it without closing the guider.

From #4191

Tested in browser: Chrome 60