### PR TITLE
Remove loadDynamicOptions

### DIFF
--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -9,82 +9,92 @@ import {
 	waitForChild,
 	waitForEvent,
 	newSitetable,
+	markStart,
+	markEnd,
+	markCheckpoint,
 } from '../utils';
+import { _logPerfSummary } from '../utils/profiling';
 import { _loadModuleOptions } from './options/options';
 import { _loadModulePrefs, _runModuleStage } from './modules/modules';
 import { _addModuleBodyClasses } from './modules/bodyClasses';
 import { migrate } from './migrate';
 
-let start;
-
-export function init() {
+export async function init() {
 	if (sessionStorage.getItem(RES_DISABLED_KEY)) return;
 
-	start();
-}
+	// DOMContentLoaded; used as a fallback for init stages
+	const contentLoaded = Promise.race([
+		waitForEvent(window, 'DOMContentLoaded', 'load'),
+		waitFor(() => document.readyState === 'interactive' || document.readyState === 'complete', 500),
+	]);
 
-// DOM / browser state
+	// --- initialization start ---
 
-const sourceLoaded = new Promise(resolve => (start = resolve));
+	const tag = markStart();
 
-// Edge has weird bugs with MutationObservers
-// so just make a best effort at divining when the head and body are ready
+	await _loadI18n();
+	markCheckpoint(tag, 'i18n');
 
-export const bodyStart: Promise<*> = sourceLoaded
-	.then(() => Promise.race([
+	await Promise.all([
+		migrate(),
+		_loadModuleOptions(),
+		_loadModulePrefs(),
+	]);
+	markCheckpoint(tag, 'storage');
+
+	_addModuleBodyClasses();
+	markCheckpoint(tag, 'classes');
+
+	await _runModuleStage('always', { skipEnabledCheck: true });
+	markCheckpoint(tag, 'always');
+
+	await _runModuleStage('beforeLoad');
+	markCheckpoint(tag, 'beforeLoad');
+
+	// --- <body> start ---
+
+	// Edge has weird bugs with MutationObservers
+	// so just make a best effort at divining when the head and body are ready
+	await Promise.race([
 		waitForChild(document.documentElement, 'body'),
 		waitFor(() => document.body, 100),
 		contentLoaded,
-	]));
+	]);
+	markCheckpoint(tag, 'body');
 
-export const bodyReady: Promise<*> = bodyStart
-	.then(() => Promise.race([
+	// add pending classes to <body>
+	BodyClasses.add();
+	markCheckpoint(tag, 'flush');
+
+	// --- <body> complete ---
+
+	await Promise.race([
 		// `document.body === null` shouldn't be possible at this point,
 		// but apparently it is for some Chrome users
 		waitFor(() => document.body, 10).then(body => waitForChild(body, '.debuginfo')),
 		contentLoaded, // in case reddit removes or changes .debuginfo
-	]));
+	]);
+	markCheckpoint(tag, 'content');
 
-export const contentLoaded: Promise<*> = sourceLoaded
-	.then(() => Promise.race([
-		waitForEvent(window, 'DOMContentLoaded', 'load'),
-		waitFor(() => document.readyState === 'interactive' || document.readyState === 'complete', 500),
-	]));
+	initObservers();
+	markCheckpoint(tag, 'observers');
 
-export const loadComplete: Promise<*> = contentLoaded
-	.then(() => Promise.race([
+	await Promise.all([
+		newSitetable(document.body),
+		_runModuleStage('go'),
+	]);
+	markCheckpoint(tag, 'go/sitetable');
+
+	// --- load complete ---
+
+	await Promise.race([
 		waitForEvent(window, 'load'),
 		waitFor(() => document.readyState === 'complete', 500),
-	]));
+	]);
+	markCheckpoint(tag, 'load');
 
-// Module stages
+	await _runModuleStage('afterLoad');
+	markEnd(tag, 'afterLoad');
 
-export const loadI18n: Promise<void> = sourceLoaded
-	.then(() => _loadI18n());
-
-export const loadOptions: Promise<*> = loadI18n
-	.then(() => Promise.all([
-		migrate(),
-		_loadModuleOptions(),
-		_loadModulePrefs(),
-	]));
-
-export const addModuleBodyClasses: Promise<void> = loadOptions
-	.then(() => _addModuleBodyClasses());
-
-export const always: Promise<void> = loadOptions
-	.then(() => _runModuleStage('always', { skipEnabledCheck: true }));
-
-export const beforeLoad: Promise<void> = loadOptions
-	.then(() => _runModuleStage('beforeLoad'));
-
-export const go: Promise<*> = Promise.all([beforeLoad, bodyReady])
-	.then(() => {
-		initObservers();
-		return Promise.all([newSitetable(document.body), _runModuleStage('go')]);
-	});
-
-export const afterLoad: Promise<void> = Promise.all([go, loadComplete])
-	.then(() => _runModuleStage('afterLoad'));
-
-bodyStart.then(() => BodyClasses.add());
+	_logPerfSummary();
+}

