### PR TITLE
Add Search Keybinding & RES-Console Commands

### DIFF
--- a/lib/modules/commandLine.js
+++ b/lib/modules/commandLine.js
@@ -572,7 +572,7 @@ registerCommand(/^\/([nthrcgp])?/, '/n, /t, /h, /r, /c, /g, or /p - goes to new,
 	}
 );
 
-registerCommand(/^s(?:earch)?:\s?(.*)/, 's[earch]: [query] - searches the current subreddit (if any) or all of Reddit',
+registerCommand(cmd => ['s', 'search'].includes(cmd), 's[earch] [query] - searches the current subreddit (if any) or all of Reddit',
 	(command, val) => {
 		const subreddit = currentSubreddit();
 		if (!subreddit) {
@@ -582,20 +582,18 @@ registerCommand(/^s(?:earch)?:\s?(.*)/, 's[earch]: [query] - searches the curren
 	},
 	(command, val, match, e) => {
 		const subreddit = currentSubreddit();
-
 		if (!subreddit) {
-			navigateTo(`search?q=${val}`, e);
+			navigateTo(string.encode`/search?q=${val}`, e);
 			return;
 		}
-
-		navigateTo(`/r/${subreddit}/search?q=${val}&restrict_sr=on`, e);
+		navigateTo(string.encode`/r/${subreddit}/search?q=${val}&restrict_sr=on`, e);
 	}
 );
 
-registerCommand(/^sr:\s?(.*)/, 'sr: [query] - searches all of Reddit',
+registerCommand('sr', 'sr [query] - searches all of Reddit',
 	(command, val) => `Search all of Reddit: ${val}`,
 	(command, val, match, e) => {
-		navigateTo(`/search?q=${val}`, e);
+		navigateTo(string.encode`/search?q=${val}`, e);
 	}
 );
 

--- a/lib/modules/commandLine.js
+++ b/lib/modules/commandLine.js
@@ -572,6 +572,33 @@ registerCommand(/^\/([nthrcgp])?/, '/n, /t, /h, /r, /c, /g, or /p - goes to new,
 	}
 );
 
+registerCommand(/^s(?:earch)?:\s?(.*)/, 's[earch]: [query] - searches the current subreddit (if any) or all of Reddit',
+	(command, val) => {
+		const subreddit = currentSubreddit();
+		if (!subreddit) {
+			return `Search all of Reddit: ${val}`;
+		}
+		return `Search /r/${subreddit}: ${val}`;
+	},
+	(command, val, match, e) => {
+		const subreddit = currentSubreddit();
+
+		if (!subreddit) {
+			navigateTo(`search?q=${val}`, e);
+			return;
+		}
+
+		navigateTo(`/r/${subreddit}/search?q=${val}&restrict_sr=on`, e);
+	}
+);
+
+registerCommand(/^sr:\s?(.*)/, 'sr: [query] - searches all of Reddit',
+	(command, val) => `Search all of Reddit: ${val}`,
+	(command, val, match, e) => {
+		navigateTo(`/search?q=${val}`, e);
+	}
+);
+
 registerCommand('?', false,
 	() => {
 		const descriptions = commands

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -723,6 +723,13 @@ module.options = {
 		callback() { CommentNavigator.moveDown(); },
 	},
 	// numbers and numpad numbers are used to access links (see getLinkKeys)
+	focusOnSearchBox: {
+		type: 'keycode',
+		value: [191, false, false, false, false], // "/"
+		description: 'keyboardNavFocusOnSearchBoxDesc',
+		title: 'keyboardNavFocusOnSearchBoxTitle',
+		callback: focusOnSearchBox,
+	},
 };
 
 module.beforeLoad = () => {
@@ -1289,4 +1296,8 @@ function openLink(index, altMode = false) {
 	} else {
 		location.href = link.href;
 	}
+}
+
+function focusOnSearchBox() {
+	$('form#search input[name="q"]').focus();
 }

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -722,14 +722,14 @@ module.options = {
 		title: 'keyboardNavCommentNavigatorMoveDownTitle',
 		callback() { CommentNavigator.moveDown(); },
 	},
-	// numbers and numpad numbers are used to access links (see getLinkKeys)
 	focusOnSearchBox: {
 		type: 'keycode',
-		value: [191, false, false, false, false], // "/"
+		value: [191, true, false, false, false], // alt-/
 		description: 'keyboardNavFocusOnSearchBoxDesc',
 		title: 'keyboardNavFocusOnSearchBoxTitle',
-		callback: focusOnSearchBox,
+		callback() { document.querySelector('#search input[name="q"]').focus(); },
 	},
+	// numbers and numpad numbers are used to access links (see getLinkKeys)
 };
 
 module.beforeLoad = () => {
@@ -1296,8 +1296,4 @@ function openLink(index, altMode = false) {
 	} else {
 		location.href = link.href;
 	}
-}
-
-function focusOnSearchBox() {
-	$('form#search input[name="q"]').focus();
 }

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -867,6 +867,12 @@
 	"keyboardNavAmbiguousShortcutPromptFollowUp": {
 		"message": "You can change this later from the $1 settings"
 	},
+	"keyboardNavFocusOnSearchBoxTitle": {
+		"message": "Focus on Search Box"
+	},
+	"keyboardNavFocusOnSearchBoxDesc": {
+		"message": "Focuses the cursor in the search box"
+	},
 	"localDateName": {
 		"message": "Local Date"
 	},

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -871,7 +871,7 @@
 		"message": "Focus on Search Box"
 	},
 	"keyboardNavFocusOnSearchBoxDesc": {
-		"message": "Focuses the cursor in the search box"
+		"message": "Focuses the cursor in the search box."
 	},
 	"localDateName": {
 		"message": "Local Date"


### PR DESCRIPTION
Closes #2211 
Tested in browser: Firefox 54.0, Chrome 59.0.3071.109

This PR adds:

1. A "/" keybinding to focus the cursor on the search box anywhere on Reddit.
2. Two new commands on the RES Command Console

The two new commands are

1. `s[earch]: <query>` - Search current subreddit (if any) or all of Reddit for "query"
2. `sr: <query>` - Search all of Reddit for "query"

Any thoughts?
