### PR TITLE
userTagger: Clean-up, split votes into ups and downs

### DIFF
--- a/lib/core/migrate/migrate.js
+++ b/lib/core/migrate/migrate.js
@@ -557,6 +557,22 @@ const migrations = [
 			}
 			Storage.set('RESmodules.newCommentCount.subscriptions', subscriptions);
 		},
+	}, {
+		versionNumber: '5.9.1-userTagger-refresh',
+		async go() {
+			let tags = await Storage.wrapPrefix('tag.', (): any => ({})).getAll();
+			for (const tag of Object.values(tags)) {
+				if (tag.votes > 0) tag.votesUp = tag.votes;
+				if (tag.votes < 0) tag.votesDown = -tag.votes;
+				Reflect.deleteProperty(tag, 'votes');
+				if (tag.tag) tag.text = tag.tag;
+				Reflect.deleteProperty(tag, 'tag');
+				if (tag.ignore) tag.ignored = tag.ignore;
+				Reflect.deleteProperty(tag, 'ignore');
+			}
+			tags = _.mapKeys(tags, (v, k) => `tag.${k}`); // Restore prefix
+			await Storage.setMultiple(tags);
+		},
 	},
 
 ];  // ^^ Add new migrations ^^

--- a/lib/css/_zindex.scss
+++ b/lib/css/_zindex.scss
@@ -9,7 +9,6 @@ $zindex-autocomplete-dropdown: _(0);
 $zindex-go-mode-panel:         _(1);
 $zindex-key-help:              _(2);
 $zindex-res-hover:             _(3);
-$zindex-user-tagger:           _(4);
 $zindex-show-link-title:       _(5);
 
 // Dialogs

--- a/lib/css/modules/_hover.scss
+++ b/lib/css/modules/_hover.scss
@@ -67,3 +67,26 @@
 		content: none;
 	}
 }
+
+.fieldPair {
+	display: flex;
+	margin-bottom: 12px;
+
+	&-label {
+		float: left;
+		width: 140px;
+	}
+
+	&-text {
+		float: left;
+		min-width: 240px;
+
+		a {
+			display: block;
+			max-width: 25em;
+			text-overflow: ellipsis;
+			overflow: hidden;
+			white-space: nowrap;
+		}
+	}
+}

--- a/lib/css/modules/_userInfo.scss
+++ b/lib/css/modules/_userInfo.scss
@@ -1,28 +1,4 @@
 #authorInfoToolTip {
