### PR TITLE
Don't show use subreddit style checkbox on user pages

### DIFF
--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -188,7 +188,7 @@ module.beforeLoad = () => {
 
 module.go = () => {
 	if (module.options.subredditStyleCheckbox.value) {
-		const sidebarHeader = document.querySelector('.titlebox h1');
+		const sidebarHeader = document.querySelector('.titlebox h1.redditname');
 		// $FlowIssue need 0.40
 		if (sidebarHeader) sidebarHeader.after(makeStyleToggle().container);
 	}


### PR DESCRIPTION
Relevant issue: fixes #4352 
Tested in browser: Chrome version 59 on Linux
The redditname class name is there for the h1 in in the subreddit page and but not in the user page.