### PR TITLE
selectedEntry: Set always enabled, add style "line".

### DIFF
--- a/lib/core/migrate/migrate.js
+++ b/lib/core/migrate/migrate.js
@@ -557,6 +557,22 @@ const migrations = [
 			}
 			Storage.set('RESmodules.newCommentCount.subscriptions', subscriptions);
 		},
+	}, {
+		versionNumber: '5.9.0-selectedEntry',
+		async go() {
+			await Migrators.moveOption('selectedEntry', 'addFocusBGColor', 'selectedEntry', 'setColors');
+			await Migrators.moveOption('selectedEntry', 'focusBGColor', 'selectedEntry', 'backgroundColor');
+			await Migrators.moveOption('selectedEntry', 'focusBGColorNight', 'selectedEntry', 'backgroundColorNight');
+			await Migrators.moveOption('selectedEntry', 'focusFGColorNight', 'selectedEntry', 'textColorNight');
+			await Migrators.moveOption('selectedEntry', 'addFocusBorder', 'selectedEntry', 'addOutline');
+			await Migrators.moveOption('selectedEntry', 'focusBorder', 'selectedEntry', 'outlineStyle');
+			await Migrators.moveOption('selectedEntry', 'focusBorderNight', 'selectedEntry', 'outlineStyleNight');
+
+			if ((await Storage.get('RES.modulePrefs') || { selectedEntry: true }).selectedEntry === false) {
+				await Options.set('selectedEntry', 'setColors', false);
+				await Options.set('selectedEntry', 'addLine', true);
+			}
+		},
 	},
 
 ];  // ^^ Add new migrations ^^

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -17,7 +17,6 @@ import {
 	idleThrottle,
 } from '../utils';
 import type { ScrollStyle } from '../utils/dom';
-import * as Hover from './hover';
 
 export const module: Module<*> = new Module('selectedEntry');
 
@@ -138,7 +137,6 @@ module.go = () => {
 		addFocusBorder();
 	}
 
-	addListener((selected, unselected) => unselected && Hover.infocard('showParent').close(false), 'beforePaint');
 	addListener(updateActiveElement, 'beforePaint');
 	addListener(selected => BodyClasses.toggle(!!selected, 'res-entry-is-selected'), 'beforePaint');
 	addListener((selected, unselected, { scrollStyle, direction }) => scrollToElement(selected.entry, { from: unselected && unselected.entry, scrollStyle, direction }), 'beforePaint');

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -3,7 +3,6 @@
 import _ from 'lodash';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
-import { Session } from '../environment';
 import {
 	Thing,
 	addCSS,
@@ -14,7 +13,6 @@ import {
 	watchForThings,
 	frameThrottle,
 	idleThrottle,
-	reifyPromise,
 } from '../utils';
 import type { ScrollStyle } from '../utils/dom';
 
@@ -98,12 +96,6 @@ module.options = {
 		advanced: true,
 	},
 };
