### PR TITLE
automatic backups: make backup/restoring fail-safe

### DIFF
--- a/lib/environment/storage.js
+++ b/lib/environment/storage.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import _ from 'lodash';
-import { sendSynchronous } from '../../browser';
+import { sendMessage, sendSynchronous } from '../../browser';
 
 export function get(key: string): Promise<any | null> {
 	return sendSynchronous('storage', ['get', key]);
@@ -21,6 +21,10 @@ export function set(key: string, value: mixed) {
 
 export function setMultiple(valueMap: { [key: string]: mixed }) {
 	return sendSynchronous('storage', ['setMultiple', null, valueMap]);
+}
+
+export function compareAndSet(key: string, oldValue: mixed, newValue: mixed): Promise<boolean> {
+	return sendMessage('storage-cas', [key, oldValue, newValue]);
 }
 
 /*
@@ -76,6 +80,10 @@ class Wrapper<T> {
 
 	patch(value: $Shape<T>): Promise<void> {
 		return patch(this._key(), (value: any));
+	}
+
+	compareAndSet(oldValue: T, newValue: T): Promise<boolean> {
+		return compareAndSet(this._key(), oldValue, newValue);
 	}
 
 	deletePath(...path: string[]): Promise<void> {
@@ -148,6 +156,10 @@ class PrefixWrapper<T> {
 
 	patch(key: string, value: $Shape<T>): Promise<void> {
 		return patch(this._keyGen(key), (value: any));
+	}
+
+	compareAndSet(key: string, oldValue: T, newValue: T): Promise<boolean> {
+		return compareAndSet(this._keyGen(key), oldValue, newValue);
 	}
 
 	deletePath(key: string, ...path: string[]): Promise<void> {

--- a/lib/modules/backupAndRestore.js
+++ b/lib/modules/backupAndRestore.js
@@ -5,6 +5,7 @@ import { Module } from '../core/module';
 import { MINUTE, Alert, formatDateTime } from '../utils';
 import { Storage, i18n, multicast } from '../environment';
 import * as Notifications from './notifications';
+import * as SettingsNavigation from './settingsNavigation';
 import { serialize, deserialize } from './backupAndRestore/serialization';
 import * as Providers from './backupAndRestore/providers';
 
@@ -56,6 +57,8 @@ module.options = {
 		description: 'backupAndRestoreAutomaticBackupsDesc',
 		title: 'backupAndRestoreAutomaticBackupsTitle',
 		onChange() {
+			// reset the last check time, in case we switched providers or turned it off
+			lastCheckStorage.set(0);
 			handleAutomaticSync();
 		},
 	},
@@ -94,50 +97,67 @@ module.afterLoad = async () => {
 	await handleAutomaticSync();
 };
 
-// Last modified date is a millisecond timestamp per each specific provider.
-// While it should be a sensible timestamp, it should not be compared or set to Date.now() as they may differ by a few seconds.
 const lastModifiedStorage = Storage.wrapPrefix('backup.lastModified.', () => (0: number));
-// Last check date is a local millisecond timestamp based on Date.now().
 const lastCheckStorage = Storage.wrap('backup.lastCheck', (0: number));
 
 async function handleAutomaticSync() {
 	const automaticProviderKey = module.options.automaticBackups.value;
-	if (automaticProviderKey !== 'none') {
-		const providerClass = Object.values(Providers).find(p => p.key === automaticProviderKey);
-		if (!providerClass) throw new Error(`Can't find provider with key ${automaticProviderKey}`);
+	if (automaticProviderKey === 'none') return;
 
-		const now = Date.now();
-		if ((now - await lastCheckStorage.get()) > 15 * MINUTE) {
-			await lastCheckStorage.set(now);
-			// last check was 5 minutes ago, check again
-			const provider = await new providerClass().init();
-			const lastRemoteBackup = await provider.readLastModified().catch(e => {
-				console.warn('Failed to read last modified:', e);
-				return 0;
-			});
-			const lastLocalBackup = await lastModifiedStorage.get(automaticProviderKey);
+	const providerClass = Object.values(Providers).find(p => p.key === automaticProviderKey);
+	if (!providerClass) throw new Error(`Can't find provider with key ${automaticProviderKey}`);
 
-			if (lastRemoteBackup > lastLocalBackup) {
-				await restore(provider, {
-					shouldAlert: module.options.warnBeforeAutomaticRestore.value,
-					alertPrefix: `Found new automatic backup from ${providerClass.name}.`,
-				});
-			} else {
-				// no new remote backup, make a local backup
-				if (lastLocalBackup > lastRemoteBackup) {
-					console.warn('Remote backup at', lastRemoteBackup, 'went back in time compared to local at', lastLocalBackup);
-				}
-				await backup(provider);
-			}
-		}
+	const now = Date.now();
+	const lastCheck = await lastCheckStorage.get();
+	if ((now - lastCheck) < (15 * MINUTE)) return;
+
+	// If multiple tabs pass the above check, only one will CAS successfully.
+	if (!await lastCheckStorage.compareAndSet(lastCheck, now)) return;
+	// From this point forward, it is guaranteed that only one tab can enter (per 15 minutes).
+
+	// Create provider, get permissions, etc.
+	const provider = await new providerClass().init();
+
+	// Read the remote backup to get the last modified time.
+	// This has some overhead, but only 2x at worst.
+	// (If we've reached this point, we're definitely going to be uploading or downloading the backup.)
+	// ...and it guarantees that the modified time remains in sync with the backup.
+	let remoteBackup;
+	const lastModifiedKey = lastModifiedStorage._keyGen(providerClass.key);
+	try {
+		remoteBackup = deserialize(await provider.read());
+	} catch (e) {
+		console.warn('Failed to read automatic backup:', e);
+		remoteBackup = { [lastModifiedKey]: 0 };
+	}
+
+	// We must use a positive check for restoring, to fail safe if the remote backup has no modified time.
+	// i.e. because `(undefined > 12345) === (undefined < 12345) === false`
+	if ((remoteBackup[lastModifiedKey]: any) > await lastModifiedStorage.get(providerClass.key)) {
+		// This will download the backup a second time, which in theory might download a newer version (which would be good, but quite rare).
+		// Restoring should be the uncommon case, though, so this is left as-is (for now) for simplicity.
+		await restore(provider, module.options.warnBeforeAutomaticRestore.value ? 'automatic' : 'none');
+	} else {
+		await backup(provider);
 	}
 }
 
 async function backup(provider) {
 	const { key, text, notifyBackupDone } = provider.constructor;
+	// Write to lastModified and store it in the blob.
+	// At this point, we know that there is no remote backup newer than local. [*]
+	// In the worst case, the backup request fails, but this modified time has already been set to the current date.
+	// That's still okay, because:
+	// a. If a new remote backup happens, it should happen after this millisecond (because [*]), so its timestamp
+	//    will be greater than this value, and will get restored as expected.
+	// b. If no new remote backup happens, then our local modified time will still be equal to/ahead of the remote,
+	//    and we'll just try backing up again after the next check.
+	// (theoretically, there is a very short timeframe between the check for [*] and this backup,
+	//  during which another client [but not this one, thanks to the lastCheck CAS] could create a new backup,
+	//  but it should be very short [~1 second] and would require using two machines simultaneously, which we warn about)
+	await lastModifiedStorage.set(key, Date.now());
 	const storage = await Storage.getAll();
-	const newUpdateDate = await provider.write(serialize(storage));
-	await lastModifiedStorage.set(key, newUpdateDate);
+	await provider.write(serialize(storage));
 
 	if (notifyBackupDone) {
 		Notifications.showNotification({
@@ -149,27 +169,44 @@ async function backup(provider) {
 	}
 }
 
-async function restore(provider, { shouldAlert = true, alertPrefix = '' } = {}) {
-	const { key } = provider.constructor;
-	const { data, modified } = await provider.read();
+async function restore(provider, alertType: 'normal' | 'automatic' | 'none' = 'normal') {
+	const { key, name } = provider.constructor;
+	const data = await provider.read();
 	const storage = deserialize(data);
 
-	if (shouldAlert) {
+	const lastModifiedKey = lastModifiedStorage._keyGen(key);
+	if (alertType !== 'none') {
 		try {
 			await Alert.open(`
-			<p><b>${alertPrefix}</b></p>
+			${alertType === 'automatic' ? `
+				<p><b>Found new automatic backup from ${name}.</b></p>
+				<br>
+			` : ''}
 			<p>Restoring a backup will <b>permanently</b> overwrite your current storage. Are you sure you want to do this?</p>
 			<br>
-			<p>${modified ? `Backup date: ${formatDateTime(new Date(modified))}` : ''}</p>
+			${alertType === 'automatic' ? `
+				<p>If you click cancel, you will be taken to the settings page where you can disable automatic backups or create a new backup to overwrite this one.</p>
+				<br>
+			` : ''}
+			<p>${storage[lastModifiedKey] ? `Backup date: ${formatDateTime(new Date((storage[lastModifiedKey]: any)))}` : ''}</p>
 			<p>Backup size: ${numeral(data.length).format('0.0 b')}</p>
 		`, { cancelable: true });
 		} catch (e) {
+			if (alertType === 'automatic') {
+				SettingsNavigation.loadSettingsPage(module.moduleID, 'automaticBackups');
+			}
 			return;
 		}
 	}
 
+	// This is the only correctness-related write involved in restoring a backup.
+	// This operation is atomic (probably--at least, as atomic as our limited API can be), so if it fails
+	// then the remote timestamp will still be ahead of the local timestamp, and we'll try restoring again
+	// after the next check.
+	// This will reset the lastCheck time to whatever it was when this backup was created,
+	// potentially meaning the next pageload will create a new backup.
+	// That's fine, because we can assume that the other client was in a consistent state.
 	await Storage.setMultiple(storage);
-	await lastModifiedStorage.set(key, modified);
 
 	Alert.open(i18n('backupAndRestoreImported'));
 	warnTabsAboutRestore(module.options.reloadWarning.value);

--- a/lib/modules/backupAndRestore/providers/Dropbox.js
+++ b/lib/modules/backupAndRestore/providers/Dropbox.js
@@ -28,28 +28,14 @@ export class Dropbox extends Provider {
 		return this;
 	}
 
-	async readLastModified() {
-		const { server_modified: modified } = await ajax({
-			method: 'POST',
-			url: 'https://api.dropboxapi.com/2/files/get_metadata',
-			data: JSON.stringify({ path: FILE }),
-			headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${this.accessToken}` },
-			type: 'json',
-		});
-		return Date.parse(modified);
-	}
-
 	async read() {
 		try {
-			const { text, headers } = await ajax({
+			return await ajax({
 				method: 'POST',
 				url: 'https://content.dropboxapi.com/2/files/download',
 				query: { arg: JSON.stringify({ path: FILE }) },
 				headers: { Authorization: `Bearer ${this.accessToken}` },
-				type: 'raw',
 			});
-			const modified = JSON.parse(headers['dropbox-api-result']).server_modified;
-			return { data: text, modified: Date.parse(modified) };
 		} catch (e) {
 			if (e.status === 409) {
 				throw new Error('Could not find backup.');
@@ -60,7 +46,7 @@ export class Dropbox extends Provider {
 	}
 
 	async write(data: string) {
-		const { server_modified: modified } = await ajax({
+		await ajax({
 			method: 'POST',
 			url: 'https://content.dropboxapi.com/2/files/upload',
 			query: { arg: JSON.stringify({ path: FILE, mode: 'overwrite', mute: true }) },
@@ -68,6 +54,5 @@ export class Dropbox extends Provider {
 			headers: { 'Content-Type': 'application/octet-stream', Authorization: `Bearer ${this.accessToken}` },
 			type: 'json',
 		});
-		return Date.parse(modified);
 	}
 }

--- a/lib/modules/backupAndRestore/providers/File.js
+++ b/lib/modules/backupAndRestore/providers/File.js
@@ -18,11 +18,7 @@ export class File extends Provider {
 				const file = link.files[0];
 				const reader = new FileReader();
 				reader.onload = () => {
-					resolve({
-						data: reader.result,
-						// $FlowIssue no File.prototype.lastModified
-						modified: file.lastModified || null /* Edge has no lastModified and can't deal with undefined */,
-					});
+					resolve(reader.result);
 				};
 				reader.readAsText(file);
 			});
