### PR TITLE
Remove URLSearchParams shim in Firefox

### DIFF
--- a/firefox/beta/manifest.json
+++ b/firefox/beta/manifest.json
@@ -8,7 +8,7 @@
 	"applications": {
 		"gecko": {
 			"id": "jid1-xUfzOsOFlzSOXg@jetpack",
-			"strict_min_version": "53.0"
+			"strict_min_version": "54.0"
 		}
 	},
 	"icons": {

--- a/firefox/firefox.entry.js
+++ b/firefox/firefox.entry.js
@@ -3,14 +3,3 @@
 /* Firefox-specific polyfills */
 
 import 'intersection-observer';
-
-// Firefox doesn't support objects in URLSearchParams constructor (until Firefox 54)
-// https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams#Browser_compatibility
-window.URLSearchParams = class URLSearchParams extends window.URLSearchParams {
-	constructor(init) {
-		if (typeof init === 'object' && !Array.isArray(init)) {
-			init = Object.entries(init);
-		}
-		super(init);
-	}
-};

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -8,7 +8,7 @@
 	"applications": {
 		"gecko": {
 			"id": "jid1-xUfzOsOFlzSOXg@jetpack",
-			"strict_min_version": "53.0"
+			"strict_min_version": "54.0"
 		}
 	},
 	"icons": {


### PR DESCRIPTION
Tested in browser: Firefox 54