### PR TITLE
selectedEntry: Set always enabled, add style "line"

### DIFF
--- a/lib/constants/sessionStorage.js
+++ b/lib/constants/sessionStorage.js
@@ -3,3 +3,4 @@
 export const RES_DISABLED_KEY = 'RES.disabled';
 export const PERF_PROFILING_KEY = 'RES.perfProfiling';
 export const MODULE_PROFILING_KEY = 'RES.moduleProfiling';
+export const LAST_SELECTED_ENTRY_KEY = 'RES.lastSelectedEntry';

--- a/lib/core/migrate/migrate.js
+++ b/lib/core/migrate/migrate.js
@@ -573,6 +573,22 @@ const migrations = [
 			tags = _.mapKeys(tags, (v, k) => `tag.${k}`); // Restore prefix
 			await Storage.setMultiple(tags);
 		},
+	}, {
+		versionNumber: '5.9.1-selectedEntry',
+		async go() {
+			await Migrators.moveOption('selectedEntry', 'addFocusBGColor', 'selectedEntry', 'setColors');
+			await Migrators.moveOption('selectedEntry', 'focusBGColor', 'selectedEntry', 'backgroundColor');
+			await Migrators.moveOption('selectedEntry', 'focusBGColorNight', 'selectedEntry', 'backgroundColorNight');
+			await Migrators.moveOption('selectedEntry', 'focusFGColorNight', 'selectedEntry', 'textColorNight');
+			await Migrators.moveOption('selectedEntry', 'addFocusBorder', 'selectedEntry', 'addOutline');
+			await Migrators.moveOption('selectedEntry', 'focusBorder', 'selectedEntry', 'outlineStyle');
+			await Migrators.moveOption('selectedEntry', 'focusBorderNight', 'selectedEntry', 'outlineStyleNight');
+
+			if ((await Storage.get('RES.modulePrefs') || { selectedEntry: true }).selectedEntry === false) {
+				await Options.set('selectedEntry', 'setColors', false);
+				await Options.set('selectedEntry', 'addLine', true);
+			}
+		},
 	},
 
 ];  // ^^ Add new migrations ^^

