### PR TITLE
Comment filters

### DIFF
--- a/lib/css/modules/_commentNavigator.scss
+++ b/lib/css/modules/_commentNavigator.scss
@@ -13,7 +13,7 @@
 
 	&-choices {
 		cursor: initial;
-		z-index: 1;
+		z-index: 41;
 		display: none;
 		position: absolute;
 		background-color: rgba(255, 255, 255, .9);

--- a/lib/css/modules/_filteReddit.scss
+++ b/lib/css/modules/_filteReddit.scss
@@ -9,8 +9,22 @@ body.hideOver18 {
 .search-result.RESFiltered {
 	// For some reason does the scss linter complain on body:not()
 	body.res:not(.res-filters-disabled):not(.res-show-filter-reason) &:not(.res-filterline-highlight-match) {
-		// !important since many custom stylesheets overrides it otherwise
-		display: none !important;
+		&:not(.res-thing-has-visible-child),
+		&.res-thing-has-visible-child.collapsed { // seperate line since :not() didn't work with multiple classes
+			// !important since many custom stylesheets overrides it otherwise
+			display: none !important;
+		}
+
+		&.res-thing-has-visible-child:not(.res-selected) {
+			> :not(.child) {
+				opacity: .3;
+			}
+
+			> .entry {
+				max-height: 60px;
+				position: relative; // Make sure that all children are confined
+			}
+		}
 	}
 
 	body.res &.res-filterline-highlight-match > .entry {
@@ -18,7 +32,9 @@ body.hideOver18 {
 	}
 
 	body.res-show-filter-reason & {
-		opacity: .7;
+		> :not(.child) {
+			opacity: .7;
+		}
 
 		&::before {
 			content: attr(filter-reason);
@@ -42,6 +58,10 @@ body.hideOver18 {
 	margin-bottom: 1px;
 	background-color: rgba(255, 255, 255, .9);
 	clear: left;
+
+	.comments-page & {
+		margin-left: 10px;
+	}
 }
 
 .res-filteReddit-filterline-pad-until-ready {

--- a/lib/modules/commentNavigator.js
+++ b/lib/modules/commentNavigator.js
@@ -300,7 +300,7 @@ function move(to) {
 
 	const element = currentPosts()[index];
 	if (element) {
-		scrollToElement(element, { scrollStyle: 'top' });
+		scrollToElement(element, null, { scrollStyle: 'top' });
 		SelectedEntry.select(Thing.checkedFrom(element));
 	}
 

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -283,6 +283,23 @@ module.options = {
 		},
 		get cases() { Cases.populatePrimitives(); return { ...Cases.getByContext('post'), ...Cases.getByContext('browse') }; },
 	},
+	customFiltersC: {
+		type: 'builder',
+		advanced: true, // VERY
+		description: 'filteRedditCustomFiltersDesc',
+		title: 'filteRedditCustomFiltersTitle',
+		value: [],
+		addItemText: '+add custom filter',
+		defaultTemplate() {
+			return {
+				note: '',
+				ver: 2,
+				body: Cases.getConditions('group'),
+				ondemand: false,
+			};
+		},
+		get cases() { Cases.populatePrimitives(); return { ...Cases.getByContext('comment'), ...Cases.getByContext('browse') }; },
+	},
 };
 
 module.include = [
@@ -290,6 +307,7 @@ module.include = [
 	'modqueue',
 	'profile',
 	'comments',
+	'commentsLinklist',
 	'search',
 ];
 module.exclude = [
@@ -304,7 +322,7 @@ module.shouldRun = () => !(
 const featureTips = {
 	filterline: {
 		message: `
-RES allows you to easily apply complex filters to post listings. To toggle Filterline, click on the tab.
+RES allows you to easily apply complex filters to post listings and comments. To toggle Filterline, click on the tab.
 	`,
 		title: 'Filterline',
 		position: 6,
@@ -346,15 +364,31 @@ type LineState = {
 
 const pageID = fullLocation();
 const filterlineStorage = Storage.wrap(`filterline.${pageID}`, ({}: LineState));
+const thingType = isPageType('comments', 'commentsLinklist') ? 'comment' : 'post';
+const customFilterVariant = thingType === 'post' ? 'customFiltersP' : 'customFiltersC';
 
 // If filterlineStorage is empty, look for default filters
-export const defaultFilters: Array<{ type: string, storage: *, text: string }> = [
-	{
+export const defaultFilters: Array<{| type: string, text: string, storage: * |}> = []; // Decreasing precedense
+if (thingType === 'comment') {
+	if (currentSubreddit()) {
+		defaultFilters.push({
+			type: 'subreddit',
+			text: 'This subreddit',
+			storage: Storage.wrap(`RESmodules.filteReddit.commentDefault-${String(currentSubreddit())}`, (null: null | *)),
+		});
+	}
+	defaultFilters.push({
+		type: 'everywhere',
+		text: 'Everywhere',
+		storage: Storage.wrap('RESmodules.filteReddit.commentDefault', (null: null | *)),
+	});
+} else if (thingType === 'post') {
+	defaultFilters.push({
 		type: 'everywhere',
 		text: 'Everywhere',
 		storage: Storage.wrap('RESmodules.filteReddit.postDefault', (null: null | *)),
-	},
-]; // Decreasing precedense
+	});
+}
 
 async function getDefaultFilters() {
 	for (const { storage } of defaultFilters) {
@@ -374,7 +408,7 @@ module.beforeLoad = fastAsync(function*() {
 	// start initializing filterline early
 	createFilterline(yield initialFilterlineState.get());
 
-	watchForThings(['post'], registerThing, { immediate: true });
+	watchForThings([thingType], registerThing, { immediate: true });
 });
 
 const $nsfwSwitch = _.once(() => $(CreateElement.toggleButton(undefined, 'nsfwSwitchToggle', module.options.NSFWfilter.value)));
@@ -413,14 +447,14 @@ const createFilterline = _.once(({
 	filters: storedFilters = {},
 	visible: initialVisibility = module.options.showFilterline.value,
 } = {}) => {
-	Cases.populatePrimitives(['browse', 'post']);
-	const filterline = new Filterline(filterlineStorage);
+	Cases.populatePrimitives(['browse', thingType]);
+	const filterline = new Filterline(filterlineStorage, thingType);
 
 	const filters = {};
 	const addDefaultFilter = (type, state) => { filters[type] = { type, state, undeletable: true }; };
 
 	function addExternalFilter(type: $Keys<typeof module.options>, getConditions) {
-		Cases.createAdHoc(type, () => Cases.getGroup('any', getConditions()), 'external', 'post');
+		Cases.createAdHoc(type, () => Cases.getGroup('any', getConditions()), 'external', thingType);
 		addDefaultFilter(type, false);
 	}
 
@@ -429,15 +463,16 @@ const createFilterline = _.once(({
 			.forEach(v => addDefaultFilter(v, null));
 	}
 
-	function addPostFilters() {
-		module.options.customFiltersP.value
-			.filter(({ ondemand }) => ondemand)
-			.forEach(v => addOndemandCase(v));
+	module.options[customFilterVariant].value
+		.filter(({ ondemand }) => ondemand)
+		.forEach(v => addOndemandCase(v));
 
-		addExternalFilter('customFiltersP', () => module.options.customFiltersP.value.filter(v => !v.ondemand).map(v => {
-			externalFilterSourceMap.set(v.body, v);
-			return v.body;
-		}));
+	addExternalFilter(customFilterVariant, () => module.options[customFilterVariant].value.filter(v => !v.ondemand).map(v => {
+		externalFilterSourceMap.set(v.body, v);
+		return v.body;
+	}));
+
+	function addPostFilters() {
 		addExternalFilter('keywords', () => getStringMatchConditions('keywords', 'postTitle'));
 		addExternalFilter('domains', () => getStringMatchConditions('domains', 'domain', { fullMatch: false }));
 		if (
@@ -461,7 +496,16 @@ const createFilterline = _.once(({
 		]);
 	}
 
-	addPostFilters();
+	function addCommentFilters() {
+		addLineDefaults([
+			'hasExpando',
+			'score',
+			'isRead',
+		]);
+	}
+
+	if (thingType === 'post') addPostFilters();
+	else if (thingType === 'comment') addCommentFilters();
 
 	if (storedFilters) _.merge(filters, storedFilters);
 	filterline.restoreState(filters);
@@ -472,15 +516,19 @@ const createFilterline = _.once(({
 		BodyClasses.add('res-filteReddit-filterline-pad-until-ready');
 	}
 
-	const insertFilterline = _.once(() => {
-		filterline.createElement();
-
-		$(filterline.element).insertBefore(document.querySelector('#siteTable, .search-result-listing'));
-
-		BodyClasses.remove('res-filteReddit-filterline-pad-until-ready');
-	});
-
 	function go() {
+		const insertFilterline = _.once(() => {
+			filterline.createElement();
+
+			if (isPageType('comments')) {
+				$(filterline.element).insertBefore(document.querySelector('.comments-page .nestedlisting'));
+			} else {
+				$(filterline.element).insertBefore(document.querySelector('#siteTable, .search-result-listing'));
+			}
+
+			BodyClasses.remove('res-filteReddit-filterline-pad-until-ready');
+		});
+
 		const filterlineTab = CreateElement.tabMenuItem({
 			text: '',
 			title: 'Toggle Filterline',
@@ -568,7 +616,7 @@ export function addOndemandCase(customFilter: BuilderRootValue, forceUseful: boo
 
 	let cased;
 	if (Cases.isUseful(conditions.type) || forceUseful) {
-		cased = Cases.createAdHoc(name, () => conditions, 'ondemand', 'post');
+		cased = Cases.createAdHoc(name, () => conditions, 'ondemand', thingType);
 	} else {
 		cased = Cases.Inert;
 	}
@@ -585,7 +633,7 @@ export function addCustomFilter(data: {| body: *, ondemand: * |}): BuilderRootVa
 		...data,
 	}: any);
 
-	Options.set(module, 'customFiltersP', [customFilter, ...module.options.customFiltersP.value]);
+	Options.set(module, customFilterVariant, [customFilter, ...module.options[customFilterVariant].value]);
 
 	return customFilter;
 }
@@ -599,7 +647,7 @@ export function getCustomFilter(entry: *): BuilderRootValue {
 export function updateCustomFilter(customFilter: BuilderRootValue, val: any) {
 	const { body } = customFilter;
 	Object.assign(body, val);
-	Options.set(module, 'customFiltersP', module.options.customFiltersP.value);
+	Options.set(module, customFilterVariant, module.options[customFilterVariant].value);
 }
 
 export function removeExternalFilterEntry(externalType: string, entry: *) {

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -538,7 +538,7 @@ const createFilterline = _.once(({
 
 		filterlineTab.addEventListener('change', ({ detail: newVisibilityState }: any) => {
 			toggleVisibility(newVisibilityState);
-			if (visible) scrollToElement(filterline.element, { scrollStyle: 'legacy' });
+			if (visible) scrollToElement(filterline.element, null, { scrollStyle: 'legacy' });
 		});
 
 		const ensureVisible = () => { if (!visible) filterlineTab.click(); };

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -76,12 +76,6 @@ module.options = {
 		description: 'filteRedditExcludeOwnPostsDesc',
 		title: 'filteRedditExcludeOwnPostsTitle',
 	},
-	excludeCommentsPage: {
-		type: 'boolean',
-		value: true,
-		description: 'filteRedditExcludeCommentsPageDesc',
-		title: 'filteRedditExcludeCommentsPageTitle',
-	},
 	excludeModqueue: {
 		type: 'boolean',
 		value: true,
@@ -304,8 +298,7 @@ module.exclude = [
 
 module.shouldRun = () => !(
 	module.options.excludeModqueue.value && isPageType('modqueue') ||
-	module.options.excludeUserPages.value && isPageType('profile') ||
-	module.options.excludeCommentsPage.value && isPageType('comments')
+	module.options.excludeUserPages.value && isPageType('profile')
 );
 
 const featureTips = {

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -289,7 +289,7 @@ module.options = {
 		description: 'filteRedditCustomFiltersDesc',
 		title: 'filteRedditCustomFiltersTitle',
 		value: [],
-		addItemText: '+add custom filter',
+		addItemText: 'filteRedditAddCustomFilter',
 		defaultTemplate() {
 			return {
 				note: '',

--- a/lib/modules/filteReddit/Case.js
+++ b/lib/modules/filteReddit/Case.js
@@ -94,7 +94,7 @@ export class Case {
 	}
 
 	// Determines where cases are available; usually set by Cases.populate
-	static contexts: Array<'browse' | 'post'>;
+	static contexts: Array<'browse' | 'post' | 'comment'>;
 
 	// For Filterline
 	static unique: boolean = false;

--- a/lib/modules/filteReddit/Filterline.js
+++ b/lib/modules/filteReddit/Filterline.js
@@ -41,6 +41,7 @@ type NewFilterOpts = {|
 
 export class Filterline {
 	things: Set<Thing> = new Set();
+	thingType: string;
 
 	storage: *;
 	filters: Filter[] = []; // Non-inert filters
@@ -57,8 +58,9 @@ export class Filterline {
 	poweredElement: HTMLInputElement;
 	hideCheckbox: HTMLInputElement;
 
-	constructor(storage: *) {
+	constructor(storage: *, thingType: *) {
 		this.storage = storage;
+		this.thingType = thingType;
 	}
 
 	isInitialized() {
@@ -101,7 +103,7 @@ export class Filterline {
 	}
 
 	getPickable(): Class<Case>[] {
-		return Object.values(Cases.getByContext('post', false))
+		return Object.values(Cases.getByContext(this.thingType, false))
 			.filter(v => !v.disabled && v.variant !== 'external');
 	}
 
@@ -172,7 +174,7 @@ export class Filterline {
 			this.toggleShowFilterReason(showFilterReasonCheckbox.checked);
 		});
 
-		if (loggedInUser()) {
+		if (this.thingType === 'post' && loggedInUser()) {
 			const hideFiltered = string.html`
 				<div class="res-filterline-hide-filtered">
 					<label>

--- a/lib/modules/filteReddit/Filterline.js
+++ b/lib/modules/filteReddit/Filterline.js
@@ -399,7 +399,7 @@ export class Filterline {
 	}
 
 	addFilter(filter: Filter) {
-		if (filter.baseCase === Cases.Inert) {
+		if (filter.baseCase === Cases.Inert || filter.baseCase.disabled) {
 			this.inertFilters.push(filter);
 			return;
 		}

--- a/lib/modules/filteReddit/LineFilter.js
+++ b/lib/modules/filteReddit/LineFilter.js
@@ -91,7 +91,7 @@ export class LineFilter extends Filter {
 
 	// Memoize in order to preserve the builder when infocard closes
 	getBuilder = _.memoize((filterline, card) => {
-		const builderCases = Cases.getByContext('post');
+		const builderCases = Cases.getByContext(filterline.thingType);
 
 		let lastConditions = this.case.conditions;
 
@@ -260,7 +260,9 @@ export class LineFilter extends Filter {
 				for (const thing of allMatching) thing.element.classList.add('res-filterline-highlight-match');
 			});
 
-			addButton(body, 'Permanently hide', 'match-actions', 'native-hide').then(() => { filterline.hide(allMatching); });
+			if (filterline.thingType === 'post') {
+				addButton(body, 'Permanently hide', 'match-actions', 'native-hide').then(() => { filterline.hide(allMatching); });
+			}
 		}
 
 		return []; // Don't register any changes

--- a/lib/modules/filteReddit/cases.js
+++ b/lib/modules/filteReddit/cases.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import { fastAsync } from '../../utils';
 import { Case } from './Case';
 import * as postCases from './postCases';
+import * as commentCases from './commentCases';
 import * as browseCases from './browseCases';
 
 export class Inert extends Case {
@@ -198,7 +199,7 @@ export function createAdHoc(type: string, getConditions: () => *, variant: *, co
 
 const available: { [type: string]: Class<Case> } = {};
 
-export function add(type: *, c: Class<Case>, ...contexts: Array<'post' | 'browse'>) {
+export function add(type: *, c: Class<Case>, ...contexts: Array<'post' | 'comment' | 'browse'>) {
 	if (available.hasOwnProperty(type) && c !== available[type]) {
 		console.error(`A case named ${type} already exists. Existing:`, available[type].defaultConditions, 'Ignoring:', c.defaultConditions);
 		return;
@@ -212,7 +213,7 @@ export function add(type: *, c: Class<Case>, ...contexts: Array<'post' | 'browse
 
 const primitives = new Set();
 
-export function populatePrimitives(types: Array<*> = ['post', 'browse']) {
+export function populatePrimitives(types: Array<*> = ['post', 'comment', 'browse']) {
 	function fill(cases, ...contexts) {
 		for (const [k, v] of Object.entries(cases)) {
 			add(k, v, ...contexts);
@@ -226,9 +227,10 @@ export function populatePrimitives(types: Array<*> = ['post', 'browse']) {
 		true: True,
 	});
 
-	fill({ group: Group }, 'post', 'browse');
+	fill({ group: Group }, 'post', 'comment', 'browse');
 
 	if (types.includes('post')) fill(postCases, 'post');
+	if (types.includes('comment')) fill(commentCases, 'comment');
 	if (types.includes('browse')) fill(browseCases, 'browse');
 }
 

--- a/lib/modules/filteReddit/commentCases/CommentContent.js
+++ b/lib/modules/filteReddit/commentCases/CommentContent.js
@@ -1,0 +1,27 @@
+/* @flow */
+
+import { Case } from '../Case';
+
+export class CommentContent extends Case {
+	static text = 'Comment content';
+
+	static parseCriterion(input: *) { return { patt: input }; }
+
+	static defaultConditions = { patt: '' };
+	static fields = ['comment contains ', { type: 'text', id: 'patt' }];
+	static reconcilable = true;
+
+	static pattern = 'RegEx';
+
+	trueText = `comment contains ${this.value}`;
+	falseText = `¬ comment contains ${this.value}`;
+
+	constructor(conditions: *) {
+		super(Case.buildRegex(conditions.patt, { fullMatch: false }));
+	}
+
+	evaluate(thing: *, values: * = [this.value]) {
+		const md = thing.entry.querySelector('.md');
+		return !!md && values.some(v => v.test(md.textContent));
+	}
+}

--- a/lib/modules/filteReddit/commentCases/CommentLength.js
+++ b/lib/modules/filteReddit/commentCases/CommentLength.js
@@ -1,0 +1,32 @@
+/* @flow */
+
+import { Case } from '../Case';
+import { numericalCompare, prettyOperator, inverseOperator } from '../../../utils';
+
+const options = ['characters', 'words'];
+
+export class CommentLength extends Case {
+	static text = 'Comment length';
+
+	static parseCriterion(input: *) { return { op: '>=', kind: 'words', val: parseInt(input, 10) }; }
+
+	static fields = ['comment length is ', { type: 'select', options: 'COMPARISON', id: 'op' }, ' ', { type: 'number', id: 'val' }, ' ', { type: 'select', id: 'kind', options }];
+	static defaultConditions = { op: '>', kind: 'words', val: 0 };
+
+	static pattern = 'integer';
+
+	trueText = `length ${prettyOperator(this.value.op)} ${this.value.val} ${this.value.kind}`;
+	falseText = `length ${prettyOperator(inverseOperator(this.value.op))} ${this.value.val} ${this.value.kind}`;
+
+	validator() { return Number.isInteger(this.value.val); }
+
+	evaluate(thing: *) {
+		const md = thing.entry.querySelector('.md');
+		if (!md) return false;
+		switch (this.value.kind) {
+			case 'characters': return numericalCompare(this.value.op, md.textContent.length, this.value.val);
+			case 'words': return numericalCompare(this.value.op, md.textContent.split(' ').length, this.value.val);
+			default: return false;
+		}
+	}
+}

--- a/lib/modules/filteReddit/commentCases/Depth.js
+++ b/lib/modules/filteReddit/commentCases/Depth.js
@@ -1,0 +1,26 @@
+/* @flow */
+
+import { Case } from '../Case';
+import { numericalCompare, prettyOperator, inverseOperator } from '../../../utils';
+
+export class Depth extends Case {
+	static text = 'Comment depth';
+
+	static parseCriterion(input: *) { return { op: '==', val: parseInt(input, 10) }; }
+	static thingToCriterion(thing: *) { return String(thing.getParents().length); }
+
+	static defaultConditions = { op: '>', val: 0 };
+	static fields = ['comment\'s depth ', { type: 'select', options: 'COMPARISON', id: 'op' }, ' ', { type: 'number', id: 'val' }];
+
+	static pattern = 'integer';
+
+	trueText = `depth ${prettyOperator(this.value.op)} ${this.value.val}`;
+	falseText = `depth ${prettyOperator(inverseOperator(this.value.op))} ${this.value.val}`;
+
+	validator() { return this.value.val >= 0; }
+
+	evaluate(thing: *) {
+		const depth = thing.getParents().length;
+		return isNaN(depth) ? false : numericalCompare(this.value.op, depth, this.value.val);
+	}
+}

--- a/lib/modules/filteReddit/commentCases/IsDeleted.js
+++ b/lib/modules/filteReddit/commentCases/IsDeleted.js
@@ -1,0 +1,15 @@
+/* @flow */
+
+import { Case } from '../Case';
+
+export class IsDeleted extends Case {
+	static text = 'Deleted';
+
+	static fields = ['comment is deleted'];
+
+	static unique = true;
+
+	evaluate(thing: *) {
+		return thing.isDeleted();
+	}
+}

--- a/lib/modules/filteReddit/commentCases/IsRead.js
+++ b/lib/modules/filteReddit/commentCases/IsRead.js
@@ -1,0 +1,20 @@
+/* @flow */
+
+import { Case } from '../Case';
+import * as ReadComments from '../../readComments';
+import * as Modules from '../../../core/modules';
+
+export class IsRead extends Case {
+	static text = 'Read';
+
+	static fields = ['comment is read'];
+	static get disabled(): boolean {
+		return !Modules.isRunning(ReadComments);
+	}
+
+	static unique = true;
+
+	evaluate(thing: *) {
+		return ReadComments.isRead(thing);
+	}
+}

--- a/lib/modules/filteReddit/commentCases/index.js
+++ b/lib/modules/filteReddit/commentCases/index.js
@@ -1,0 +1,17 @@
+/* @flow */
+
+export { CommentContent as commentContent } from './CommentContent.js';
+export { CommentLength as commentLength } from './CommentLength.js';
+export { Depth as depth } from './Depth.js';
+export { Expando as hasExpando } from '../postCases/Expando.js';
+export { IsDeleted as isDeleted } from './IsDeleted.js';
+export { IsRead as isRead } from './IsRead.js';
+export { PostAfter as postAfter } from '../postCases/PostAfter.js';
+export { PostAge as postAge } from '../postCases/PostAge.js';
+export { Score as score } from '../postCases/Score.js';
+export { Selector as selector } from '../postCases/Selector.js';
+export { UserAttr as userAttr } from '../postCases/UserAttr.js';
+export { UserFlair as userFlair } from '../postCases/UserFlair.js';
+export { UserVoteWeight as userVoteWeight } from '../postCases/UserVoteWeight.js';
+export { Username as username } from '../postCases/Username.js';
+export { VoteType as voteType } from '../postCases/VoteType.js';

--- a/lib/modules/filteReddit/postCases/Expando.js
+++ b/lib/modules/filteReddit/postCases/Expando.js
@@ -9,8 +9,8 @@ export class Expando extends Case {
 
 	static parseCriterion(input: string) { return { types: input.split(/[\s|]/).filter(Boolean) }; }
 	static thingToCriterion(thing: *) {
-		const entryExpando = E.getEntryExpandoFrom(thing);
-		return entryExpando && entryExpando.getTypes().join(' & ') || '';
+		const expando = thing.isPost() ? E.getEntryExpandoFrom(thing) : E.getTextExpandosFrom(thing)[0];
+		return expando && expando.getTypes().join(' & ') || '';
 	}
 
 	static defaultConditions = { types: [] };
@@ -32,8 +32,13 @@ export class Expando extends Case {
 	}
 
 	evaluate(thing: *) {
-		const expando = E.getEntryExpandoFrom(thing);
-		return this._matches(expando);
+		if (thing.isPost()) {
+			const expando = E.getEntryExpandoFrom(thing);
+			return this._matches(expando);
+		} else {
+			const expandos = E.getTextExpandosFrom(thing);
+			return expandos.some(this._matches.bind(this));
+		}
 	}
 
 	onObserve() {

--- a/lib/modules/filteReddit/postCases/UserAttr.js
+++ b/lib/modules/filteReddit/postCases/UserAttr.js
@@ -8,6 +8,7 @@ const options = [
 	['a moderator', 'moderator'],
 	['an admin', 'admin'],
 	['me', 'me'],
+	['op', 'submitter'],
 ];
 
 export class UserAttr extends Case {

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -362,7 +362,7 @@ export function loadNextPage(scrollToLoadWidget: boolean = false): Promise<void>
 		loadPromise = loadPage(nextPageURL).then(() => { loadPromise = null; });
 	}
 
-	if (scrollToLoadWidget) scrollToElement(loaderWidget, { scrollStyle: 'middle', direction: 'down' });
+	if (scrollToLoadWidget) scrollToElement(loaderWidget, null, { scrollStyle: 'middle', direction: 'down' });
 
 	return loadPromise;
 }

--- a/lib/modules/readComments.js
+++ b/lib/modules/readComments.js
@@ -1,0 +1,85 @@
+/* @flow */
+
+import { Module } from '../core/module';
+import { Storage, isPrivateBrowsing } from '../environment';
+import {
+	DAY,
+	WEEK,
+	execRegexes,
+	reifyPromise,
+	fastAsync,
+} from '../utils';
+import * as SelectedEntry from './selectedEntry';
+
+export const module: Module<*> = new Module('readComments');
+
+module.moduleName = 'readCommentsName';
+module.category = 'commentsCategory';
+module.description = 'readCommentsDesc';
+module.options = {
+	cleanComments: {
+		type: 'text',
+		value: '30',
+		description: 'readCommentsCleanCommentsDesc',
+		title: 'readCommentsCleanCommentsTitle',
+	},
+	monitorWhenIncognito: {
+		type: 'boolean',
+		value: false,
+		description: 'readCommentsMonitorWhenIncognitoDesc',
+		title: 'readCommentsMonitorWhenIncognitoTitle',
+		advanced: true,
+	},
+};
+
+module.include = ['comments', 'commentsLinklist'];
+
+const currentId = (execRegexes.comments(location.pathname) || [])[2] || location.pathname;
+const lastCleanStorage = Storage.wrap('RESmodules.readComments.lastClean', 0);
+const entryStorage = Storage.wrapPrefix('readComments.', (): {|
+	updateTime: number,
+	ids: { [string]: true },
+|} => ({
+	updateTime: Date.now(),
+	ids: {},
+}));
+const initialStorage = reifyPromise(
+	entryStorage.get(currentId).then(({ ids }) => new Set(Object.keys(ids)))
+);
+
+module.beforeLoad = async () => {
+	if (!module.options.monitorWhenIncognito.value && isPrivateBrowsing()) return;
+
+	const ids = await initialStorage.get();
+
+	SelectedEntry.addListener(selected => {
+		if (selected.isComment() && selected.isVisible()) {
+			const id = selected.getFullname();
+			ids.add(id);
+			entryStorage.patch(currentId, { ids: { [id]: true }, updateTime: Date.now() });
+		}
+	}, 'beforePaint');
+};
+
+module.afterLoad = () => {
+	maybePruneOldEntries();
+};
+
+async function maybePruneOldEntries() {
+	const now = Date.now();
+	if ((now - await lastCleanStorage.get()) < WEEK) return;
+	lastCleanStorage.set(now);
+
+	const keepTrackPeriod = DAY * parseInt(module.options.cleanComments.value, 10);
+	for (const [id, { updateTime }] of Object.entries(await entryStorage.getAll())) {
+		if ((now - updateTime) > keepTrackPeriod) {
+			entryStorage.delete(id);
+		}
+	}
+}
+
+export const isRead = fastAsync(function*(thing: *): * {
+	if (!initialStorage) return false;
+	const ids = yield initialStorage.get();
+	return ids.has(thing.getFullname());
+});

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -12,7 +12,6 @@ import {
 	elementInViewport,
 	getPercentageVisibleYAxis,
 	scrollToElement,
-	scrollToElementAnchor,
 	watchForThings,
 	frameThrottle,
 	idleThrottle,
@@ -105,16 +104,29 @@ module.beforeLoad = () => {
 		watchForThings(['post', 'comment', 'message'], selectInitial);
 	}
 
-	addListener((selected, unselected, { scrollStyle }) => scrollToElementAnchor(selected.entry, unselected && unselected.entry, { scrollStyle }), 'beforeScroll');
 	addListener(selected => BodyClasses.toggle(!!selected, 'res-entry-is-selected'), 'beforePaint');
 
 	if (module.options.addLine.value) styleLine();
 	if (module.options.setColors.value) styleColor();
 	styleOutline();
 
-	// Must be registered after the listener which modifies selected entry attributes, as that may impact layout
-	// so that `scrollToElement` will not scroll correctly
-	addListener((selected, unselected, { scrollStyle, direction }) => scrollToElement(selected.entry, unselected && unselected.entry, { scrollStyle, direction }), 'beforePaint');
+	// Filtered comments may be collapsed or expanded (causing height change) depending on whether they are selected
+	let anchor;
+	addListener((selected, unselected, { scrollStyle }) => {
+		if (
+			(['none', 'adopt']: Array<ScrollStyle>).includes(scrollStyle) &&
+			(selected.isFiltered() || unselected && unselected.isFiltered())
+		) {
+			anchor = {
+				to: selected.entry.getBoundingClientRect().top,
+				from: unselected && unselected.entry.getBoundingClientRect().top,
+			};
+		} else {
+			anchor = undefined;
+		}
+	}, 'beforeScroll');
+
+	addListener((selected, unselected, { scrollStyle, direction }) => scrollToElement(selected.entry, unselected && unselected.entry, { scrollStyle, direction, anchor }), 'beforePaint');
 };
 
 module.go = () => {

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -12,6 +12,7 @@ import {
 	elementInViewport,
 	getPercentageVisibleYAxis,
 	scrollToElement,
+	scrollToElementAnchor,
 	watchForThings,
 	frameThrottle,
 	idleThrottle,
@@ -104,12 +105,16 @@ module.beforeLoad = () => {
 		watchForThings(['post', 'comment', 'message'], selectInitial);
 	}
 
+	addListener((selected, unselected, { scrollStyle }) => scrollToElementAnchor(selected.entry, unselected && unselected.entry, { scrollStyle }), 'beforeScroll');
 	addListener(selected => BodyClasses.toggle(!!selected, 'res-entry-is-selected'), 'beforePaint');
-	addListener((selected, unselected, { scrollStyle, direction }) => scrollToElement(selected.entry, { from: unselected && unselected.entry, scrollStyle, direction }), 'beforePaint');
 
 	if (module.options.addLine.value) styleLine();
 	if (module.options.setColors.value) styleColor();
 	styleOutline();
+
+	// Must be registered after the listener which modifies selected entry attributes, as that may impact layout
+	// so that `scrollToElement` will not scroll correctly
+	addListener((selected, unselected, { scrollStyle, direction }) => scrollToElement(selected.entry, unselected && unselected.entry, { scrollStyle, direction }), 'beforePaint');
 };
 
 module.go = () => {

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -722,7 +722,7 @@ export function toggleThingExpandos(thing: Thing, { scrollOnToggle, isUserAction
 	if (openExpandos.length) {
 		for (const expando of openExpandos) expando.collapse();
 
-		if (scrollOnToggle) scrollToElement(thing.entry, { scrollStyle: 'directional' });
+		if (scrollOnToggle) scrollToElement(thing.entry, null, { scrollStyle: 'directional' });
 	} else {
 		for (const expando of expandos) {
 			if (
@@ -734,7 +734,7 @@ export function toggleThingExpandos(thing: Thing, { scrollOnToggle, isUserAction
 			}
 		}
 
-		if (scrollOnToggle) scrollToElement(thing.entry, { scrollStyle: 'top' });
+		if (scrollOnToggle) scrollToElement(thing.entry, null, { scrollStyle: 'top' });
 	}
 }
 

--- a/lib/modules/showImages/expando.js
+++ b/lib/modules/showImages/expando.js
@@ -285,16 +285,17 @@ export class Expando {
 	}
 
 	scrollToButton(returnElement?: Element) {
-		if (returnElement) {
+		const _returnElement = returnElement;
+		if (_returnElement) {
 			$('<span title="Restore position" class="res-expando-restore-position">')
 				.insertAfter(this.button)
 				.click(e => {
 					e.target.remove();
-					scrollToElement((returnElement: any), { scrollStyle: 'middle' });
+					scrollToElement(_returnElement, null, { scrollStyle: 'middle' });
 				});
 		}
 
-		scrollToElement(this.button, { scrollStyle: 'top' });
+		scrollToElement(this.button, null, { scrollStyle: 'top' });
 	}
 
 	attachMedia() {

--- a/lib/modules/showImages/expando.js
+++ b/lib/modules/showImages/expando.js
@@ -95,10 +95,11 @@ export class Expando {
 
 	static getTextExpandosFrom(thing: ?Thing): Expando[] {
 		if (!thing) return [];
-		const entryExpando = Expando.getEntryExpandoFrom(thing);
-		return filterMap(Array.from(thing.entry.querySelectorAll(Expando.expandoSelector)), v => {
+		const md = thing.entry.querySelector('.md');
+		if (!md) return [];
+		return filterMap(Array.from(md.querySelectorAll(Expando.expandoSelector)), v => {
 			const exp = expandos.get(v);
-			if (exp && exp !== entryExpando) return [exp];
+			if (exp) return [exp];
 		});
 	}
 

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -2,6 +2,7 @@
 
 import _ from 'lodash';
 import { filterMap } from './array';
+import { frameThrottleQueuePositionReset } from './async';
 import { downcast } from './flow';
 import { currentSubreddit, regexes } from './location';
 

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -115,8 +115,7 @@ export class Thing {
 		for (const p of this.getParents()) p.refreshChildFilterVisibility();
 	}
 
-	// `frameThrottleQueuePositionReset` ensures that the children's `isVisible` is current.
-	// When invoked, the function is placed last in the queue.
+	// `frameThrottleQueuePositionReset` ensures that children will be evaluated first
 	refreshChildFilterVisibility = frameThrottleQueuePositionReset(() => {
 		this.element.classList.toggle('res-thing-has-visible-child', Array.from(this.children).some(v => v.isVisible()));
 	});

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -522,7 +522,7 @@ export class Thing {
 
 	isInCollapsed(): boolean {
 		const parent_ = this.getParent();
-		return !!(parent_ && parent_.getClosest(function() { this.isCollapsed(); }));
+		return !!(parent_ && parent_.getClosest(function() { return this.isCollapsed(); }));
 	}
 
 	isVisible(): boolean {

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -449,7 +449,7 @@ export class Thing {
 	}
 
 	getFullname(): string {
-		return downcast(this.element.getAttribute('data-fullname'), 'string');
+		return this.element.getAttribute('data-fullname') || '';
 	}
 
 	getUserattrsElement(): ?HTMLElement {

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -562,7 +562,7 @@ export class Thing {
 	}
 
 	isSelected() {
-		return this.element.matches('[res-selected]');
+		return this.element.classList.contains('res-selected');
 	}
 
 	isUpvoted() {

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -60,6 +60,9 @@ export class Thing {
 	element: HTMLElement;
 	entry: HTMLElement;
 
+	parent: ?Thing;
+	children = new Set();
+
 	// may be set by filters
 	filter: *;
 
@@ -97,12 +100,26 @@ export class Thing {
 
 		this.element = thing;
 		this.entry = entry;
+
+		this.parent = this.getParent();
+		if (this.parent && this.isComment()) {
+			this.parent.children.add(this);
+		}
 	}
 
 	setFilter(filter: ?*) {
 		this.filter = filter;
 		this.element.classList.toggle('RESFiltered', !!filter);
+
+		if (this.children.size) this.refreshChildFilterVisibility();
+		for (const p of this.getParents()) p.refreshChildFilterVisibility();
 	}
+
+	// `frameThrottleQueuePositionReset` ensures that the children's `isVisible` is current.
+	// When invoked, the function is placed last in the queue.
+	refreshChildFilterVisibility = frameThrottleQueuePositionReset(() => {
+		this.element.classList.toggle('res-thing-has-visible-child', Array.from(this.children).some(v => v.isVisible()));
+	});
 
 	getThreadTop(): Thing {
 		let thing = this; // eslint-disable-line consistent-this
@@ -120,6 +137,13 @@ export class Thing {
 		while ((current = current.parentElement)) {
 			if (current.classList.contains('thing')) return Thing.checkedFrom(downcast(current, HTMLElement));
 		}
+	}
+
+	getParents(): Thing[] {
+		const parents = [];
+		let level = this; // eslint-disable-line consistent-this
+		while ((level = level.parent)) parents.push(level);
+		return parents;
 	}
 
 	getNext({ direction = 'down' }: {| direction?: 'up' | 'down' |} = {}, things: HTMLElement[] = Thing.thingElements()): ?Thing {
@@ -512,6 +536,10 @@ export class Thing {
 		return this.element.classList.contains('locked');
 	}
 
+	isDeleted(): boolean {
+		return this.element.classList.contains('deleted');
+	}
+
 	isFiltered(): boolean {
 		return !document.body.classList.contains('res-filters-disabled') &&
 			this.element.classList.contains('RESFiltered');
@@ -528,13 +556,13 @@ export class Thing {
 
 	isVisible(): boolean {
 		return (
-			!this.isFiltered() &&
+			!(this.isFiltered() && !this.element.classList.contains('res-thing-has-visible-child')) &&
 			!this.isInCollapsed()
 		);
 	}
 
 	isSelected() {
-		return this.element.classList.contains('RES-keyNav-activeThing');
+		return this.element.matches('[res-selected]');
 	}
 
 	isUpvoted() {

--- a/lib/utils/async.js
+++ b/lib/utils/async.js
@@ -270,6 +270,42 @@ export function frameThrottle(callback) {
 }
 /* eslint-enable no-redeclare */
 
+export const frameThrottleQueuePositionReset = (() => {
+	let queues = [];
+
+	const run = frameThrottle(() => {
+		for (const fn of queues) {
+			try {
+				fn();
+			} catch (e) { /* empty */ }
+		}
+		queues = [];
+	});
+
+	return function(callback: () => void) {
+		let args = [];
+		let queued = false;
+
+		function runCallback() {
+			queued = false;
+			callback();
+		}
+
+		return (...a: Array<*>) => {
+			args = a;
+
+			if (queued) {
+				_.pull(queues, callback);
+			} else {
+				queued = true;
+			}
+
+			queues.push(callback);
+			run();
+		};
+	};
+})();
+
 /**
  * Returns a wrapper function, similar to _.throttle, that will only invoke the latest `callback` in the next upcoming idle period.
  *

--- a/lib/utils/async.js
+++ b/lib/utils/async.js
@@ -270,6 +270,11 @@ export function frameThrottle(callback) {
 }
 /* eslint-enable no-redeclare */
 
+/*
+ * Similar to frameThrottle, but has a separate queue.
+ * When the returned wrapper function is invoked, `callback` will be placed last in the execution queue
+ * regardless of its current position.
+ */
 export const frameThrottleQueuePositionReset = (() => {
 	let queues = [];
 

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -214,14 +214,52 @@ function padBottom(scrollTop, viewportHeight) {
 	}
 }
 
+const isAnchoredScrollStyle = scrollStyle => (['none', 'adopt']: Array<ScrollStyle>).includes(scrollStyle);
+let anchoredTop: ?number;
+let anchoredFromTop: ?number;
+
+export function scrollToElementAnchor(to: Element, from: ?Element, { scrollStyle }: { scrollStyle: ScrollStyle }): void {
+	if (isAnchoredScrollStyle(scrollStyle)) {
+		({ top: anchoredTop } = to.getBoundingClientRect());
+		if (from) ({ top: anchoredFromTop } = from.getBoundingClientRect());
+	}
+}
+
 export type ScrollStyle = 'none' | 'top' | 'adopt' | 'middle' | 'page' | 'legacy' | 'directional';
 type Direction = 'up' | 'down';
 
-export function scrollToElement(element: Element, { scrollStyle, direction: selectedDirection, from }: {| scrollStyle: ScrollStyle, direction?: Direction, from?: ?Element |}): void {
-	if (scrollStyle === 'none') return;
-
+export function scrollToElement(to: Element, from: ?Element, { scrollStyle, direction: selectedDirection }: {| scrollStyle: ScrollStyle, direction?: Direction |}): void {
 	const viewport = getViewportDimensions();
-	const target = _.assignIn({}, element.getBoundingClientRect()); // top, right, bottom, left are relative to viewport
+
+	// First run scrollStyles which depend on the position of the from element
+	// or is vulnerable to height changes occuring from changing Thing selection
+	if (isAnchoredScrollStyle(scrollStyle)) {
+		let diff;
+
+		if (from && scrollStyle === 'adopt') {
+			const fromTop = typeof anchoredFromTop === 'number' ?
+				anchoredFromTop :
+				from.getBoundingClientRect().top;
+			diff = to.getBoundingClientRect().top - fromTop;
+
+			if (fromTop < 0) {
+				// Compensate to show top when it is above viewport
+				diff += fromTop;
+			} else if (fromTop > viewport.height - 60) {
+				// Always show at minimum the top 60px of the element
+				diff += fromTop - viewport.height + 60;
+			}
+		} else {
+			diff = typeof anchoredTop === 'number' ?
+				to.getBoundingClientRect().top - anchoredTop :
+				0;
+		}
+
+		if (diff) scrollTo(0, window.scrollY + diff, false);
+		return;
+	}
+
+	const target = _.assignIn({}, to.getBoundingClientRect()); // top, right, bottom, left are relative to viewport
 	target.top -= viewport.yOffset;
 	target.bottom -= viewport.yOffset;
 
@@ -235,25 +273,11 @@ export function scrollToElement(element: Element, { scrollStyle, direction: sele
 		// Always scroll element to top of page; pad bottom if necessary
 		padBottom(top, viewport.height);
 		scrollTo(0, top);
-	} else if (from && scrollStyle === 'adopt') {
-		// Replace the viewport position of `from` with `element`
-		const { top: fromTop } = from.getBoundingClientRect();
-		let diff = element.getBoundingClientRect().top - fromTop;
-
-		if (fromTop < 0) {
-			// Compensate to show top when it is above viewport
-			diff += fromTop;
-		} else if (fromTop > viewport.height - 60) {
-			// Always show at minimum the top 60px of the element
-			diff += fromTop - viewport.height + 60;
-		}
-
-		scrollTo(0, window.scrollY + diff, false);
 	} else if (scrollStyle === 'middle') {
 		const buffer = (viewport.height - target.height) / 2;
 		const newScrollY = top - buffer;
 
-		if (elementInViewport(element)) {
+		if (elementInViewport(to)) {
 			const viewportDirection = newScrollY >= window.scrollY ? 'down' : 'up';
 			// Having these go in opposite directions is jarring
 			if (viewportDirection !== selectedDirection) return;

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -214,52 +214,20 @@ function padBottom(scrollTop, viewportHeight) {
 	}
 }
 
-const isAnchoredScrollStyle = scrollStyle => (['none', 'adopt']: Array<ScrollStyle>).includes(scrollStyle);
-let anchoredTop: ?number;
-let anchoredFromTop: ?number;
-
-export function scrollToElementAnchor(to: Element, from: ?Element, { scrollStyle }: { scrollStyle: ScrollStyle }): void {
-	if (isAnchoredScrollStyle(scrollStyle)) {
-		({ top: anchoredTop } = to.getBoundingClientRect());
-		if (from) ({ top: anchoredFromTop } = from.getBoundingClientRect());
-	}
-}
-
 export type ScrollStyle = 'none' | 'top' | 'adopt' | 'middle' | 'page' | 'legacy' | 'directional';
 type Direction = 'up' | 'down';
+type Anchor = {| to: number, from: ?number |};
 
-export function scrollToElement(to: Element, from: ?Element, { scrollStyle, direction: selectedDirection }: {| scrollStyle: ScrollStyle, direction?: Direction |}): void {
-	if (!to.offsetParent) return;
-
-	const viewport = getViewportDimensions();
-
-	// First run scrollStyles which depend on the position of the from element
-	// or is vulnerable to height changes occuring from changing Thing selection
-	if (isAnchoredScrollStyle(scrollStyle)) {
-		let diff;
-
-		if (from && scrollStyle === 'adopt') {
-			const fromTop = typeof anchoredFromTop === 'number' ?
-				anchoredFromTop :
-				from.getBoundingClientRect().top;
-			diff = to.getBoundingClientRect().top - fromTop;
-
-			if (fromTop < 0) {
-				// Compensate to show top when it is above viewport
-				diff += fromTop;
-			} else if (fromTop > viewport.height - 60) {
-				// Always show at minimum the top 60px of the element
-				diff += fromTop - viewport.height + 60;
-			}
-		} else {
-			diff = typeof anchoredTop === 'number' ?
-				to.getBoundingClientRect().top - anchoredTop :
-				0;
+export function scrollToElement(to: Element, from: ?Element, { scrollStyle, direction: selectedDirection, anchor }: {| scrollStyle: ScrollStyle, direction?: Direction, anchor?: Anchor |}): void {
+	if (scrollStyle === 'none') {
+		if (anchor && typeof anchor.to === 'number') {
+			const diff = to.getBoundingClientRect().top - anchor.to;
+			if (diff) window.scrollBy(diff);
 		}
-
-		if (diff) scrollTo(0, window.scrollY + diff, false);
 		return;
 	}
+
+	const viewport = getViewportDimensions();
 
 	const target = _.assignIn({}, to.getBoundingClientRect()); // top, right, bottom, left are relative to viewport
 	target.top -= viewport.yOffset;
@@ -275,6 +243,22 @@ export function scrollToElement(to: Element, from: ?Element, { scrollStyle, dire
 		// Always scroll element to top of page; pad bottom if necessary
 		padBottom(top, viewport.height);
 		scrollTo(0, top);
+	} else if (from && scrollStyle === 'adopt') {
+		// Replace the viewport position of `from` with `element`
+		const fromTop = anchor && typeof anchor.from === 'number' ?
+			anchor.from :
+			from.getBoundingClientRect().top;
+		let diff = to.getBoundingClientRect().top - fromTop;
+
+		if (fromTop < 0) {
+			// Compensate to show top when it is above viewport
+			diff += fromTop;
+		} else if (fromTop > viewport.height - 60) {
+			// Always show at minimum the top 60px of the element
+			diff += fromTop - viewport.height + 60;
+		}
+
+		scrollTo(0, window.scrollY + diff, false);
 	} else if (scrollStyle === 'middle') {
 		const buffer = (viewport.height - target.height) / 2;
 		const newScrollY = top - buffer;

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -229,6 +229,8 @@ export type ScrollStyle = 'none' | 'top' | 'adopt' | 'middle' | 'page' | 'legacy
 type Direction = 'up' | 'down';
 
 export function scrollToElement(to: Element, from: ?Element, { scrollStyle, direction: selectedDirection }: {| scrollStyle: ScrollStyle, direction?: Direction |}): void {
+	if (!to.offsetParent) return;
+
 	const viewport = getViewportDimensions();
 
 	// First run scrollStyles which depend on the position of the from element

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -50,6 +50,7 @@ export {
 	getPercentageVisibleYAxis,
 	scrollTo,
 	scrollToElement,
+	scrollToElementAnchor,
 	waitForChild,
 	waitForDescendant,
 	watchForChildren,

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -50,7 +50,6 @@ export {
 	getPercentageVisibleYAxis,
 	scrollTo,
 	scrollToElement,
-	scrollToElementAnchor,
 	waitForChild,
 	waitForDescendant,
 	watchForChildren,

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -28,6 +28,7 @@ export {
 	batch,
 	forEachChunked,
 	frameThrottle,
+	frameThrottleQueuePositionReset,
 	idleThrottle,
 	keyedMutex,
 	mutex,

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -2277,12 +2277,6 @@
 	"filteRedditExcludeOwnPostsDesc": {
 		"message": "Don't filter your own posts."
 	},
-	"filteRedditExcludeCommentsPageTitle": {
-		"message": "Exclude Comments Page"
-	},
-	"filteRedditExcludeCommentsPageDesc": {
-		"message": "When visiting the comments page for a filtered link, allow the link/expando to be shown."
-	},
 	"filteRedditExcludeModqueueTitle": {
 		"message": "Exclude Modqueue"
 	},

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -1164,6 +1164,24 @@
 	"newCommentCountMonitorPostsVisitedIncognitoDesc": {
 		"message": "Monitor the number of comments and edit dates of posts you have visited while browsing in incognito/private mode."
 	},
+	"readCommentsName": {
+		"message": "Read Comments"
+	},
+	"readCommentsDesc": {
+		"message": "Keep track of what comments you have read. Useful for filtering comments."
+	},
+	"readCommentsCleanCommentsTitle": {
+		"message": "Clean Comments"
+	},
+	"readCommentsCleanCommentsDesc": {
+		"message": "Number of days to keep track of a comment page."
+	},
+	"readCommentsMonitorWhenIncognitoTitle": {
+		"message": "Monitor When Incognito"
+	},
+	"readCommentsMonitorWhenIncognitoDesc": {
+		"message": "Keep track while browsing in incognito/private mode."
+	},
 	"nightModeName": {
 		"message": "Night Mode"
 	},

--- a/tests/readComments.js
+++ b/tests/readComments.js
@@ -1,0 +1,27 @@
+module.exports = {
+	'basic usage': browser => {
+		if (browser.options.desiredCapabilities.browserName === 'firefox') {
+			// geckodriver doesn't support elementSendKeys https://github.com/mozilla/geckodriver/issues/159
+			browser.end();
+			return;
+		}
+
+		const a = '#thing_t1_dcuk08v';
+		const b = '#thing_t1_dcuk1bk';
+
+		browser
+			.url('https://www.reddit.com/r/RESIntegrationTests/comments/5pxfg2/keyboard_nav/')
+			.waitForElementVisible('.res-toggle-filterline-visibility')
+			.click(`${a} > .entry`)
+
+			// See that the comment is remember read by filtering out read comments
+			.refresh()
+			.waitForElementVisible('.res-toggle-filterline-visibility')
+			.keys(['f'])
+			.waitForElementVisible('#keyCommandLineWidget')
+			.keys(['isRead', browser.Keys.ENTER])
+			.waitForElementPresent(`${b}.RESFiltered`)
+			.assert.elementNotPresent(`${a}.RESFiltered`)
+			.end();
+	},
+};


### PR DESCRIPTION
Like on listing pages, things which don't match the filters are hidden. For parents of non-hidden things it only restricts height and reduces opacity instead of hiding them completely, unless a parent is selected, in which case that comment is shown normally.

New comment-specific cases:
- Comment length (words / characters)
- Comment depth
- Comment content
- IsRead (comment has been selected earlier)

Filter by submitter and a given string:
![image](https://user-images.githubusercontent.com/1748521/30035775-d413ec3a-91ad-11e7-8ab0-cccee2e91a50.png)

Hide read comments the next time the page is loaded (comments are marked read by selecting them):
![image](https://user-images.githubusercontent.com/1748521/30035843-876dc1fc-91ae-11e7-887f-00b3f8c5379b.png)



Nice-to-haves for future implementation:
- Filter when page is rendering (by listen to mutations), as currently the whole page must load before filtering is initiated — which can take a while on larger comment pages
- Options how much of hidden parent comments that shall be visible
- Chunk filter application when many comments / filters (this is likely not necessary, since when filters are hiding things, less time is used on reflow)
- Next/prev keyboard shortcuts and `res-thing-has-visible-child` behavior — new shortcut for jumping to next non-filtered?
- Add way to force display all children of a thread? I.e. an indicator "this comment has n hidden child comments"
- Better handling of "Load more comments" when all loaded comments are filtered

--
~~Depends on #4191~~
Closes #1741
Closes #1742
Closes #1778
Closes #1897 (subreddit by case `selector` with criterion `[data-subreddit=NotMyJob]`)
Closes #2223 (subreddit default filters)
  