### PR TITLE
ner: Don't scroll when clicking on load next page

### DIFF
--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -317,7 +317,7 @@ function buildLoaderWidget() {
 	widget.id = 'progressIndicator';
 	widget.className = 'neverEndingReddit';
 
-	widget.addEventListener('click', (e: Event) => { if (e.target.tagName !== 'A') loadNextPage(true); });
+	widget.addEventListener('click', (e: Event) => { if (e.target.tagName !== 'A') loadNextPage(); });
 
 	return widget;
 }


### PR DESCRIPTION
When clicking the widget, the action being initiated can viewed, so it is scrolling to the widget is unnecessary.