### PR TITLE
GoogleDrive: Use external lib to decode Base64

### DIFF
--- a/lib/modules/backupAndRestore/providers/GoogleDrive.js
+++ b/lib/modules/backupAndRestore/providers/GoogleDrive.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import { Base64 } from 'js-base64';
 import { ajax, launchAuthFlow, Permissions } from '../../../environment';
 import { Alert } from '../../../utils';
 import { Provider } from './Provider';
@@ -68,7 +69,7 @@ export class GoogleDrive extends Provider {
 				Authorization: `Bearer ${this.accessToken}`,
 			},
 		});
-		return atob(data);
+		return Base64.decode(data);
 	}
 
 	async write(data: string) {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "jquery": "3.2.1",
     "jquery-sortable": "0.9.13",
     "jquery.tokeninput": "Reddit-Enhancement-Suite/jquery-tokeninput",
+    "js-base64": "2.1.9",
     "lodash": "4.17.4",
     "moment": "2.18.1",
     "numeral": "2.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4822,7 +4822,7 @@ jquery@^2.1.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
 
-js-base64@^2.1.9:
+js-base64@2.1.9, js-base64@^2.1.9:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
 


### PR DESCRIPTION
`atob` doesn't support unicode

Fixes #4353