--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -62,14 +62,9 @@ export const loadComplete: Promise<*> = contentLoaded
 export const loadI18n: Promise<void> = sourceLoaded
 	.then(() => _loadI18n());
 
-export const runMigrations: Promise<void> = loadI18n
-	.then(() => migrate());
-
-export const loadDynamicOptions: Promise<void> = loadI18n
-	.then(() => _runModuleStage('loadDynamicOptions', { skipEnabledCheck: true }));
-
-export const loadOptions: Promise<*> = loadDynamicOptions
+export const loadOptions: Promise<*> = loadI18n
 	.then(() => Promise.all([
+		migrate(),
 		_loadModuleOptions(),
 		_loadModulePrefs(),
 	]));

--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -29,7 +29,6 @@ export class Module<RawOpt: { [string]: any }, Opt: { [string]: ModuleOption<Raw
 	sort: number = 0;
 
 	// no default value for cleaner profiling (modules without a stage defined won't be timed)
-	loadDynamicOptions: (() => Promise<void> | void) | void = undefined;
 	beforeLoad: (() => Promise<void> | void) | void = undefined;
 	go: (() => Promise<void> | void) | void = undefined;
 	afterLoad: (() => Promise<void> | void) | void = undefined;

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -4,15 +4,14 @@ import _ from 'lodash';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
 import * as Modules from '../core/modules';
-import * as Init from '../core/init';
 import { Storage, ajax } from '../environment';
 import {
 	Thing,
 	addCSS,
 	elementInViewport,
 	scrollToElement,
-	fastAsync,
 	newSitetable,
+	waitForChild,
 	watchForElements,
 	documentLoggedInUser,
 	loggedInUser,
@@ -421,13 +420,14 @@ async function loadPage(url: string) {
 	if (nextPageURL) attachLoaderWidget(newLoaderWidget);
 }
 
-const appendPage = fastAsync(function*(newSiteTable, pageHTML = newSiteTable.outerHTML) {
+async function appendPage(newSiteTable, pageHTML = newSiteTable.outerHTML) {
 	const lastPageMarker = $('<div>', { class: 'NERPageMarker', text: `Page ${currPage + 1}` })
 		.append(SettingsNavigation.makeUrlHashLink(module.moduleID, undefined, ' ', 'gearIcon'))
 		.data({ currPage, nextPageURL, pageHTML })
 		.get(0);
 
-	yield Init.bodyReady;
+	await waitForChild(document.documentElement, 'body');
+	await waitForChild(document.body, '.footer-parent, .debuginfo');
 
 	const firstLen = $(siteTable()).find('.link:last .rank').text().length;
 	const lastLen = $(newSiteTable).find('.link:last .rank').text().length;
@@ -443,7 +443,7 @@ const appendPage = fastAsync(function*(newSiteTable, pageHTML = newSiteTable.out
 	if (!nextPageURL) endNER('No more pages');
 
 	window.dispatchEvent(new Event('neverEndingLoad', { bubbles: true, cancelable: true }));
-});
+}
 
 function endNER(text) {
 	$('<div>', {

--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -109,6 +109,16 @@ module.onToggle = toggle => {
 	}
 };
 
+if (process.env.BUILD_TARGET === 'edge') {
+	// (hopefully) temporary workaround to avoid FOUC on Edge, which loads extensions _very_ slowly
+	Promise.resolve().then(() => {
+		if (localStorage.getItem('res.nightmode')) {
+			BodyClasses.add(className());
+			updateNightSwitch(true);
+		}
+	});
+}
+
 module.beforeLoad = () => {
 	if (isNightModeOn()) {
 		enableNightMode();
@@ -393,10 +403,12 @@ const enableNightMode = multicast(() => {
 	Options.set(module, 'nightModeOn', true);
 	BodyClasses.add(className());
 	updateNightSwitch(true);
+	if (process.env.BUILD_TARGET === 'edge') localStorage.setItem('res.nightmode', 'true');
 }, { name: 'enableNightMode' });
 
 const disableNightMode = multicast(() => {
 	Options.set(module, 'nightModeOn', false);
 	BodyClasses.remove(className());
 	updateNightSwitch(false);
+	if (process.env.BUILD_TARGET === 'edge') localStorage.removeItem('res.nightmode');
 }, { name: 'disableNightMode' });

--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -100,7 +100,6 @@ module.options = {
 	},
 };
 
-const localStorageKey = 'RES_nightMode';
 const nightmodeOverrideStorage = Storage.wrap('RESmodules.nightMode.nightModeOverrideStart', (null: null | number));
 
 module.onToggle = toggle => {
@@ -110,18 +109,7 @@ module.onToggle = toggle => {
 	}
 };
 
-module.loadDynamicOptions = () => {
-	// To avoid the flash of unstyled content, the very first thing we should do is get a hold
-	// of the document object and add necessary classes...
-	if (typeof localStorage === 'object' && localStorage.getItem(localStorageKey)) {
-		// No need to check the background - we're in night mode for sure.
-		enableNightMode();
-	}
-};
-
 module.beforeLoad = () => {
-	// If night mode is enabled, set a localStorage token so that in the future,
-	// we can add the res-nightmode class to the page prior to page load.
 	if (isNightModeOn()) {
 		enableNightMode();
 	} else {
@@ -161,8 +149,6 @@ export function isNightModeOn(): boolean {
 }
 
 export async function isNightmodeCompatible(): Promise<boolean> {
-	await Init.loadOptions;
-
 	if (!isNightModeOn()) {
 		// nightmode is off
 		return true;
@@ -405,14 +391,12 @@ const className = () => {
 
 const enableNightMode = multicast(() => {
 	Options.set(module, 'nightModeOn', true);
-	localStorage.setItem(localStorageKey, 'true');
 	BodyClasses.add(className());
 	updateNightSwitch(true);
 }, { name: 'enableNightMode' });
 
 const disableNightMode = multicast(() => {
 	Options.set(module, 'nightModeOn', false);
-	localStorage.removeItem(localStorageKey);
 	BodyClasses.remove(className());
 	updateNightSwitch(false);
 }, { name: 'disableNightMode' });

--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -4,7 +4,6 @@ import _ from 'lodash';
 import { getTimes as getSunriseSunset } from 'suncalc';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
-import * as Init from '../core/init';
 import * as Modules from '../core/modules';
 import * as Options from '../core/options';
 import {
@@ -15,6 +14,7 @@ import {
 	currentSubreddit,
 	HOUR,
 	MINUTE,
+	waitForChild,
 } from '../utils';
 import { Session, Storage, i18n, multicast } from '../environment';
 import * as CommandLine from './commandLine';
@@ -196,7 +196,8 @@ export async function isNightmodeCompatible(): Promise<boolean> {
 	return updateCache(subreddit);
 
 	async function updateCache(subreddit) {
-		await Init.bodyReady;
+		await waitForChild(document.documentElement, 'body');
+		await waitForChild(document.body, '.content'); // first element after .side
 		// Check the sidebar for a link [](#/RES_SR_Config/NightModeCompatible) that indicates the sub is night mode compatible.
 		const isCompatible = !!document.querySelector('.side a[href="#/RES_SR_Config/NightModeCompatible"]');
 		Session.set(`isNightmodeCompatible.${subreddit.toLowerCase()}`, isCompatible);

--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -175,11 +175,14 @@ module.options = {
 
 const ignoredSubredditStyleStorage = Storage.wrap('RESmodules.styleTweaks.ignoredSubredditStyles', ([]: string[]));
 
-module.loadDynamicOptions = () => {
-	toggleSubredditStyleIfNecessary();
-};
-
 module.beforeLoad = () => {
+	toggleSubredditStyleIfNecessary();
+
+	PageAction.onClick(() => {
+		const toggle = !makeStyleToggle().checkbox.checked;
+		toggleSubredditStyle(toggle);
+	});
+
 	if (module.options.highlightTopLevel.value) {
 		const highlightTopLevelColor = module.options.highlightTopLevelColor.value || module.options.highlightTopLevelColor.default;
 		const highlightTopLevelSize = parseInt(module.options.highlightTopLevelSize.value || module.options.highlightTopLevelSize.default, 10);
@@ -191,6 +194,8 @@ module.beforeLoad = () => {
 			}
 		`);
 	}
+
+	registerCommandLine();
 };
 
 module.go = () => {
@@ -199,18 +204,9 @@ module.go = () => {
 		if (sidebarHeader) sidebarHeader.after(makeStyleToggle().container);
 	}
 
-	updatePageAction();
-
-	PageAction.onClick(() => {
-		const toggle = !makeStyleToggle().checkbox.checked;
-		toggleSubredditStyle(toggle);
-	});
-
 	if ($('#show_stylesheets').length) {
 		$('label[for=show_stylesheets]').after(string.escape` <span class="little gray">(${i18n('styleTweaksRedditPrefsMessage')} <a href="/r/Enhancement/wiki/srstyle">${i18n('styleTweaksClickToLearnMore')}</a>)</span>`);
 	}
-
-	registerCommandLine();
 };
 
 export function updatePageAction() {

--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -3,7 +3,6 @@
 import _ from 'lodash';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
-import * as Init from '../core/init';
 import { PageAction, Storage, i18n } from '../environment';
 import {
 	BodyClasses,
@@ -11,7 +10,6 @@ import {
 	asyncSome,
 	currentSubreddit,
 	isCurrentSubreddit,
-	mutex,
 	string,
 } from '../utils';
 import * as CommandLine from './commandLine';
@@ -360,23 +358,10 @@ async function toggleSubredditStyle(toggle, subreddit = currentSubreddit()) {
 }
 
 const toggleElements = (() => {
-	const getStylesheet = _.once(async () => {
-		const query = () => (document.head || document.documentElement).querySelector('link[title=applied_subreddit_stylesheet]');
+	const getStylesheet = _.once(() => document.head.querySelector('link[ref=applied_subreddit_stylesheet]'));
 
-		return (
-			// parsing has started
-			// the stylesheet element may or may not be in the DOM
-			query() ||
-			// <body> parsing has started (i.e. the entire <head> is parsed)
-			// if there is a stylesheet, the element will be in the DOM
-			await Init.bodyStart.then(query) ||
-			// subreddit styles disabled natively; no stylesheet element
-			null
-		);
-	});
-
-	const toggleStylesheet = mutex(async shouldRestore => {
-		const stylesheet = await getStylesheet();
+	function toggleStylesheet(shouldRestore) {
+		const stylesheet = getStylesheet();
 
 		if (!stylesheet) return;
 
@@ -390,26 +375,21 @@ const toggleElements = (() => {
 				stylesheet.remove();
 			}
 		}
-	});
+	}
 
-	const getHeaderImg = _.once(async () => {
+	const getHeaderImg = _.once(() => {
 		// subreddits with a custom header image will have:
 		// `<a id="header-img-a"><img id="header-img"/></a>`
 		// subreddits with the default will just have:
 		// `<a id="header-img" class="default-header"></a>`
-		const query = () => document.getElementById('header-img-a');
-		const imgQuery = () => document.getElementById('header-img');
+		const imgWrapper = document.getElementById('header-img-a');
+		const headerImg = imgWrapper && document.getElementById('header-img');
 
-		const imgWrapper = (
-			await Init.bodyStart.then(query) ||
-			await Init.bodyReady.then(query)
-		);
-
-		return { imgWrapper, headerImg: imgWrapper && imgQuery() };
+		return { imgWrapper, headerImg };
 	});
 
-	const toggleHeaderImg = mutex(async shouldRestore => {
-		const { imgWrapper, headerImg } = await getHeaderImg();
+	function toggleHeaderImg(shouldRestore) {
+		const { imgWrapper, headerImg } = getHeaderImg();
 
 		if (!imgWrapper || !headerImg) return;
 
@@ -426,10 +406,10 @@ const toggleElements = (() => {
 				imgWrapper.classList.add('default-header');
 			}
 		}
-	});
+	}
 
-	return shouldRestore => Promise.all([
-		toggleStylesheet(shouldRestore),
-		toggleHeaderImg(shouldRestore),
-	]);
+	return shouldRestore => {
+		toggleStylesheet(shouldRestore);
+		toggleHeaderImg(shouldRestore);
+	};
 })();

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -138,6 +138,7 @@ export {
 export {
 	markStart,
 	markEnd,
+	markCheckpoint,
 } from './profiling';
 
 export {

--- a/lib/utils/profiling.js
+++ b/lib/utils/profiling.js
@@ -9,4 +9,25 @@ export function markStart(): string {
 
 export function markEnd(tag: string, name: string) {
 	performance.measure(name, tag);
+	performance.clearMarks(tag);
+}
+
+export function markCheckpoint(tag: string, name: string) {
+	performance.measure(name, tag);
+	performance.clearMarks(tag);
+	performance.mark(tag);
+}
+
+export function _logPerfSummary() {
+	const timestamps = [];
+	// find all continguous measures
+	// this corresponds to the checkpoints in init(), since it starts before everything else and is contiguous
+	// this is somewhat a hack, but it's simple and it doesn't matter if this breaks completely
+	let nextStart = 0;
+	for (const { name, startTime, duration } of performance.getEntriesByType('measure')) {
+		if (startTime < nextStart) continue;
+		nextStart = startTime + duration;
+		timestamps.push(`${duration | 0} ${name}`);
+	}
+	console.log(timestamps.join(' | '));
 }


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: fixes #4262; #4422 may also be fixed
Tested in browser: Chrome 61, Firefox 55, ~~Edge 15~~ (Edge fails)

On my machine, these special-cases are no longer necessary to avoid FOUC (yay, Firefox is fast now).

But this is pretty risky, so it needs a beta cycle.

The main benefit of this, other than fixing the above issue, is that it becomes easier to reason about module state, because it becomes harder to have code run before options are loaded. (Except for a function getting called immediately at the top level, which should be more obviously wrong.)