### PR TITLE
Revert stylesheet loading changes

### DIFF
--- a/lib/modules/stylesheet.js
+++ b/lib/modules/stylesheet.js
@@ -4,7 +4,6 @@ import _ from 'lodash';
 import { filter, flow } from 'lodash/fp';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
-import { ajax, Session } from '../environment';
 import {
 	BodyClasses,
 	currentMultireddit,
@@ -12,7 +11,6 @@ import {
 	currentUserProfile,
 	filterMap,
 	loggedInUser,
-	keyedMutex,
 } from '../utils';
 import * as CustomToggles from './customToggles';
 
@@ -248,29 +246,10 @@ const urlRegexp = /^(?:https?:\/\/[\w\.]+)?\/\w+/;
 
 const sanitizeStylesheetUrls = filterMap(([url]) => {
 	if (subredditNameRegexp.test(url)) {
-		return [`/r/${subredditNameRegexp.exec(url)[1]}`];
+		return [`/r/${subredditNameRegexp.exec(url)[1]}/stylesheet.css`];
 	} else if (urlRegexp.test(url)) {
 		return [url];
 	}
-});
-
-const getOrLoadSubredditStylesheet = keyedMutex(async subreddit => {
-	const sessionKey = `stylesheet.${subreddit}`;
-
-	const cachedStylesheet = await Session.get(sessionKey);
-	if (cachedStylesheet) return cachedStylesheet;
-
-	const { data: { images, stylesheet } } = await ajax({
-		url: `${subreddit}/about/stylesheet.json`,
-		type: 'json',
-	});
-
-	const stylesheetWithImages = images.reduce(
-		(css, { name, url }) => css.replace(new RegExp(`%%${name}%%`, 'g'), url.replace('http:', 'https:')),
-		stylesheet
-	);
-	Session.set(sessionKey, stylesheetWithImages);
-	return stylesheetWithImages;
 });
 
 function loadStylesheets() {
@@ -279,16 +258,10 @@ function loadStylesheets() {
 		sanitizeStylesheetUrls
 	)(module.options.loadStylesheets.value);
 
-	const [subredditStylesheets, remoteStylesheets] = _.partition(stylesheetUrls, url => url.startsWith('/r/'));
-
-	remoteStylesheetManager.sync(remoteStylesheets);
-
-	Promise.all(subredditStylesheets.map(getOrLoadSubredditStylesheet))
-		.then(subredditStylesheetManager.sync);
+	stylesheetManager.sync(stylesheetUrls);
 }
 
-const remoteStylesheetManager = stylesheetElementManager(url => $('<link rel="stylesheet">').attr('href', url));
-const subredditStylesheetManager = stylesheetElementManager(css => $('<style>', { text: css }));
+const stylesheetManager = stylesheetElementManager(url => $('<link rel="stylesheet">').attr('href', url));
 
 function applyCssSnippets() {
 	const snippets = module.options.snippets.value

--- a/lib/modules/stylesheet.js
+++ b/lib/modules/stylesheet.js
@@ -40,7 +40,9 @@ module.options = {
 		title: 'stylesheetLoadStylesheetsTitle',
 		type: 'table',
 		description: 'stylesheetLoadStylesheetsDesc',
-		value: ([]: Array<[string, string, string, string]>),
+		value: ([
+			// loading stylesheets is expensive for reddit (#4302), so this should not have a default value
+		]: Array<[string, string, string, string]>),
 		fields: [{
 			key: 'urlOrSubreddit',
 			name: 'url or subreddit',


### PR DESCRIPTION
Tested in browser: Chrome 60

Reddit fixed the issue on their end; the old implementation is faster and simpler. It's fine if we don't cache as long as we don't hammer the endpoint (which won't happen unless there's a default value).