-
-// Keep track the last selected entry so in order to restore selection when returning to it
-// Hash the location into a minimal hash since `Session` is cleared only when extension is restarted
-const hasher = str => str.split('').reduce((v, c) => ((v << 5) - v) + c.charCodeAt(0), 0).toString(36);
-const lastSelectedPath = `lastSelected.${hasher(document.location.pathname.replace(/\/$/, ''))}`;
-const initialLastSelectedId = reifyPromise(Session.get(lastSelectedPath));
 
 module.beforeLoad = () => {
 	watchForThings(['post', 'comment', 'message'], selectInitial);
@@ -240,7 +232,7 @@ const selectInitial = _.once(firstThing => {
 		// `scrollRestoration` may also be set in neverEndingReddit
 		const scrollToSelected = history.scrollRestoration === 'manual';
 
-		const lastSelectedId = initialLastSelectedId.get();
+		const lastSelectedId = history.state && history.state.lastSelectedId;
 		const lastSelected = lastSelectedId && Thing.things().find(v => v.getFullname() === lastSelectedId);
 
 		const target = (lastSelected || firstThing).getClosestVisible() || lastSelected || firstThing;
@@ -251,7 +243,9 @@ const selectInitial = _.once(firstThing => {
 		});
 	}
 
-	addListener(selected => { Session.set(lastSelectedPath, selected.getFullname()); });
+	addListener(selected => {
+		history.replaceState({ ...history.state, lastSelectedId: selected.getFullname() }, document.title);
+	}, 'beforeScroll');
 });
 
 const movers = {

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -24,6 +24,7 @@ module.moduleName = 'selectedEntryName';
 module.category = 'browsingCategory';
 module.include = ['comments', 'linklist', 'commentsLinklist', 'modqueue', 'profile', 'inbox', 'search'];
 module.description = 'selectedEntryDesc';
+module.alwaysEnabled = true;
 
 module.options = {
 	autoSelectOnScroll: {
@@ -32,110 +33,92 @@ module.options = {
 		value: false,
 		description: 'selectedEntryAutoSelectOnScrollDesc',
 	},
-	selectThingOnLoad: {
-		title: 'selectedEntrySelectThingOnLoadTitle',
-		type: 'boolean',
-		value: true,
-		description: 'selectedEntrySelectThingOnLoadDesc',
-	},
 	selectLastThingOnLoad: {
 		title: 'selectedEntrySelectLastThingOnLoadTitle',
-		dependsOn: options => options.selectThingOnLoad.value,
 		type: 'boolean',
 		value: true,
 		description: 'selectedEntrySelectLastThingOnLoadDesc',
 	},
 	scrollToSelectedThingOnLoad: {
 		title: 'selectedEntryScrollToSelectedThingOnLoadTitle',
-		dependsOn: options => options.selectThingOnLoad.value,
 		type: 'boolean',
 		value: false,
-		description: 'selectedEntryScrollToSelectedThingOnLoadDesc',
-	},
-	selectOnClick: {
-		title: 'selectedEntrySelectOnClickTitle',
-		type: 'boolean',
-		value: true,
-		description: 'selectedEntrySelectOnClickDesc',
 		advanced: true,
+		description: 'selectedEntryScrollToSelectedThingOnLoadDesc',
+		dependsOn: options => options.selectLastThingOnLoad.value,
 	},
-	addFocusBGColor: {
-		title: 'selectedEntryAddFocusBGColorTitle',
+	addLine: {
+		title: 'selectedEntryAddLineTitle',
+		type: 'boolean',
+		value: false,
+		description: 'selectedEntryAddLineDesc',
+	},
+	setColors: {
+		title: 'selectedEntrySetColorsTitle',
 		type: 'boolean',
 		value: true,
-		description: 'selectedEntryAddFocusBGColorDesc',
+		description: 'selectedEntrySetColorsDesc',
 	},
-	focusBGColor: {
-		title: 'selectedEntryFocusBGColorTitle',
+	backgroundColor: {
+		title: 'selectedEntryBackgroundColorTitle',
 		type: 'color',
 		value: '#F0F3FC',
-		description: 'selectedEntryFocusBGColorDesc',
+		description: 'selectedEntryBackgroundColorDesc',
 		advanced: true,
-		dependsOn: options => options.addFocusBGColor.value,
+		dependsOn: options => options.setColors.value,
 	},
-	focusBGColorNight: {
-		title: 'selectedEntryFocusBGColorNightTitle',
+	backgroundColorNight: {
+		title: 'selectedEntryBackgroundColorNightTitle',
 		type: 'color',
 		value: '#373737',
-		description: 'selectedEntryFocusBGColorNightDesc',
+		description: 'selectedEntryBackgroundColorNightDesc',
 		advanced: true,
-		dependsOn: options => options.addFocusBGColor.value,
+		dependsOn: options => options.setColors.value,
 	},
-	focusFGColorNight: {
-		title: 'selectedEntryFocusFGColorNightTitle',
+	textColorNight: {
+		title: 'selectedEntryTextColorNightTitle',
 		type: 'color',
 		value: '#DDDDDD',
-		description: 'selectedEntryFocusFGColorNightDesc',
+		description: 'selectedEntryTextColorNightDesc',
 		advanced: true,
-		dependsOn: options => options.addFocusBGColor.value,
+		dependsOn: options => options.setColors.value,
 	},
-	addFocusBorder: {
-		title: 'selectedEntryAddFocusBorderTitle',
-		type: 'boolean',
-		value: true,
-		description: 'selectedEntryAddFocusBorderDesc',
-	},
-	focusBorder: {
-		title: 'selectedEntryFocusBorderTitle',
+	outlineStyle: {
+		title: 'selectedEntryOutlineStyleTitle',
 		type: 'text',
 		value: '',
-		description: 'selectedEntryFocusBorderDesc',
+		description: 'selectedEntryOutlineStyleDesc',
 		advanced: true,
-		dependsOn: options => options.addFocusBorder.value,
 	},
-	focusBorderNight: {
-		title: 'selectedEntryFocusBorderNightTitle',
+	outlineStyleNight: {
+		title: 'selectedEntryOutlineStyleNightTitle',
 		type: 'text',
 		value: '',
-		description: 'selectedEntryFocusBorderNightDesc',
+		description: 'selectedEntryOutlineStyleNightDesc',
 		advanced: true,
-		dependsOn: options => options.addFocusBorder.value,
 	},
 };
 
 module.beforeLoad = () => {
-	if (module.options.selectThingOnLoad.value) {
-		setupLastSelectedCache();
-		watchForThings(['post', 'comment', 'message'], selectInitial);
-	}
+	setupLastSelectedCache();
+	watchForThings(['post', 'comment', 'message'], selectInitial);
 };
 
 module.go = () => {
 	watchForThings(['comment'], onNewComments);
 
+	// Select Thing on manual click
+	$(document.body).on('mouseup', Thing.bodyThingSelector, e => {
+		if (!click.isProgrammaticEvent(e)) onClick(e);
+	});
+
 	if (module.options.autoSelectOnScroll.value) {
 		window.addEventListener('scroll', _.debounce(() => { if (!recentKeyMove) autoSelect(); }, 300));
 	}
-	if (module.options.selectOnClick.value) {
-		$(document.body).on('mouseup', Thing.bodyThingSelector, handleClick);
-	}
 
-	if (module.options.addFocusBGColor.value) {
-		addFocusBGColor();
-	}
-	if (module.options.addFocusBorder.value) {
-		addFocusBorder();
-	}
+	if (module.options.addLine.value) styleLine();
+	if (module.options.setColors.value) styleColor();
+	styleOutline();
 
 	addListener(updateActiveElement, 'beforePaint');
 	addListener(selected => BodyClasses.toggle(!!selected, 'res-entry-is-selected'), 'beforePaint');
@@ -146,19 +129,6 @@ const onClick = _.throttle(e => {
 	const thing = Thing.from(e.target);
 	if (thing) select(thing, { scrollStyle: 'none' });
 }, 100, { trailing: false });
-
-export function handleClick(e: MouseEvent) {
-	// Exposed so modules which stop propagation on click events inside things can explicitly pass the event to this module
-	if (!module.options.selectOnClick.value) {
-		return;
-	}
-	if (click.isProgrammaticEvent(e)) {
-		// Use modules['select'].select(thing), don't rely on click handling
-		return;
-	}
-
-	onClick(e);
-}
 
 export let selectedThing: ?Thing;
 let selectedContainer: ?Element;
@@ -318,10 +288,6 @@ const selectInitial = _.once(fastAsync(function*(firstThing) {
 }));
 
 async function findLastSelectedThing() {
-	if (!module.options.selectLastThingOnLoad.value) {
-		return false;
-	}
-
 	await setupLastSelectedCache();
 
 	const url = urlForSelectedCache();
@@ -373,50 +339,49 @@ export function move(direction: $Keys<typeof movers>, options?: SelectOptionsWit
 	refreshKeyMoveTimer();
 }
 
-// old style: .RES-keyNav-activeElement { '+borderType+': '+focusBorder+'; background-color: '+focusBGColor+'; } \
-// this new pure CSS arrow will not work because to position it we must have .RES-keyNav-activeElement position relative, but that screws up image viewer's absolute positioning to
-// overlay over the sidebar... yikes.
-// .RES-keyNav-activeElement:after { content: ""; float: right; margin-right: -5px; border-color: transparent '+focusBorderColor+' transparent transparent; border-style: solid; border-width: 3px 4px 3px 0; } \
-
 // why !important on .RES-keyNav-activeElement?  Because some subreddits are unfortunately using !important for no good reason on .entry divs...
 
-function addFocusBGColor() {
-	const focusBGColor = module.options.focusBGColor.value || module.options.focusBGColor.default;
-	const focusBGColorNight = module.options.focusBGColorNight.value || module.options.focusBGColorNight.default;
-	const focusFGColorNight = module.options.focusFGColorNight.value || module.options.focusFGColorNight.default;
-
+function styleLine() {
 	addCSS(`
-		.RES-keyNav-activeElement,
-		.RES-keyNav-activeElement .md-container {
-			background-color: ${focusBGColor} !important;
-		}
-
-		.res-nightmode .RES-keyNav-activeElement > .tagline,
-		.res-nightmode .RES-keyNav-activeElement .md-container > .md,
-		.res-nightmode .RES-keyNav-activeElement .md-container > .md p {
-			color: ${focusFGColorNight} !important;
-		}
-
-		.res-nightmode .RES-keyNav-activeElement,
-		.res-nightmode .RES-keyNav-activeElement .md-container {
-			background-color: ${focusBGColorNight} !important;
-		}
+		.RES-keyNav-activeElement { box-shadow: 3px 0 0 -1px #c2d2e0; !important; }
+		.res-nightmode .RES-keyNav-activeElement { box-shadow: 3px 0 0 -1px grey; !important; }
 	`);
 }
 
-function addFocusBorder() {
-	const borderType = 'outline';
+function styleColor() {
+	const backgroundColor = module.options.backgroundColor.value ? `
+		.RES-keyNav-activeElement,
+		.RES-keyNav-activeElement .md-container {
+			background-color: ${module.options.backgroundColor.value} !important;
+		}` : '';
 
-	const focusBorder = module.options.focusBorder.value ?
-		`${borderType}: ${module.options.focusBorder.value};` :
-		'';
+	const backgroundColorNight = module.options.backgroundColorNight.value ? `
+		.res-nightmode .RES-keyNav-activeElement,
+		.res-nightmode .RES-keyNav-activeElement .md-container {
+			background-color: ${module.options.backgroundColorNight.value} !important;
+		}` : '';
 
-	const focusBorderNight = module.options.focusBorderNight.value ?
-		`${borderType}: ${module.options.focusBorderNight.value};` :
-		'';
+	const textColorNight = module.options.textColorNight.value ? `
+		.res-nightmode .RES-keyNav-activeElement > .tagline,
+		.res-nightmode .RES-keyNav-activeElement .md-container > .md,
+		.res-nightmode .RES-keyNav-activeElement .md-container > .md p {
+			color: ${module.options.textColorNight.value} !important;
+		}` : '';
 
-	addCSS(`
-		.RES-keyNav-activeElement { ${focusBorder} }
-		.res-nightmode .RES-keyNav-activeElement { ${focusBorderNight} }
-	`);
+	addCSS(backgroundColor + backgroundColorNight + textColorNight);
+}
+
+function styleOutline() {
+	const outlineStyle = module.options.outlineStyle.value ? `
+		.RES-keyNav-activeElement {
+			outline: ${module.options.outlineStyle.value};
+		}` : '';
+
+	const outlineStyleNight = module.options.outlineStyleNight.value ? `
+		.res-nightmode .RES-keyNav-activeElement {
+			outline: ${module.options.outlineStyleNight.value};
+		}
+	` : '';
+
+	addCSS(outlineStyle + outlineStyleNight);
 }

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -99,7 +99,10 @@ module.options = {
 	},
 };
 
-const lastSelectedPath = `lastSelected.${document.location.pathname.replace(/\/$/, '')}`;
+// Keep track the last selected entry so in order to restore selection when returning to it
+// Hash the location into a minimal hash since `Session` is cleared only when extension is restarted
+const hasher = str => str.split('').reduce((v, c) => ((v << 5) - v) + c.charCodeAt(0), 0).toString(36);
+const lastSelectedPath = `lastSelected.${hasher(document.location.pathname.replace(/\/$/, ''))}`;
 const initialLastSelectedId = reifyPromise(Session.get(lastSelectedPath));
 
 module.beforeLoad = () => {

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -235,19 +235,21 @@ function autoSelect() {
 }
 
 const selectInitial = _.once(firstThing => {
-	if (module.options.scrollToSelectedThingOnLoad.value) history.scrollRestoration = 'manual';
-	// `scrollRestoration` may also be set in neverEndingReddit
-	const scrollToSelected = history.scrollRestoration === 'manual';
+	if (!selectedThing) {
+		if (module.options.scrollToSelectedThingOnLoad.value) history.scrollRestoration = 'manual';
+		// `scrollRestoration` may also be set in neverEndingReddit
+		const scrollToSelected = history.scrollRestoration === 'manual';
 
-	const lastSelectedId = initialLastSelectedId.get();
-	const lastSelected = lastSelectedId && Thing.things().find(v => v.getFullname() === lastSelectedId);
+		const lastSelectedId = initialLastSelectedId.get();
+		const lastSelected = lastSelectedId && Thing.things().find(v => v.getFullname() === lastSelectedId);
 
-	const target = (lastSelected || firstThing).getClosestVisible() || lastSelected || firstThing;
+		const target = (lastSelected || firstThing).getClosestVisible() || lastSelected || firstThing;
 
-	select(target, {
-		scrollStyle: scrollToSelected ? 'legacy' : 'none',
-		paintImmediate: true,
-	});
+		select(target, {
+			scrollStyle: scrollToSelected ? 'legacy' : 'none',
+			paintImmediate: true,
+		});
+	}
 
 	addListener(selected => { Session.set(lastSelectedPath, selected.getFullname()); });
 });

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -122,13 +122,10 @@ module.go = () => {
 	}
 
 	if (!selectedThing) requestAnimationFrame(autoSelect);
-
-	addListener(selected => {
-		history.replaceState({ ...history.state, lastSelectedId: selected.getFullname() }, document.title);
-	}, 'beforeScroll');
 };
 
 const onClick = _.throttle(e => {
+	addLastSelectedListener();
 	const thing = Thing.from(e.target);
 	if (thing) select(thing, { scrollStyle: 'none' });
 }, 100, { trailing: false });
@@ -243,6 +240,12 @@ function selectInitial(thing) {
 	select(target, { scrollStyle: scrollToSelected ? 'legacy' : 'none' });
 }
 
+const addLastSelectedListener = _.once(() => {
+	addListener(selected => {
+		history.replaceState({ ...history.state, lastSelectedId: selected.getFullname() }, document.title);
+	}, 'beforeScroll');
+});
+
 const movers = {
 	closestVisible: (thing: Thing) => thing.getClosestVisible(false),
 	up: (thing: Thing) => thing.getNext({ direction: 'up' }),
@@ -279,6 +282,7 @@ export function move(direction: $Keys<typeof movers>, options?: SelectOptionsWit
 		return;
 	}
 
+	addLastSelectedListener();
 	select(target, options);
 
 	recentKeyMove = true;

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -120,6 +120,12 @@ module.go = () => {
 	if (module.options.addLine.value) styleLine();
 	if (module.options.setColors.value) styleColor();
 	styleOutline();
+
+	if (!selectedThing) requestAnimationFrame(autoSelect);
+
+	addListener(selected => {
+		history.replaceState({ ...history.state, lastSelectedId: selected.getFullname() }, document.title);
+	}, 'beforeScroll');
 };
 
 const onClick = _.throttle(e => {
@@ -133,7 +139,6 @@ let selectedContainer: ?Element;
 type SelectOptions = {
 	allowMediaBrowse?: boolean,
 	scrollStyle: ScrollStyle,
-	paintImmediate?: boolean, // Set `true` when `select` is invoked during the animation phase, in order for `beforePaint` not to be delayed to the next animation frame
 };
 
 type SelectOptionsWithDirection = SelectOptions & { direction?: 'down' | 'up' };
@@ -168,10 +173,7 @@ const runCallbacks = (() => {
 
 	return (new_, old, opt) => {
 		if (listeners.beforeScroll.length) runListeners(listeners.beforeScroll, new_, old, opt);
-		if (listeners.beforePaint.length) {
-			if (opt.paintImmediate) runListeners(listeners.beforePaint, new_, old, opt);
-			else runPaint(new_, old, opt);
-		}
+		if (listeners.beforePaint.length) runPaint(new_, old, opt);
 		if (listeners.idle.length) runIdle(new_, old, opt);
 	};
 })();
@@ -226,27 +228,20 @@ function autoSelect() {
 	}
 }
 
-const selectInitial = _.once(firstThing => {
-	if (!selectedThing) {
-		if (module.options.scrollToSelectedThingOnLoad.value) history.scrollRestoration = 'manual';
-		// `scrollRestoration` may also be set in neverEndingReddit
-		const scrollToSelected = history.scrollRestoration === 'manual';
+const lastSelectedId = history.state && history.state.lastSelectedId;
 
-		const lastSelectedId = history.state && history.state.lastSelectedId;
-		const lastSelected = lastSelectedId && Thing.things().find(v => v.getFullname() === lastSelectedId);
+function selectInitial(thing) {
+	if (selectedThing) return;
+	if (thing.getFullname() !== lastSelectedId) return;
+	const target = thing.getClosestVisible();
+	if (!target) return;
 
-		const target = (lastSelected || firstThing).getClosestVisible() || lastSelected || firstThing;
+	if (module.options.scrollToSelectedThingOnLoad.value) history.scrollRestoration = 'manual';
+	// `scrollRestoration` may also be set in neverEndingReddit
+	const scrollToSelected = history.scrollRestoration === 'manual';
 
-		select(target, {
-			scrollStyle: scrollToSelected ? 'legacy' : 'none',
-			paintImmediate: true,
-		});
-	}
-
-	addListener(selected => {
-		history.replaceState({ ...history.state, lastSelectedId: selected.getFullname() }, document.title);
-	}, 'beforeScroll');
-});
+	select(target, { scrollStyle: scrollToSelected ? 'legacy' : 'none' });
+}
 
 const movers = {
 	closestVisible: (thing: Thing) => thing.getClosestVisible(false),

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -146,7 +146,7 @@ export function addListener(callback: (new_: Thing, old: ?Thing, opt: SelectOpti
 
 const runCallbacks = (() => {
 	function runListeners(listeners, new_, old, opt) {
-		for (const listener of listeners) listener(new_, old, opt);
+		for (const listener of listeners) try { listener(new_, old, opt); } catch (e) { console.error(e); }
 	}
 
 	function throttle(throttler, listeners) {

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -103,6 +103,10 @@ module.beforeLoad = () => {
 	addListener(updateActiveElement, 'beforePaint');
 	addListener(selected => BodyClasses.toggle(!!selected, 'res-entry-is-selected'), 'beforePaint');
 	addListener((selected, unselected, { scrollStyle, direction }) => scrollToElement(selected.entry, { from: unselected && unselected.entry, scrollStyle, direction }), 'beforePaint');
+
+	if (module.options.addLine.value) styleLine();
+	if (module.options.setColors.value) styleColor();
+	styleOutline();
 };
 
 module.go = () => {
@@ -116,10 +120,6 @@ module.go = () => {
 	if (module.options.autoSelectOnScroll.value) {
 		window.addEventListener('scroll', _.debounce(() => { if (!recentKeyMove) autoSelect(); }, 300));
 	}
-
-	if (module.options.addLine.value) styleLine();
-	if (module.options.setColors.value) styleColor();
-	styleOutline();
 
 	if (!selectedThing) requestAnimationFrame(autoSelect);
 

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -10,11 +10,11 @@ import {
 	BodyClasses,
 	click,
 	elementInViewport,
-	fastAsync,
 	scrollToElement,
 	watchForThings,
 	frameThrottle,
 	idleThrottle,
+	reifyPromise,
 } from '../utils';
 import type { ScrollStyle } from '../utils/dom';
 
@@ -99,8 +99,10 @@ module.options = {
 	},
 };
 
+const lastSelectedPath = `lastSelected.${document.location.pathname.replace(/\/$/, '')}`;
+const initialLastSelectedId = reifyPromise(Session.get(lastSelectedPath));
+
 module.beforeLoad = () => {
-	setupLastSelectedCache();
 	watchForThings(['post', 'comment', 'message'], selectInitial);
 };
 
@@ -229,54 +231,14 @@ function autoSelect() {
 	}
 }
 
-const lastSelectedKey = 'RESmodules.selectedThing.lastSelectedCache';
-let lastSelectedCache;
-
-const setupLastSelectedCache = _.once(async () => {
-	lastSelectedCache = await Session.get(lastSelectedKey) || {};
-
-	// clean cache every so often and delete any urls that haven't been visited recently
-	const clearCachePeriod = 21600000; // 6 hours
-	const itemExpiration = 3600000; // 1 hour
-	const now = Date.now();
-	if (!lastSelectedCache.lastScan || (now - lastSelectedCache.lastScan > clearCachePeriod)) {
-		for (const idx in lastSelectedCache) {
-			if (lastSelectedCache[idx] && (now - lastSelectedCache[idx].updated > itemExpiration)) {
-				delete lastSelectedCache[idx];
-			}
-		}
-		lastSelectedCache.lastScan = now;
-		Session.set(lastSelectedKey, lastSelectedCache);
-	}
-});
-
-function urlForSelectedCache() {
-	let url = document.location.pathname;
-	// remove any trailing slash from the URL
-	if (url.endsWith('/')) {
-		url = url.slice(0, -1);
-	}
-
-	return url;
-}
-
-function updateLastSelectedCache(selected) {
-	if (!lastSelectedCache) return;
-
-	const url = urlForSelectedCache();
-	lastSelectedCache[url] = {
-		fullname: selected.getFullname(),
-		updated: Date.now(),
-	};
-	Session.set('RESmodules.selectedThing.lastSelectedCache', lastSelectedCache);
-}
-
-const selectInitial = _.once(fastAsync(function*(firstThing) {
+const selectInitial = _.once(firstThing => {
 	if (module.options.scrollToSelectedThingOnLoad.value) history.scrollRestoration = 'manual';
 	// `scrollRestoration` may also be set in neverEndingReddit
 	const scrollToSelected = history.scrollRestoration === 'manual';
 
-	const lastSelected = yield findLastSelectedThing();
+	const lastSelectedId = initialLastSelectedId.get();
+	const lastSelected = lastSelectedId && Thing.things().find(v => v.getFullname() === lastSelectedId);
+
 	const target = (lastSelected || firstThing).getClosestVisible() || lastSelected || firstThing;
 
 	select(target, {
@@ -284,18 +246,8 @@ const selectInitial = _.once(fastAsync(function*(firstThing) {
 		paintImmediate: true,
 	});
 
-	addListener(updateLastSelectedCache);
-}));
-
-async function findLastSelectedThing() {
-	await setupLastSelectedCache();
-
-	const url = urlForSelectedCache();
-	const lastSelected = lastSelectedCache[url] && lastSelectedCache[url].fullname;
-	if (lastSelected) {
-		return Thing.things().find(v => v.getFullname() === lastSelected);
-	}
-}
+	addListener(selected => { Session.set(lastSelectedPath, selected.getFullname()); });
+});
 
 const movers = {
 	closestVisible: (thing: Thing) => thing.getClosestVisible(false),

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -99,6 +99,10 @@ module.options = {
 
 module.beforeLoad = () => {
 	watchForThings(['post', 'comment', 'message'], selectInitial);
+
+	addListener(updateActiveElement, 'beforePaint');
+	addListener(selected => BodyClasses.toggle(!!selected, 'res-entry-is-selected'), 'beforePaint');
+	addListener((selected, unselected, { scrollStyle, direction }) => scrollToElement(selected.entry, { from: unselected && unselected.entry, scrollStyle, direction }), 'beforePaint');
 };
 
 module.go = () => {
@@ -116,10 +120,6 @@ module.go = () => {
 	if (module.options.addLine.value) styleLine();
 	if (module.options.setColors.value) styleColor();
 	styleOutline();
-
-	addListener(updateActiveElement, 'beforePaint');
-	addListener(selected => BodyClasses.toggle(!!selected, 'res-entry-is-selected'), 'beforePaint');
-	addListener((selected, unselected, { scrollStyle, direction }) => scrollToElement(selected.entry, { from: unselected && unselected.entry, scrollStyle, direction }), 'beforePaint');
 };
 
 const onClick = _.throttle(e => {

--- a/lib/modules/showParent.js
+++ b/lib/modules/showParent.js
@@ -4,6 +4,7 @@ import { $ } from '../vendor';
 import { Thing } from '../utils';
 import { Module } from '../core/module';
 import * as Hover from './hover';
+import * as SelectedEntry from './selectedEntry';
 
 export const module: Module<*> = new Module('showParent');
 
@@ -59,6 +60,8 @@ module.go = () => {
 			fadeSpeed: module.options.fadeSpeed.value,
 		});
 	});
+
+	SelectedEntry.addListener((selected, unselected) => unselected && Hover.infocard(module.moduleID).close(false), 'beforePaint');
 };
 
 export function startHover(button: HTMLElement, options: * = {}) {

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -1414,7 +1414,7 @@
 		"message": "Selected Entry"
 	},
 	"selectedEntryDesc": {
-		"message": "Style the currently selected submission or comment. For use with Keyboard Navigation."
+		"message": "Style the currently selected submission or comment."
 	},
 	"settingsConsoleName": {
 		"message": "Settings Console"
@@ -2671,37 +2671,31 @@
 	"selectedEntryAutoSelectOnScrollDesc": {
 		"message": "Automatically select the topmost item while scrolling"
 	},
-	"selectedEntrySelectThingOnLoadDesc": {
-		"message": "Automatically select a post/comment when the page loads"
-	},
 	"selectedEntrySelectLastThingOnLoadDesc": {
 		"message": "Automatically select the last thing you had selected"
 	},
 	"selectedEntryScrollToSelectedThingOnLoadDesc": {
 		"message": "Automatically scroll to the post/comment that is selected when the page loads"
 	},
-	"selectedEntrySelectOnClickDesc": {
-		"message": "Allows you to click on an item to select it"
+	"selectedEntryAddLineDesc": {
+		"message": "Show a line on right side."
 	},
-	"selectedEntryAddFocusBGColorDesc": {
-		"message": "Use a background color"
+	"selectedEntrySetColorsDesc": {
+		"message": "Set colors"
 	},
-	"selectedEntryFocusBGColorDesc": {
+	"selectedEntryBackgroundColorDesc": {
 		"message": "The background color"
 	},
-	"selectedEntryFocusBGColorNightDesc": {
+	"selectedEntryBackgroundColorNightDesc": {
 		"message": "The background color while using Night Mode"
 	},
-	"selectedEntryFocusFGColorNightDesc": {
+	"selectedEntryTextColorNightDesc": {
 		"message": "The text color while using Night Mode"
 	},
-	"selectedEntryAddFocusBorderDesc": {
-		"message": "Use a border"
-	},
-	"selectedEntryFocusBorderDesc": {
+	"selectedEntryOutlineStyleDesc": {
 		"message": "Border appearance. E.g. `1px dashed gray` (CSS)"
 	},
-	"selectedEntryFocusBorderNightDesc": {
+	"selectedEntryOutlineStyleNightDesc": {
 		"message": "Border appearance using Night Mode (as above)"
 	},
 	"settingsNavigationShowAllOptionsDesc": {
@@ -2924,38 +2918,32 @@
 	"selectedEntryAutoSelectOnScrollTitle": {
 		"message": "Auto Select On Scroll"
 	},
-	"selectedEntrySelectThingOnLoadTitle": {
-		"message": "Select Thing On Load"
-	},
 	"selectedEntrySelectLastThingOnLoadTitle": {
 		"message": "Select Last Thing On Load"
 	},
 	"selectedEntryScrollToSelectedThingOnLoadTitle": {
 		"message": "Scroll To Selected Thing On Load"
 	},
-	"selectedEntrySelectOnClickTitle": {
-		"message": "Select On Click"
+	"selectedEntryAddLineTitle": {
+		"message": "Add Line"
 	},
-	"selectedEntryAddFocusBGColorTitle": {
-		"message": "Add Focus BG Color"
+	"selectedEntrySetColorsTitle": {
+		"message": "Set Colors"
 	},
-	"selectedEntryFocusBGColorTitle": {
-		"message": "Focus BG Color"
+	"selectedEntryBackgroundColorTitle": {
+		"message": "Background Color"
 	},
-	"selectedEntryFocusBGColorNightTitle": {
-		"message": "Focus BG Color Night"
+	"selectedEntryBackgroundColorNightTitle": {
+		"message": "Background Color Night"
 	},
-	"selectedEntryFocusFGColorNightTitle": {
-		"message": "Focus FG Color Night"
+	"selectedEntryTextColorNightTitle": {
+		"message": "Text Color Night"
 	},
-	"selectedEntryAddFocusBorderTitle": {
-		"message": "Add Focus Border"
+	"selectedEntryOutlineStyleTitle": {
+		"message": "Outline Style"
 	},
-	"selectedEntryFocusBorderTitle": {
-		"message": "Focus Border"
-	},
-	"selectedEntryFocusBorderNightTitle": {
-		"message": "Focus Border Night"
+	"selectedEntryOutlineStyleNightTitle": {
+		"message": "Outline Style Night"
 	},
 	"RESTipsMenuItemTitle": {
 		"message": "Menu Item"


### PR DESCRIPTION
Since several modules now depend on `selectedEntry`, it's probably best to set it to `alwaysEnabled` in order to reduce complexity.

A new style `line` is added, as a less obtrusive alternative to outline and highlighting:
![image](https://user-images.githubusercontent.com/1748521/28298485-d0f5fc7e-6b73-11e7-90fd-1a8ddcb51ac7.png)

Users that earlier have disabled the module will be migrated to use it. I'm also considering changing to the default style to it, as I believe most users don't need the whole entry highlighted.
 