### PR TITLE
Edge 16: remove unnecessary polyfills

### DIFF
--- a/edge/edge.entry.js
+++ b/edge/edge.entry.js
@@ -2,18 +2,70 @@
 
 /* Microsoft Edge Support */
 
-// polyfill DOM4 methods
-import 'dom4';
-
-// polyfill fetch()
-import './remove-fetch';
-import 'whatwg-fetch';
-
 window.chrome = window.browser; // eslint-disable-line no-native-reassign
 
 // DOM Collection iteration
-NodeList.prototype[Symbol.iterator] = Array.prototype[Symbol.iterator];
 HTMLCollection.prototype[Symbol.iterator] = Array.prototype[Symbol.iterator];
+
+// https://github.com/WebReflection/dom4
+// Copyright (C) 2013-2015 by Andrea Giammarchi - @WebReflection
+// MIT license
+
+function textNodeIfString(node) {
+	return typeof node === 'string' ? document.createTextNode(node) : node;
+}
+
+function contentToNode(nodes) {
+	if (nodes.length === 1) {
+		return textNodeIfString(nodes);
+	}
+	const fragment = document.createDocumentFragment();
+	for (const node of nodes) {
+		fragment.appendChild(textNodeIfString(node));
+	}
+	return fragment;
+}
+
+Element.prototype.prepend = function prepend(...nodes) {
+	const firstChild = this.firstChild;
+	const node = contentToNode(nodes);
+	if (firstChild) {
+		this.insertBefore(node, firstChild);
+	} else {
+		this.appendChild(node);
+	}
+};
+
+Element.prototype.append = function append(...nodes) {
+	this.appendChild(contentToNode(nodes));
+};
+
+Element.prototype.before = function before(...nodes) {
+	const parentNode = this.parentNode;
+	if (parentNode) {
+		parentNode.insertBefore(contentToNode(nodes), this);
+	}
+};
+
+Element.prototype.after = function after(...nodes) {
+	const parentNode = this.parentNode;
+	const nextSibling = this.nextSibling;
+	const node = contentToNode(nodes);
+	if (parentNode) {
+		if (nextSibling) {
+			parentNode.insertBefore(node, nextSibling);
+		} else {
+			parentNode.appendChild(node);
+		}
+	}
+};
+
+Element.prototype.replaceWith = function replaceWith(...nodes) {
+	const parentNode = this.parentNode;
+	if (parentNode) {
+		parentNode.replaceChild(contentToNode(nodes), this);
+	}
+};
 
 // polyfill IntersectionObserverEntry.prototype.isIntersecting
 // Snippet from https://github.com/WICG/IntersectionObserver/pull/224

--- a/edge/remove-fetch.js
+++ b/edge/remove-fetch.js
@@ -1,4 +1,0 @@
-/* @flow */
-
-// fetch() is present, but broken in Edge
-window.fetch = undefined;

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     ]
   },
   "dependencies": {
-    "dom4": "1.8.5",
     "element-resize-detector": "1.1.12",
     "escape-string-regexp": "1.0.5",
     "favico.js": "0.3.10",
@@ -72,8 +71,7 @@
     "snudown-js": "2.0.0",
     "suncalc": "1.8.0",
     "tinycolor2": "1.4.1",
-    "url-search-params": "0.10.0",
-    "whatwg-fetch": "2.0.3"
+    "url-search-params": "0.10.0"
   },
   "devDependencies": {
     "autoprefixer": "7.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3001,10 +3001,6 @@ dom-serializer@0, dom-serializer@~0.1.0:
     domelementtype "~1.1.1"
     entities "~1.1.1"
 
-dom4@1.8.5:
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/dom4/-/dom4-1.8.5.tgz#4de3a2e59af45b2af8b30bc595713ecae5037037"
-
 domain-browser@^1.1.1, domain-browser@~1.1.0:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
@@ -9187,10 +9183,6 @@ webpack@3.6.0:
 well-known-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/well-known-symbols/-/well-known-symbols-1.0.0.tgz#73c78ae81a7726a8fa598e2880801c8b16225518"
-
-whatwg-fetch@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
 whet.extend@~0.9.9:
   version "0.9.9"


### PR DESCRIPTION
Tested in browser: Edge 16 (16257)

Effectively closes #4096, we'll remove the remaining individual polyfills as necessary