### PR TITLE
newCommentCount: Optionally show count when there's no new comments

### DIFF
--- a/lib/css/modules/_newCommentCount.scss
+++ b/lib/css/modules/_newCommentCount.scss
@@ -1,6 +1,6 @@
 .newComments {
 	display: inline;
-	color: orangered;
+	.res-hasNewComments & { color: orangered; }
 }
 
 .RESSubscriptionButton {

--- a/lib/css/modules/_nightMode.scss
+++ b/lib/css/modules/_nightMode.scss
@@ -1310,7 +1310,7 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 		color: rgb(130, 130, 130);
 	}
 
-	.newComments {
+	.res-hasNewComments .newComments {
 		color: rgb(210, 90, 50);
 	}
 

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -33,6 +33,12 @@ module.moduleName = 'newCommentCountName';
 module.category = 'submissionsCategory';
 module.description = 'newCommentCountDesc';
 module.options = {
+	alwaysShow: {
+		type: 'boolean',
+		value: true,
+		description: 'newCommentCountAlwaysShowDesc',
+		title: 'newCommentCountAlwaysShowTitle',
+	},
 	cleanComments: {
 		type: 'text',
 		value: '7',
@@ -157,9 +163,10 @@ export async function getNewCount(thing: Thing): Promise<?number> {
 
 async function displayNewCommentCount(thing) {
 	const newCount = await getNewCount(thing);
-	if (!newCount) return;
+	if (typeof newCount !== 'number') return;
+	if (!newCount && !module.options.alwaysShow.value) return;
 
-	thing.element.classList.add('res-hasNewComments');
+	if (newCount) thing.element.classList.add('res-hasNewComments');
 
 	$(thing.getCommentCountElement())
 		.append(`<span class="newComments">&nbsp;(${newCount} new)</span>`);

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -33,11 +33,11 @@ module.moduleName = 'newCommentCountName';
 module.category = 'submissionsCategory';
 module.description = 'newCommentCountDesc';
 module.options = {
-	alwaysShow: {
+	hideWhenUnchanged: {
 		type: 'boolean',
-		value: true,
-		description: 'newCommentCountAlwaysShowDesc',
-		title: 'newCommentCountAlwaysShowTitle',
+		value: false,
+		description: 'newCommentCountHideWhenUnchangedDesc',
+		title: 'newCommentCountHideWhenUnchangedTitle',
 	},
 	cleanComments: {
 		type: 'text',
@@ -164,7 +164,7 @@ export async function getNewCount(thing: Thing): Promise<?number> {
 async function displayNewCommentCount(thing) {
 	const newCount = await getNewCount(thing);
 	if (typeof newCount !== 'number') return;
-	if (!newCount && !module.options.alwaysShow.value) return;
+	if (!newCount && module.options.hideWhenUnchanged.value) return;
 
 	if (newCount) thing.element.classList.add('res-hasNewComments');
 

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -35,7 +35,7 @@ module.description = 'newCommentCountDesc';
 module.options = {
 	hideWhenUnchanged: {
 		type: 'boolean',
-		value: false,
+		value: true,
 		description: 'newCommentCountHideWhenUnchangedDesc',
 		title: 'newCommentCountHideWhenUnchangedTitle',
 	},

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -1155,6 +1155,12 @@
 	"newCommentCountDesc": {
 		"message": "Tells you how many comments have been posted since you last viewed a thread."
 	},
+	"newCommentCountAlwaysShowTitle": {
+		"message": "Always Show"
+	},
+	"newCommentCountAlwaysShowDesc": {
+		"message": "Display the new comment count also when there's no new comments."
+	},
 	"newCommentCountCleanCommentsTitle": {
 		"message": "Clean Comments"
 	},

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -1155,11 +1155,11 @@
 	"newCommentCountDesc": {
 		"message": "Tells you how many comments have been posted since you last viewed a thread."
 	},
-	"newCommentCountAlwaysShowTitle": {
-		"message": "Always Show"
+	"newCommentCountHideWhenUnchangedTitle": {
+		"message": "Hide When Unchanged"
 	},
-	"newCommentCountAlwaysShowDesc": {
-		"message": "Display the new comment count also when there's no new comments."
+	"newCommentCountHideWhenUnchangedDesc": {
+		"message": "Only display the count when there are new comments."
 	},
 	"newCommentCountCleanCommentsTitle": {
 		"message": "Clean Comments"


### PR DESCRIPTION
By default enabled since it is useful to track comment pages which has been opened, but has no new activity.

![image](https://user-images.githubusercontent.com/7673145/30505916-b1c7aacc-9a45-11e7-8ed8-1577918aa9f7.png)