### PR TITLE
Use exclude_matches instead of cancelling init at runtime

### DIFF
--- a/chrome/beta/manifest.json
+++ b/chrome/beta/manifest.json
@@ -31,6 +31,25 @@
 		"matches": [
 			"https://*.reddit.com/*"
 		],
+		"exclude_matches": [
+			"https://mod.reddit.com/*",
+			"https://ads.reddit.com/*",
+			"https://i.reddit.com/*",
+			"https://m.reddit.com/*",
+			"https://static.reddit.com/*",
+			"https://thumbs.reddit.com/*",
+			"https://blog.reddit.com/*",
+			"https://code.reddit.com/*",
+			"https://about.reddit.com/*",
+			"https://*.reddit.com/*.compact",
+			"https://*.reddit.com/*.compact?*",
+			"https://*.reddit.com/*.mobile",
+			"https://*.reddit.com/*.mobile?*",
+			"https://*.reddit.com/*.json",
+			"https://*.reddit.com/*.json?*",
+			"https://*.reddit.com/*.json-html",
+			"https://*.reddit.com/*.json-html?*"
+		],
 		"js": [
 			"{{../chrome.entry.js}}",
 			"{{../../lib/main.entry.js}}"

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -31,6 +31,25 @@
 		"matches": [
 			"https://*.reddit.com/*"
 		],
+		"exclude_matches": [
+			"https://mod.reddit.com/*",
+			"https://ads.reddit.com/*",
+			"https://i.reddit.com/*",
+			"https://m.reddit.com/*",
+			"https://static.reddit.com/*",
+			"https://thumbs.reddit.com/*",
+			"https://blog.reddit.com/*",
+			"https://code.reddit.com/*",
+			"https://about.reddit.com/*",
+			"https://*.reddit.com/*.compact",
+			"https://*.reddit.com/*.compact?*",
+			"https://*.reddit.com/*.mobile",
+			"https://*.reddit.com/*.mobile?*",
+			"https://*.reddit.com/*.json",
+			"https://*.reddit.com/*.json?*",
+			"https://*.reddit.com/*.json-html",
+			"https://*.reddit.com/*.json-html?*"
+		],
 		"js": [
 			"{{./chrome.entry.js}}",
 			"{{../lib/main.entry.js}}"

--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -28,6 +28,25 @@
 		"matches": [
 			"https://*.reddit.com/*"
 		],
+		"exclude_matches": [
+			"https://mod.reddit.com/*",
+			"https://ads.reddit.com/*",
+			"https://i.reddit.com/*",
+			"https://m.reddit.com/*",
+			"https://static.reddit.com/*",
+			"https://thumbs.reddit.com/*",
+			"https://blog.reddit.com/*",
+			"https://code.reddit.com/*",
+			"https://about.reddit.com/*",
+			"https://*.reddit.com/*.compact",
+			"https://*.reddit.com/*.compact?*",
+			"https://*.reddit.com/*.mobile",
+			"https://*.reddit.com/*.mobile?*",
+			"https://*.reddit.com/*.json",
+			"https://*.reddit.com/*.json?*",
+			"https://*.reddit.com/*.json-html",
+			"https://*.reddit.com/*.json-html?*"
+		],
 		"js": [
 			"{{file-loader?name=[name].[ext]!url-search-params/build/url-search-params.js}}",
 			"{{./edge.entry.js}}",

--- a/firefox/beta/manifest.json
+++ b/firefox/beta/manifest.json
@@ -35,6 +35,25 @@
 		"matches": [
 			"https://*.reddit.com/*"
 		],
+		"exclude_matches": [
+			"https://mod.reddit.com/*",
+			"https://ads.reddit.com/*",
+			"https://i.reddit.com/*",
+			"https://m.reddit.com/*",
+			"https://static.reddit.com/*",
+			"https://thumbs.reddit.com/*",
+			"https://blog.reddit.com/*",
+			"https://code.reddit.com/*",
+			"https://about.reddit.com/*",
+			"https://*.reddit.com/*.compact",
+			"https://*.reddit.com/*.compact?*",
+			"https://*.reddit.com/*.mobile",
+			"https://*.reddit.com/*.mobile?*",
+			"https://*.reddit.com/*.json",
+			"https://*.reddit.com/*.json?*",
+			"https://*.reddit.com/*.json-html",
+			"https://*.reddit.com/*.json-html?*"
+		],
 		"js": [
 			"{{../firefox.entry.js}}",
 			"{{../../lib/main.entry.js}}"

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -35,6 +35,25 @@
 		"matches": [
 			"https://*.reddit.com/*"
 		],
+		"exclude_matches": [
+			"https://mod.reddit.com/*",
+			"https://ads.reddit.com/*",
+			"https://i.reddit.com/*",
+			"https://m.reddit.com/*",
+			"https://static.reddit.com/*",
+			"https://thumbs.reddit.com/*",
+			"https://blog.reddit.com/*",
+			"https://code.reddit.com/*",
+			"https://about.reddit.com/*",
+			"https://*.reddit.com/*.compact",
+			"https://*.reddit.com/*.compact?*",
+			"https://*.reddit.com/*.mobile",
+			"https://*.reddit.com/*.mobile?*",
+			"https://*.reddit.com/*.json",
+			"https://*.reddit.com/*.json?*",
+			"https://*.reddit.com/*.json-html",
+			"https://*.reddit.com/*.json-html?*"
+		],
 		"js": [
 			"{{./firefox.entry.js}}",
 			"{{../lib/main.entry.js}}"

--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -20,14 +20,8 @@ import { // eslint-disable-line import/order
 let start;
 
 export function init() {
-	if (
-		!document.documentElement.getAttribute('xmlns') || // Only run on r2
-		(/^(?:i|m|static|thumbs|blog|code|mod|about|ads)\./i).test(location.hostname) ||
-		(/^\/advertising/).test(location.pathname) ||
-		(/\.(?:compact|mobile|json|json-html)$/i).test(location.pathname)
-	) {
-		return;
-	}
+	// Only run on r2
+	if (!document.documentElement.getAttribute('xmlns')) return;
 
 	if (sessionStorage.getItem(RES_DISABLED_KEY)) return;
 

--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -34,7 +34,7 @@ export function init() {
 
 const sourceLoaded = new Promise(resolve => (start = resolve));
 
-// Edge sometimes has weird bugs with MutationObservers
+// Edge has weird bugs with MutationObservers
 // so just make a best effort at divining when the head and body are ready
 
 export const headReady = sourceLoaded
@@ -53,7 +53,7 @@ export const bodyStart = sourceLoaded
 
 export const bodyReady = bodyStart
 	.then(() => Promise.race([
-		waitFor(() => document.body, 10).then(body => waitForChild(body, '.debuginfo')),
+		waitForChild(document.body, '.debuginfo'),
 		contentLoaded, // in case reddit removes or changes .debuginfo
 	]));
 

--- a/lib/core/modules/modules.js
+++ b/lib/core/modules/modules.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-import _ from 'lodash';
 import { flow, keyBy, map } from 'lodash/fp';
 import { Storage, i18n } from '../../environment';
 import {
@@ -14,22 +13,21 @@ const moduleContext = require.context('../../modules', false, /\.js$/);
 
 const enabled = {};
 
-const _modules = _.once(flow(
+const modules = flow(
 	() => moduleContext.keys(),
 	map(moduleContext),
 	map(e => e.module),
 	map(mod => downcast(mod, Module)), // ensure that all modules are instances of `Module`
 	keyBy(mod => mod.moduleID)
-));
+)();
 
 if (process.env.NODE_ENV === 'development') {
 	// for debugging only! do not use `modules` in any committed code
-	window.modules = _modules;
+	window.modules = modules;
 }
 
 export async function _loadModulePrefs() {
 	const storedPrefs = await Storage.get('RES.modulePrefs') || {};
-	const modules = _modules();
 
 	for (const id in modules) {
 		if (modules[id].alwaysEnabled) {
@@ -51,7 +49,7 @@ export function setEnabled(opaqueId: OpaqueModuleId, enable: boolean) {
 }
 
 export function all(): Array<Module<any>> {
-	return Object.values(_modules());
+	return Object.values(modules);
 }
 
 export function isEnabled(opaqueId: OpaqueModuleId): boolean {
@@ -85,15 +83,13 @@ export function get(opaqueId: OpaqueModuleId): Module<any> {
 }
 
 function _get(id) {
-	if (!(id in _modules())) {
-		throw new Error(`Module "${id}" not found.`);
-	}
-
-	return getUnchecked(id);
+	const mod = getUnchecked(id);
+	if (!mod) throw new Error(`Module "${id}" not found.`);
+	return mod;
 }
 
-export function getUnchecked(id: string): Module<any> {
-	return _modules()[id];
+export function getUnchecked(id: string): void | Module<any> {
+	return modules[id];
 }
 
 export function getByCategory(category: string): Array<Module<any>> {


### PR DESCRIPTION
Tested in browser: Chrome 60, Firefox 53, Edge 15

So that we run nothing at all on those pages. I should've done #3795 this way originally.