@@ -43,6 +39,6 @@ export class File extends Provider {
 		const date = new Date();
 		link.download = `RES-${date.getUTCFullYear()}-${date.getMonth() + 1}-${date.getDate()}-${Math.round(date.getTime() / 1000)}-${Metadata.version.replace(/\./g, '_')}.resbackup`;
 		click(link);
-		return Promise.resolve(date.valueOf() /* convert to number */);
+		return Promise.resolve();
 	}
 }

--- a/lib/modules/backupAndRestore/providers/GoogleDrive.js
+++ b/lib/modules/backupAndRestore/providers/GoogleDrive.js
@@ -34,7 +34,7 @@ export class GoogleDrive extends Provider {
 		const { files: [file] } = await ajax({
 			method: 'GET',
 			url: 'https://content.googleapis.com/drive/v3/files',
-			query: { fields: 'files(id,modifiedTime)', q: `name="${FILE}"`, spaces: FOLDER },
+			query: { fields: 'files(id)', q: `name="${FILE}"`, spaces: FOLDER },
 			headers: { Authorization: `Bearer ${this.accessToken}` },
 			type: 'json',
 		});
@@ -56,12 +56,6 @@ export class GoogleDrive extends Provider {
 		});
 	}
 
-	async readLastModified() {
-		const file = await this.getExistingFile();
-		if (!file) throw new Error('Could not find backup.');
-		return Date.parse(file.modifiedTime);
-	}
-
 	async read() {
 		const file = await this.getExistingFile();
 		if (!file) throw new Error('Could not find backup.');
@@ -74,19 +68,18 @@ export class GoogleDrive extends Provider {
 				Authorization: `Bearer ${this.accessToken}`,
 			},
 		});
