### PR TITLE
Expandos are no longer direct children of .entry

### DIFF
--- a/lib/modules/showImages/expando.js
+++ b/lib/modules/showImages/expando.js
@@ -10,12 +10,10 @@ import {
 } from '../../utils';
 import type { Thing } from '../../utils';
 
-// @type {WeakMap.<expandoButton, Expando>}
 export const expandos: WeakMap<Element, Expando> = new WeakMap();
 
 // Used for specifying primary expando for any given link
-// @type {Map.<string, Expando>} - key: href
-export const primaryExpandos: Map<string, Expando> = new Map();
+export const primaryExpandos: Map<string /* href */, Expando> = new Map();
 
 type OnExpandCallback = () => void;
 
@@ -54,13 +52,13 @@ export class Expando {
 	static getEntryExpandoFrom(thing: ?Thing): ?Expando {
 		if (!thing) return null;
 
-		const button = $(thing.entry).find('.expando-button')[0];
+		const button = thing.entry.querySelector('.expando-button');
 		if (!button) return null;
 
 		let expando = expandos.get(button);
 
 		if (!expando) {
-			const box = $(thing.entry).find('.expando')[0];
+			const box = thing.entry.querySelector('.expando');
 
 			const buttonPlaceholder = document.createElement('span');
 			const boxPlaceholder = document.createElement('span');
@@ -73,12 +71,16 @@ export class Expando {
 				expand() { if (!this.open) this.toggle(); },
 				toggle() { click(button); },
 				detach() {
-					$(button).replaceWith(buttonPlaceholder);
-					$(box).replaceWith(boxPlaceholder);
+					// $FlowIssue need 0.40
+					button.replaceWith(buttonPlaceholder);
+					// $FlowIssue need 0.40
+					box.replaceWith(boxPlaceholder);
 				},
 				reattach() {
-					$(buttonPlaceholder).replaceWith(button);
-					$(boxPlaceholder).replaceWith(box);
+					// $FlowIssue need 0.40
+					buttonPlaceholder.replaceWith(button);
+					// $FlowIssue need 0.40
+					boxPlaceholder.replaceWith(box);
 				},
 				getTypes() {
 					return [


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: https://www.reddit.com/r/RESissues/comments/6iw03n/two_media_expandos_per_post/
Tested in browser: Chrome 60

Only the two selector changes will be backported for the hotfix.