### PR TITLE
Fixes Wikipedia expando issue with LaTeX for math formulas 

### DIFF
--- a/lib/modules/hosts/wikipedia.js
+++ b/lib/modules/hosts/wikipedia.js
@@ -54,7 +54,7 @@ export default new Host('wikipedia', {
 		// Clean up returned data
 		const $wikiData = $('<div>', { html: data.parse.text['*'] });
 		// Remove unwanted sections
-		$wikiData.find('.metadata, .hatnote, .mw-editsection, .reference, .references').remove();
+		$wikiData.find('.metadata, .hatnote, .mw-editsection, .mwe-math-mathml-inline, .reference, .references').remove();
 		// Update all links to use the article's URL as baseURL
 		$wikiData.find('a').attr('href', (i, old) => new URL(old, `https://${language}.wikipedia.org/wiki/${article}`).href);
 


### PR DESCRIPTION
The Unicode renderings and LaTeX code for math symbols in Wikipedia articles are removed from the HTML that is rendered by the Wikipedia expando, leaving just the fall-back images. This makes it easier to read and is less cluttered.

This is what it looked like before:
![screenshot_20170615_211849](https://user-images.githubusercontent.com/7196382/27312084-bf789fb6-5533-11e7-93db-bdd6f3912770.png)

This is what it looks like with the patch applied:
![screenshot_20170619_211220](https://user-images.githubusercontent.com/7196382/27312115-050a676c-5534-11e7-9081-36bd01c7b6f3.png)



<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: #4319 
Tested in browser: Chrome