-		return { data: atob(data), modified: Date.parse(file.modifiedTime) };
+		return atob(data);
 	}
 
 	async write(data: string) {
 		const { id } = await this.getOrCreateFile();
-		const { modifiedTime } = await ajax({
+		await ajax({
 			method: 'PATCH',
 			url: `https://content.googleapis.com/upload/drive/v3/files/${id}`,
-			query: { uploadType: 'media', fields: 'modifiedTime' },
+			query: { uploadType: 'media' },
 			data,
 			headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${this.accessToken}` },
 			type: 'json',
 		});
-		return Date.parse(modifiedTime);
 	}
 }

--- a/lib/modules/backupAndRestore/providers/OneDrive.js
+++ b/lib/modules/backupAndRestore/providers/OneDrive.js
@@ -34,7 +34,9 @@ export class OneDrive extends Provider {
 			return await ajax({
 				method: 'GET',
 				url: `https://api.onedrive.com/v1.0/drive/special/approot:/${FILE}`,
-				query: { select: 'lastModifiedDateTime,@content.downloadUrl' },
+				// `id` is necessary because the first thing selected can't start with @
+				// and I have no idea how to escape it (quoting, backslash, etc. don't work...)
+				query: { select: 'id,@content.downloadUrl' },
 				headers: { Authorization: `Bearer ${this.accessToken}` },
 				type: 'json',
 			});
@@ -47,28 +49,21 @@ export class OneDrive extends Provider {
 		}
 	}
 
-	async readLastModified() {
-		const file = await this.getMetadata();
-		return Date.parse(file.lastModifiedDateTime);
-	}
-
 	async read() {
 		const file = await this.getMetadata();
-		const data = await ajax({
+		return ajax({
 			method: 'GET',
 			url: file['@content.downloadUrl'],
 		});
-		return { data, modified: Date.parse(file.lastModifiedDateTime) };
 	}
 
 	async write(data: string) {
-		const file = await ajax({
+		await ajax({
 			method: 'PUT',
 			url: `https://api.onedrive.com/v1.0/drive/special/approot:/${FILE}:/content`,
 			data,
 			headers: { Authorization: `Bearer ${this.accessToken}` },
 			type: 'json',
 		});
-		return Date.parse(file.lastModifiedDateTime);
 	}
 }

--- a/lib/modules/backupAndRestore/providers/Provider.js
+++ b/lib/modules/backupAndRestore/providers/Provider.js
@@ -1,8 +1,6 @@
 /* @flow */
+
 /* eslint-disable no-unused-vars */
-
-type ModifiedTime = number;
-
 export class Provider {
 	static key = 'abstract';
 	static text = 'Abstract';
@@ -13,11 +11,7 @@ export class Provider {
 		return Promise.resolve(this);
 	}
 
-	readLastModified(): Promise<ModifiedTime> {
-		return Promise.reject(new Error('This provider does not support retrieving last modified date without a backup.'));
-	}
+	read(): Promise<string> { throw new Error('unimplemented'); }
 
-	read(): Promise<{| data: string, modified: ModifiedTime |}> { throw new Error('unimplemented'); }
-
-	write(data: string): Promise<ModifiedTime> { throw new Error('unimplemented'); }
+	write(data: string): Promise<void> { throw new Error('unimplemented'); }
 }


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: closes #4309
Tested in browser: Chrome 60, Firefox 53

Two main things:
- set the timestamp forward locally first, and store it in the backup (instead of using the host's metadata), so the remote doesn't spuriously get "ahead" of the local time (FTR: this is basically @larsjohnsen's original implementation)
- CAS the last check timestamp so definitely only one tab will be restoring (this, combined with the previous point, is simpler and should be equally sound as doing it on the background page)

Also go to the options page if the user cancels restoration.