-	.authorFieldPair {
-		clear: both;
-		overflow: auto;
-		margin-bottom: 12px;
-	}
-
-	.authorLabel {
-		float: left;
-		width: 140px;
-	}
-
-	.authorDetail {
-		float: left;
-		min-width: 240px;
-
-		a {
-			display: block;
-			max-width: 25em;
-			text-overflow: ellipsis;
-			overflow: hidden;
-			white-space: nowrap;
-		}
-	}
-
 	.blueButton {
 		float: right;
 		margin-left: 8px;

--- a/lib/css/modules/_userTagger.scss
+++ b/lib/css/modules/_userTagger.scss
@@ -92,6 +92,7 @@
 a.voteWeight {
 	text-decoration: none;
 	color: #369;
+	margin-left: 3px;
 
 	&:hover {
 		text-decoration: none;
@@ -101,8 +102,6 @@ a.voteWeight {
 	.md & {
 		user-select: none;
 	}
-
-	margin-left: 3px;
 }
 
 .RESUserTag {

--- a/lib/css/modules/_userTagger.scss
+++ b/lib/css/modules/_userTagger.scss
@@ -1,31 +1,6 @@
 #userTaggerToolTip {
-	display: none;
-	position: absolute;
-	width: 336px;
-	box-sizing: border-box;
-	z-index: $zindex-user-tagger;
-
-	form > div {
-		clear: both;
-		margin: 5px 0;
-	}
-
-	label {
-		margin: 5px 0;
-		float: left;
-		width: 110px;
-	}
-
-	input[type=text],
-	select {
-		margin-top: 5px;
-		width: 200px;
-		box-sizing: border-box;
-	}
-
-	input[type=checkbox] {
-		margin-top: 5px;
-		float: left;
+	.fieldPair-label {
+		width: 85px;
 	}
 
 	input[type=submit] {
@@ -70,11 +45,6 @@
 		display: flex;
 		align-items: center;
 	}
-}
-
-#userTaggerClose {
-	right: 7px;
-	top: 7px;
 }
 
 .res-ignored-message {
@@ -131,15 +101,12 @@ a.voteWeight {
 	.md & {
 		user-select: none;
 	}
-}
 
-#benefits {
-	width: 200px;
-	margin-left: 0;
+	margin-left: 3px;
 }
 
 .RESUserTag {
-	color: black;
+	display: inline-block;
 
 	// unselectable in comments/markdown for usability
 	.md & {
@@ -154,37 +121,18 @@ a.voteWeight {
 	color: #9BD;
 }
 
-.userTagLink.RESUserTagImage:hover {
-	text-decoration: none;
-}
+.userTagLink {
+	color: black;
 
-.hoverHelp {
-	cursor: pointer;
-	color: #369;
-}
+	&:hover { text-decoration: none !important; }
 
-.userTagLink.hasTag,
-#userTaggerPreview {
-	display: inline;
-	padding: 0 4px;
-	line-height: normal;
-	border: 1px solid #c7c7c7;
-	border-radius: 3px;
-}
-
-.userTagLink.hasTag {
-	font-size: .9em;
-}
-
-#userTaggerPreview {
-	display: inline-block;
-	height: 1.6em;
-	line-height: 1.6em;
-	margin: 5px 0 0 0 !important;
-	box-sizing: border-box;
-	max-width: 200px;
-	overflow: hidden;
-	text-overflow: ellipsis;
+	&.hasTag {
+		padding: 0 4px;
+		line-height: normal;
+		border: 1px solid #c7c7c7;
+		border-radius: 3px;
+		font-size: .9em;
+	}
 }
 
 #userTaggerTable th {

--- a/lib/modules/RESTips.js
+++ b/lib/modules/RESTips.js
@@ -226,7 +226,7 @@ const tips: Array<Tip> = [{
 	position: 5,
 }, {
 	message: 'Click the tag icon next to a user to tag that user with any name you like - you can also color code the tag.',
-	attachTo: '.RESUserTagImage:visible',
+	attachTo: '.RESUserTagImage',
 	position: 3,
 	options: [{ moduleID: 'userTagger' }],
 }, {
@@ -306,7 +306,7 @@ const tips: Array<Tip> = [{
 	message: 'See that little [vw] next to users you\'ve voted on?  That\'s their vote weight - it moves up and down as you vote the same user up / down.',
 	options: [{
 		moduleID: 'userTagger',
-		key: 'vwTooltip',
+		key: 'vwNumber',
 	}],
 }];
 
@@ -351,7 +351,14 @@ function showTip(tip: Tip, guiderObj) {
 	const { continuation } = lastTip = tip;
 	if (continuation) {
 		const origGuiderObj = { ...guiderObj };
-		const onclick = () => showTip((featureTips.get(continuation()): any), origGuiderObj);
+		const onclick = async () => {
+			const upcomingId = continuation();
+			let nextTip;
+			while (!(nextTip = featureTips.get(upcomingId))) {
+				await new Promise(r => setTimeout(r, 100)); // eslint-disable-line no-await-in-loop
+			}
+			showTip(nextTip, origGuiderObj);
+		};
 		guiderObj.buttons = [...guiderObj.buttons, { name: 'More', onclick }];
 	}
 

--- a/lib/modules/commandLine.js
+++ b/lib/modules/commandLine.js
@@ -141,12 +141,12 @@ export function toggleCmdLine(force?: boolean = true, initialCmd?: string = '') 
 	}
 }
 
-function cmdLineHelper(val) {
+async function cmdLineHelper(val) {
 	const splitWords = val.split(' ');
 	const command = splitWords[0];
 	splitWords.splice(0, 1);
 	val = splitWords.join(' ');
-	const tip = getTip(command, val);
+	const tip = await getTip(command, val);
 	cmdLineShowTip(tip);
 	if (tip) {
 		cmdLineShowError(false);
@@ -184,7 +184,7 @@ const commands = [];
 export function registerCommand<T>(
 	commandPredicate: RegExp | string | (cmd: string, val: string) => false | void | T,
 	description: string | string[] | false,
-	getTip: (cmd: string, val: string, predResult: T) => string | false | void,
+	getTip: (cmd: string, val: string, predResult: T) => string | false | void | Promise<string>,
 	executeCommand: (cmd: string, val: string, predResult: T, e: KeyboardEvent) => string | false | void
 ) {
 	commands.push({

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -472,7 +472,7 @@ export function makeEditBar() {
 				.parent()
 			);
 		if (Modules.isRunning(UserTagger)) {
-			UserTagger.applyTagToAuthor((commentingAs.find('a')[0]: any), true);
+			UserTagger.applyToUser((commentingAs.find('a')[0]: any), { voteWeight: false });
 		}
 		const loggedIn = loggedInUser();
 		if (
@@ -1193,7 +1193,7 @@ async function getSubredditCompletions(query) {
 
 async function getUserCompletions(query) {
 	const tagNames = Object.keys(await UserTagger.tagStorage.getAll());
-	const pageNames = Array.from(document.querySelectorAll('.author')).map(e => e.textContent);
+	const pageNames = Array.from(UserTagger.tags.keys());
 	return [...tagNames, ...pageNames]
 		.filter(e => e.toLowerCase().startsWith(query.toLowerCase()))
 		.sort()

--- a/lib/modules/hover.js
+++ b/lib/modules/hover.js
@@ -199,7 +199,9 @@ class Hover {
 					this._startHideTimer();
 				}
 			})
-			.on('click', '.RESCloseButton', () => this.close(true));
+			.on('click', '.RESCloseButton', () => this.close(true))
+			// Close on escape when inner element is focused
+			.on('keyup', ({ which }: KeyboardEvent) => { if (which === 27) this.close(true); });
 	}
 
 	begin() {

--- a/lib/modules/troubleshooter.js
+++ b/lib/modules/troubleshooter.js
@@ -97,8 +97,8 @@ async function clearTags() {
 	if (confirm) {
 		const tags = await UserTagger.tagStorage.getAll();
 		const keysToDelete = [];
-		for (const [key, { tag, votes }] of Object.entries(tags)) {
-			if ((votes === 1 || votes === 0 || votes === -1) && typeof tag !== 'string') {
+		for (const [key, { text, votesUp = 0, votesDown = 0 }] of Object.entries(tags)) {
+			if (!text && votesUp <= 1 && votesDown <= 1) {
 				keysToDelete.push(key);
 			}
 		}

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -193,13 +193,11 @@ async function showUserInfo(card, username, thing) {
 		<div class="fieldPair"><div class="fieldPair-label">${i18n('userInfoCommentKarma')}</div> <div class="fieldPair-text">${formatNumber(data.comment_karma)}</div></div>
 	`;
 
-	const nameLowercase = (data.name || '').toLowerCase();
-
 	const userTaggerEnabled = Modules.isRunning(UserTagger);
-	const userTag = userTaggerEnabled && await UserTagger.tagStorage.get(nameLowercase);
+	const userTag = userTaggerEnabled && await UserTagger.Tag.get(data.name);
 
 	if (userTaggerEnabled) {
-		userHTML += `<div class="fieldPair"><div class="fieldPair-label">${i18n('userInfoUserTag')}</div> <div class="fieldPair-text" style="display:flex"><a class="author" hidden href="/u/${data.name}"/></div></div>`;
+		userHTML += `<div class="fieldPair"><div class="fieldPair-label">${i18n('userInfoUserTag')}</div> <div class="fieldPair-text" style="display:flex"><a class="author" style="display: none;" href="/u/${data.name}"/></div></div>`;
 	}
 
 	if (userTag && userTag.link) {
@@ -224,20 +222,24 @@ async function showUserInfo(card, username, thing) {
 		userHTML += string.escape`<div class="${isHighlight ? 'blueButton' : 'redButton'}" id="highlightUser" data-userid="${data.id}">${isHighlight ? i18n('userInfoHighlight') : i18n('userInfoUnhighlight')}</div>`;
 	}
 
-	if (userTaggerEnabled) {
-		const isUnignore = userTag && userTag.ignore;
-		userHTML += string.escape`<div class="${isUnignore ? 'redButton' : 'blueButton'}" id="ignoreUser" user="${nameLowercase}">&empty; ${isUnignore ? i18n('userInfoUnignore') : i18n('userInfoIgnore')}</div>`;
+	if (userTag) {
+		const getButton = () => string.escape`<div class="${userTag.ignored ? 'redButton' : 'blueButton'}" id="ignoreUser">&empty; ${userTag.ignored ? i18n('userInfoUnignore') : i18n('userInfoIgnore')}</div>`;
+
+		$body.on('click', '#ignoreUser', (e: Event) => {
+			if (e.target.classList.contains('blueButton')) userTag.ignore();
+			else userTag.unignore();
+			$(e.target).replaceWith(getButton());
+		});
+
+		userHTML += getButton();
 	}
 
 	userHTML += '<div class="clear"></div></div>'; // closes bottomButtons div
 
 	$body.append(userHTML);
 
-	if (userTaggerEnabled) {
-		const ignoreButton = $body.find('#ignoreUser');
-		ignoreButton.on('click', ignoreUser);
-		const tagAnchorPoint = downcast($body[0].querySelector('a[href*="/u/"]'), HTMLAnchorElement);
-		UserTagger.applyTagToAuthor(tagAnchorPoint, false, true);
+	if (userTag) {
+		userTag.add(downcast($body.find('.author').get(0), HTMLAnchorElement), { renderTaggingIcon: true });
 	}
 
 	if (module.options.highlightButton.value) {
@@ -309,21 +311,4 @@ function toggleUserHighlightButton(authorInfoToolTipHighlight, canHighlight) {
 		.toggleClass('blueButton', canHighlight)
 		.toggleClass('redButton', !canHighlight)
 		.text(canHighlight ? i18n('userInfoHighlight') : i18n('userInfoUnhighlight'));
-}
-
-function ignoreUser(e: Event) {
-	let thisIgnore;
-	if (e.target.classList.contains('blueButton')) {
-		e.target.classList.remove('blueButton');
-		e.target.classList.add('redButton');
-		$(e.target).html(string.escape`&empty; ${i18n('userInfoUnignore')}`);
-		thisIgnore = true;
-	} else {
-		e.target.classList.remove('redButton');
-		e.target.classList.add('blueButton');
-		$(e.target).html(string.escape`&empty; ${i18n('userInfoIgnore')}`);
-		thisIgnore = false;
-	}
-	const thisName = e.target.getAttribute('user');
-	UserTagger.ignoreUser(thisName, thisIgnore);
 }

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -185,10 +185,12 @@ async function showUserInfo(card, username, thing) {
 
 	card.populate([header]);
 
+	const $body = $('<div id="authorInfoToolTip" />');
+
 	let userHTML = string.escape`
-		<div class="authorFieldPair"><div class="authorLabel">${i18n('userInfoRedditorSince')}</div> <div class="authorDetail">${formatDate(d)} (${formatDateDiff(d)})</div></div>
-		<div class="authorFieldPair"><div class="authorLabel">${i18n('userInfoPostKarma')}</div> <div class="authorDetail">${formatNumber(data.link_karma)}</div></div>
-		<div class="authorFieldPair"><div class="authorLabel">${i18n('userInfoCommentKarma')}</div> <div class="authorDetail">${formatNumber(data.comment_karma)}</div></div>
+		<div class="fieldPair"><div class="fieldPair-label">${i18n('userInfoRedditorSince')}</div> <div class="fieldPair-text">${formatDate(d)} (${formatDateDiff(d)})</div></div>
+		<div class="fieldPair"><div class="fieldPair-label">${i18n('userInfoPostKarma')}</div> <div class="fieldPair-text">${formatNumber(data.link_karma)}</div></div>
+		<div class="fieldPair"><div class="fieldPair-label">${i18n('userInfoCommentKarma')}</div> <div class="fieldPair-text">${formatNumber(data.comment_karma)}</div></div>
 	`;
 
 	const nameLowercase = (data.name || '').toLowerCase();
@@ -197,11 +199,12 @@ async function showUserInfo(card, username, thing) {
 	const userTag = userTaggerEnabled && await UserTagger.tagStorage.get(nameLowercase);
 
 	if (userTaggerEnabled) {
-		userHTML += `<div class="authorFieldPair"><div class="authorLabel">${i18n('userInfoUserTag')}</div> <div class="authorDetail" style="display:flex"><a href="/u/${data.name}"/></div></div>`;
+		userHTML += `<div class="fieldPair"><div class="fieldPair-label">${i18n('userInfoUserTag')}</div> <div class="fieldPair-text" style="display:flex"><a class="author" hidden href="/u/${data.name}"/></div></div>`;
 	}
+
 	if (userTag && userTag.link) {
 		const links = userTag.link.split(/\s/).reduce((acc, url) => acc + string.escape`<a target="_blank" rel="noopener noreferer" href="${url}">${url.replace(/^https?:\/\/(www\.)?/, '')}</a>`, '');
-		userHTML += `<div class="authorFieldPair"><div class="authorLabel">${i18n('userInfoLink')}</div> <div class="authorDetail">${links}</div></div>`;
+		userHTML += `<div class="fieldPair"><div class="fieldPair-label">${i18n('userInfoLink')}</div> <div class="fieldPair-text">${links}</div></div>`;
 	}
 
 	userHTML += string.escape`
@@ -228,22 +231,23 @@ async function showUserInfo(card, username, thing) {
 
 	userHTML += '<div class="clear"></div></div>'; // closes bottomButtons div
 
-	const body = $('<div id="authorInfoToolTip" />').append(userHTML);
+	$body.append(userHTML);
 
 	if (userTaggerEnabled) {
-		const ignoreButton = body.find('#ignoreUser');
+		const ignoreButton = $body.find('#ignoreUser');
 		ignoreButton.on('click', ignoreUser);
-		const tagAnchorPoint = downcast(body[0].querySelector('a[href*="/u/"]'), HTMLAnchorElement);
+		const tagAnchorPoint = downcast($body[0].querySelector('a[href*="/u/"]'), HTMLAnchorElement);
 		UserTagger.applyTagToAuthor(tagAnchorPoint, false, true);
 	}
+
 	if (module.options.highlightButton.value) {
-		body.find('#highlightUser').on('click', ({ target }: Event) => {
+		$body.find('#highlightUser').on('click', ({ target }: Event) => {
 			const userid = target.getAttribute('data-userid');
 			toggleUserHighlight(target, userid);
 		});
 	}
 	if (module.options.gildComments.value && thing && thing.isComment()) {
-		body.find('#gildUser').on('click', (e: MouseEvent) => {
+		$body.find('#gildUser').on('click', (e: MouseEvent) => {
 			if (!thing || e.ctrlKey || e.cmdKey || e.shiftKey) return;
 
 			hideAuthorInfo();
@@ -254,7 +258,7 @@ async function showUserInfo(card, username, thing) {
 	}
 
 	if (module.options.useQuickMessage.value && Modules.isRunning(QuickMessage)) {
-		body.find('a.composeButton').on('click', (e: JQueryMouseEventObject) => {
+		$body.find('a.composeButton').on('click', (e: JQueryMouseEventObject) => {
 			if (e.which === 1) {
 				e.preventDefault();
 
@@ -276,7 +280,7 @@ async function showUserInfo(card, username, thing) {
 		});
 	}
 
-	return [null, body];
+	return [null, $body];
 }
 
 function hideAuthorInfo() {

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -114,93 +114,7 @@ module.beforeLoad = () => {
 module.go = () => {
 	// If we're on the dashboard, add a tab to it...
 	if (isCurrentSubreddit('dashboard')) {
-		// add tab to dashboard
-		const $tabPage = Dashboard.addTab('userTaggerContents', i18n('userTaggerMyUserTags'), module.moduleID);
-		// populate the contents of the tab
-		const $showDiv = $(string.html`<div class="show">${i18n('userTaggerShow')} </div>`);
-		const $tagFilter = $(string.html`<select id="tagFilter"><option>${i18n('userTaggerTaggedUsers')}</option><option>${i18n('userTaggerAllUsers')}</option></select>`);
-		$($showDiv).append($tagFilter);
-		$tabPage.append($showDiv);
-		$('#tagFilter').change(() => drawUserTagTable());
-
-		const tagsPerPage = parseInt(Dashboard.module.options.tagsPerPage.value, 10);
-		if (tagsPerPage) {
-			const controlWrapper = document.createElement('div');
-			controlWrapper.id = 'tagPageControls';
-			$(controlWrapper).data({
-				page: 1,
-				pageCount: 1,
-			});
-
-			const leftButton = document.createElement('a');
-			leftButton.className = 'res-step noKeyNav';
-			leftButton.addEventListener('click', () => {
-				const { page, pageCount } = $(controlWrapper).data();
-				if (page === 1) {
-					$(controlWrapper).data('page', pageCount);
-				} else {
-					$(controlWrapper).data('page', page - 1);
-				}
-				drawUserTagTable();
-			});
-			$(controlWrapper).append(string.escape`${i18n('userTaggerPage')} `);
-			controlWrapper.appendChild(leftButton);
-
-			const posLabel = document.createElement('span');
-			posLabel.className = 'res-step-progress';
-			posLabel.textContent = '1 of 2';
-			controlWrapper.appendChild(posLabel);
-
-			const rightButton = document.createElement('a');
-			rightButton.className = 'res-step res-step-reverse noKeyNav';
-			rightButton.addEventListener('click', () => {
-				const { page, pageCount } = $(controlWrapper).data();
-				if (page === pageCount) {
-					$(controlWrapper).data('page', 1);
-				} else {
-					$(controlWrapper).data('page', page + 1);
-				}
-				drawUserTagTable();
-			});
-			controlWrapper.appendChild(rightButton);
-
-			$tabPage.append(controlWrapper);
-		}
-		const $thisTable = $(string.html`
-			<table id="userTaggerTable">
-				<thead>
-					<tr>
-						<th sort="username" class="active">${i18n('userTaggerUsername')}<span class="sortAsc"></span></th>
-						<th sort="tag">${i18n('userTaggerTag')}</th>
-						<th sort="ignore">${i18n('userTaggerIgnored')}</th>
-						<th sort="color">${i18n('userTaggerColor')}</th>
-						<th sort="votes">${i18n('userTaggerVoteWeight')}</th>
-					</tr>
-				</thead>
-				<tbody></tbody>
-			</table>
-		`);
-
-		$tabPage.append($thisTable);
-		$('#userTaggerTable thead th').click(function(e) {
-			e.preventDefault();
-			const $this = $(this);
-
-			if ($this.hasClass('delete')) {
-				return false;
-			}
-			if ($this.hasClass('active')) {
-				$this.toggleClass('descending');
-			}
-			$this.addClass('active');
-			$this.siblings().removeClass('active').find('SPAN').remove();
-			$this.find('.sortAsc, .sortDesc').remove();
-			$this.append($(e.target).hasClass('descending') ?
-				'<span class="sortDesc" />' :
-				'<span class="sortAsc" />');
-			drawUserTagTable($(e.target).attr('sort'), $(e.target).hasClass('descending'));
-		});
-		drawUserTagTable();
+		addDashboardFunctionality();
 	}
 
 	if (module.options.trackVoteWeight.value && loggedInUser()) {
@@ -426,154 +340,6 @@ async function handleVoteClick($this) {
 	}
 
 	colorUser(thisVWobj, thisAuthor, votes);
-}
-
-let currentSortMethod, isDescending;
-
-async function drawUserTagTable(sortMethod, descending) {
-	currentSortMethod = sortMethod || currentSortMethod;
-	isDescending = (descending === undefined || descending === null) ? isDescending : descending;
-	const taggedUsers = [];
-	const filterType = $('#tagFilter').val();
-	const tags = await tagStorage.getAll();
-	for (const tagIndex in tags) {
-		if (filterType === 'tagged users') {
-			if (typeof tags[tagIndex].tag !== 'undefined') {
-				taggedUsers.push(tagIndex);
-			}
-		} else {
-			taggedUsers.push(tagIndex);
-		}
-	}
-	switch (currentSortMethod) {
-		case 'tag':
-			taggedUsers.sort((a, b) => {
-				const tagA = (typeof tags[a].tag === 'undefined') ? 'zzzzz' : tags[a].tag.toLowerCase();
-				const tagB = (typeof tags[b].tag === 'undefined') ? 'zzzzz' : tags[b].tag.toLowerCase();
-				return (tagA > tagB) ? 1 : (tagB > tagA) ? -1 : 0;
-			});
-			if (isDescending) {
-				taggedUsers.reverse();
-			}
-			break;
-		case 'ignore':
-			taggedUsers.sort((a, b) => {
-				const tagA = (typeof tags[a].ignore === 'undefined') ? 'z' : 'a';
-				const tagB = (typeof tags[b].ignore === 'undefined') ? 'z' : 'a';
-				return (tagA > tagB) ? 1 : (tagB > tagA) ? -1 : 0;
-			});
-			if (isDescending) {
-				taggedUsers.reverse();
-			}
-			break;
-		case 'color':
-			taggedUsers.sort((a, b) => {
-				const colorA = (typeof tags[a].color === 'undefined') ? 'zzzzz' : tags[a].color.toLowerCase();
-				const colorB = (typeof tags[b].color === 'undefined') ? 'zzzzz' : tags[b].color.toLowerCase();
-				return (colorA > colorB) ? 1 : (colorB > colorA) ? -1 : 0;
-			});
-			if (isDescending) {
-				taggedUsers.reverse();
-			}
-			break;
-		case 'votes':
-			taggedUsers.sort((a, b) => {
-				const tagA = (typeof tags[a].votes === 'undefined') ? 0 : tags[a].votes;
-				const tagB = (typeof tags[b].votes === 'undefined') ? 0 : tags[b].votes;
-				return (
-					(tagA > tagB) ? 1 :
-					(tagA < tagB) ? -1 :
-					(a.toLowerCase() > b.toLowerCase()) ? 1 :
-					(a.toLowerCase() < b.toLowerCase()) ? -1 :
-					0
-				);
-			});
-			if (isDescending) {
-				taggedUsers.reverse();
-			}
-			break;
-		case 'username':
-			/* falls through */
-		default:
-			// sort users, ignoring case
-			taggedUsers.sort((a, b) =>
-				(a.toLowerCase() > b.toLowerCase()) ? 1 : (b.toLowerCase() > a.toLowerCase()) ? -1 : 0
-			);
-			if (isDescending) {
-				taggedUsers.reverse();
-			}
-			break;
-	}
-	$('#userTaggerTable tbody').html('');
-	const tagsPerPage = parseInt(Dashboard.module.options.tagsPerPage.value, 10);
-	const count = taggedUsers.length;
-	let start = 0;
-	let end = count;
-
-	if (tagsPerPage) {
-		const $tagControls = $('#tagPageControls');
-		let page = $tagControls.data('page');
-		const pages = Math.ceil(count / tagsPerPage);
-		page = Math.min(page, pages);
-		page = Math.max(page, 1);
-		$tagControls.data('page', page).data('pageCount', pages);
-		$tagControls.find('.res-step-progress').text(i18n('userTaggerPageXOfY', page, pages));
-		start = tagsPerPage * (page - 1);
-		end = Math.min(count, tagsPerPage * page);
-	}
-
-	taggedUsers
-		.slice(start, end)
-		.forEach((thisUser, userIndex) => {
-			const thisTag = (typeof tags[thisUser].tag === 'undefined') ? '' : tags[thisUser].tag;
-			const thisVotes = (typeof tags[thisUser].votes === 'undefined') ? 0 : tags[thisUser].votes;
-			const thisColor = (typeof tags[thisUser].color === 'undefined') ? '' : tags[thisUser].color;
-			const thisIgnore = (typeof tags[thisUser].ignore === 'undefined') ? ignoreIcons.NORMAL : ignoreIcons.IGNORED;
-
-			const userTagLink = document.createElement('a');
-			if (thisTag === '') {
-				// thisTag = '<div class="RESUserTagImage"></div>';
-				userTagLink.setAttribute('class', 'userTagLink RESUserTagImage');
-			} else {
-				userTagLink.setAttribute('class', 'userTagLink hasTag');
-			}
-			$(userTagLink).text(thisTag);
-			if (thisColor) {
-				const bgColor = (thisColor === 'none') ? 'transparent' : thisColor;
-				userTagLink.setAttribute('style', `background-color: ${bgColor}; color: ${bgToTextColorMap[thisColor]} !important;`);
-			}
-			userTagLink.setAttribute('username', thisUser);
-			userTagLink.setAttribute('title', i18n('userTaggerSetATag'));
-			userTagLink.setAttribute('href', 'javascript:void 0'); // eslint-disable-line no-script-url
-			userTagLink.addEventListener('click', function(e: Event) {
-				e.preventDefault();
-				openUserTagPrompt(e.target, this.getAttribute('username'));
-			}, true);
-
-			$('#userTaggerTable tbody').append(`
-			    <tr>
-			        <td>
-			            <span class="res-icon res-right deleteIcon" data-icon="&#xf056;" user="${thisUser}"></span>
-			            <a class="author" href="/user/${thisUser}">${thisUser}</a>
-                    </td>
-                    <td id="tag_${userIndex}"></td>
-                    <td id="ignore_${userIndex}" class="res-icon">${thisIgnore}</td>
-                    <td><span style="color: ${thisColor}">${thisColor}</span></td>
-                    <td>${thisVotes}</td>
-                </tr>
-            `);
-
-			$(`#tag_${userIndex}`).append(userTagLink);
-		});
-	$('#userTaggerTable tbody .deleteIcon').click(function() {
-		const thisUser = $(this).attr('user').toLowerCase();
-		const $button = $(this);
-		Alert.open(i18n('userTaggerAreYouSureYouWantToDeleteTag', thisUser), { cancelable: true })
-			.then(() => {
-				tagStorage.delete(thisUser);
-				$button.closest('tr').remove();
-			});
-	});
 }
 
 function saveTagForm() {
@@ -1004,4 +770,241 @@ export async function ignoreUser(username: string, ignore: boolean) {
 		tag = '';
 	}
 	setUserTag(username, tag, color, thisIgnore, link, votes, true /* noclick */);
+}
+
+function addDashboardFunctionality() {
+	const $tabPage = Dashboard.addTab('userTaggerContents', i18n('userTaggerMyUserTags'), module.moduleID);
+	// populate the contents of the tab
+	const $showDiv = $(string.html`<div class="show">${i18n('userTaggerShow')} </div>`);
+	const $tagFilter = $(string.html`<select id="tagFilter"><option>${i18n('userTaggerTaggedUsers')}</option><option>${i18n('userTaggerAllUsers')}</option></select>`);
+	$($showDiv).append($tagFilter);
+	$tabPage.append($showDiv);
+	$('#tagFilter').change(() => drawUserTagTable());
+
+	const tagsPerPage = parseInt(Dashboard.module.options.tagsPerPage.value, 10);
+	if (tagsPerPage) {
+		const controlWrapper = document.createElement('div');
+		controlWrapper.id = 'tagPageControls';
+		$(controlWrapper).data({
+			page: 1,
+			pageCount: 1,
+		});
+
+		const leftButton = document.createElement('a');
+		leftButton.className = 'res-step noKeyNav';
+		leftButton.addEventListener('click', () => {
+			const { page, pageCount } = $(controlWrapper).data();
+			if (page === 1) {
+				$(controlWrapper).data('page', pageCount);
+			} else {
+				$(controlWrapper).data('page', page - 1);
+			}
+			drawUserTagTable();
+		});
+		$(controlWrapper).append(string.escape`${i18n('userTaggerPage')} `);
+		controlWrapper.appendChild(leftButton);
+
+		const posLabel = document.createElement('span');
+		posLabel.className = 'res-step-progress';
+		posLabel.textContent = '1 of 2';
+		controlWrapper.appendChild(posLabel);
+
+		const rightButton = document.createElement('a');
+		rightButton.className = 'res-step res-step-reverse noKeyNav';
+		rightButton.addEventListener('click', () => {
+			const { page, pageCount } = $(controlWrapper).data();
+			if (page === pageCount) {
+				$(controlWrapper).data('page', 1);
+			} else {
+				$(controlWrapper).data('page', page + 1);
+			}
+			drawUserTagTable();
+		});
+		controlWrapper.appendChild(rightButton);
+
+		$tabPage.append(controlWrapper);
+	}
+	const $thisTable = $(string.html`
+		<table id="userTaggerTable">
+			<thead>
+				<tr>
+					<th sort="username" class="active">${i18n('userTaggerUsername')}<span class="sortAsc"></span></th>
+					<th sort="tag">${i18n('userTaggerTag')}</th>
+					<th sort="ignore">${i18n('userTaggerIgnored')}</th>
+					<th sort="color">${i18n('userTaggerColor')}</th>
+					<th sort="votes">${i18n('userTaggerVoteWeight')}</th>
+				</tr>
+			</thead>
+			<tbody></tbody>
+		</table>
+	`);
+
+	$tabPage.append($thisTable);
+	$('#userTaggerTable thead th').click(function(e) {
+		e.preventDefault();
+		const $this = $(this);
+
+		if ($this.hasClass('delete')) {
+			return false;
+		}
+		if ($this.hasClass('active')) {
+			$this.toggleClass('descending');
+		}
+		$this.addClass('active');
+		$this.siblings().removeClass('active').find('SPAN').remove();
+		$this.find('.sortAsc, .sortDesc').remove();
+		$this.append($(e.target).hasClass('descending') ?
+			'<span class="sortDesc" />' :
+			'<span class="sortAsc" />');
+		drawUserTagTable($(e.target).attr('sort'), $(e.target).hasClass('descending'));
+	});
+	drawUserTagTable();
+}
+
+let currentSortMethod, isDescending;
+
+async function drawUserTagTable(sortMethod, descending) {
+	currentSortMethod = sortMethod || currentSortMethod;
+	isDescending = (descending === undefined || descending === null) ? isDescending : descending;
+	const taggedUsers = [];
+	const filterType = $('#tagFilter').val();
+	const tags = await tagStorage.getAll();
+	for (const tagIndex in tags) {
+		if (filterType === 'tagged users') {
+			if (typeof tags[tagIndex].tag !== 'undefined') {
+				taggedUsers.push(tagIndex);
+			}
+		} else {
+			taggedUsers.push(tagIndex);
+		}
+	}
+	switch (currentSortMethod) {
+		case 'tag':
+			taggedUsers.sort((a, b) => {
+				const tagA = (typeof tags[a].tag === 'undefined') ? 'zzzzz' : tags[a].tag.toLowerCase();
+				const tagB = (typeof tags[b].tag === 'undefined') ? 'zzzzz' : tags[b].tag.toLowerCase();
+				return (tagA > tagB) ? 1 : (tagB > tagA) ? -1 : 0;
+			});
+			if (isDescending) {
+				taggedUsers.reverse();
+			}
+			break;
+		case 'ignore':
+			taggedUsers.sort((a, b) => {
+				const tagA = (typeof tags[a].ignore === 'undefined') ? 'z' : 'a';
+				const tagB = (typeof tags[b].ignore === 'undefined') ? 'z' : 'a';
+				return (tagA > tagB) ? 1 : (tagB > tagA) ? -1 : 0;
+			});
+			if (isDescending) {
+				taggedUsers.reverse();
+			}
+			break;
+		case 'color':
+			taggedUsers.sort((a, b) => {
+				const colorA = (typeof tags[a].color === 'undefined') ? 'zzzzz' : tags[a].color.toLowerCase();
+				const colorB = (typeof tags[b].color === 'undefined') ? 'zzzzz' : tags[b].color.toLowerCase();
+				return (colorA > colorB) ? 1 : (colorB > colorA) ? -1 : 0;
+			});
+			if (isDescending) {
+				taggedUsers.reverse();
+			}
+			break;
+		case 'votes':
+			taggedUsers.sort((a, b) => {
+				const tagA = (typeof tags[a].votes === 'undefined') ? 0 : tags[a].votes;
+				const tagB = (typeof tags[b].votes === 'undefined') ? 0 : tags[b].votes;
+				return (
+					(tagA > tagB) ? 1 :
+					(tagA < tagB) ? -1 :
+					(a.toLowerCase() > b.toLowerCase()) ? 1 :
+					(a.toLowerCase() < b.toLowerCase()) ? -1 :
+					0
+				);
+			});
+			if (isDescending) {
+				taggedUsers.reverse();
+			}
+			break;
+		case 'username':
+			/* falls through */
+		default:
+			// sort users, ignoring case
+			taggedUsers.sort((a, b) =>
+				(a.toLowerCase() > b.toLowerCase()) ? 1 : (b.toLowerCase() > a.toLowerCase()) ? -1 : 0
+			);
+			if (isDescending) {
+				taggedUsers.reverse();
+			}
+			break;
+	}
+	$('#userTaggerTable tbody').html('');
+	const tagsPerPage = parseInt(Dashboard.module.options.tagsPerPage.value, 10);
+	const count = taggedUsers.length;
+	let start = 0;
+	let end = count;
+
+	if (tagsPerPage) {
+		const $tagControls = $('#tagPageControls');
+		let page = $tagControls.data('page');
+		const pages = Math.ceil(count / tagsPerPage);
+		page = Math.min(page, pages);
+		page = Math.max(page, 1);
+		$tagControls.data('page', page).data('pageCount', pages);
+		$tagControls.find('.res-step-progress').text(i18n('userTaggerPageXOfY', page, pages));
+		start = tagsPerPage * (page - 1);
+		end = Math.min(count, tagsPerPage * page);
+	}
+
+	taggedUsers
+		.slice(start, end)
+		.forEach((thisUser, userIndex) => {
+			const thisTag = (typeof tags[thisUser].tag === 'undefined') ? '' : tags[thisUser].tag;
+			const thisVotes = (typeof tags[thisUser].votes === 'undefined') ? 0 : tags[thisUser].votes;
+			const thisColor = (typeof tags[thisUser].color === 'undefined') ? '' : tags[thisUser].color;
+			const thisIgnore = (typeof tags[thisUser].ignore === 'undefined') ? ignoreIcons.NORMAL : ignoreIcons.IGNORED;
+
+			const userTagLink = document.createElement('a');
+			if (thisTag === '') {
+				// thisTag = '<div class="RESUserTagImage"></div>';
+				userTagLink.setAttribute('class', 'userTagLink RESUserTagImage');
+			} else {
+				userTagLink.setAttribute('class', 'userTagLink hasTag');
+			}
+			$(userTagLink).text(thisTag);
+			if (thisColor) {
+				const bgColor = (thisColor === 'none') ? 'transparent' : thisColor;
+				userTagLink.setAttribute('style', `background-color: ${bgColor}; color: ${bgToTextColorMap[thisColor]} !important;`);
+			}
+			userTagLink.setAttribute('username', thisUser);
+			userTagLink.setAttribute('title', i18n('userTaggerSetATag'));
+			userTagLink.setAttribute('href', 'javascript:void 0'); // eslint-disable-line no-script-url
+			userTagLink.addEventListener('click', function(e: Event) {
+				e.preventDefault();
+				openUserTagPrompt(e.target, this.getAttribute('username'));
+			}, true);
+
+			$('#userTaggerTable tbody').append(`
+			    <tr>
+			        <td>
+			            <span class="res-icon res-right deleteIcon" data-icon="&#xf056;" user="${thisUser}"></span>
+			            <a class="author" href="/user/${thisUser}">${thisUser}</a>
+                    </td>
+                    <td id="tag_${userIndex}"></td>
+                    <td id="ignore_${userIndex}" class="res-icon">${thisIgnore}</td>
+                    <td><span style="color: ${thisColor}">${thisColor}</span></td>
+                    <td>${thisVotes}</td>
+                </tr>
+            `);
+
+			$(`#tag_${userIndex}`).append(userTagLink);
+		});
+	$('#userTaggerTable tbody .deleteIcon').click(function() {
+		const thisUser = $(this).attr('user').toLowerCase();
+		const $button = $(this);
+		Alert.open(i18n('userTaggerAreYouSureYouWantToDeleteTag', thisUser), { cancelable: true })
+			.then(() => {
+				tagStorage.delete(thisUser);
+				$button.closest('tr').remove();
+			});
+	});
 }

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -141,7 +141,7 @@ function getUsername(element: HTMLAnchorElement): string {
 		if (test) {
 			return test[1];
 		} else {
-			throw new Error(`Regex failed on ${element.href}, returning.`);
+			throw new Error(`Regex failed on ${element.href}`);
 		}
 	} else {
 		return element.getAttribute('data-user') || element.innerText || '';
@@ -297,7 +297,7 @@ export class Tag {
 					href="javascript:void 0"
 					title="${i18n('userTaggerYourVotesFor', this.id, `+${this.votesUp} -${this.votesDown}`)}"
 					style="${getVoteWeightStyle(this)}"
-				>${module.options.vwNumber.value && `[${this.votes > 0 ? '+' : ''}${this.votes}]` || '[vw]'}</a>
+				>${module.options.vwNumber.value ? `[${this.votes > 0 ? '+' : ''}${this.votes}]` : '[vw]'}</a>
 			`;
 			instance.vw.addEventListener('click', () => this.openPrompt(instance));
 			(instance.tagger || instance.element).after(instance.vw);
@@ -384,7 +384,7 @@ function populateDialog(tag: Tag, card) {
 	};
 
 	let ignored = tag.ignored;
-	$(body.querySelector('.res-usertag-ignore label')).after(
+	body.querySelector('.res-usertag-ignore label').after(
 		CreateElement.toggleButton(
 			ignore => {
 				if (ignore && !elements.text.value) elements.text.value = 'ignored';
@@ -447,7 +447,7 @@ function registerCommandLine() {
 				tag.load({ text: val });
 				tag.save();
 			} else {
-				i18n('userTaggerTagCanNotSetTag');
+				return i18n('userTaggerTagCanNotSetTag');
 			}
 		}
 	);

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -296,7 +296,7 @@ export class Tag {
 					class="voteWeight"
 					href="javascript:void 0"
 					title="${i18n('userTaggerYourVotesFor', this.id, `+${this.votesUp} -${this.votesDown}`)}"
-					style="${getVoteWeightStyle(this.votes)}"
+					style="${getVoteWeightStyle(this)}"
 				>${module.options.vwNumber.value && `[${this.votes > 0 ? '+' : ''}${this.votes}]` || '[vw]'}</a>
 			`;
 			instance.vw.addEventListener('click', () => this.openPrompt(instance));
@@ -622,23 +622,27 @@ function ignoredPlaceholder(thing) {
 	return $wrapper;
 }
 
-function getVoteWeightStyle(votes) {
+function getVoteWeightStyle({ votes, votesUp, votesDown }) {
 	let red = 255;
 	let green = 255;
 	let blue = 255;
-	if (votes > 0) {
-		red = Math.max(0, (255 - (8 * votes)));
+	let alpha = 1;
+	if (votesUp > votesDown) {
+		red = Math.max(0, 255 - 8 * votes);
 		green = 255;
-		blue = Math.max(0, (255 - (8 * votes)));
-	} else if (votes < 0) {
+		blue = Math.max(0, 255 - 8 * votes);
+		alpha = Math.abs(votes) / (votesUp + votesDown);
+	} else if (votesUp < votesDown) {
 		red = 255;
 		green = Math.max(0, (255 - Math.abs(8 * votes)));
 		blue = Math.max(0, (255 - Math.abs(8 * votes)));
+		alpha = Math.abs(votes) / (votesUp + votesDown);
 	}
-	const rgb = `rgb(${red}, ${green}, ${blue})`;
+
+	const color = `rgba(${red}, ${green}, ${blue}, ${0.2 + alpha * 0.8})`;
 	return NightMode.isNightModeOn() ?
-		`color: ${rgb};` :
-		`background-color: ${rgb};`;
+		`color: ${color};` :
+		`background-color: ${color};`;
 }
 
 function addDashboardFunctionality() {

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -3,7 +3,6 @@
 import _ from 'lodash';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
-import * as Modules from '../core/modules';
 import {
 	Alert,
 	CreateElement,
@@ -11,6 +10,7 @@ import {
 	batch,
 	click,
 	downcast,
+	filterMap,
 	isCurrentSubreddit,
 	isPageType,
 	loggedInUser,
@@ -20,7 +20,7 @@ import {
 import { Storage, openNewTabs, i18n } from '../environment';
 import * as CommandLine from './commandLine';
 import * as Dashboard from './dashboard';
-import * as KeyboardNav from './keyboardNav';
+import * as Hover from './hover';
 import * as NightMode from './nightMode';
 import * as Notifications from './notifications';
 import * as SelectedEntry from './selectedEntry';
@@ -38,13 +38,6 @@ module.options = {
 		value: true,
 		description: 'userTaggerShowTaggingIconDesc',
 	},
-	/*
-	defaultMark: {
-		type: 'text',
-		value: '_',
-		description: 'clickable mark for users with no tag'
-	},
-	*/
 	hardIgnore: {
 		title: 'userTaggerHardIgnoreTitle',
 		type: 'boolean',
@@ -87,28 +80,26 @@ module.options = {
 		advanced: true,
 		dependsOn: options => options.trackVoteWeight.value,
 	},
-	vwTooltip: {
-		title: 'userTaggerVwTooltipTitle',
-		type: 'boolean',
-		value: true,
-		description: 'userTaggerVWTooltipDesc',
-		advanced: true,
-		dependsOn: options => options.trackVoteWeight.value,
-	},
 };
 
 export const usernameRE = /(?:u|user)\/([\w\-]+)/;
 
 export const tagStorage = Storage.wrapPrefix('tag.', () => (({}: any): {|
-	tag?: string,
+	text?: string,
 	link?: string,
 	color?: string,
 	ignore?: boolean,
-	votes?: number,
+	votesDown?: number,
+	votesUp?: number,
 |}), user => user.toLowerCase());
 
+const getTagBatched = batch(async users => {
+	const tags = await tagStorage.batchNullable(users);
+	return users.map(user => tags[user.toLowerCase()]);
+}, { size: Infinity, delay: 0 });
+
 module.beforeLoad = () => {
-	watchForElements(['siteTable', 'newComments'], usernameSelector, applyTagToAuthor);
+	watchForElements(['siteTable', 'newComments'], usernameSelector, applyToUser);
 };
 
 module.go = () => {
@@ -121,154 +112,345 @@ module.go = () => {
 		attachVoteHandler();
 	}
 
-	addTagger();
-
 	registerCommandLine();
 };
 
 export const usernameSelector = '.contents .author, .noncollapsed a.author, p.tagline a.author, #friend-table span.user a, .sidecontentbox .author, div.md a[href^="/u/"]:not([href*="/m/"]), div.md a[href*="reddit.com/u/"]:not([href*="/m/"]), .usertable a.author, .usertable span.user a, div.wiki-page-content .author';
+
+export async function applyToUser(element: *, {
+	renderTaggingIcon = module.options.showTaggingIcon.value,
+	renderVoteWeight = module.options.trackVoteWeight.value,
+}: * = {}) {
+	const username = getUsername(element);
+
+	// Get tags immediately so that it can be rendered at once without having to wait for storage
+	// since in most cases there's no applied tag
+	const tag = Tag.getUnfilled(username);
+	tag.add(element, { renderVoteWeight, renderTaggingIcon });
+	await tag.fill();
+
+	if (tag.ignored && element.classList.contains('author') && !isPageType('profile')) {
+		const thing = Thing.from(element);
+		if (thing) ignore(thing);
+	}
+}
+
+function getUsername(element: HTMLAnchorElement): string {
+	if (element.href) {
+		const test = element.href.match(usernameRE);
+		if (test) {
+			return test[1];
+		} else {
+			throw new Error(`Regex failed on ${element.href}, returning.`);
+		}
+	} else {
+		return element.getAttribute('data-user') || element.innerText || '';
+	}
+}
+
+export const tags: Map<string, Tag> = new Map();
+
+export class Tag {
+	static defaultTagElement = (e => () => e().cloneNode(true))(_.once(() => Tag.buildTagElement()));
+	static buildTagElement({ text, color } = {}) {
+		return string.html`
+			<span class="RESUserTag">
+				<a
+					class="userTagLink ${(text || color) ? 'hasTag' : 'RESUserTagImage'}"
+					${color && string._html`style="background-color: ${color}; color: ${bgToTextColorMap[color]} !important;"`}
+					title="set a tag"
+					href="javascript:void 0"
+				>${text}</a>
+			</span>
+		`;
+	}
+
+	static getUnfilled(id: string): Tag {
+		let tag = tags.get(id);
+		if (!tag) {
+			tag = new Tag(id);
+			tags.set(id, tag);
+		}
+
+		return tag;
+	}
+
+	static async get(id: string): Promise<Tag> {
+		const tag = Tag.getUnfilled(id);
+		await tag.fill();
+		return tag;
+	}
+
+	id: string;
+	text: ?string = null;
+	link: ?string = null;
+	color: ?string = null;
+	ignored: boolean = false;
+	votesUp: number = 0;
+	votesDown: number = 0;
+
+	instances: Array<{
+		element: HTMLElement,
+		tagger?: HTMLElement,
+		vw?: HTMLElement,
+		renderTaggingIcon: boolean,
+		renderVoteWeight: boolean,
+	}> = [];
+
+	constructor(id: $PropertyType<this, 'id'> = '~dummy') {
+		this.id = id;
+	}
+
+	fill = _.once(async () => {
+		const data = await getTagBatched(this.id);
+		if (data) this.load(data);
+	});
+
+	load(data: *) {
+		if (data.color !== undefined) this.color = data.color;
+		if (data.ignored !== undefined) this.ignored = data.ignored;
+		if (data.link !== undefined) this.link = data.link;
+		if (data.text !== undefined) this.text = data.text;
+		if (data.votesDown !== undefined) this.votesDown = data.votesDown;
+		if (data.votesUp !== undefined) this.votesUp = data.votesUp;
+
+		for (const instance of this.instances) this.render(instance);
+	}
+
+	extract() {
+		return {
+			color: this.color,
+			ignored: this.ignored,
+			link: this.link,
+			text: this.text,
+			votesDown: this.votesDown,
+			votesUp: this.votesUp,
+		};
+	}
+
+	save() {
+		const base = (new Tag()).extract();
+		const data = this.extract();
+		tagStorage.set(this.id, _.pickBy(data, (v, k) => base[k] !== v));
+	}
+
+	add(element: HTMLAnchorElement, { renderTaggingIcon = false, renderVoteWeight = false }: {| renderTaggingIcon?: boolean, renderVoteWeight?: boolean |} = {}) {
+		// Don't add widgets for self
+		if (this.id === loggedInUser()) return;
+
+		const instance = { element, renderTaggingIcon, renderVoteWeight };
+		this.instances.push(instance);
+		this.render(instance);
+	}
+
+	get votes(): number {
+		return this.votesUp - this.votesDown;
+	}
+
+	ignore({ showNotice = true }: { showNotice: boolean } = {}) {
+		if (showNotice) {
+			Notifications.showNotification({
+				moduleID: module.moduleID,
+				notificationID: 'addedToIgnoreList',
+				message: `
+					<p>Now ignoring content posted by ${this.id}.</p>
+					${isPageType('inbox') ? `
+						<p>If you wish to block ${this.id} from sending you messages, go to <a href="/message/messages/">your messages</a> and click 'block user' underneath their last message.</p>
+						<p><a href="https://www.reddit.com/r/changelog/comments/ijfps/reddit_change_users_may_block_other_users_that/">About blocking users</a>.</p>
+					` : ''}
+				`,
+				closeDelay: 5000,
+			});
+		}
+
+		this.ignored = true;
+		if (!this.text) this.text = 'ignored';
+		this.save();
+	}
+
+	unignore() {
+		this.ignored = false;
+		if (this.text === 'ignored') this.text = null;
+		this.save();
+	}
+
+	openPrompt(instance: *) {
+		if (this.link === null && module.options.storeSourceLink.value) {
+			// since we haven't yet set a tag or a link for this user, auto populate a link for the
+			// user based on where we are tagging from.
+			this.link = getLinkBasedOnTagLocation(instance.element);
+		}
+
+		Hover.infocard('userTagger')
+			.target(instance.tagger || instance.element)
+			.options({ openDelay: 0, width: 350 })
+			.populateWith(card => populateDialog(this, card))
+			.begin();
+	}
+
+	render(instance: *) {
+		if (instance.vw) instance.vw.remove();
+		if (instance.renderVoteWeight && (this.votesUp || this.votesDown)) {
+			instance.vw = string.html`
+				<a
+					class="voteWeight"
+					href="javascript:void 0"
+					title="${i18n('userTaggerYourVotesFor', this.id, `+${this.votesUp} -${this.votesDown}`)}"
+					style="${getVoteWeightStyle(this.votes)}"
+				>${module.options.vwNumber.value && `[${this.votes > 0 ? '+' : ''}${this.votes}]` || '[vw]'}</a>
+			`;
+			instance.vw.addEventListener('click', () => this.openPrompt(instance));
+			(instance.tagger || instance.element).after(instance.vw);
+		}
+
+		if (instance.tagger) instance.tagger.remove();
+		if (this.text || this.color || instance.renderTaggingIcon) {
+			// `defaultTagElement` is a lot fast than `buildTagElement`
+			instance.tagger = (this.text || this.color) ? Tag.buildTagElement(this) : Tag.defaultTagElement();
+			instance.tagger.addEventListener('click', () => this.openPrompt(instance));
+			instance.element.after(instance.tagger);
+		}
+	}
+}
 
 const ignoreIcons = {
 	IGNORED: '\uF038',
 	NORMAL: '\uF03B',
 };
 
-const $tagDialog = _.once(() => {
+function populateDialog(tag: Tag, card) {
+	const head = string.html`<div><span class="res-icon">&#xF0AC;</span>&nbsp;<span>${tag.id}</span></div>`;
+
 	const colors = Object.entries(bgToTextColorMap)
 		.map(([color, textColor]) => ({
 			textColor,
-			bgColor: (color === 'none') ? 'transparent' : color,
 			color,
 		}));
 
-	const $tagger = $(string.html`
-		<div id="userTaggerToolTip" class="RESDialogSmall">
-			<h3><span class="res-icon">&#xF0AC;</span>&nbsp;<span>User</span></h3>
-			<div id="userTaggerToolTipContents" class="RESDialogContents">
-				<form name="userTaggerForm" action="">
-					<input type="hidden" id="userTaggerName">
-					<div>
-						<label for="userTaggerTag">Tag</label>
-						<input type="text" id="userTaggerTag">
-					</div>
-					<div>
-						<label for="userTaggerColor">Color</label>
-						<select id="userTaggerColor">
-							${colors.map(({ textColor, bgColor, color }) => string._html`
-								<option style="color: ${textColor}; background-color: ${bgColor} !important" value="${color}">${color}</option>
-							`)}
-						</select>
-					</div>
-					<div>
-						<label for="userTaggerPreview">Preview</label>
-						<span id="userTaggerPreview"></span>
-					</div>
-					<div class="res-usertag-ignore">
-						<label for="userTaggerIgnore">Ignore</label>
-					</div>
-					<div>
-						<label for="userTaggerLink">
-							<span class="userTaggerOpenLink">
-								<a title="open link">Source URL</a>
-							</span>
-						</label>
-						<input type="text" id="userTaggerLink">
-					</div>
-					<div>
-						<label for="userTaggerVoteWeight" title="The sum of upvotes and downvotes you have given this redditor">Vote Weight
-							<span class="hoverHelp" title="manually edit vote weight (sum of upvotes and downvotes) for this redditor">(?)</span>
-						</label>
-						<input type="text" size="2" id="userTaggerVoteWeight">
-					</div>
-					<div class="res-usertagger-footer">
-						<a href="/r/dashboard#userTaggerContents" target="_blank" rel="noopener noreferer">View tagged users</a>
-						<input type="submit" id="userTaggerSave" value="✓ save tag">
-					</div>
-				</form>
-				<div id="userTaggerClose" class="RESCloseButton">&times;</div>
+	const body = string.html`
+		<form id="userTaggerToolTip">
+			<div class="fieldPair">
+				<label class="fieldPair-label" for="userTaggerText">Text</label>
+				<input class="fieldPair-text" type="text" id="userTaggerText" value="${tag.text}">
 			</div>
-		</div>
-	`);
+			<div class="fieldPair">
+				<label class="fieldPair-label" for="userTaggerColor">Color</label>
+				<select id="userTaggerColor" value="${tag.color}">
+					${colors.map(({ textColor, color }) => string._html`
+						<option style="color: ${textColor}; background-color: ${color}" value="${color}">${color}</option>
+					`)}
+				</select>
+			</div>
+			<div class="fieldPair">
+				<label class="fieldPair-label" for="userTaggerPreview">Preview</label>
+				<span id="userTaggerPreview"></span>
+			</div>
+			<div class="fieldPair res-usertag-ignore">
+				<label class="fieldPair-label" for="userTaggerIgnore">Ignore</label>
+				${string.safe(SettingsNavigation.makeUrlHashLink(module.moduleID, 'hardIgnore', ' configure ', 'gearIcon'))}
+			</div>
+			<div class="fieldPair">
+				<label class="fieldPair-label" for="userTaggerLink">
+					<span class="userTaggerOpenLink">
+						<a title="open link" href="javascript:void 0">Source URL</a>
+					</span>
+				</label>
+				<input class="fieldPair-text" type="text" id="userTaggerLink" value="${tag.link}">
+			</div>
+			<div class="fieldPair">
+				<label class="fieldPair-label" for="userTaggerVotesUp" title="Upvotes you have given this redditor">Upvotes</label>
+				<input type="number" style="width: 50px;" id="userTaggerVotesUp" value="${tag.votesUp}">
+			</div>
+			<div class="fieldPair">
+				<label class="fieldPair-label" for="userTaggerVotesDown" title="Downvotes you have given this redditor">Downvotes</label>
+				<input type="number" style="width: 50px;" id="userTaggerVotesDown" value="${tag.votesDown}">
+			</div>
+			<div class="res-usertagger-footer">
+				<a href="/r/dashboard#userTaggerContents" target="_blank" rel="noopener noreferer">View tagged users</a>
+				<input type="submit" id="userTaggerSave" value="✓ save tag">
+			</div>
+		</form>
+	`;
 
-	const ignoreToggleButton = CreateElement.toggleButton(undefined, 'userTaggerIgnore', false, ignoreIcons.IGNORED, ignoreIcons.NORMAL, false, true);
-	ignoreToggleButton.classList.add('reverseToggleButton');
-	const ignoreSettingsLink = SettingsNavigation.makeUrlHashLink(module.moduleID, 'hardIgnore', ' configure ', 'gearIcon');
-	$tagger.find('.res-usertag-ignore').append(ignoreToggleButton, ignoreSettingsLink);
+	const elements = {
+		color: downcast(body.querySelector('#userTaggerColor'), HTMLSelectElement),
+		link: downcast(body.querySelector('#userTaggerLink'), HTMLInputElement),
+		openLink: downcast(body.querySelector('.userTaggerOpenLink a'), HTMLAnchorElement),
+		preview: downcast(body.querySelector('#userTaggerPreview'), HTMLElement),
+		save: downcast(body.querySelector('#userTaggerSave'), HTMLElement),
+		text: downcast(body.querySelector('#userTaggerText'), HTMLInputElement),
+		votesDown: downcast(body.querySelector('#userTaggerVotesDown'), HTMLInputElement),
+		votesUp: downcast(body.querySelector('#userTaggerVotesUp'), HTMLInputElement),
+	};
 
-	// Add event listeners.
-	const $tag = $tagger.find('#userTaggerTag')
-		.on('keyup', updateTagPreview)
-		.on('keydown', (e: KeyboardEvent) => {
-			if (e.keyCode === 27) {
-				// close on ESC key.
-				closeUserTagPrompt();
-			}
-		});
-	const $color = $tagger.find('#userTaggerColor').on('change', updateTagPreview);
-	const $link = $tagger.find('#userTaggerLink').on('keyup', updateOpenLink);
-	const $openLink = $tagger.find('.userTaggerOpenLink a').on('click', (e: Event) => {
+	let ignored = tag.ignored;
+	$(body.querySelector('.res-usertag-ignore label')).after(
+		CreateElement.toggleButton(
+			ignore => {
+				if (ignore && !elements.text.value) elements.text.value = 'ignored';
+				if (!ignore && elements.text.value === 'ignored') elements.text.value = '';
+				ignored = ignore;
+			},
+			'userTaggerIgnore',
+			ignored,
+			ignoreIcons.IGNORED,
+			ignoreIcons.NORMAL,
+			false,
+			true
+		)
+	);
+
+	function extract() {
+		return {
+			color: elements.color.value === 'none' ? null : elements.color.value,
+			ignored,
+			link: elements.link.value || null,
+			text: elements.text.value || null,
+			votesDown: parseInt(elements.votesDown.value, 10) || 0,
+			votesUp: parseInt(elements.votesUp.value, 10) || 0,
+		};
+	}
+
+	function updateTagPreview() {
+		elements.preview.innerHTML = '';
+		elements.preview.appendChild(Tag.buildTagElement(extract()));
+	}
+
+	elements.openLink.addEventListener('click', () => openNewTabs('none', ...elements.link.value.split(/\s/)));
+	$(body).on('change input click', updateTagPreview);
+	body.addEventListener('submit', e => {
 		e.preventDefault();
-		const links = $('#userTaggerLink').val().split(/\s/);
-		openNewTabs('none', ...links);
-	});
-	$tagger.find('#userTaggerSave').on('click', (e: Event) => {
-		e.preventDefault();
-		saveTagForm();
-	});
-	$tagger.find('#userTaggerClose').on('click', closeUserTagPrompt);
-	$tagger.find('form').on('submit', e => {
-		e.preventDefault();
-		saveTagForm();
+		tag.load(extract());
+		tag.save();
+		card.close();
 	});
 
-	const name = downcast($tagger.find('#userTaggerName').get(0), HTMLInputElement);
-	const tag = downcast($tag.get(0), HTMLInputElement);
-	const color = downcast($color.get(0), HTMLSelectElement);
-	const link = downcast($link.get(0), HTMLInputElement);
-	const ignore = downcast($tagger.find('#userTaggerIgnore').get(0), HTMLInputElement);
-	const ignoreContainer = downcast($tagger.find('#userTaggerIgnoreContainer').get(0), HTMLElement);
-	const votes = downcast($tagger.find('#userTaggerVoteWeight').get(0), HTMLInputElement);
-	const $preview = $tagger.find('#userTaggerPreview');
-	const $usernameTitle = $tagger.find('h3 span:last-of-type');
+	updateTagPreview();
+	setTimeout(() => elements.text.focus());
 
-	return { $tagger, $preview, $usernameTitle, $openLink, name, tag, color, link, ignore, ignoreContainer, votes };
-});
-
-function addTagger() {
-	$tagDialog().$tagger.appendTo(document.body);
+	return [head, body];
 }
 
 function registerCommandLine() {
+	let tag;
+
 	CommandLine.registerCommand('tag', `tag [text] - ${i18n('userTaggerCommandLineDescription')}`,
-		(command, val) => {
-			const tagLink = getAuthorTagLink();
-			if (tagLink) {
-				return i18n(val ? 'userTaggerTagUserAs' : 'userTaggerTagUser', tagLink.getAttribute('username'), val);
-			} else {
-				return i18n('userTaggerTagCanNotSetTag');
-			}
+		async (command, val) => {
+			const username = SelectedEntry.selectedThing && SelectedEntry.selectedThing.getAuthor();
+			tag = username && await Tag.get(username);
+			return tag ?
+				i18n(val ? 'userTaggerTagUserAs' : 'userTaggerTagUser', tag.id, val) :
+				i18n('userTaggerTagCanNotSetTag');
 		},
 		(command, val) => {
-			const tagLink = getAuthorTagLink();
-			if (tagLink) {
-				click(tagLink);
-				setTimeout(() => {
-					if (val !== '') {
-						$tagDialog().tag.value = val;
-					}
-				}, 20);
+			if (tag) {
+				tag.load({ text: val });
+				tag.save();
 			} else {
-				return i18n('userTaggerTagCanNotSetTag');
+				i18n('userTaggerTagCanNotSetTag');
 			}
 		}
 	);
-
-	function getAuthorTagLink() {
-		const selected = SelectedEntry.selectedThing;
-		const searchArea = selected ? selected.entry : document.body;
-
-		return searchArea.querySelector('a.userTagLink');
-	}
 }
 
 function attachVoteHandler() {
@@ -276,20 +458,18 @@ function attachVoteHandler() {
 	// which is necessary so we run before reddit's handler
 	document.body.addEventListener('click', (e: MouseEvent) => {
 		if (e.button !== 0) return;
-		const $target = $(e.target);
-		if ($target.is('.arrow')) {
-			handleVoteClick($target);
+		if (e.target.classList.contains('arrow')) {
+			handleVoteClick(e.target);
 		}
 	}, true);
 }
 
-async function handleVoteClick($this) {
+async function handleVoteClick(arrow) {
+	const $this = $(arrow);
 	const $otherArrow = $this.siblings('.arrow');
-	const thing = Thing.checkedFrom($this.get(0));
-	const thisAuthor = thing.getAuthor();
 
-	// Stop if the post is archived (unvotable) or you are voting on your own post/comment/etc.
-	if ($this.hasClass('archived') || !thisAuthor || thisAuthor === loggedInUser()) {
+	// Stop if the post is archived (unvotable)
+	if ($this.hasClass('archived')) {
 		return;
 	}
 
@@ -302,56 +482,40 @@ async function handleVoteClick($this) {
 	// 6) downmodded before, switching to upmod
 
 	// classes are changed AFTER this event is triggered
-	let voteDelta = 0;
+	let up = 0;
+	let down = 0;
 	if ($this.hasClass('up')) {
 		// adding an upvote
-		voteDelta++;
+		up = 1;
 		if ($otherArrow.hasClass('downmod')) {
 			// also removing a downvote
-			voteDelta++;
+			down = -1;
 		}
 	} else if ($this.hasClass('upmod')) {
 		// removing an upvote directly
-		voteDelta--;
+		up = -1;
 	} else if ($this.hasClass('down')) {
 		// adding a downvote
-		voteDelta--;
+		down = 1;
 		if ($otherArrow.hasClass('upmod')) {
 			// also removing an upvote
-			voteDelta--;
+			down = -1;
 		}
 	} else if ($this.hasClass('downmod')) {
 		// removing a downvote directly
-		voteDelta++;
+		down = -1;
 	}
 
 	// must load tag object _after_ checking the DOM, so that classes will not be changed
-	const tagObject = await tagStorage.get(thisAuthor);
-	const votes = (parseInt(tagObject.votes, 10) || 0) + voteDelta;
-
-	tagObject.votes = votes;
-	tagStorage.patch(thisAuthor, { votes });
-
-	const thisAuthorObj = thing.getAuthorElement();
-	let thisVWobj = $(thisAuthorObj).nextAll('.voteWeight')[0];
-	if (!thisVWobj /*:: && thisAuthorObj */) {
-		addAuthorTag(thisAuthorObj, false, thisAuthor, tagObject);
-		thisVWobj = $(thisAuthorObj).nextAll('.voteWeight')[0];
-	}
-
-	colorUser(thisVWobj, thisAuthor, votes);
-}
-
-function saveTagForm() {
-	const { name, tag, color, ignore, link, votes } = $tagDialog();
-	setUserTag(
-		name.value,
-		tag.value,
-		color.value,
-		ignore.checked,
-		link.value,
-		parseInt(votes.value, 10) || 0
-	);
+	const thing = Thing.checkedFrom(arrow);
+	const username = thing.getAuthor();
+	const tag = username && await Tag.get(username);
+	if (!tag) throw new Error('No tag');
+	tag.load({
+		votesUp: tag.votesUp + up,
+		votesDown: tag.votesDown + down,
+	});
+	tag.save();
 }
 
 const bgToTextColorMap = {
@@ -378,53 +542,7 @@ const bgToTextColorMap = {
 	yellow: 'black',
 };
 
-let clickedTag;
-
-async function openUserTagPrompt(obj, username) {
-	clickedTag = obj;
-	$tagDialog().$usernameTitle.text(username);
-	$tagDialog().name.value = username;
-
-	const { link, tag, votes, color, ignore: _ignore } = await tagStorage.get(username);
-
-	if (typeof link !== 'undefined') {
-		$tagDialog().link.value = link;
-	} else {
-		$tagDialog().link.value = '';
-	}
-	if (typeof tag !== 'undefined') {
-		$tagDialog().tag.value = tag;
-	} else {
-		$tagDialog().tag.value = '';
-		if (typeof link === 'undefined') {
-			// since we haven't yet set a tag or a link for this user, auto populate a link for the
-			// user based on where we are tagging from.
-			setLinkBasedOnTagLocation(obj);
-		}
-	}
-	const ignored = !!_ignore;
-	$tagDialog().ignore.checked = ignored;
-	$tagDialog().ignoreContainer.classList.toggle('enabled', ignored);
-	if (typeof votes !== 'undefined') {
-		$tagDialog().votes.value = String(votes);
-	} else {
-		$tagDialog().votes.value = '';
-	}
-	if (typeof color !== 'undefined') {
-		$($tagDialog().color).val(color);
-	} else {
-		$tagDialog().color.selectedIndex = 0;
-	}
-
-	setTaggerPosition();
-
-	$tagDialog().tag.focus();
-	updateOpenLink();
-	updateTagPreview();
-	return false;
-}
-
-function setLinkBasedOnTagLocation(obj) {
+function getLinkBasedOnTagLocation(obj) {
 	const closestEntry = $(obj).closest('.entry');
 	let linkTitle = '';
 	if (!module.options.useCommentsLinkAsSource.value) {
@@ -435,223 +553,13 @@ function setLinkBasedOnTagLocation(obj) {
 		linkTitle = $(closestEntry).find('a.bylink');
 	}
 	if (linkTitle.length) {
-		$tagDialog().link.value = $(linkTitle).attr('href');
+		return $(linkTitle).attr('href');
 	} else {
 		const permaLink = $(closestEntry).find('.flat-list.buttons li.first a');
 		if (permaLink.length) {
-			$tagDialog().link.value = $(permaLink).attr('href');
+			return $(permaLink).attr('href');
 		}
 	}
-}
-
-function updateTagPreview() {
-	const bgcolor = $($tagDialog().color).find('option:selected').val();
-	$tagDialog().$preview
-		.text($tagDialog().tag.value)
-		.css({
-			backgroundColor: (bgcolor === 'none') ? 'transparent' : bgcolor,
-			color: bgToTextColorMap[bgcolor],
-		});
-}
-
-function updateOpenLink(e?: Event) {
-	const $link = $tagDialog().$openLink;
-	const el = e ? e.target : $tagDialog().link;
-	if ($(el).val().length > 0) {
-		$link.attr('href', $(el).val().split(/\s/)[0]);
-	} else {
-		$link.removeAttr('href');
-	}
-}
-
-function setTaggerPosition() {
-	const { top, left } = $(clickedTag).offset();
-	const right = document.body.clientWidth - left;
-
-	$tagDialog().$tagger.css({ top });
-	$tagDialog().$tagger.show();
-
-	if (left < right) {
-		$tagDialog().$tagger.css({ right: 'auto', left });
-	} else {
-		$tagDialog().$tagger.css({ right, left: 'auto' });
-	}
-}
-
-function closeUserTagPrompt() {
-	$tagDialog().$tagger.hide();
-	if (Modules.isRunning(KeyboardNav)) {
-		// remove focus from any input fields from the prompt so that keyboard navigation works again...
-		$tagDialog().$tagger.find('input, button').blur();
-	}
-}
-
-async function setUserTag(username, tag, color, ignore, link, votes, noclick) {
-	const tagObject = await tagStorage.get(username);
-	if ((tag !== null && tag !== '') || ignore) {
-		if (tag === '') {
-			tag = 'ignored';
-		}
-		tagObject.tag = tag;
-		tagObject.link = link;
-		tagObject.color = color;
-		const bgColor = (color === 'none') ? 'transparent' : color;
-		if (ignore) {
-			tagObject.ignore = true;
-
-			Notifications.showNotification({
-				moduleID: module.moduleID,
-				notificationID: 'addedToIgnoreList',
-				message: `
-					<p>Now ignoring content posted by ${username}.</p>
-					${isPageType('inbox') ? `
-						<p>If you wish to block ${username} from sending you messages, go to <a href="/message/messages/">your messages</a> and click 'block user' underneath their last message.</p>
-						<p><a href="https://www.reddit.com/r/changelog/comments/ijfps/reddit_change_users_may_block_other_users_that/">About blocking users</a>.</p>
-					` : ''}
-				`,
-				closeDelay: 5000,
-			});
-		} else {
-			delete tagObject.ignore;
-		}
-		if (!noclick) {
-			clickedTag.setAttribute('class', 'userTagLink hasTag');
-			clickedTag.setAttribute('style', `background-color: ${bgColor}; color: ${bgToTextColorMap[color]} !important;`);
-			$(clickedTag).text(tag);
-		}
-	} else {
-		delete tagObject.tag;
-		delete tagObject.color;
-		delete tagObject.link;
-		if (tagObject.tag === 'ignored') {
-			delete tagObject.tag;
-		}
-		delete tagObject.ignore;
-
-		if (!noclick) {
-			clickedTag.setAttribute('style', 'background-color: transparent');
-			clickedTag.setAttribute('class', 'userTagLink RESUserTagImage');
-			$(clickedTag).html('');
-		}
-	}
-
-	tagObject.votes = (isNaN(votes)) ? 0 : votes;
-
-	if (!noclick) {
-		const thisVW: ?HTMLAnchorElement = (clickedTag.parentNode: any).parentNode.querySelector('a.voteWeight');
-		if (thisVW) {
-			colorUser(thisVW, username, votes);
-		}
-	}
-	if (_.isEmpty(tagObject)) {
-		tagStorage.delete(username);
-	} else {
-		tagStorage.set(username, tagObject);
-	}
-	closeUserTagPrompt();
-}
-
-const getTagBatched = batch(async users => {
-	const tags = await tagStorage.batch(users);
-	return users.map(user => tags[user.toLowerCase()]);
-}, { size: Infinity, delay: 0 });
-
-export async function applyTagToAuthor(thisAuthorObj: HTMLAnchorElement, noEdit: boolean = false, alwaysShow: boolean = false) {
-	let thisAuthor;
-	if (thisAuthorObj.href) {
-		const test = thisAuthorObj.href.match(usernameRE);
-		if (test) {
-			thisAuthor = test[1];
-		} else {
-			console.error(`Regex failed on ${thisAuthorObj.href}, returning.`);
-			return;
-		}
-	} else {
-		thisAuthor = (
-			thisAuthorObj.getAttribute('data-user') ||
-			thisAuthorObj.innerText ||
-			''
-		);
-	}
-
-	let tagElement;
-	if (module.options.showTaggingIcon.value || alwaysShow) {
-		tagElement = addAuthorTag(thisAuthorObj, noEdit, thisAuthor, undefined, alwaysShow);
-	}
-
-	const tagObject = await getTagBatched(thisAuthor);
-
-	if (!_.isEmpty(tagObject)) {
-		if (tagElement) tagElement.remove();
-		addAuthorTag(thisAuthorObj, noEdit, thisAuthor, tagObject, alwaysShow);
-	}
-
-	if (
-		tagObject.ignore && !noEdit &&
-		thisAuthorObj.classList.contains('author') && !isPageType('profile')
-	) {
-		const thing = Thing.from(thisAuthorObj);
-		if (thing) ignore(thing);
-	}
-}
-
-function addAuthorTag(thisAuthorObj: HTMLAnchorElement, noEdit: boolean, thisAuthor, { votes = 0, color, tag } = {}, alwaysShow: boolean = false) {
-	let userTagLink;
-
-	function addUserTag() {
-		userTagLink = document.createElement('a');
-		if (!tag) {
-			userTagLink.setAttribute('class', 'userTagLink RESUserTagImage');
-		} else {
-			userTagLink.setAttribute('class', 'userTagLink hasTag');
-		}
-		$(userTagLink).text(tag || '');
-		if (color) {
-			const bgColor = (color === 'none') ? 'transparent' : color;
-			userTagLink.setAttribute('style', `background-color: ${bgColor}; color: ${bgToTextColorMap[color]} !important;`);
-		}
-		if (!noEdit) {
-			userTagLink.setAttribute('username', thisAuthor);
-			userTagLink.setAttribute('title', 'set a tag');
-			userTagLink.setAttribute('href', 'javascript:void 0'); // eslint-disable-line no-script-url
-			userTagLink.addEventListener('click', function(e: Event) {
-				e.preventDefault();
-				openUserTagPrompt(e.target, this.getAttribute('username'));
-			}, true);
-		}
-
-		const userTag = document.createElement('span');
-		userTag.appendChild(userTagLink);
-		userTag.classList.add('RESUserTag');
-		$(thisAuthorObj).after(userTag);
-		return userTag;
-	}
-
-	function addTrackVoteWeight() {
-		const userVoteFrag = document.createDocumentFragment();
-		const spacer = document.createTextNode(' ');
-		userVoteFrag.appendChild(spacer);
-		const userVoteWeight = document.createElement('a');
-		userVoteWeight.setAttribute('href', '#');
-		userVoteWeight.setAttribute('class', 'voteWeight');
-		$(userVoteWeight).text('[vw]');
-		userVoteWeight.addEventListener('click', (e: Event) => {
-			e.preventDefault();
-			if (!userTagLink) addUserTag();
-			openUserTagPrompt(userTagLink, thisAuthor);
-		}, true);
-		colorUser(userVoteWeight, thisAuthor, votes);
-		userVoteFrag.appendChild(userVoteWeight);
-		$(userVoteFrag).insertAfter(thisAuthorObj);
-	}
-
-	if (noEdit) {
-		if (tag) return addUserTag();
-		return;
-	}
-
-	if (module.options.trackVoteWeight.value) addTrackVoteWeight();
-	if (tag || module.options.showTaggingIcon.value || alwaysShow) return addUserTag();
 }
 
 // Ignore content from certain users.
@@ -714,62 +622,23 @@ function ignoredPlaceholder(thing) {
 	return $wrapper;
 }
 
-function colorUser(obj, author, votes) {
-	if (module.options.trackVoteWeight.value) {
-		votes = parseInt(votes, 10);
-		let red = 255;
-		let green = 255;
-		let blue = 255;
-		let voteString = '+';
-		if (votes > 0) {
-			red = Math.max(0, (255 - (8 * votes)));
-			green = 255;
-			blue = Math.max(0, (255 - (8 * votes)));
-		} else if (votes < 0) {
-			red = 255;
-			green = Math.max(0, (255 - Math.abs(8 * votes)));
-			blue = Math.max(0, (255 - Math.abs(8 * votes)));
-			voteString = '';
-		}
-		voteString += votes;
-		const rgb = `rgb(${red}, ${green}, ${blue})`;
-		if (obj) {
-			if (votes === 0) {
-				obj.style.display = 'none';
-			} else {
-				obj.style.display = 'inline';
-				if (NightMode.isNightModeOn()) {
-					obj.style.color = rgb;
-				} else {
-					obj.style.backgroundColor = rgb;
-				}
-				if (module.options.vwNumber.value) {
-					obj.textContent = `[${voteString}]`;
-				}
-				if (module.options.vwTooltip.value) {
-					obj.setAttribute('title', i18n('userTaggerYourVotesFor', author, voteString));
-				}
-			}
-		}
+function getVoteWeightStyle(votes) {
+	let red = 255;
+	let green = 255;
+	let blue = 255;
+	if (votes > 0) {
+		red = Math.max(0, (255 - (8 * votes)));
+		green = 255;
+		blue = Math.max(0, (255 - (8 * votes)));
+	} else if (votes < 0) {
+		red = 255;
+		green = Math.max(0, (255 - Math.abs(8 * votes)));
+		blue = Math.max(0, (255 - Math.abs(8 * votes)));
 	}
-}
-
-export async function ignoreUser(username: string, ignore: boolean) {
-	const thisIgnore = ignore !== false;
-	const {
-		color = 'none',
-		link = '',
-		votes = 0,
-		tag: oldTag = '',
-	} = await tagStorage.get(username);
-	let tag = oldTag;
-
-	if (thisIgnore && tag === '') {
-		tag = 'ignored';
-	} else if (!thisIgnore && tag === 'ignored') {
-		tag = '';
-	}
-	setUserTag(username, tag, color, thisIgnore, link, votes, true /* noclick */);
+	const rgb = `rgb(${red}, ${green}, ${blue})`;
+	return NightMode.isNightModeOn() ?
+		`color: ${rgb};` :
+		`background-color: ${rgb};`;
 }
 
 function addDashboardFunctionality() {
@@ -832,7 +701,8 @@ function addDashboardFunctionality() {
 					<th sort="tag">${i18n('userTaggerTag')}</th>
 					<th sort="ignore">${i18n('userTaggerIgnored')}</th>
 					<th sort="color">${i18n('userTaggerColor')}</th>
-					<th sort="votes">${i18n('userTaggerVoteWeight')}</th>
+					<th sort="votesDown">${i18n('userTaggerVotesDown')}</th>
+					<th sort="votesUp">${i18n('userTaggerVotesUp')}</th>
 				</tr>
 			</thead>
 			<tbody></tbody>
@@ -866,80 +736,46 @@ let currentSortMethod, isDescending;
 async function drawUserTagTable(sortMethod, descending) {
 	currentSortMethod = sortMethod || currentSortMethod;
 	isDescending = (descending === undefined || descending === null) ? isDescending : descending;
-	const taggedUsers = [];
 	const filterType = $('#tagFilter').val();
-	const tags = await tagStorage.getAll();
-	for (const tagIndex in tags) {
-		if (filterType === 'tagged users') {
-			if (typeof tags[tagIndex].tag !== 'undefined') {
-				taggedUsers.push(tagIndex);
-			}
-		} else {
-			taggedUsers.push(tagIndex);
-		}
-	}
+	const tagsData = await tagStorage.getAll();
+	const tags = filterMap(Object.entries(tagsData), ([k, v]) => {
+		const tag = Tag.getUnfilled(k);
+		tag.load(v);
+		if (filterType === 'tagged users' && !tag.text) return;
+		return [tag];
+	});
+
 	switch (currentSortMethod) {
 		case 'tag':
-			taggedUsers.sort((a, b) => {
-				const tagA = (typeof tags[a].tag === 'undefined') ? 'zzzzz' : tags[a].tag.toLowerCase();
-				const tagB = (typeof tags[b].tag === 'undefined') ? 'zzzzz' : tags[b].tag.toLowerCase();
-				return (tagA > tagB) ? 1 : (tagB > tagA) ? -1 : 0;
-			});
-			if (isDescending) {
-				taggedUsers.reverse();
-			}
+			tags.sort((a, b) => a.text.localeCompare(b.text));
 			break;
 		case 'ignore':
-			taggedUsers.sort((a, b) => {
-				const tagA = (typeof tags[a].ignore === 'undefined') ? 'z' : 'a';
-				const tagB = (typeof tags[b].ignore === 'undefined') ? 'z' : 'a';
-				return (tagA > tagB) ? 1 : (tagB > tagA) ? -1 : 0;
-			});
-			if (isDescending) {
-				taggedUsers.reverse();
-			}
+			tags.sort((a, b) => Number(a.ignored) - Number(b.ignored));
 			break;
 		case 'color':
-			taggedUsers.sort((a, b) => {
-				const colorA = (typeof tags[a].color === 'undefined') ? 'zzzzz' : tags[a].color.toLowerCase();
-				const colorB = (typeof tags[b].color === 'undefined') ? 'zzzzz' : tags[b].color.toLowerCase();
-				return (colorA > colorB) ? 1 : (colorB > colorA) ? -1 : 0;
-			});
-			if (isDescending) {
-				taggedUsers.reverse();
-			}
+			tags.sort((a, b) => a.color.localeCompare(b.color));
 			break;
-		case 'votes':
-			taggedUsers.sort((a, b) => {
-				const tagA = (typeof tags[a].votes === 'undefined') ? 0 : tags[a].votes;
-				const tagB = (typeof tags[b].votes === 'undefined') ? 0 : tags[b].votes;
-				return (
-					(tagA > tagB) ? 1 :
-					(tagA < tagB) ? -1 :
-					(a.toLowerCase() > b.toLowerCase()) ? 1 :
-					(a.toLowerCase() < b.toLowerCase()) ? -1 :
-					0
-				);
-			});
-			if (isDescending) {
-				taggedUsers.reverse();
-			}
+		case 'votesDown':
+			tags.sort((a, b) => a.votesDown - b.votesDown);
+			break;
+		case 'votesUp':
+			tags.sort((a, b) => a.votesUp - b.votesUp);
 			break;
 		case 'username':
 			/* falls through */
 		default:
 			// sort users, ignoring case
-			taggedUsers.sort((a, b) =>
-				(a.toLowerCase() > b.toLowerCase()) ? 1 : (b.toLowerCase() > a.toLowerCase()) ? -1 : 0
-			);
-			if (isDescending) {
-				taggedUsers.reverse();
-			}
+			tags.sort((a, b) => a.id.localeCompare(b.id));
 			break;
 	}
+
+	if (isDescending) {
+		tags.reverse();
+	}
+
 	$('#userTaggerTable tbody').html('');
 	const tagsPerPage = parseInt(Dashboard.module.options.tagsPerPage.value, 10);
-	const count = taggedUsers.length;
+	const count = tags.length;
 	let start = 0;
 	let end = count;
 
@@ -955,48 +791,26 @@ async function drawUserTagTable(sortMethod, descending) {
 		end = Math.min(count, tagsPerPage * page);
 	}
 
-	taggedUsers
+	tags
 		.slice(start, end)
-		.forEach((thisUser, userIndex) => {
-			const thisTag = (typeof tags[thisUser].tag === 'undefined') ? '' : tags[thisUser].tag;
-			const thisVotes = (typeof tags[thisUser].votes === 'undefined') ? 0 : tags[thisUser].votes;
-			const thisColor = (typeof tags[thisUser].color === 'undefined') ? '' : tags[thisUser].color;
-			const thisIgnore = (typeof tags[thisUser].ignore === 'undefined') ? ignoreIcons.NORMAL : ignoreIcons.IGNORED;
+		.forEach(tag => {
+			const d = $(`
+				<tr>
+					<td>
+						<span class="res-icon res-right deleteIcon" data-icon="&#xf056;" user="${tag.id}"></span>
+						<a href="/user/${tag.id}">${tag.id}</a>
+					</td>
+					<td><a class="author" hidden></a></td>
+					<td class="res-icon">${tag.ignored ? ignoreIcons.IGNORED : ignoreIcons.NORMAL}</td>
+					<td><span style="color: ${tag.color}">${tag.color ? tag.color : ''}</span></td>
+					<td>${tag.votesDown}</td>
+					<td>${tag.votesUp}</td>
+				</tr>
+			`).get(0);
 
-			const userTagLink = document.createElement('a');
-			if (thisTag === '') {
-				// thisTag = '<div class="RESUserTagImage"></div>';
-				userTagLink.setAttribute('class', 'userTagLink RESUserTagImage');
-			} else {
-				userTagLink.setAttribute('class', 'userTagLink hasTag');
-			}
-			$(userTagLink).text(thisTag);
-			if (thisColor) {
-				const bgColor = (thisColor === 'none') ? 'transparent' : thisColor;
-				userTagLink.setAttribute('style', `background-color: ${bgColor}; color: ${bgToTextColorMap[thisColor]} !important;`);
-			}
-			userTagLink.setAttribute('username', thisUser);
-			userTagLink.setAttribute('title', i18n('userTaggerSetATag'));
-			userTagLink.setAttribute('href', 'javascript:void 0'); // eslint-disable-line no-script-url
-			userTagLink.addEventListener('click', function(e: Event) {
-				e.preventDefault();
-				openUserTagPrompt(e.target, this.getAttribute('username'));
-			}, true);
+			tag.add(d.querySelector('.author'), { renderTaggingIcon: true });
 
-			$('#userTaggerTable tbody').append(`
-			    <tr>
-			        <td>
-			            <span class="res-icon res-right deleteIcon" data-icon="&#xf056;" user="${thisUser}"></span>
-			            <a class="author" href="/user/${thisUser}">${thisUser}</a>
-                    </td>
-                    <td id="tag_${userIndex}"></td>
-                    <td id="ignore_${userIndex}" class="res-icon">${thisIgnore}</td>
-                    <td><span style="color: ${thisColor}">${thisColor}</span></td>
-                    <td>${thisVotes}</td>
-                </tr>
-            `);
-
-			$(`#tag_${userIndex}`).append(userTagLink);
+			$('#userTaggerTable tbody').append(d);
 		});
 	$('#userTaggerTable tbody .deleteIcon').click(function() {
 		const thisUser = $(this).attr('user').toLowerCase();

--- a/locales/locales/de.json
+++ b/locales/locales/de.json
@@ -2431,10 +2431,6 @@
         "message": "Logo-Link",
         "description": ""
     },
-    "userTaggerVWTooltipDesc": {
-        "message": "Show the vote weight tooltip on hover (i.e. \"your votes for...\")",
-        "description": ""
-    },
     "aboutOptionsBugs": {
         "message": "Falls etwas nicht funktioniert, besuche /r/RESissues um Hilfe zu bekommen.",
         "description": ""
@@ -2545,10 +2541,6 @@
     },
     "keyboardNavMoveToParentTitle": {
         "message": "Zu Übergeordneten Kommentar gehen",
-        "description": ""
-    },
-    "userTaggerVwTooltipTitle": {
-        "message": "VW Tooltip",
         "description": ""
     },
     "toggleCommentsOnClickLeftEdgeTitle": {

--- a/locales/locales/el.json
+++ b/locales/locales/el.json
@@ -2431,10 +2431,6 @@
         "message": "Σύνδεσμος Λογοτύπου",
         "description": ""
     },
-    "userTaggerVWTooltipDesc": {
-        "message": "Εμφάνιση του αιωρούμενου εργαλείου βάρους ψήφου κατά την αιώρηση του ποντικιού (π.χ. \"οι ψήφοι σου για...\")",
-        "description": ""
-    },
     "aboutOptionsBugs": {
         "message": "Αν κάτι δεν δουλεύει σωστά, πήγαινε στο /r/RESIssues για βοήθεια.",
         "description": ""
@@ -2545,10 +2541,6 @@
     },
     "keyboardNavMoveToParentTitle": {
         "message": "Μετακίνηση στον Γονέα",
-        "description": ""
-    },
-    "userTaggerVwTooltipTitle": {
-        "message": "VW Tooltip",
         "description": ""
     },
     "toggleCommentsOnClickLeftEdgeTitle": {

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -2531,8 +2531,11 @@
 	"userTaggerColor": {
 		"message": "Color"
 	},
-	"userTaggerVoteWeight": {
-		"message": "Vote Weight"
+	"userTaggerVotesUp": {
+		"message": "Upvotes"
+	},
+	"userTaggerVotesDown": {
+		"message": "Downvotes"
 	},
 	"userTaggerCommandLineDescription": {
 		"message": "tags author of currently selected link/comment."

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -2779,9 +2779,6 @@
 	"userTaggerVWNumberDesc": {
 		"message": "Show the number (i.e. [+6]) rather than [vw]"
 	},
-	"userTaggerVWTooltipDesc": {
-		"message": "Show the vote weight tooltip on hover (i.e. \"your votes for...\")"
-	},
 	"scrollOnCollapseDesc": {
 		"message": "Scrolls to next comment when a comment is collapsed."
 	},
@@ -3034,9 +3031,6 @@
 	},
 	"userTaggerVwNumberTitle": {
 		"message": "VW Number"
-	},
-	"userTaggerVwTooltipTitle": {
-		"message": "VW Tooltip"
 	},
 	"singleClickOpenOrderTitle": {
 		"message": "Open Order"

--- a/locales/locales/en@lolcat.json
+++ b/locales/locales/en@lolcat.json
@@ -2431,10 +2431,6 @@
         "message": "Logo Link",
         "description": ""
     },
-    "userTaggerVWTooltipDesc": {
-        "message": "Show the vote weight tooltip on hover (i.e. \"your votes for...\")",
-        "description": ""
-    },
     "aboutOptionsBugs": {
         "message": "If something isn't working right, visit /r/RESissues for help.",
         "description": ""
@@ -2545,10 +2541,6 @@
     },
     "keyboardNavMoveToParentTitle": {
         "message": "Move To Parent",
-        "description": ""
-    },
-    "userTaggerVwTooltipTitle": {
-        "message": "VW Tooltip",
         "description": ""
     },
     "toggleCommentsOnClickLeftEdgeTitle": {

--- a/locales/locales/en@pirate.json
+++ b/locales/locales/en@pirate.json
@@ -2431,10 +2431,6 @@
         "message": "Logo Link",
         "description": ""
     },
-    "userTaggerVWTooltipDesc": {
-        "message": "Show the vote weight tooltip on hover (i.e. \"your votes for...\")",
-        "description": ""
-    },
     "aboutOptionsBugs": {
         "message": "If somethin' ain't workin' rightly, visit /r/RESissues fer help.",
         "description": ""
@@ -2545,10 +2541,6 @@
     },
     "keyboardNavMoveToParentTitle": {
         "message": "Move To Parent",
-        "description": ""
-    },
-    "userTaggerVwTooltipTitle": {
-        "message": "VW Tooltip",
         "description": ""
     },
     "toggleCommentsOnClickLeftEdgeTitle": {

--- a/locales/locales/en_CA.json
+++ b/locales/locales/en_CA.json
@@ -2431,10 +2431,6 @@
         "message": "Logo Link",
         "description": ""
     },
-    "userTaggerVWTooltipDesc": {
-        "message": "Show the vote weight tooltip on hover (i.e. \"your votes for...\")",
-        "description": ""
-    },
     "aboutOptionsBugs": {
         "message": "If something isn't working right, visit /r/RESissues for help.",
         "description": ""
@@ -2545,10 +2541,6 @@
     },
     "keyboardNavMoveToParentTitle": {
         "message": "Move To Parent",
-        "description": ""
-    },
-    "userTaggerVwTooltipTitle": {
-        "message": "VW Tooltip",
         "description": ""
     },
     "toggleCommentsOnClickLeftEdgeTitle": {

--- a/locales/locales/en_GB.json
+++ b/locales/locales/en_GB.json
@@ -2431,10 +2431,6 @@
         "message": "Logo Link",
         "description": ""
     },
-    "userTaggerVWTooltipDesc": {
-        "message": "Show the vote weight tooltip on hover (i.e. \"your votes for...\")",
-        "description": ""
-    },
     "aboutOptionsBugs": {
         "message": "If something isn't working right, visit /r/RESissues for help.",
         "description": ""
@@ -2545,10 +2541,6 @@
     },
     "keyboardNavMoveToParentTitle": {
         "message": "Move To Parent",
-        "description": ""
-    },
-    "userTaggerVwTooltipTitle": {
-        "message": "VW Tooltip",
         "description": ""
     },
     "toggleCommentsOnClickLeftEdgeTitle": {

--- a/locales/locales/es.json
+++ b/locales/locales/es.json
@@ -2431,10 +2431,6 @@
         "message": "Enlace del Logo.",
         "description": ""
     },
-    "userTaggerVWTooltipDesc": {
-        "message": "Show the vote weight tooltip on hover (i.e. \"your votes for...\")",
-        "description": ""
-    },
     "aboutOptionsBugs": {
         "message": "Si algo no está funcionando bien, visita /r/RESIssues para obtener ayuda.",
         "description": ""
@@ -2545,10 +2541,6 @@
     },
     "keyboardNavMoveToParentTitle": {
         "message": "Moverse a padre",
-        "description": ""
-    },
-    "userTaggerVwTooltipTitle": {
-        "message": "VW Tooltip",
         "description": ""
     },
     "toggleCommentsOnClickLeftEdgeTitle": {

--- a/locales/locales/es_419.json
+++ b/locales/locales/es_419.json
@@ -2431,10 +2431,6 @@
         "message": "Enlace del Logo",
         "description": ""
     },
-    "userTaggerVWTooltipDesc": {
-        "message": "Show the vote weight tooltip on hover (i.e. \"your votes for...\")",
-        "description": ""
-    },
     "aboutOptionsBugs": {
         "message": "Si algo no esta funcionando como debería, visita el subreddit /r/RESissues para encontrar ayuda.",
         "description": ""
@@ -2545,10 +2541,6 @@
     },
     "keyboardNavMoveToParentTitle": {
         "message": "Mover A Padre",
-        "description": ""
-    },
-    "userTaggerVwTooltipTitle": {
-        "message": "VW Tooltip",
         "description": ""
     },
     "toggleCommentsOnClickLeftEdgeTitle": {

--- a/locales/locales/he.json
+++ b/locales/locales/he.json
@@ -2431,10 +2431,6 @@
         "message": "קישור לוגו",
         "description": ""
     },
-    "userTaggerVWTooltipDesc": {
-        "message": "Show the vote weight tooltip on hover (i.e. \"your votes for...\")",
-        "description": ""
-    },
     "aboutOptionsBugs": {
         "message": "אם דבר מה אינו עובד כשורה, בקש עזרה ב- /r/RESissues",
         "description": ""
@@ -2545,10 +2541,6 @@
     },
     "keyboardNavMoveToParentTitle": {
         "message": "עבור להורה",
-        "description": ""
-    },
-    "userTaggerVwTooltipTitle": {
-        "message": "VW Tooltip",
         "description": ""
     },
     "toggleCommentsOnClickLeftEdgeTitle": {

--- a/locales/locales/it.json
+++ b/locales/locales/it.json
@@ -2431,10 +2431,6 @@
         "message": "Link Logo",
         "description": ""
     },
-    "userTaggerVWTooltipDesc": {
-        "message": "Show the vote weight tooltip on hover (i.e. \"your votes for...\")",
-        "description": ""
-    },
     "aboutOptionsBugs": {
         "message": "Se qualcosa non funziona, visita /r/RESissues per trovare aiuto.",
         "description": ""
@@ -2545,10 +2541,6 @@
     },
     "keyboardNavMoveToParentTitle": {
         "message": "Move To Parent",
-        "description": ""
-    },
-    "userTaggerVwTooltipTitle": {
-        "message": "VW Tooltip",
         "description": ""
     },
     "toggleCommentsOnClickLeftEdgeTitle": {

--- a/locales/locales/pl.json
+++ b/locales/locales/pl.json
@@ -2431,10 +2431,6 @@
         "message": "Link w logo",
         "description": ""
     },
-    "userTaggerVWTooltipDesc": {
-        "message": "Pokaż ramkę informacyjną z balansem głosów po najechaniu (np. \"twoje głosy dla...\").",
-        "description": ""
-    },
     "aboutOptionsBugs": {
         "message": "Jeśli coś działa nie tak, odwiedź /r/RESissues by uzyskać pomoc.",
         "description": ""
@@ -2545,10 +2541,6 @@
     },
     "keyboardNavMoveToParentTitle": {
         "message": "Idź do rodzica",
-        "description": ""
-    },
-    "userTaggerVwTooltipTitle": {
-        "message": "Ramka balansu głosów",
         "description": ""
     },
     "toggleCommentsOnClickLeftEdgeTitle": {

--- a/locales/locales/pt.json
+++ b/locales/locales/pt.json
@@ -2431,10 +2431,6 @@
         "message": "Ligação do Logótipo",
         "description": ""
     },
-    "userTaggerVWTooltipDesc": {
-        "message": "Show the vote weight tooltip on hover (i.e. \"your votes for...\")",
-        "description": ""
-    },
     "aboutOptionsBugs": {
         "message": "Caso alguma coisa não esteja a funcionar correctamente visita /r/RESissues para obteres ajuda.",
         "description": ""
@@ -2545,10 +2541,6 @@
     },
     "keyboardNavMoveToParentTitle": {
         "message": "Mover para o pai",
-        "description": ""
-    },
-    "userTaggerVwTooltipTitle": {
-        "message": "VW Tooltip",
         "description": ""
     },
     "toggleCommentsOnClickLeftEdgeTitle": {

--- a/locales/locales/pt_BR.json
+++ b/locales/locales/pt_BR.json
@@ -2431,10 +2431,6 @@
         "message": "Link do Logotipo",
         "description": ""
     },
-    "userTaggerVWTooltipDesc": {
-        "message": "Show the vote weight tooltip on hover (i.e. \"your votes for...\")",
-        "description": ""
-    },
     "aboutOptionsBugs": {
         "message": "Caso algo não funcione corretamente, visite /r/RESIssues para obter ajuda.",
         "description": ""
@@ -2545,10 +2541,6 @@
     },
     "keyboardNavMoveToParentTitle": {
         "message": "Move To Parent",
-        "description": ""
-    },
-    "userTaggerVwTooltipTitle": {
-        "message": "VW Tooltip",
         "description": ""
     },
     "toggleCommentsOnClickLeftEdgeTitle": {

--- a/locales/locales/pt_PT.json
+++ b/locales/locales/pt_PT.json
@@ -2431,10 +2431,6 @@
         "message": "Ligação do Logótipo",
         "description": ""
     },
-    "userTaggerVWTooltipDesc": {
-        "message": "Show the vote weight tooltip on hover (i.e. \"your votes for...\")",
-        "description": ""
-    },
     "aboutOptionsBugs": {
         "message": "Caso alguma coisa não esteja a funcionar correctamente visita /r/RESissues para obteres ajuda.",
         "description": ""
@@ -2545,10 +2541,6 @@
     },
     "keyboardNavMoveToParentTitle": {
         "message": "Mover para o pai",
-        "description": ""
-    },
-    "userTaggerVwTooltipTitle": {
-        "message": "VW Tooltip",
         "description": ""
     },
     "toggleCommentsOnClickLeftEdgeTitle": {

--- a/tests/RESTips.js
+++ b/tests/RESTips.js
@@ -13,13 +13,17 @@ module.exports = {
 
 		browser
 			.url('https://www.reddit.com/?limit=1')
-			.waitForElementVisible('.guider')
 			.perform(function checkNext(browser, done) {
 				browser
+					.waitForElementPresent('.guider')
 					.execute(`
-						const last = Array.from(document.querySelectorAll('.guider')).slice(-1)[0];
-						return [last.id, last.textContent];
-					`, [], ({ value: [id, textContent] }) => {
+						return Array.from(document.querySelectorAll('.guiders_description')).slice(-1)[0].textContent;
+					`, [], ({ value: textContent }) => {
+						if (!textContent) {
+							browser.assert.fail('tip is empty');
+							return;
+						}
+
 						if (seenTips.has(textContent)) {
 							browser.assert.equal(seenTips.size, 21, 'saw all tips');
 							browser.end();
@@ -29,7 +33,8 @@ module.exports = {
 						seenTips.add(textContent);
 
 						browser
-							.click(`[id="${id}"] .guiders_button`)
+							.execute('document.querySelector(".guiders_button").click()') // button may not be in viewport
+							.execute('document.querySelector(".guider").remove()')
 							.perform(checkNext);
 					});
 

--- a/tests/userInfo.js
+++ b/tests/userInfo.js
@@ -13,7 +13,7 @@ module.exports = {
 			.moveToElement('.thing.link .author', 0, 0)
 			.pause(1000)
 			.waitForElementVisible('.RESHover')
-			.assert.containsText('.RESHover', '/u/erikdesjardins')
+			.assert.containsText('.RESHover', 'erikdesjardins')
 			.assert.visible('.RESHover a[href$="/user/erikdesjardins"]')
 			.assert.visible('.RESHover a[href$="/user/erikdesjardins/submitted/"]')
 			.assert.visible('.RESHover a[href$="/user/erikdesjardins/comments/"]')

--- a/tests/userTagger.js
+++ b/tests/userTagger.js
@@ -28,7 +28,7 @@ module.exports = {
 			.waitForElementVisible(tag(post))
 			.click(tag(post))
 			.assert.visible('#userTaggerToolTip')
-			.setValue('#userTaggerToolTip #userTaggerTag', ['test tag'])
+			.setValue('#userTaggerToolTip #userTaggerText', ['test tag'])
 			.click('#userTaggerSave')
 			.click(loadChildComment)
 			.waitForElementVisible(tag(childComment))

--- a/tests/userTagger.js
+++ b/tests/userTagger.js
@@ -38,6 +38,14 @@ module.exports = {
 			.url('https://www.reddit.com/by_id/t3_5sgqzh')
 			.waitForElementVisible(tag(post))
 			.assert.containsText(tag(post), 'test tag')
+
+			// cli
+			.keys(['.'])
+			.assert.visible('#keyCommandLineWidget')
+			.keys(['tag tag via cli'])
+			.waitForElementVisible('#keyCommandInputTip:not(:empty)')
+			.keys([browser.Keys.ENTER])
+			.assert.containsText(tag(post), 'tag via cli')
 			.end();
 	},
 };


### PR DESCRIPTION
- When modifying a users tag, change is reflected on all instances of that tag
- `votes` is splitted into `votesDown` and `votesUp`, so it will be more useful for a future `userVoteWeight` filter
- VoteWeight is more useful: The opacity is the proportional to the ratio of the sum of votes to total number of votes.
- Utilizes `Hover.infocard` for tagging dialog
- `Tag` can be reused for a future subredditTagger module
- Performance improvement by cloning exisiting tag icon
- Always show voteWeight tooltip - remove minimially useful option
- Make the 'saveSourceLink' option useful
- Fix tagging via cli

Tested in browser: Chrome 61
