### PR TITLE
Added a shortcut to show/hide child comment trees on the comment page.

### DIFF
--- a/lib/modules/hideChildComments.js
+++ b/lib/modules/hideChildComments.js
@@ -118,3 +118,9 @@ function addToggleChildrenButton(comment) {
 	li.appendChild(a);
 	menu.appendChild(li);
 }
+
+export function toggle(thing: *) {
+	const button = thing.entry.querySelector('a.toggleChildren');
+	if (!button) throw new Error('Toggle button not found');
+	button.click();
+}

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -584,6 +584,14 @@ module.options = {
 			click(getFirstElementInThingByQuery('.entry .edit-usertext', ASSERT, getSelected()));
 		},
 	},
+	showChildComments: {
+		type: 'keycode',
+		include: ['comments', 'commentsLinklist'],
+		value: [67, false, false, false, false], // c
+		description: 'keyboardNavShowChildCommentsDesc',
+		title: 'keyboardNavShowChildCommentsTitle',
+		callback: showChildComments,
+	},
 	followPermalink: {
 		type: 'keycode',
 		include: ['comments', 'commentsLinklist', 'inbox'],
@@ -1120,6 +1128,16 @@ function reply(selected = getSelected()) {
 		// User cannot reply directly from this page, so go to where they can reply
 		getFirstElementInThingByQuery('.buttons a.comments, .buttons a.bylink', NOASSERT, selected)
 	));
+}
+
+function showChildComments() {
+	const selected = SelectedEntry.selectedThing;
+	if (!selected) return;
+
+	const button = selected.entry.querySelector('a.toggleChildren');
+	if (button) {
+		click(button);
+	}
 }
 
 function navigateTo(newWindow, href) {

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -29,6 +29,7 @@ import * as CommandLine from './commandLine';
 import * as CommentNavigator from './commentNavigator';
 import * as EasterEgg from './easterEgg';
 import * as FilteReddit from './filteReddit';
+import * as HideChildComments from './hideChildComments';
 import * as NeverEndingReddit from './neverEndingReddit';
 import * as Notifications from './notifications';
 import * as NoParticipation from './noParticipation';
@@ -586,11 +587,13 @@ module.options = {
 	},
 	showChildComments: {
 		type: 'keycode',
-		include: ['comments', 'commentsLinklist'],
+		requiresModule: HideChildComments,
 		value: [67, false, false, false, false], // c
 		description: 'keyboardNavShowChildCommentsDesc',
 		title: 'keyboardNavShowChildCommentsTitle',
-		callback: showChildComments,
+		callback(selected = getSelected()) {
+			HideChildComments.toggle(selected);
+		},
 	},
 	followPermalink: {
 		type: 'keycode',
@@ -1128,16 +1131,6 @@ function reply(selected = getSelected()) {
 		// User cannot reply directly from this page, so go to where they can reply
 		getFirstElementInThingByQuery('.buttons a.comments, .buttons a.bylink', NOASSERT, selected)
 	));
-}
-
-function showChildComments() {
-	const selected = SelectedEntry.selectedThing;
-	if (!selected) return;
-
-	const button = selected.entry.querySelector('a.toggleChildren');
-	if (button) {
-		click(button);
-	}
 }
 
 function navigateTo(newWindow, href) {

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -759,6 +759,12 @@
 	"keyboardNavEditDesc": {
 		"message": "Edit current comment or self-post."
 	},
+	"keyboardNavShowChildCommentsTitle": {
+		"message": "Show child comments"
+	},
+	"keyboardNavShowChildCommentsDesc": {
+		"message": "Show/hide the child comments tree (comment pages only)."
+	},
 	"keyboardNavFollowPermalinkTitle": {
 		"message": "Follow Permalink"
 	},


### PR DESCRIPTION
"C" by default.

Fixes #1274.

Tested in Chrome and Firefox.

I have the feeling that one shortcut should serve to expand comment trees, collapse them and load more comments—instead of two shortcuts (C and Enter) plus navigation to "load more comments."

With "show/hide child comments" for nested comments enabled, the present change allows to use one shortcut to expand top-level comments (if collapsed by default) and collapse trees of child comments.

However, I also think that child comment trees that were deliberately collapsed should be highlighted visually, like it happens now with Enter—because I use this regularly to find comments that I just read but didn't think to save or leave a reply.  Not sure how this is best done, yet.