### PR TITLE
Fix inaccurate viewport size in certain subreddits

### DIFF
--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -64,15 +64,13 @@ click.isProgrammaticEvent = (e: MouseEvent): boolean => e.clientX === 1 && e.cli
 export const getViewportSize = _.memoize((): { width: number, height: number } => {
 	waitForEvent(window, 'resize').then(() => { getViewportSize.cache.clear(); });
 
-	// Temporarily append a dummy node to document.body
-	const tempNode = document.createElement('div');
-	tempNode.style.width = tempNode.style.height = '100%';
-	tempNode.style.position = 'fixed';
-	document.body.appendChild(tempNode);
-
-	const result = _.pick(tempNode.getBoundingClientRect(), ['height', 'width']);
-	document.body.removeChild(tempNode);
-	return result;
+	const viewportSizedElement = document.createElement('div');
+	viewportSizedElement.style.width = viewportSizedElement.style.height = '100%';
+	viewportSizedElement.style.position = 'fixed';
+	document.body.appendChild(viewportSizedElement);
+	const size = _.pick(viewportSizedElement.getBoundingClientRect(), ['height', 'width']);
+	viewportSizedElement.remove();
+	return size;
 });
 
 export function elementInViewport(ele: Element): boolean {

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -63,7 +63,16 @@ click.isProgrammaticEvent = (e: MouseEvent): boolean => e.clientX === 1 && e.cli
 
 export const getViewportSize = _.memoize((): { width: number, height: number } => {
 	waitForEvent(window, 'resize').then(() => { getViewportSize.cache.clear(); });
-	return _.pick(document.documentElement.getBoundingClientRect(), ['width', 'height']);
+
+	// Temporarily append a dummy node to document.body
+	const tempNode = document.createElement('div');
+	tempNode.style.width = tempNode.style.height = '100%';
+	tempNode.style.position = 'fixed';
+	document.body.appendChild(tempNode);
+
+	const result = _.pick(tempNode.getBoundingClientRect(), ['height', 'width']);
+	document.body.removeChild(tempNode);
+	return result;
 });
 
 export function elementInViewport(ele: Element): boolean {


### PR DESCRIPTION
Relevant issue: Fixes #4420 
Tested in browser: Chrome

This changes `getViewportSize` to use `document.documentelement.client[Width|Height]` instead of `getBoundingClientRect`, which was sometimes giving the size of the entire document instead of the size of the viewport.

I chose the new technique based on [this Stack Overflow answer](https://stackoverflow.com/questions/1248081/get-the-browser-viewport-dimensions-with-javascript/8876069#8876069). However, I'm pretty apprehensive about the change, since there appear to be a few different approaches and they don't seem to be terribly well documented.