### PR TITLE
Gfycat detail route regex.

### DIFF
--- a/lib/modules/hosts/gfycat.js
+++ b/lib/modules/hosts/gfycat.js
@@ -16,7 +16,7 @@ export default new Host('gfycat', {
 			type: 'boolean',
 		},
 	},
-	detect: ({ pathname }) => (/^\/(\w+)(?:\.gif)?/i).exec(pathname),
+	detect: ({ pathname }) => (/^\/(?:gifs\/detail\/)?(\w+)(?:\.gif)?/i).exec(pathname),
 	async handleLink(href, [, id], info = null) {
 		const isMobileResolution = this.options.useMobileGfycat.value;
 


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: Updating regex for parsing gfyid from details page.
Tested in browser: Chrome 61.0.3163.91
