### PR TITLE
Prevent Hover from closing when mouse is inside selected item

### DIFF
--- a/lib/modules/hover.js
+++ b/lib/modules/hover.js
@@ -161,7 +161,10 @@ class Hover {
 	}
 
 	target(element: HTMLElement) {
-		this._target = element;
+		if (this._target !== element) {
+			this.close();
+			this._target = element;
+		}
 
 		return this;
 	}
@@ -286,6 +289,7 @@ class Hover {
 		this.visible = true;
 
 		$(this._target).on('mouseleave', () => this._startHideTimer());
+		$(this._target).on('mouseenter', () => this._cancelHideTimer());
 	}
 
 	_startHideTimer() {

--- a/lib/modules/hover.js
+++ b/lib/modules/hover.js
@@ -161,7 +161,6 @@ class Hover {
 	}
 
 	target(element: HTMLElement) {
-		this.close();
 		this._target = element;
 
 		return this;
@@ -262,7 +261,9 @@ class Hover {
 	}
 
 	_addShowListeners() {
-		$(this._target).on('mouseleave.RESHover', () => this._cancelShow());
+		$(this._target).on('mouseleave.RESHover', () => {
+			if (!this.visible) this._cancelShow();
+		});
 	}
 
 	_clearShowListeners() {
@@ -270,10 +271,6 @@ class Hover {
 	}
 
 	_startShowTimer() {
-		if (this.visible) {
-			// Close and reopen container.
-			this._cancelShow();
-		}
 		this._cancelShowTimer();
 		this.showTimer = setTimeout(() => this._afterShowTimer(), this._options.openDelay);
 	}


### PR DESCRIPTION
Fixes #3494.

Due to the extra padding on the selected navbar item, the hover div overlaps the selected item div when it is visible. This causes the `mouseleave` event to be fired (as seen [here](https://jsfiddle.net/1LwqLdsm/1/)). To fix this, I added a check before calling Hover.close() from the `mouseleave` event, as well as remove other unnecessary calls to Hover.close().

Relevant issue: #3494
Tested in browser: chrome
