### PR TITLE
Fixed sub-tagger interfering with new "crosspost" function

### DIFF
--- a/lib/modules/subredditTagger.js
+++ b/lib/modules/subredditTagger.js
@@ -54,7 +54,7 @@ function scanTitle(thing) {
 	const tagToAdd = getTag(thing);
 	if (tagToAdd !== undefined) {
 		const tagText = $('<span>').append(escapeHTML(tagToAdd)).append('&nbsp;');
-		$(thing.getTitleElement()).prepend(tagText);
+		$(thing.getTitleElement()).parent().prepend(tagText);
 	}
 }
 


### PR DESCRIPTION
The crosspost pulls the inner html from the .thing to construct the recommended title. Moving it outside of the <a> tag fixes the problem. 
http://i.imgur.com/jqm3ttc.png

<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: 
Tested in browser: 