--- a/lib/modules/RESTips.js
+++ b/lib/modules/RESTips.js
@@ -242,10 +242,10 @@ const tips: Array<Tip> = [{
 	options: [{ moduleID: 'keyboardNav' }],
 	keyboard: 'toggleHelp',
 }, {
-	message: 'Did you know you can configure the appearance of a number of things in RES? For example: keyboard navigation lets you configure the look of the "selected" box, and commentBoxes lets you configure the borders / shadows.',
+	message: 'Did you know you can configure the appearance of a number of things in RES? For example: Selected Entry lets you configure the look of the "selected" box, and commentBoxes lets you configure the borders / shadows.',
 	options: [{
 		moduleID: 'selectedEntry',
-		key: 'focusBGColor',
+		key: 'setColors',
 	}, {
 		moduleID: 'commentStyle',
 		key: 'commentBoxes',

--- a/lib/modules/pageNavigator.js
+++ b/lib/modules/pageNavigator.js
@@ -7,6 +7,7 @@ import { getHeaderOffset, isPageType, scrollTo, Thing, frameThrottle, string } f
 import { i18n } from '../environment/i18n';
 import * as Floater from './floater';
 import * as SettingsNavigation from './settingsNavigation';
+import * as SelectedEntry from './selectedEntry';
 
 export const module: Module<*> = new Module('pageNavigator');
 
@@ -58,6 +59,7 @@ function backToTop() {
 	$backToTop.on('click', (e: Event) => {
 		e.preventDefault();
 		scrollTo(0, 0);
+		SelectedEntry.move('top');
 	});
 	Floater.addElement($backToTop);
 }

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -17,7 +17,6 @@ import {
 	idleThrottle,
 } from '../utils';
 import type { ScrollStyle } from '../utils/dom';
-import * as Hover from './hover';
 
 export const module: Module<*> = new Module('selectedEntry');
 
@@ -138,7 +137,6 @@ module.go = () => {
 		addFocusBorder();
 	}
 
-	addListener((selected, unselected) => unselected && Hover.infocard('showParent').close(false), 'beforePaint');
 	addListener(updateActiveElement, 'beforePaint');
 	addListener(selected => BodyClasses.toggle(!!selected, 'res-entry-is-selected'), 'beforePaint');
 	addListener((selected, unselected, { scrollStyle, direction }) => scrollToElement(selected.entry, { from: unselected && unselected.entry, scrollStyle, direction }), 'beforePaint');

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -3,6 +3,7 @@
 import _ from 'lodash';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
+import { LAST_SELECTED_ENTRY_KEY } from '../constants/sessionStorage';
 import {
 	Thing,
 	addCSS,
@@ -223,7 +224,10 @@ function autoSelect() {
 	if (mostVisible) select(mostVisible);
 }
 
-const lastSelectedId = history.state && history.state.lastSelectedId;
+const lastSelectedKey = `${LAST_SELECTED_ENTRY_KEY}-${location.pathname}`;
+// Use sessionStorage as it matches the lifetime expectation of remembering the last selection
+// `history.state` is also suitable, but updating state incurs too much overhead
+const lastSelectedId = sessionStorage[lastSelectedKey];
 
 function selectInitial(thing) {
 	if (selectedThing) return;
@@ -240,7 +244,7 @@ function selectInitial(thing) {
 
 const addLastSelectedListener = _.once(() => {
 	addListener(selected => {
-		history.replaceState({ ...history.state, lastSelectedId: selected.getFullname() }, document.title);
+		sessionStorage[lastSelectedKey] = selected.getFullname();
 	}, 'beforeScroll');
 });
 

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -124,13 +124,10 @@ module.go = () => {
 	}
 
 	if (!selectedThing) requestAnimationFrame(autoSelect);
-
-	addListener(selected => {
-		history.replaceState({ ...history.state, lastSelectedId: selected.getFullname() }, document.title);
-	}, 'beforeScroll');
 };
 
 const onClick = _.throttle(e => {
+	addLastSelectedListener();
 	const thing = Thing.from(e.target);
 	if (thing) select(thing, { scrollStyle: 'none' });
 }, 100, { trailing: false });
@@ -245,6 +242,12 @@ function selectInitial(thing) {
 	select(target, { scrollStyle: scrollToSelected ? 'legacy' : 'none' });
 }
 
+const addLastSelectedListener = _.once(() => {
+	addListener(selected => {
+		history.replaceState({ ...history.state, lastSelectedId: selected.getFullname() }, document.title);
+	}, 'beforeScroll');
+});
+
 const movers = {
 	closestVisible: (thing: Thing) => thing.getClosestVisible(false),
 	up: (thing: Thing) => thing.getNext({ direction: 'up' }),
@@ -281,6 +284,7 @@ export function move(direction: $Keys<typeof movers>, options?: SelectOptionsWit
 		return;
 	}
 
+	addLastSelectedListener();
 	select(target, options);
 
 	recentKeyMove = true;

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -9,6 +9,7 @@ import {
 	BodyClasses,
 	click,
 	elementInViewport,
+	getPercentageVisibleYAxis,
 	scrollToElement,
 	watchForThings,
 	frameThrottle,
@@ -217,14 +218,9 @@ function updateActiveElement(selected, last) {
 }
 
 function autoSelect() {
-	if (selectedThing && elementInViewport(selectedThing.element)) return;
-
-	for (const thing of Thing.visibleThings()) {
-		if (elementInViewport(thing.element)) {
-			select(thing);
-			break;
-		}
-	}
+	if (selectedThing && elementInViewport(selectedThing.entry)) return;
+	const mostVisible = _.maxBy(Thing.visibleThings(), ({ entry }) => getPercentageVisibleYAxis(entry));
+	if (mostVisible) select(mostVisible);
 }
 
 const lastSelectedId = history.state && history.state.lastSelectedId;

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -24,6 +24,7 @@ module.moduleName = 'selectedEntryName';
 module.category = 'browsingCategory';
 module.include = ['comments', 'linklist', 'commentsLinklist', 'modqueue', 'profile', 'inbox', 'search'];
 module.description = 'selectedEntryDesc';
+module.alwaysEnabled = true;
 
 module.options = {
 	autoSelectOnScroll: {
@@ -32,90 +33,75 @@ module.options = {
 		value: false,
 		description: 'selectedEntryAutoSelectOnScrollDesc',
 	},
-	selectThingOnLoad: {
-		title: 'selectedEntrySelectThingOnLoadTitle',
-		type: 'boolean',
-		value: true,
-		description: 'selectedEntrySelectThingOnLoadDesc',
-	},
 	selectLastThingOnLoad: {
 		title: 'selectedEntrySelectLastThingOnLoadTitle',
-		dependsOn: options => options.selectThingOnLoad.value,
 		type: 'boolean',
 		value: true,
 		description: 'selectedEntrySelectLastThingOnLoadDesc',
 	},
 	scrollToSelectedThingOnLoad: {
 		title: 'selectedEntryScrollToSelectedThingOnLoadTitle',
-		dependsOn: options => options.selectThingOnLoad.value,
 		type: 'boolean',
 		value: false,
-		description: 'selectedEntryScrollToSelectedThingOnLoadDesc',
-	},
-	selectOnClick: {
-		title: 'selectedEntrySelectOnClickTitle',
-		type: 'boolean',
-		value: true,
-		description: 'selectedEntrySelectOnClickDesc',
 		advanced: true,
+		description: 'selectedEntryScrollToSelectedThingOnLoadDesc',
+		dependsOn: options => options.selectLastThingOnLoad.value,
 	},
-	addFocusBGColor: {
-		title: 'selectedEntryAddFocusBGColorTitle',
+	addLine: {
+		title: 'selectedEntryAddLineTitle',
+		type: 'boolean',
+		value: false,
+		description: 'selectedEntryAddLineDesc',
+	},
+	setColors: {
+		title: 'selectedEntrySetColorsTitle',
 		type: 'boolean',
 		value: true,
-		description: 'selectedEntryAddFocusBGColorDesc',
+		description: 'selectedEntrySetColorsDesc',
 	},
-	focusBGColor: {
-		title: 'selectedEntryFocusBGColorTitle',
+	backgroundColor: {
+		title: 'selectedEntryBackgroundColorTitle',
 		type: 'color',
 		value: '#F0F3FC',
-		description: 'selectedEntryFocusBGColorDesc',
+		description: 'selectedEntryBackgroundColorDesc',
 		advanced: true,
-		dependsOn: options => options.addFocusBGColor.value,
+		dependsOn: options => options.setColors.value,
 	},
-	focusBGColorNight: {
-		title: 'selectedEntryFocusBGColorNightTitle',
+	backgroundColorNight: {
+		title: 'selectedEntryBackgroundColorNightTitle',
 		type: 'color',
 		value: '#373737',
-		description: 'selectedEntryFocusBGColorNightDesc',
+		description: 'selectedEntryBackgroundColorNightDesc',
 		advanced: true,
-		dependsOn: options => options.addFocusBGColor.value,
+		dependsOn: options => options.setColors.value,
 	},
-	focusFGColorNight: {
-		title: 'selectedEntryFocusFGColorNightTitle',
+	textColorNight: {
+		title: 'selectedEntryTextColorNightTitle',
 		type: 'color',
 		value: '#DDDDDD',
-		description: 'selectedEntryFocusFGColorNightDesc',
+		description: 'selectedEntryTextColorNightDesc',
 		advanced: true,
-		dependsOn: options => options.addFocusBGColor.value,
+		dependsOn: options => options.setColors.value,
 	},
-	addFocusBorder: {
-		title: 'selectedEntryAddFocusBorderTitle',
-		type: 'boolean',
-		value: true,
-		description: 'selectedEntryAddFocusBorderDesc',
-	},
-	focusBorder: {
-		title: 'selectedEntryFocusBorderTitle',
+	outlineStyle: {
+		title: 'selectedEntryOutlineStyleTitle',
 		type: 'text',
 		value: '',
-		description: 'selectedEntryFocusBorderDesc',
+		description: 'selectedEntryOutlineStyleDesc',
 		advanced: true,
-		dependsOn: options => options.addFocusBorder.value,
 	},
-	focusBorderNight: {
-		title: 'selectedEntryFocusBorderNightTitle',
+	outlineStyleNight: {
+		title: 'selectedEntryOutlineStyleNightTitle',
 		type: 'text',
 		value: '',
-		description: 'selectedEntryFocusBorderNightDesc',
+		description: 'selectedEntryOutlineStyleNightDesc',
 		advanced: true,
-		dependsOn: options => options.addFocusBorder.value,
 	},
 };
 
 module.beforeLoad = () => {
-	if (module.options.selectThingOnLoad.value) {
-		setupLastSelectedCache();
+	setupLastSelectedCache();
+	if (module.options.selectLastThingOnLoad.value) {
 		watchForThings(['post', 'comment', 'message'], selectInitial);
 	}
 };
@@ -123,19 +109,18 @@ module.beforeLoad = () => {
 module.go = () => {
 	watchForThings(['comment'], onNewComments);
 
+	// Select Thing on manual click
+	$(document.body).on('mouseup', Thing.bodyThingSelector, (e: MouseEvent) => {
+		if (!click.isProgrammaticEvent(e)) onClick(e);
+	});
+
 	if (module.options.autoSelectOnScroll.value) {
 		window.addEventListener('scroll', _.debounce(() => { if (!recentKeyMove) autoSelect(); }, 300));
 	}
-	if (module.options.selectOnClick.value) {
-		$(document.body).on('mouseup', Thing.bodyThingSelector, handleClick);
-	}
 
-	if (module.options.addFocusBGColor.value) {
-		addFocusBGColor();
-	}
-	if (module.options.addFocusBorder.value) {
-		addFocusBorder();
-	}
+	if (module.options.addLine.value) styleLine();
+	if (module.options.setColors.value) styleColor();
+	styleOutline();
 
 	addListener(updateActiveElement, 'beforePaint');
 	addListener(selected => BodyClasses.toggle(!!selected, 'res-entry-is-selected'), 'beforePaint');
@@ -146,19 +131,6 @@ const onClick = _.throttle(e => {
 	const thing = Thing.from(e.target);
 	if (thing) select(thing, { scrollStyle: 'none' });
 }, 100, { trailing: false });
-
-export function handleClick(e: MouseEvent) {
-	// Exposed so modules which stop propagation on click events inside things can explicitly pass the event to this module
-	if (!module.options.selectOnClick.value) {
-		return;
-	}
-	if (click.isProgrammaticEvent(e)) {
-		// Use modules['select'].select(thing), don't rely on click handling
-		return;
-	}
-
-	onClick(e);
-}
 
 export let selectedThing: ?Thing;
 let selectedContainer: ?Element;
@@ -318,10 +290,6 @@ const selectInitial = _.once(fastAsync(function*(firstThing) {
 }));
 
 async function findLastSelectedThing() {
-	if (!module.options.selectLastThingOnLoad.value) {
-		return false;
-	}
-
 	await setupLastSelectedCache();
 
 	const url = urlForSelectedCache();
@@ -373,50 +341,49 @@ export function move(direction: $Keys<typeof movers>, options?: SelectOptionsWit
 	refreshKeyMoveTimer();
 }
 
-// old style: .RES-keyNav-activeElement { '+borderType+': '+focusBorder+'; background-color: '+focusBGColor+'; } \
-// this new pure CSS arrow will not work because to position it we must have .RES-keyNav-activeElement position relative, but that screws up image viewer's absolute positioning to
-// overlay over the sidebar... yikes.
-// .RES-keyNav-activeElement:after { content: ""; float: right; margin-right: -5px; border-color: transparent '+focusBorderColor+' transparent transparent; border-style: solid; border-width: 3px 4px 3px 0; } \
-
 // why !important on .RES-keyNav-activeElement?  Because some subreddits are unfortunately using !important for no good reason on .entry divs...
 
-function addFocusBGColor() {
-	const focusBGColor = module.options.focusBGColor.value || module.options.focusBGColor.default;
-	const focusBGColorNight = module.options.focusBGColorNight.value || module.options.focusBGColorNight.default;
-	const focusFGColorNight = module.options.focusFGColorNight.value || module.options.focusFGColorNight.default;
-
+function styleLine() {
 	addCSS(`
-		.RES-keyNav-activeElement,
-		.RES-keyNav-activeElement .md-container {
-			background-color: ${focusBGColor} !important;
-		}
-
-		.res-nightmode .RES-keyNav-activeElement > .tagline,
-		.res-nightmode .RES-keyNav-activeElement .md-container > .md,
-		.res-nightmode .RES-keyNav-activeElement .md-container > .md p {
-			color: ${focusFGColorNight} !important;
-		}
-
-		.res-nightmode .RES-keyNav-activeElement,
-		.res-nightmode .RES-keyNav-activeElement .md-container {
-			background-color: ${focusBGColorNight} !important;
-		}
+		.RES-keyNav-activeElement { box-shadow: 3px 0 0 -1px #c2d2e0; !important; }
+		.res-nightmode .RES-keyNav-activeElement { box-shadow: 3px 0 0 -1px grey; !important; }
 	`);
 }
 
-function addFocusBorder() {
-	const borderType = 'outline';
+function styleColor() {
+	const backgroundColor = module.options.backgroundColor.value ? `
+		.RES-keyNav-activeElement,
+		.RES-keyNav-activeElement .md-container {
+			background-color: ${module.options.backgroundColor.value} !important;
+		}` : '';
 
-	const focusBorder = module.options.focusBorder.value ?
-		`${borderType}: ${module.options.focusBorder.value};` :
-		'';
+	const backgroundColorNight = module.options.backgroundColorNight.value ? `
+		.res-nightmode .RES-keyNav-activeElement,
+		.res-nightmode .RES-keyNav-activeElement .md-container {
+			background-color: ${module.options.backgroundColorNight.value} !important;
+		}` : '';
 
-	const focusBorderNight = module.options.focusBorderNight.value ?
-		`${borderType}: ${module.options.focusBorderNight.value};` :
-		'';
+	const textColorNight = module.options.textColorNight.value ? `
+		.res-nightmode .RES-keyNav-activeElement > .tagline,
+		.res-nightmode .RES-keyNav-activeElement .md-container > .md,
+		.res-nightmode .RES-keyNav-activeElement .md-container > .md p {
+			color: ${module.options.textColorNight.value} !important;
+		}` : '';
 
-	addCSS(`
-		.RES-keyNav-activeElement { ${focusBorder} }
-		.res-nightmode .RES-keyNav-activeElement { ${focusBorderNight} }
-	`);
+	addCSS(backgroundColor + backgroundColorNight + textColorNight);
+}
+
+function styleOutline() {
+	const outlineStyle = module.options.outlineStyle.value ? `
+		.RES-keyNav-activeElement {
+			outline: ${module.options.outlineStyle.value};
+		}` : '';
+
+	const outlineStyleNight = module.options.outlineStyleNight.value ? `
+		.res-nightmode .RES-keyNav-activeElement {
+			outline: ${module.options.outlineStyleNight.value};
+		}
+	` : '';
+
+	addCSS(outlineStyle + outlineStyleNight);
 }

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -148,7 +148,7 @@ export function addListener(callback: (new_: Thing, old: ?Thing, opt: SelectOpti
 
 const runCallbacks = (() => {
 	function runListeners(listeners, new_, old, opt) {
-		for (const listener of listeners) listener(new_, old, opt);
+		for (const listener of listeners) try { listener(new_, old, opt); } catch (e) { console.error(e); }
 	}
 
 	function throttle(throttler, listeners) {

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -122,6 +122,12 @@ module.go = () => {
 	if (module.options.addLine.value) styleLine();
 	if (module.options.setColors.value) styleColor();
 	styleOutline();
+
+	if (!selectedThing) requestAnimationFrame(autoSelect);
+
+	addListener(selected => {
+		history.replaceState({ ...history.state, lastSelectedId: selected.getFullname() }, document.title);
+	}, 'beforeScroll');
 };
 
 const onClick = _.throttle(e => {
@@ -135,7 +141,6 @@ let selectedContainer: ?Element;
 type SelectOptions = {
 	allowMediaBrowse?: boolean,
 	scrollStyle: ScrollStyle,
-	paintImmediate?: boolean, // Set `true` when `select` is invoked during the animation phase, in order for `beforePaint` not to be delayed to the next animation frame
 };
 
 type SelectOptionsWithDirection = SelectOptions & { direction?: 'down' | 'up' };
@@ -170,10 +175,7 @@ const runCallbacks = (() => {
 
 	return (new_, old, opt) => {
 		if (listeners.beforeScroll.length) runListeners(listeners.beforeScroll, new_, old, opt);
-		if (listeners.beforePaint.length) {
-			if (opt.paintImmediate) runListeners(listeners.beforePaint, new_, old, opt);
-			else runPaint(new_, old, opt);
-		}
+		if (listeners.beforePaint.length) runPaint(new_, old, opt);
 		if (listeners.idle.length) runIdle(new_, old, opt);
 	};
 })();
@@ -228,27 +230,20 @@ function autoSelect() {
 	}
 }
 
-const selectInitial = _.once(firstThing => {
-	if (!selectedThing) {
-		if (module.options.scrollToSelectedThingOnLoad.value) history.scrollRestoration = 'manual';
-		// `scrollRestoration` may also be set in neverEndingReddit
-		const scrollToSelected = history.scrollRestoration === 'manual';
+const lastSelectedId = history.state && history.state.lastSelectedId;
 
-		const lastSelectedId = history.state && history.state.lastSelectedId;
-		const lastSelected = lastSelectedId && Thing.things().find(v => v.getFullname() === lastSelectedId);
+function selectInitial(thing) {
+	if (selectedThing) return;
+	if (thing.getFullname() !== lastSelectedId) return;
+	const target = thing.getClosestVisible();
+	if (!target) return;
 
-		const target = (lastSelected || firstThing).getClosestVisible() || lastSelected || firstThing;
+	if (module.options.scrollToSelectedThingOnLoad.value) history.scrollRestoration = 'manual';
+	// `scrollRestoration` may also be set in neverEndingReddit
+	const scrollToSelected = history.scrollRestoration === 'manual';
 
-		select(target, {
-			scrollStyle: scrollToSelected ? 'legacy' : 'none',
-			paintImmediate: true,
-		});
-	}
-
-	addListener(selected => {
-		history.replaceState({ ...history.state, lastSelectedId: selected.getFullname() }, document.title);
-	}, 'beforeScroll');
-});
+	select(target, { scrollStyle: scrollToSelected ? 'legacy' : 'none' });
+}
 
 const movers = {
 	closestVisible: (thing: Thing) => thing.getClosestVisible(false),

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -101,6 +101,10 @@ module.beforeLoad = () => {
 	if (module.options.selectLastThingOnLoad.value) {
 		watchForThings(['post', 'comment', 'message'], selectInitial);
 	}
+
+	addListener(updateActiveElement, 'beforePaint');
+	addListener(selected => BodyClasses.toggle(!!selected, 'res-entry-is-selected'), 'beforePaint');
+	addListener((selected, unselected, { scrollStyle, direction }) => scrollToElement(selected.entry, { from: unselected && unselected.entry, scrollStyle, direction }), 'beforePaint');
 };
 
 module.go = () => {
@@ -118,10 +122,6 @@ module.go = () => {
 	if (module.options.addLine.value) styleLine();
 	if (module.options.setColors.value) styleColor();
 	styleOutline();
-
-	addListener(updateActiveElement, 'beforePaint');
-	addListener(selected => BodyClasses.toggle(!!selected, 'res-entry-is-selected'), 'beforePaint');
-	addListener((selected, unselected, { scrollStyle, direction }) => scrollToElement(selected.entry, { from: unselected && unselected.entry, scrollStyle, direction }), 'beforePaint');
 };
 
 const onClick = _.throttle(e => {

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -105,6 +105,10 @@ module.beforeLoad = () => {
 	addListener(updateActiveElement, 'beforePaint');
 	addListener(selected => BodyClasses.toggle(!!selected, 'res-entry-is-selected'), 'beforePaint');
 	addListener((selected, unselected, { scrollStyle, direction }) => scrollToElement(selected.entry, { from: unselected && unselected.entry, scrollStyle, direction }), 'beforePaint');
+
+	if (module.options.addLine.value) styleLine();
+	if (module.options.setColors.value) styleColor();
+	styleOutline();
 };
 
 module.go = () => {
@@ -118,10 +122,6 @@ module.go = () => {
 	if (module.options.autoSelectOnScroll.value) {
 		window.addEventListener('scroll', _.debounce(() => { if (!recentKeyMove) autoSelect(); }, 300));
 	}
-
-	if (module.options.addLine.value) styleLine();
-	if (module.options.setColors.value) styleColor();
-	styleOutline();
 
 	if (!selectedThing) requestAnimationFrame(autoSelect);
 

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -3,14 +3,12 @@
 import _ from 'lodash';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
-import { Session } from '../environment';
 import {
 	Thing,
 	addCSS,
 	BodyClasses,
 	click,
 	elementInViewport,
-	fastAsync,
 	scrollToElement,
 	watchForThings,
 	frameThrottle,
@@ -100,7 +98,6 @@ module.options = {
 };
 
 module.beforeLoad = () => {
-	setupLastSelectedCache();
 	if (module.options.selectLastThingOnLoad.value) {
 		watchForThings(['post', 'comment', 'message'], selectInitial);
 	}
@@ -231,73 +228,27 @@ function autoSelect() {
 	}
 }
 
-const lastSelectedKey = 'RESmodules.selectedThing.lastSelectedCache';
-let lastSelectedCache;
+const selectInitial = _.once(firstThing => {
+	if (!selectedThing) {
+		if (module.options.scrollToSelectedThingOnLoad.value) history.scrollRestoration = 'manual';
+		// `scrollRestoration` may also be set in neverEndingReddit
+		const scrollToSelected = history.scrollRestoration === 'manual';
 
-const setupLastSelectedCache = _.once(async () => {
-	lastSelectedCache = await Session.get(lastSelectedKey) || {};
+		const lastSelectedId = history.state && history.state.lastSelectedId;
+		const lastSelected = lastSelectedId && Thing.things().find(v => v.getFullname() === lastSelectedId);
 
-	// clean cache every so often and delete any urls that haven't been visited recently
-	const clearCachePeriod = 21600000; // 6 hours
-	const itemExpiration = 3600000; // 1 hour
-	const now = Date.now();
-	if (!lastSelectedCache.lastScan || (now - lastSelectedCache.lastScan > clearCachePeriod)) {
-		for (const idx in lastSelectedCache) {
-			if (lastSelectedCache[idx] && (now - lastSelectedCache[idx].updated > itemExpiration)) {
-				delete lastSelectedCache[idx];
-			}
-		}
-		lastSelectedCache.lastScan = now;
-		Session.set(lastSelectedKey, lastSelectedCache);
+		const target = (lastSelected || firstThing).getClosestVisible() || lastSelected || firstThing;
+
+		select(target, {
+			scrollStyle: scrollToSelected ? 'legacy' : 'none',
+			paintImmediate: true,
+		});
 	}
+
+	addListener(selected => {
+		history.replaceState({ ...history.state, lastSelectedId: selected.getFullname() }, document.title);
+	}, 'beforeScroll');
 });
-
-function urlForSelectedCache() {
-	let url = document.location.pathname;
-	// remove any trailing slash from the URL
-	if (url.endsWith('/')) {
-		url = url.slice(0, -1);
-	}
-
-	return url;
-}
-
-function updateLastSelectedCache(selected) {
-	if (!lastSelectedCache) return;
-
-	const url = urlForSelectedCache();
-	lastSelectedCache[url] = {
-		fullname: selected.getFullname(),
-		updated: Date.now(),
-	};
-	Session.set('RESmodules.selectedThing.lastSelectedCache', lastSelectedCache);
-}
-
-const selectInitial = _.once(fastAsync(function*(firstThing) {
-	if (module.options.scrollToSelectedThingOnLoad.value) history.scrollRestoration = 'manual';
-	// `scrollRestoration` may also be set in neverEndingReddit
-	const scrollToSelected = history.scrollRestoration === 'manual';
-
-	const lastSelected = yield findLastSelectedThing();
-	const target = (lastSelected || firstThing).getClosestVisible() || lastSelected || firstThing;
-
-	select(target, {
-		scrollStyle: scrollToSelected ? 'legacy' : 'none',
-		paintImmediate: true,
-	});
-
-	addListener(updateLastSelectedCache);
-}));
-
-async function findLastSelectedThing() {
-	await setupLastSelectedCache();
-
-	const url = urlForSelectedCache();
-	const lastSelected = lastSelectedCache[url] && lastSelectedCache[url].fullname;
-	if (lastSelected) {
-		return Thing.things().find(v => v.getFullname() === lastSelected);
-	}
-}
 
 const movers = {
 	closestVisible: (thing: Thing) => thing.getClosestVisible(false),

--- a/lib/modules/showParent.js
+++ b/lib/modules/showParent.js
@@ -4,6 +4,7 @@ import { $ } from '../vendor';
 import { Thing } from '../utils';
 import { Module } from '../core/module';
 import * as Hover from './hover';
+import * as SelectedEntry from './selectedEntry';
 
 export const module: Module<*> = new Module('showParent');
 
@@ -59,6 +60,8 @@ module.go = () => {
 			fadeSpeed: module.options.fadeSpeed.value,
 		});
 	});
+
+	SelectedEntry.addListener((selected, unselected) => unselected && Hover.infocard(module.moduleID).close(false), 'beforePaint');
 };
 
 export function startHover(button: HTMLElement, options: * = {}) {

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -1411,7 +1411,7 @@
 		"message": "Selected Entry"
 	},
 	"selectedEntryDesc": {
-		"message": "Style the currently selected submission or comment. For use with Keyboard Navigation."
+		"message": "Style the currently selected submission or comment."
 	},
 	"settingsConsoleName": {
 		"message": "Settings Console"
@@ -2704,37 +2704,31 @@
 	"selectedEntryAutoSelectOnScrollDesc": {
 		"message": "Automatically select the topmost item while scrolling"
 	},
-	"selectedEntrySelectThingOnLoadDesc": {
-		"message": "Automatically select a post/comment when the page loads"
-	},
 	"selectedEntrySelectLastThingOnLoadDesc": {
 		"message": "Automatically select the last thing you had selected"
 	},
 	"selectedEntryScrollToSelectedThingOnLoadDesc": {
 		"message": "Automatically scroll to the post/comment that is selected when the page loads"
 	},
-	"selectedEntrySelectOnClickDesc": {
-		"message": "Allows you to click on an item to select it"
+	"selectedEntryAddLineDesc": {
+		"message": "Show a line on right side."
 	},
-	"selectedEntryAddFocusBGColorDesc": {
-		"message": "Use a background color"
+	"selectedEntrySetColorsDesc": {
+		"message": "Set colors"
 	},
-	"selectedEntryFocusBGColorDesc": {
+	"selectedEntryBackgroundColorDesc": {
 		"message": "The background color"
 	},
-	"selectedEntryFocusBGColorNightDesc": {
+	"selectedEntryBackgroundColorNightDesc": {
 		"message": "The background color while using Night Mode"
 	},
-	"selectedEntryFocusFGColorNightDesc": {
+	"selectedEntryTextColorNightDesc": {
 		"message": "The text color while using Night Mode"
 	},
-	"selectedEntryAddFocusBorderDesc": {
-		"message": "Use a border"
-	},
-	"selectedEntryFocusBorderDesc": {
+	"selectedEntryOutlineStyleDesc": {
 		"message": "Border appearance. E.g. `1px dashed gray` (CSS)"
 	},
-	"selectedEntryFocusBorderNightDesc": {
+	"selectedEntryOutlineStyleNightDesc": {
 		"message": "Border appearance using Night Mode (as above)"
 	},
 	"settingsNavigationShowAllOptionsDesc": {
@@ -2948,38 +2942,32 @@
 	"selectedEntryAutoSelectOnScrollTitle": {
 		"message": "Auto Select On Scroll"
 	},
-	"selectedEntrySelectThingOnLoadTitle": {
-		"message": "Select Thing On Load"
-	},
 	"selectedEntrySelectLastThingOnLoadTitle": {
 		"message": "Select Last Thing On Load"
 	},
 	"selectedEntryScrollToSelectedThingOnLoadTitle": {
 		"message": "Scroll To Selected Thing On Load"
 	},
-	"selectedEntrySelectOnClickTitle": {
-		"message": "Select On Click"
+	"selectedEntryAddLineTitle": {
+		"message": "Add Line"
 	},
-	"selectedEntryAddFocusBGColorTitle": {
-		"message": "Add Focus BG Color"
+	"selectedEntrySetColorsTitle": {
+		"message": "Set Colors"
 	},
-	"selectedEntryFocusBGColorTitle": {
-		"message": "Focus BG Color"
+	"selectedEntryBackgroundColorTitle": {
+		"message": "Background Color"
 	},
-	"selectedEntryFocusBGColorNightTitle": {
-		"message": "Focus BG Color Night"
+	"selectedEntryBackgroundColorNightTitle": {
+		"message": "Background Color Night"
 	},
-	"selectedEntryFocusFGColorNightTitle": {
-		"message": "Focus FG Color Night"
+	"selectedEntryTextColorNightTitle": {
+		"message": "Text Color Night"
 	},
-	"selectedEntryAddFocusBorderTitle": {
-		"message": "Add Focus Border"
+	"selectedEntryOutlineStyleTitle": {
+		"message": "Outline Style"
 	},
-	"selectedEntryFocusBorderTitle": {
-		"message": "Focus Border"
-	},
-	"selectedEntryFocusBorderNightTitle": {
-		"message": "Focus Border Night"
+	"selectedEntryOutlineStyleNightTitle": {
+		"message": "Outline Style Night"
 	},
 	"RESTipsMenuItemTitle": {
 		"message": "Menu Item"


### PR DESCRIPTION
Since several modules now depend on `selectedEntry`, it's probably best to set it to `alwaysEnabled` in order to reduce complexity.

A new style `line` is added, as a less obtrusive alternative to outline and highlighting:
![image](https://user-images.githubusercontent.com/1748521/28298485-d0f5fc7e-6b73-11e7-90fd-1a8ddcb51ac7.png)

Users that earlier have disabled the module will be migrated to use it.

Tested in: Firefox 57, Chrome 62
Re-creating the PR since I accidentally deleted the branch so #4355 became closed.