### PR TITLE
newCommentCount: use sharded storage only for comment counts, not subscriptions

### DIFF
--- a/lib/core/migrate/migrate.js
+++ b/lib/core/migrate/migrate.js
@@ -545,6 +545,18 @@ const migrations = [
 			await Storage.setMultiple(remappedEntries);
 			await Storage.delete('RESmodules.commentHidePersistor.hidePersistor');
 		},
+	}, {
+		versionNumber: '5.8.2-unshard-newCommentCount-subscriptions',
+		async go() {
+			const subscriptions = {};
+			for (const [key, val] of Object.entries(await Storage.getAll())) {
+				if (!key.startsWith('newCommentCount.')) continue;
+				if ((val: any).subscriptionDate) subscriptions[key] = val;
+				// don't bother deleting it; it's still valid for comment count storage
+				// and it'll eventually be pruned as with any count
+			}
+			Storage.set('RESmodules.newCommentCount.subscriptions', subscriptions);
+		},
 	},
 
 ];  // ^^ Add new migrations ^^

--- a/lib/modules/commentHidePersistor.js
+++ b/lib/modules/commentHidePersistor.js
@@ -16,9 +16,8 @@ module.include = [
 	'inbox',
 ];
 
-const expireAfterDays = 7;
 const currentId: string = (execRegexes.comments(location.pathname) || [])[2];
