### PR TITLE
Exempt message-count from elements list

### DIFF
--- a/lib/modules/userbarHider.js
+++ b/lib/modules/userbarHider.js
@@ -45,7 +45,6 @@ module.options = {
 };
 
 let userbar, $userbarToggle;
-
 module.go = () => {
 	userbarHider();
 };
@@ -102,8 +101,7 @@ function updateToggleButton(userbarHidden) {
 }
 
 function toggleUserbarElementsDisplay(userbarHidden) {
-	const elements = $(userbar).children().not($userbarToggle);
-
+	const elements = $(userbar).children().not($userbarToggle).not('.message-count');
 	if (userbarHidden) {
 		AccountSwitcher.closeAccountMenu();
 		elements.css('display', 'none');

--- a/lib/modules/userbarHider.js
+++ b/lib/modules/userbarHider.js
@@ -45,6 +45,7 @@ module.options = {
 };
 
 let userbar, $userbarToggle;
+
 module.go = () => {
 	userbarHider();
 };
@@ -102,6 +103,7 @@ function updateToggleButton(userbarHidden) {
 
 function toggleUserbarElementsDisplay(userbarHidden) {
 	const elements = $(userbar).children().not($userbarToggle).not('.message-count');
+	
 	if (userbarHidden) {
 		AccountSwitcher.closeAccountMenu();
 		elements.css('display', 'none');


### PR DESCRIPTION
`.message-count` from the module `orangered` is defaulted to `display: hidden`. The module `userbarHider` sets all elements in the userbar to visible when the userbar is shown, thus causing the new message indicator to show even when there isn't a new message.
Relevant issue: Closes #4435
Tested in browser: Chrome
