### PR TITLE
Fix selectedEntry in Firefox > 54

### DIFF
--- a/lib/utils/async.js
+++ b/lib/utils/async.js
@@ -287,8 +287,9 @@ export function idleThrottle<Fn:(...args: any) => void>(callback: Fn): Fn {
 	let args = [];
 	let queued = false;
 
-	const requestIdle = window.requestIdleCallback ?
-		window.requestIdleCallback : // XXX Only available in Chrome / Opera
+	// Firefox does not support `requestIdleCallback` from the extension environment
+	const requestIdle = process.env.BUILD_TARGET !== 'firefox' && window.requestIdleCallback ?
+		window.requestIdleCallback :
 		fn => requestAnimationFrame(() => { requestAnimationFrame(fn); });
 
 	function runCallback() {


### PR DESCRIPTION
Firefox 55 implemented `requestIdleCallback`, but it does not work from the extension's environment.
`TypeError: 'requestIdleCallback' called on an object that does not implement interface Window.`

Fixes https://www.reddit.com/r/RESissues/comments/6sqk1x/update_to_firefox_55_breaks_message/

Tested in browser: Firefox 55, Firefox 57
