### PR TITLE
accountSwitcher: Add 2FA support

### DIFF
--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -37,7 +37,7 @@ module.options = {
 			type: 'password',
 		}, {
 			key: '2fa',
-			name: 'accountSwitcherUses2Fa',
+			name: 'accountSwitcherRequiresOtp',
 			type: 'boolean',
 			value: false,
 		}],
@@ -317,14 +317,16 @@ function findMatchingAccount(username, partialMatch) {
 async function switchTo(user) {
 	const account = findMatchingAccount(user);
 	if (!account) return;
-	const [username, password, uses2Fa] = account;
+	const [username, password, requiresOtp] = account;
 
-	// Don't await promise yet so that the PIN can be entered while logging out
+	// Don't await promise yet so that the OTP can be entered while logging out
 	const logoutPromise = loggedInUser() && ajax({ method: 'POST', url: '/logout' });
 
-	let pin;
-	if (uses2Fa) {
-		pin = window.prompt(`Enter 2FA PIN for user ${user}`);
+	let otp;
+	if (requiresOtp) {
+		otp = {
+			otp: window.prompt(i18n('accountSwitcherOptPrompt', username)),
+		};
 	}
 
 	await logoutPromise;
@@ -334,7 +336,8 @@ async function switchTo(user) {
 		url: '/api/login',
 		data: {
 			user: username,
-			passwd: pin ? `${password}:${pin}` : password,
+			passwd: password,
+			...otp,
 			rem: module.options.keepLoggedIn.value ? 'on' : 'off',
 		},
 		type: 'json',

--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -35,8 +35,13 @@ module.options = {
 			key: 'password',
 			name: 'accountSwitcherPassword',
 			type: 'password',
+		}, {
+			key: '2fa',
+			name: 'accountSwitcherUses2Fa',
+			type: 'boolean',
+			value: false,
 		}],
-		value: ([]: Array<[string, string]>),
+		value: ([]: Array<[string, string, boolean]>),
 		description: 'accountSwitcherAccountsDesc',
 		title: 'accountSwitcherAccountsTitle',
 	},
@@ -312,21 +317,24 @@ function findMatchingAccount(username, partialMatch) {
 async function switchTo(user) {
 	const account = findMatchingAccount(user);
 	if (!account) return;
-	const [username, password] = account;
+	const [username, password, uses2Fa] = account;
 
-	if (loggedInUser()) {
-		await ajax({
-			method: 'POST',
-			url: '/logout',
-		});
+	// Don't await promise yet so that the PIN can be entered while logging out
+	const logoutPromise = loggedInUser() && ajax({ method: 'POST', url: '/logout' });
+
+	let pin;
+	if (uses2Fa) {
+		pin = window.prompt(`Enter 2FA PIN for user ${user}`);
 	}
+
+	await logoutPromise;
 
 	const { success, jquery } = await ajax({
 		method: 'POST',
 		url: '/api/login',
 		data: {
 			user: username,
-			passwd: password,
+			passwd: pin ? `${password}:${pin}` : password,
 			rem: module.options.keepLoggedIn.value ? 'on' : 'off',
 		},
 		type: 'json',

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -143,8 +143,8 @@
 	"accountSwitcherPassword": {
 		"message": "password"
 	},
-	"accountSwitcherUses2Fa": {
-		"message": "uses 2FA"
+	"accountSwitcherRequiresOtp": {
+		"message": "requires OTP (2FA is enabled)"
 	},
 	"accountSwitcherSnoo": {
 		"message": "snoo (alien)"
@@ -284,7 +284,7 @@
 	},
 	"contributeDesc": {
 		"message": "RES is entirely free - If you like our work, a contribution would be greatly appreciated.\n\nIf you would like to donate to RES, visit our [Contribution page](https://redditenhancementsuite.com/contribute/).\n\nCan't contribute a few bucks? How about a few lines of code? Our source code can be viewed on our [Github page](https://github.com/honestbleeps/Reddit-Enhancement-Suite/)."
-	},	
+	},
 	"customTogglesName": {
 		"message": "Custom Toggles"
 	},
@@ -1664,6 +1664,9 @@
 	},
 	"accountSwitcherDropDownStyleDesc": {
 		"message": "Use the \"snoo\" icon, or older style dropdown?"
+	},
+	"accountSwitcherOptPrompt": {
+		"message": "Enter the 6 digit code from your authenticator app for $1"
 	},
 	"backupAndRestoreReloadWarningTitle": {
 		"message": "Reload Warning"

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -143,6 +143,9 @@
 	"accountSwitcherPassword": {
 		"message": "password"
 	},
+	"accountSwitcherUses2Fa": {
+		"message": "uses 2FA"
+	},
 	"accountSwitcherSnoo": {
 		"message": "snoo (alien)"
 	},


### PR DESCRIPTION
Prompts the user for a PIN if 2FA is marked enabled for the selected account.

Closes #4403 