-const lastCleanStorage = Storage.wrap('RESmodules.commentHidePersistor.lastClean', (null: null | number));
+const lastCleanStorage = Storage.wrap('RESmodules.commentHidePersistor.lastClean', 0);
 const entryStorage = Storage.wrapPrefix('commentHidePersistor.', (): {
 	updateTime: number,
 	collapsedThings?: { [fullName: string]: boolean },
@@ -36,20 +35,18 @@ module.go = () => {
 	listenToCommentCollapse();
 };
 
-module.afterLoad = async () => {
-	// Clean counts every six hours
-	const lastClean = await lastCleanStorage.get() || 0;
-	if ((Date.now() - lastClean) > 0.25 * DAY) {
-		pruneOldEntries();
-	}
+module.afterLoad = () => {
+	maybePruneOldEntries();
 };
 
-async function pruneOldEntries() {
+async function maybePruneOldEntries() {
+	// Clean counts every six hours
 	const now = Date.now();
+	if ((now - await lastCleanStorage.get()) < 0.25 * DAY) return;
 	lastCleanStorage.set(now);
-	const keepTrackPeriod = DAY * parseInt(expireAfterDays, 10);
+
 	for (const [id, data] of Object.entries(await entryStorage.getAll())) {
-		if ((now - data.updateTime) > keepTrackPeriod) {
+		if ((now - data.updateTime) > 7 * DAY) {
 			entryStorage.delete(id);
 		}
 	}

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -78,15 +78,23 @@ module.options = {
 
 const currentId: ?string = (execRegexes.comments(location.pathname) || [])[2];
 const lastCleanStorage = Storage.wrap('RESmodules.newCommentCount.lastClean', 0);
-const lastSubscriptionCheckStorage = Storage.wrap('RESmodules.newCommentCount.lastSubscriptionCheck', 0);
-const entryStorage = Storage.wrapPrefix('newCommentCount.', (): {
-	subscriptionDate?: number,
+const entryStorage = Storage.wrapPrefix('newCommentCount.', (): {|
 	count: number,
-	editedTime: number,
-	url: string,
-	title: string,
 	updateTime: number,
-} => { throw new Error('Default value should never be retrieved'); });
+|} => {
+	throw new Error('Default value should never be retrieved');
+});
+
+const subscriptionStorage = Storage.wrap('RESmodules.newCommentCount.subscriptions', ({}: {
+	[id: string]: {|
+		count: number,
+		subscriptionDate: number,
+		editedTime: number,
+		updateTime: number,
+		url: string,
+		title: string,
+	|},
+}));
 
 module.beforeLoad = () => {
 	updateToggleSubscriptionButton();
@@ -106,22 +114,17 @@ module.go = () => {
 	}
 };
 
-module.afterLoad = async () => {
-	const lastSubscriptionCheck = await lastSubscriptionCheckStorage.get();
+module.afterLoad = () => {
 	// Avoid missing notifications by only running the check when document is visible
-	if (!document.hidden && (Date.now() - lastSubscriptionCheck) > 5 * MINUTE) {
+	if (!document.hidden) {
 		checkSubscriptions();
-	}
-
-	// Clean counts every six hours
-	const lastClean = await lastCleanStorage.get();
-	if ((Date.now() - lastClean) > 0.25 * DAY) {
-		pruneOldEntries();
 	}
 
 	if (isPageType('comments')) {
 		updateCurrentEntry();
 	}
+
+	maybePruneOldEntries();
 };
 
 const getEntryBatched = batch(async ids => {
@@ -129,19 +132,14 @@ const getEntryBatched = batch(async ids => {
 	return ids.map(id => entries[id]);
 }, { size: Infinity, delay: 0 });
 
-function setEntry(id: string, newCommentCount, newEditedTime) {
+function setEntry(id: string, newCommentCount) {
 	if (!module.options.monitorPostsVisited.value) return false;
 	if (!module.options.monitorPostsVisitedIncognito.value && isPrivateBrowsing()) return false;
 
-	const patch = {
+	entryStorage.set(id, {
 		count: newCommentCount,
-		url: location.href.replace(location.hash, ''),
-		title: document.title,
 		updateTime: Date.now(),
-		editedTime: newEditedTime,
-	};
-
-	entryStorage.patch(id, patch);
+	});
 }
 
 export async function hasEntry(thing: Thing): Promise<boolean> {
@@ -169,38 +167,38 @@ async function displayNewCommentCount(thing) {
 		.append(`<span class="newComments">&nbsp;(${newCount} new)</span>`);
 }
 
+function getListingThing() {
+	return Thing.checkedFrom(document.querySelector('#siteTable a.comments'));
+}
+
 /**
  * Handle updating page's comment counts
  */
 function updateCurrentEntry() {
-	const listingThing = Thing.from(document.querySelector('#siteTable a.comments'));
-
-	if (currentId && listingThing) {
-		setEntry(currentId, listingThing.getCommentCount(), listingThing.getPostEditTimestamp());
-	}
+	if (!currentId) return;
+	setEntry(currentId, getListingThing().getCommentCount());
 }
 
-async function updateCurrentCommentCountFromMyComment(thing) {
+function updateCurrentCommentCountFromMyComment(thing) {
 	if (!currentId) return;
 
 	const timestamp = thing.getTimestamp();
 	const isRecent = timestamp && (Date.now() - timestamp.getTime()) < 10000;
 	const isMine = loggedInUser() === thing.getAuthor();
 	if (isRecent && isMine) {
-		const { count, editedTime } = await entryStorage.get(currentId);
-		setEntry(currentId, count + 1, editedTime);
+		setEntry(currentId, getListingThing().getCommentCount() + 1);
 	}
 }
 
-async function pruneOldEntries() {
+async function maybePruneOldEntries() {
+	// Clean counts every six hours
 	const now = Date.now();
+	if ((now - await lastCleanStorage.get()) < 0.25 * DAY) return;
 	lastCleanStorage.set(now);
+
 	const keepTrackPeriod = DAY * parseInt(module.options.cleanComments.value, 10);
-	for (const [id, data] of Object.entries(await entryStorage.getAll())) {
-		// Do not automatically delete comments belonging to actively subscribed threads
-		if (data.subscriptionDate) {
-			continue;
-		} else if ((now - data.updateTime) > keepTrackPeriod) {
+	for (const [id, { updateTime }] of Object.entries(await entryStorage.getAll())) {
+		if ((now - updateTime) > keepTrackPeriod) {
 			stopTracking(id);
 		}
 	}
@@ -218,8 +216,8 @@ const updateToggleSubscriptionButton = mutex(async () => {
 	if (!currentId) throw new Error('No currentId');
 
 	const $button = getToggleSubscriptionButton();
-	const data = await entryStorage.getNullable(currentId);
-	if (data && data.subscriptionDate) {
+	const subscriptions = await subscriptionStorage.get();
+	if (currentId in subscriptions) {
 		// Unsubscribe.
 		$button
 			.html('<span class="res-icon">&#xF038;</span> unsubscribe')
@@ -240,7 +238,8 @@ const updateToggleSubscriptionButton = mutex(async () => {
 			.attr('title', 'notify me of new comments')
 			.removeClass('unsubscribe');
 		return waitForEvent($button.get(0), 'click').then(async () => {
-			await subscribe(currentId);
+			const listingThing = getListingThing();
+			await subscribe(currentId, listingThing.getCommentCount(), listingThing.getPostEditTimestamp());
 			Notifications.showNotification({
 				notificationID: 'newCommentCountSubscribe',
 				moduleID: 'newCommentCount',
@@ -257,31 +256,36 @@ const updateToggleSubscriptionButton = mutex(async () => {
 	}
 });
 
-function subscribe(id) {
+function subscribe(id, newCommentCount, newEditedTime) {
 	const now = Date.now();
-	return entryStorage.patch(id, { subscriptionDate: now });
+	return subscriptionStorage.patch({ [id]: {
+		count: newCommentCount,
+		subscriptionDate: now,
+		updateTime: now,
+		editedTime: newEditedTime,
+		url: location.href.replace(location.hash, ''),
+		title: document.title,
+	} });
 }
 
 function unsubscribe(id) {
-	return entryStorage.deletePath(id, 'subscriptionDate');
+	return subscriptionStorage.deletePath(id);
 }
 
 function stopTracking(id) {
-	return entryStorage.deletePath(id);
+	return entryStorage.delete(id);
 }
 
 async function checkSubscriptions() {
 	const now = Date.now();
-	lastSubscriptionCheckStorage.set(now);
 
-	for (const [id, subscription] of Object.entries(await entryStorage.getAll())) {
-		const { subscriptionDate } = subscription;
-		if (subscriptionDate) {
-			// If it's been subscriptionLength days since we've subscribed, we're going to delete this subscription...
-			if ((now - subscriptionDate) > (DAY * parseInt(module.options.subscriptionLength.value, 10))) {
-				unsubscribe(id);
-			}
-
+	for (const [id, subscription] of Object.entries(await subscriptionStorage.get())) {
+		const { subscriptionDate, updateTime } = subscription;
+		// If it's been subscriptionLength days since we've subscribed, we're going to delete this subscription...
+		if ((now - subscriptionDate) > (DAY * parseInt(module.options.subscriptionLength.value, 10))) {
+			unsubscribe(id);
+		} else if ((now - updateTime) > (5 * MINUTE)) {
+			subscriptionStorage.patch({ [id]: { updateTime: now } });
 			checkThread(id, subscription);
 		}
 	}
@@ -292,7 +296,7 @@ async function checkThread(id, subscription) {
 	const { count, editedTime, url, title } = subscription;
 
 	if (newCount > count) {
-		entryStorage.patch(id, { count: newCount });
+		subscriptionStorage.patch({ [id]: { count: newCount } });
 
 		const notification = await Notifications.showNotification({
 			header: 'New comments',
@@ -307,8 +311,8 @@ async function checkThread(id, subscription) {
 		promise.then(notification.close);
 		$(notification.element).find('.RESNotificationContent').append(button);
 	}
-	if (module.options.notifyEditedPosts.value && newEditedTime && newEditedTime > editedTime) {
-		entryStorage.patch(id, { editedTime: newEditedTime });
+	if (module.options.notifyEditedPosts.value && newEditedTime > editedTime) {
+		subscriptionStorage.patch({ [id]: { editedTime: newEditedTime } });
 
 		const notification = await Notifications.showNotification({
 			header: 'Post edited',
@@ -343,7 +347,7 @@ function createButton(id, type) {
 				.html('<span class="res-icon">&#xF03B;</span> renew')
 				.attr('title', `renew for ${module.options.subscriptionLength.value} days`);
 			action = async () => {
-				await subscribe(id);
+				await subscriptionStorage.patch({ [id]: { subscriptionDate: Date.now() } });
 
 				Notifications.showNotification({
 					notificationID: 'newCommentCountRenew',
@@ -359,9 +363,9 @@ function createButton(id, type) {
 				.attr('title', 'delete from list')
 				.addClass('deleteIcon');
 			action = async () => {
-				const { title } = await entryStorage.get(id);
-				return Alert.open(`Are you sure you want to stop tracking new comments on post: "${title}"?`, { cancelable: true })
-					.then(() => stopTracking(id));
+				const { [id]: { title } } = await subscriptionStorage.get();
+				return Alert.open(`Are you sure you want to unsubscribe from post: "${title}"?`, { cancelable: true })
+					.then(() => unsubscribe(id));
 			};
 			break;
 		default:
@@ -416,7 +420,7 @@ async function drawSubscriptionsTable(sortMethod, descending) {
 	currentSortMethod = sortMethod || currentSortMethod;
 	isDescending = (descending === undefined) ? isDescending : !!descending;
 	$('#newCommentsTable tbody').html('');
-	const thisCounts = filterMap(Object.entries(await entryStorage.getAll()), ([id, commentCount]) => {
+	const thisCounts = filterMap(Object.entries(await subscriptionStorage.get()), ([id, commentCount]) => {
 		const match = new URL(commentCount.url).pathname.match(regexes.subreddit);
 		if (match) {
 			return [{


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: https://www.reddit.com/r/Enhancement/comments/6nn2kb/does_580_feel_slower_to_you/; related to #4348 (this is a more aggressive implementation)
Tested in browser: Chrome 60

~~Note: not yet tested, at all~~