### PR TITLE
Google Drive backup provider: Remember which account to use if there are multiple Google accounts logged in

### DIFF
--- a/chrome/background.entry.js
+++ b/chrome/background.entry.js
@@ -10,7 +10,7 @@ addListener('addURLToHistory', url => {
 	chrome.history.addUrl({ url });
 });
 
-addListener('authFlow', ({ domain, clientId, scope, interactive }) => {
+addListener('authFlow', ({ domain, clientId, scope, loginHint, interactive }) => {
 	// Chrome supports chrome.identity.launchAuthFlow.
 	// However--and quite inexplicably--the auth process is performed in a separate context whose cookies
 	// are cleared whenever the browser is restarted, making noninteractive auth pretty much useless.
@@ -21,6 +21,9 @@ addListener('authFlow', ({ domain, clientId, scope, interactive }) => {
 	const url = new URL(domain);
 	url.searchParams.set('client_id', clientId);
 	url.searchParams.set('scope', scope);
+	if (loginHint) {
+		url.searchParams.set('login_hint', loginHint);
+	}
 	url.searchParams.set('response_type', 'token');
 	url.searchParams.set('redirect_uri', redirectUri);
 
@@ -30,6 +33,10 @@ addListener('authFlow', ({ domain, clientId, scope, interactive }) => {
 		return emulateAuthFlowInBackground(url.href);
 	}
 });
+
+addListener('saveEmail', async url =>
+	(await apiToPromise(chrome.history.getVisits)({ url })).length > 0
+);
 
 addListener('isURLVisited', async url =>
 	(await apiToPromise(chrome.history.getVisits)({ url })).length > 0

--- a/chrome/background.entry.js
+++ b/chrome/background.entry.js
@@ -34,10 +34,6 @@ addListener('authFlow', ({ domain, clientId, scope, loginHint, interactive }) =>
 	}
 });
 
-addListener('saveEmail', async url =>
-	(await apiToPromise(chrome.history.getVisits)({ url })).length > 0
-);
-
 addListener('isURLVisited', async url =>
 	(await apiToPromise(chrome.history.getVisits)({ url })).length > 0
 );

--- a/edge/background.entry.js
+++ b/edge/background.entry.js
@@ -9,7 +9,7 @@ import { emulateAuthFlowInNewWindow, emulateAuthFlowInNewTab } from '../browser/
 addListener('addURLToHistory', () => {});
 addListener('isURLVisited', () => false);
 
-addListener('authFlow', ({ domain, clientId, scope, interactive }, { index: currentIndex }) => {
+addListener('authFlow', ({ domain, clientId, scope, loginHint, interactive }, { index: currentIndex }) => {
 	// Edge does not support chrome.identity.launchAuthFlow.
 	// Its chrome.webRequest API does not support requests made by extensions,
 	// so we can't emulate noninteractive auth without a new tab.
@@ -17,6 +17,9 @@ addListener('authFlow', ({ domain, clientId, scope, interactive }, { index: curr
 	const url = new URL(domain);
 	url.searchParams.set('client_id', clientId);
 	url.searchParams.set('scope', scope);
+	if (loginHint) {
+		url.searchParams.set('login_hint', loginHint);
+	}
 	url.searchParams.set('response_type', 'token');
 	url.searchParams.set('redirect_uri', redirectUri);
 

--- a/firefox/background.entry.js
+++ b/firefox/background.entry.js
@@ -9,11 +9,14 @@ addListener('addURLToHistory', url => {
 	chrome.history.addUrl({ url });
 });
 
-addListener('authFlow', ({ domain, clientId, scope, interactive }) => {
+addListener('authFlow', ({ domain, clientId, scope, loginHint, interactive }) => {
 	const url = new URL(domain);
 	url.searchParams.set('client_id', clientId);
 	url.searchParams.set('scope', scope);
 	url.searchParams.set('response_type', 'token');
+	if (loginHint) {
+		url.searchParams.set('login_hint', loginHint);
+	}
 	url.searchParams.set('redirect_uri', 'https://redditenhancementsuite.com/oauth');
 
 	return apiToPromise(chrome.identity.launchWebAuthFlow)({ url: url.href, interactive });

--- a/firefox/beta/manifest.json
+++ b/firefox/beta/manifest.json
@@ -80,6 +80,7 @@
 		"https://api.tumblr.com/v2/blog/*/posts",
 		"https://xkcd.com/*/info.0.json",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
-		"https://content.googleapis.com/drive/v3/*"
+		"https://content.googleapis.com/drive/v3/*",
+		"https://www.googleapis.com/oauth2/v3/*"
 	]
 }

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -80,6 +80,7 @@
 		"https://api.tumblr.com/v2/blog/*/posts",
 		"https://xkcd.com/*/info.0.json",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
-		"https://content.googleapis.com/drive/v3/*"
+		"https://content.googleapis.com/drive/v3/*",
+		"https://www.googleapis.com/oauth2/v3/*"
 	]
 }

--- a/lib/constants/localStorage.js
+++ b/lib/constants/localStorage.js
@@ -3,3 +3,4 @@
 export const CACHED_LANG_KEY = 'RES.i18nCachedLang';
 export const CACHED_MESSAGES_KEY = 'RES.i18nCachedMessages';
 export const CACHED_MESSAGES_TOKEN_KEY = 'RES.i18nCachedMessagesToken';
+export const CACHED_GOOGLE_EMAIL_ADDRESS = 'RES.googleEmailAddress';

--- a/lib/constants/localStorage.js
+++ b/lib/constants/localStorage.js
@@ -3,4 +3,3 @@
 export const CACHED_LANG_KEY = 'RES.i18nCachedLang';
 export const CACHED_MESSAGES_KEY = 'RES.i18nCachedMessages';
 export const CACHED_MESSAGES_TOKEN_KEY = 'RES.i18nCachedMessagesToken';
-export const CACHED_OAUTH_LOGIN_HINT = 'RES.oauthLoginHint';

--- a/lib/constants/localStorage.js
+++ b/lib/constants/localStorage.js
@@ -3,4 +3,4 @@
 export const CACHED_LANG_KEY = 'RES.i18nCachedLang';
 export const CACHED_MESSAGES_KEY = 'RES.i18nCachedMessages';
 export const CACHED_MESSAGES_TOKEN_KEY = 'RES.i18nCachedMessagesToken';
-export const CACHED_GOOGLE_EMAIL_ADDRESS = 'RES.googleEmailAddress';
+export const CACHED_OAUTH_LOGIN_HINT = 'RES.oauthLoginHint';

--- a/lib/environment/auth.js
+++ b/lib/environment/auth.js
@@ -1,11 +1,10 @@
 /* @flow */
 
 import { sendMessage } from '../../browser';
-import { CACHED_GOOGLE_EMAIL_ADDRESS } from '../constants/localStorage';
 import { Permissions } from './';
 
 export async function launchAuthFlow(
-	{ domain, clientId, loginHint, scope = ''}: {| domain: string, clientId: string,  loginHint?: string, scope?: string |},
+	{ domain, clientId, loginHint, scope = '' }: {| domain: string, clientId: string, loginHint?: string, scope?: string |},
 	warnUserInteraction: (message: string) => Promise<void>,
 ): Promise<string> {
 	let responseUrl;

--- a/lib/environment/auth.js
+++ b/lib/environment/auth.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import { sendMessage } from '../../browser';
+import { CACHED_GOOGLE_EMAIL_ADDRESS } from '../constants/localStorage';
 import { Permissions } from './';
 
 export async function launchAuthFlow(
@@ -12,6 +13,11 @@ export async function launchAuthFlow(
 		responseUrl = await sendMessage('authFlow', { domain, clientId, scope, loginHint, interactive: false });
 	} catch (e) {
 		console.error('Noninteractive auth failed:', e);
+
+		// Invalidate google email address
+		if (domain === 'https://accounts.google.com/o/oauth2/v2/auth' && loginHint) {
+			localStorage.removeItem(CACHED_GOOGLE_EMAIL_ADDRESS);
+		}
 
 		await warnUserInteraction('You may be redirected to redditenhancementsuite.com to complete the login process.');
 

--- a/lib/environment/auth.js
+++ b/lib/environment/auth.js
@@ -5,7 +5,7 @@ import { CACHED_GOOGLE_EMAIL_ADDRESS } from '../constants/localStorage';
 import { Permissions } from './';
 
 export async function launchAuthFlow(
-	{ domain, clientId, scope = '', loginHint = '' }: {| domain: string, clientId: string, scope?: string, loginHint?: string |},
+	{ domain, clientId, loginHint, scope = ''}: {| domain: string, clientId: string,  loginHint?: string, scope?: string |},
 	warnUserInteraction: (message: string) => Promise<void>,
 ): Promise<string> {
 	let responseUrl;
@@ -13,11 +13,6 @@ export async function launchAuthFlow(
 		responseUrl = await sendMessage('authFlow', { domain, clientId, scope, loginHint, interactive: false });
 	} catch (e) {
 		console.error('Noninteractive auth failed:', e);
-
-		// Invalidate google email address
-		if (domain === 'https://accounts.google.com/o/oauth2/v2/auth' && loginHint) {
-			localStorage.removeItem(CACHED_GOOGLE_EMAIL_ADDRESS);
-		}
 
 		await warnUserInteraction('You may be redirected to redditenhancementsuite.com to complete the login process.');
 

--- a/lib/environment/auth.js
+++ b/lib/environment/auth.js
@@ -27,7 +27,3 @@ export async function launchAuthFlow(
 
 	return token;
 }
-
-export async function saveEmail(emailAddress: string): Promise<void> {
-	await sendMessage('saveEmail', emailAddress);
-}

--- a/lib/environment/auth.js
+++ b/lib/environment/auth.js
@@ -4,12 +4,12 @@ import { sendMessage } from '../../browser';
 import { Permissions } from './';
 
 export async function launchAuthFlow(
-	{ domain, clientId, scope = '' }: {| domain: string, clientId: string, scope?: string |},
+	{ domain, clientId, scope = '', loginHint = '' }: {| domain: string, clientId: string, scope?: string, loginHint?: string |},
 	warnUserInteraction: (message: string) => Promise<void>,
 ): Promise<string> {
 	let responseUrl;
 	try {
-		responseUrl = await sendMessage('authFlow', { domain, clientId, scope, interactive: false });
+		responseUrl = await sendMessage('authFlow', { domain, clientId, scope, loginHint, interactive: false });
 	} catch (e) {
 		console.error('Noninteractive auth failed:', e);
 
@@ -17,7 +17,7 @@ export async function launchAuthFlow(
 
 		await Permissions.request(['https://redditenhancementsuite.com/oauth']);
 
-		responseUrl = await sendMessage('authFlow', { domain, clientId, scope, interactive: true });
+		responseUrl = await sendMessage('authFlow', { domain, clientId, scope, loginHint, interactive: true });
 	}
 
 	const hash = new URL(responseUrl).hash.slice(1);
@@ -26,4 +26,8 @@ export async function launchAuthFlow(
 	if (!token) throw new Error('No token found in response.');
 
 	return token;
+}
+
+export async function saveEmail(emailAddress: string): Promise<void> {
+	await sendMessage('saveEmail', emailAddress);
 }

--- a/lib/modules/backupAndRestore.js
+++ b/lib/modules/backupAndRestore.js
@@ -77,11 +77,11 @@ module.loadDynamicOptions = () => {
 
 		module.options.backup.values.push({
 			text,
-			callback: () => new providerClass().init().then(backup),
+			callback: () => getProvider(providerClass).then(backup),
 		});
 		module.options.restore.values.push({
 			text,
-			callback: () => new providerClass().init().then(restore),
+			callback: () => getProvider(providerClass).then(restore),
 		});
 
 		if (supportsAutomaticBackups) {
@@ -96,6 +96,11 @@ module.loadDynamicOptions = () => {
 module.afterLoad = async () => {
 	await handleAutomaticSync();
 };
+
+function getProvider(providerClass) {
+	const loginHintStorage = Storage.wrap(`backup.loginHint.${providerClass.key}`, (null: null | *));
+	return new providerClass().init({ loginHintStorage });
+}
 
 const lastModifiedStorage = Storage.wrapPrefix('backup.lastModified.', () => (0: number));
 const lastCheckStorage = Storage.wrap('backup.lastCheck', (0: number));
@@ -116,7 +121,7 @@ async function handleAutomaticSync() {
 	// From this point forward, it is guaranteed that only one tab can enter (per 15 minutes).
 
 	// Create provider, get permissions, etc.
-	const provider = await new providerClass().init();
+	const provider = await getProvider(providerClass);
 
 	// Read the remote backup to get the last modified time.
 	// This has some overhead, but only 2x at worst.

--- a/lib/modules/backupAndRestore/providers/Dropbox.js
+++ b/lib/modules/backupAndRestore/providers/Dropbox.js
@@ -13,7 +13,7 @@ export class Dropbox extends Provider {
 
 	accessToken: string;
 
-	async init(): Promise<Provider> {
+	async init({}: *): Promise<Provider> { // eslint-disable-line no-empty-pattern
 		this.accessToken = await launchAuthFlow({
 			domain: 'https://www.dropbox.com/oauth2/authorize',
 			clientId: 'tdevom9o5xn0hnt',

--- a/lib/modules/backupAndRestore/providers/GoogleDrive.js
+++ b/lib/modules/backupAndRestore/providers/GoogleDrive.js
@@ -14,12 +14,14 @@ export class GoogleDrive extends Provider {
 	static supportsAutomaticBackups = true;
 
 	accessToken: string;
+	emailAddress: string;
 
 	async init(): Promise<Provider> {
 		this.accessToken = await launchAuthFlow({
 			domain: 'https://accounts.google.com/o/oauth2/v2/auth',
 			clientId: '568759524377-nv0o2u4afuuulkfcjd7f6guf27qkevpt.apps.googleusercontent.com',
-			scope: 'https://www.googleapis.com/auth/drive.appdata',
+			scope: 'https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/userinfo.email',
+			loginHint: this.emailAddress
 		}, async message => {
 			await Alert.open(`
 				<p><b>RES needs your permission to backup to Google Drive.</b></p>
@@ -28,7 +30,22 @@ export class GoogleDrive extends Provider {
 			await Permissions.request(['https://accounts.google.com/o/oauth2/v2/auth', 'https://content.googleapis.com/drive/v3/*']);
 		});
 
+		var decryptedToken = await this.verifyToken()
+		this.emailAddress = decryptedToken["email"]
+		console.log("Verify token response:", decryptedToken)
+		console.log("Email address found is:", this.emailAddress)
+
 		return this;
+	}
+
+	async verifyToken() {
+		return ajax({
+			method: 'POST',
+			url: 'https://www.googleapis.com/oauth2/v3/tokeninfo',
+			query: { access_token: this.accessToken },
+			headers: { 'Content-Type': 'application/json'},
+			type: 'json',
+		});
 	}
 
 	async getExistingFile() {

--- a/lib/modules/backupAndRestore/providers/GoogleDrive.js
+++ b/lib/modules/backupAndRestore/providers/GoogleDrive.js
@@ -2,6 +2,8 @@
 
 import { Base64 } from 'js-base64';
 import { ajax, launchAuthFlow, Permissions } from '../../../environment';
+import { CACHED_GOOGLE_EMAIL_ADDRESS } from '../../../constants/localStorage';
+
 import { Alert } from '../../../utils';
 import { Provider } from './Provider';
 
@@ -17,6 +19,8 @@ export class GoogleDrive extends Provider {
 	emailAddress: string;
 
 	async init(): Promise<Provider> {
+		this.emailAddress = JSON.parse(localStorage.getItem(CACHED_GOOGLE_EMAIL_ADDRESS)) || '';
+
 		this.accessToken = await launchAuthFlow({
 			domain: 'https://accounts.google.com/o/oauth2/v2/auth',
 			clientId: '568759524377-nv0o2u4afuuulkfcjd7f6guf27qkevpt.apps.googleusercontent.com',
@@ -31,9 +35,11 @@ export class GoogleDrive extends Provider {
 		});
 
 		var decryptedToken = await this.verifyToken()
-		this.emailAddress = decryptedToken["email"]
-		console.log("Verify token response:", decryptedToken)
-		console.log("Email address found is:", this.emailAddress)
+
+		if (this.emailAddress == '') {
+			this.emailAddress = decryptedToken["email"]
+			localStorage.setItem(CACHED_GOOGLE_EMAIL_ADDRESS, JSON.stringify(this.emailAddress));
+		}
 
 		return this;
 	}

--- a/lib/modules/backupAndRestore/providers/GoogleDrive.js
+++ b/lib/modules/backupAndRestore/providers/GoogleDrive.js
@@ -25,7 +25,7 @@ export class GoogleDrive extends Provider {
 			domain: 'https://accounts.google.com/o/oauth2/v2/auth',
 			clientId: '568759524377-nv0o2u4afuuulkfcjd7f6guf27qkevpt.apps.googleusercontent.com',
 			scope: 'https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/userinfo.email',
-			loginHint: this.emailAddress
+			loginHint: this.emailAddress,
 		}, async message => {
 			await Alert.open(`
 				<p><b>RES needs your permission to backup to Google Drive.</b></p>
@@ -34,24 +34,30 @@ export class GoogleDrive extends Provider {
 			await Permissions.request(['https://accounts.google.com/o/oauth2/v2/auth', 'https://content.googleapis.com/drive/v3/*']);
 		});
 
-		var decryptedToken = await this.verifyToken()
-
-		if (this.emailAddress == '') {
-			this.emailAddress = decryptedToken["email"]
-			localStorage.setItem(CACHED_GOOGLE_EMAIL_ADDRESS, JSON.stringify(this.emailAddress));
+		if (!this.emailAddress) {
+			try {
+				this.emailAddress = await this.verifyToken();
+				localStorage.setItem(CACHED_GOOGLE_EMAIL_ADDRESS, JSON.stringify(this.emailAddress));
+			} catch (err) {
+				console.error(err);
+			}
 		}
 
 		return this;
 	}
 
 	async verifyToken() {
-		return ajax({
+		const decryptedToken = await ajax({
 			method: 'GET',
 			url: 'https://www.googleapis.com/oauth2/v3/tokeninfo',
 			query: { access_token: this.accessToken },
-			headers: { 'Content-Type': 'application/json'},
+			headers: { 'Content-Type': 'application/json' },
 			type: 'json',
 		});
+		if (decryptedToken) {
+			return decryptedToken.email;
+		}
+		return null;
 	}
 
 	async getExistingFile() {

--- a/lib/modules/backupAndRestore/providers/GoogleDrive.js
+++ b/lib/modules/backupAndRestore/providers/GoogleDrive.js
@@ -50,7 +50,7 @@ export class GoogleDrive extends Provider {
 	getCachedEmailAddress() {
 		const cachedEmailAddress = localStorage.getItem(CACHED_GOOGLE_EMAIL_ADDRESS);
 		if (cachedEmailAddress) {
-			return JSON.parse(cachedEmailAddress);
+			return cachedEmailAddress;
 		}
 
 		return '';

--- a/lib/modules/backupAndRestore/providers/GoogleDrive.js
+++ b/lib/modules/backupAndRestore/providers/GoogleDrive.js
@@ -48,14 +48,19 @@ export class GoogleDrive extends Provider {
 	}
 
 	getCachedEmailAddress() {
-		return JSON.parse(localStorage.getItem(CACHED_GOOGLE_EMAIL_ADDRESS)) || '';
+		const cachedEmailAddress = localStorage.getItem(CACHED_GOOGLE_EMAIL_ADDRESS);
+		if (cachedEmailAddress) {
+			return JSON.parse(cachedEmailAddress);
+		}
+
+		return '';
 	}
 
 	setCachedEmailAddress(emailAddress: string) {
 		localStorage.setItem(CACHED_GOOGLE_EMAIL_ADDRESS, JSON.stringify(emailAddress));
 	}
 
-	async verifyToken() {
+	async verifyToken(): Promise<string> {
 		const decryptedToken = await ajax({
 			method: 'GET',
 			url: 'https://www.googleapis.com/oauth2/v3/tokeninfo',
@@ -66,7 +71,7 @@ export class GoogleDrive extends Provider {
 		if (decryptedToken) {
 			return decryptedToken.email;
 		}
-		return null;
+		return '';
 	}
 
 	async getExistingFile() {

--- a/lib/modules/backupAndRestore/providers/GoogleDrive.js
+++ b/lib/modules/backupAndRestore/providers/GoogleDrive.js
@@ -46,7 +46,7 @@ export class GoogleDrive extends Provider {
 
 	async verifyToken() {
 		return ajax({
-			method: 'POST',
+			method: 'GET',
 			url: 'https://www.googleapis.com/oauth2/v3/tokeninfo',
 			query: { access_token: this.accessToken },
 			headers: { 'Content-Type': 'application/json'},

--- a/lib/modules/backupAndRestore/providers/GoogleDrive.js
+++ b/lib/modules/backupAndRestore/providers/GoogleDrive.js
@@ -19,7 +19,7 @@ export class GoogleDrive extends Provider {
 	emailAddress: string;
 
 	async init(): Promise<Provider> {
-		this.emailAddress = JSON.parse(localStorage.getItem(CACHED_GOOGLE_EMAIL_ADDRESS)) || '';
+		this.emailAddress = this.getCachedEmailAddress();
 
 		this.accessToken = await launchAuthFlow({
 			domain: 'https://accounts.google.com/o/oauth2/v2/auth',
@@ -34,16 +34,25 @@ export class GoogleDrive extends Provider {
 			await Permissions.request(['https://accounts.google.com/o/oauth2/v2/auth', 'https://content.googleapis.com/drive/v3/*']);
 		});
 
-		if (!this.emailAddress) {
+		// Re-check email address cache, in case it got invalidated due to google account logout
+		if (!this.getCachedEmailAddress()) {
 			try {
 				this.emailAddress = await this.verifyToken();
-				localStorage.setItem(CACHED_GOOGLE_EMAIL_ADDRESS, JSON.stringify(this.emailAddress));
+				this.setCachedEmailAddress(this.emailAddress);
 			} catch (err) {
 				console.error(err);
 			}
 		}
 
 		return this;
+	}
+
+	getCachedEmailAddress() {
+		return JSON.parse(localStorage.getItem(CACHED_GOOGLE_EMAIL_ADDRESS)) || '';
+	}
+
+	setCachedEmailAddress(emailAddress: string) {
+		localStorage.setItem(CACHED_GOOGLE_EMAIL_ADDRESS, JSON.stringify(emailAddress));
 	}
 
 	async verifyToken() {

--- a/lib/modules/backupAndRestore/providers/GoogleDrive.js
+++ b/lib/modules/backupAndRestore/providers/GoogleDrive.js
@@ -2,8 +2,6 @@
 
 import { Base64 } from 'js-base64';
 import { ajax, launchAuthFlow, Permissions } from '../../../environment';
-import { CACHED_GOOGLE_EMAIL_ADDRESS } from '../../../constants/localStorage';
-
 import { Alert } from '../../../utils';
 import { Provider } from './Provider';
 
@@ -16,66 +14,38 @@ export class GoogleDrive extends Provider {
 	static supportsAutomaticBackups = true;
 
 	accessToken: string;
-	emailAddress: string;
 
 	async init(): Promise<Provider> {
-		this.emailAddress = this.getCachedEmailAddress();
+		const loginHint = this.getLoginHint();
 
 		this.accessToken = await launchAuthFlow({
 			domain: 'https://accounts.google.com/o/oauth2/v2/auth',
 			clientId: '568759524377-nv0o2u4afuuulkfcjd7f6guf27qkevpt.apps.googleusercontent.com',
-			loginHint: this.emailAddress,
 			scope: 'https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/userinfo.email',
+			...(loginHint ? { loginHint } : undefined),
 		}, async message => {
-			// Invalidate google email address
-			if (this.emailAddress) {
-				this.removeCachedEmailAddress();
-			}
-
 			await Alert.open(`
 				<p><b>RES needs your permission to backup to Google Drive.</b></p>
 				<p>${message}</p>
 			`, { cancelable: true });
 			await Permissions.request(['https://accounts.google.com/o/oauth2/v2/auth', 'https://content.googleapis.com/drive/v3/*']);
+
+			this.invalidateLoginHint();
 		});
 
-		// Re-check email address cache, in case it got invalidated due to google account logout
-		if (!this.getCachedEmailAddress()) {
-			try {
-				this.emailAddress = await this.verifyToken();
-				this.setCachedEmailAddress(this.emailAddress);
-			} catch (err) {
-				console.error(err);
-			}
-		}
+		this.refreshLoginHint();
 
 		return this;
 	}
 
-	getCachedEmailAddress() {
-		const cachedEmailAddress = localStorage.getItem(CACHED_GOOGLE_EMAIL_ADDRESS);
-		return cachedEmailAddress || '';
-	}
-
-	setCachedEmailAddress(emailAddress: string) {
-		localStorage.setItem(CACHED_GOOGLE_EMAIL_ADDRESS, emailAddress);
-	}
-
-	removeCachedEmailAddress() {
-		localStorage.removeItem(CACHED_GOOGLE_EMAIL_ADDRESS);
-	}
-
-	async verifyToken(): Promise<string> {
-		const decryptedToken = await ajax({
+	async refreshLoginHint() {
+		const { email } = await ajax({
 			method: 'GET',
 			url: 'https://www.googleapis.com/oauth2/v3/tokeninfo',
 			query: { access_token: this.accessToken },
 			type: 'json',
 		});
-		if (decryptedToken) {
-			return decryptedToken.email;
-		}
-		return '';
+		if (email) this.setLoginHint(email);
 	}
 
 	async getExistingFile() {

--- a/lib/modules/backupAndRestore/providers/GoogleDrive.js
+++ b/lib/modules/backupAndRestore/providers/GoogleDrive.js
@@ -24,9 +24,14 @@ export class GoogleDrive extends Provider {
 		this.accessToken = await launchAuthFlow({
 			domain: 'https://accounts.google.com/o/oauth2/v2/auth',
 			clientId: '568759524377-nv0o2u4afuuulkfcjd7f6guf27qkevpt.apps.googleusercontent.com',
-			scope: 'https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/userinfo.email',
 			loginHint: this.emailAddress,
+			scope: 'https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/userinfo.email',
 		}, async message => {
+			// Invalidate google email address
+			if (this.emailAddress) {
+				this.removeCachedEmailAddress();
+			}
+
 			await Alert.open(`
 				<p><b>RES needs your permission to backup to Google Drive.</b></p>
 				<p>${message}</p>
@@ -56,12 +61,15 @@ export class GoogleDrive extends Provider {
 		localStorage.setItem(CACHED_GOOGLE_EMAIL_ADDRESS, emailAddress);
 	}
 
+	removeCachedEmailAddress() {
+		localStorage.removeItem(CACHED_GOOGLE_EMAIL_ADDRESS);
+	}
+
 	async verifyToken(): Promise<string> {
 		const decryptedToken = await ajax({
 			method: 'GET',
 			url: 'https://www.googleapis.com/oauth2/v3/tokeninfo',
 			query: { access_token: this.accessToken },
-			headers: { 'Content-Type': 'application/json' },
 			type: 'json',
 		});
 		if (decryptedToken) {

--- a/lib/modules/backupAndRestore/providers/GoogleDrive.js
+++ b/lib/modules/backupAndRestore/providers/GoogleDrive.js
@@ -15,8 +15,9 @@ export class GoogleDrive extends Provider {
 
 	accessToken: string;
 
-	async init(): Promise<Provider> {
-		const loginHint = this.getLoginHint();
+	async init({ loginHintStorage }: *): Promise<Provider> {
+		const loginHint = await loginHintStorage.get();
+		let renewLoginHint = false;
 
 		this.accessToken = await launchAuthFlow({
 			domain: 'https://accounts.google.com/o/oauth2/v2/auth',
@@ -30,22 +31,24 @@ export class GoogleDrive extends Provider {
 			`, { cancelable: true });
 			await Permissions.request(['https://accounts.google.com/o/oauth2/v2/auth', 'https://content.googleapis.com/drive/v3/*']);
 
-			this.invalidateLoginHint();
+			renewLoginHint = true;
 		});
 
-		this.refreshLoginHint();
+		if (renewLoginHint) {
+			this.getActiveEmail().then(v => loginHintStorage.set(v));
+		}
 
 		return this;
 	}
 
-	async refreshLoginHint() {
+	async getActiveEmail() {
 		const { email } = await ajax({
 			method: 'GET',
 			url: 'https://www.googleapis.com/oauth2/v3/tokeninfo',
 			query: { access_token: this.accessToken },
 			type: 'json',
 		});
-		if (email) this.setLoginHint(email);
+		return email;
 	}
 
 	async getExistingFile() {

--- a/lib/modules/backupAndRestore/providers/GoogleDrive.js
+++ b/lib/modules/backupAndRestore/providers/GoogleDrive.js
@@ -53,7 +53,7 @@ export class GoogleDrive extends Provider {
 	}
 
 	setCachedEmailAddress(emailAddress: string) {
-		localStorage.setItem(CACHED_GOOGLE_EMAIL_ADDRESS, JSON.stringify(emailAddress));
+		localStorage.setItem(CACHED_GOOGLE_EMAIL_ADDRESS, emailAddress);
 	}
 
 	async verifyToken(): Promise<string> {

--- a/lib/modules/backupAndRestore/providers/GoogleDrive.js
+++ b/lib/modules/backupAndRestore/providers/GoogleDrive.js
@@ -49,11 +49,7 @@ export class GoogleDrive extends Provider {
 
 	getCachedEmailAddress() {
 		const cachedEmailAddress = localStorage.getItem(CACHED_GOOGLE_EMAIL_ADDRESS);
-		if (cachedEmailAddress) {
-			return cachedEmailAddress;
-		}
-
-		return '';
+		return cachedEmailAddress || '';
 	}
 
 	setCachedEmailAddress(emailAddress: string) {

--- a/lib/modules/backupAndRestore/providers/OneDrive.js
+++ b/lib/modules/backupAndRestore/providers/OneDrive.js
@@ -13,7 +13,7 @@ export class OneDrive extends Provider {
 
 	accessToken: string;
 
-	async init(): Promise<Provider> {
+	async init({}: *): Promise<Provider> { // eslint-disable-line no-empty-pattern
 		this.accessToken = await launchAuthFlow({
 			domain: 'https://login.live.com/oauth20_authorize.srf',
 			clientId: 'a1f95f80-0129-475b-9894-dfbb94f5ff1c',

--- a/lib/modules/backupAndRestore/providers/Provider.js
+++ b/lib/modules/backupAndRestore/providers/Provider.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import { CACHED_OAUTH_LOGIN_HINT } from '../../../constants/localStorage';
+
 /* eslint-disable no-unused-vars */
 export class Provider {
 	static key = 'abstract';
@@ -9,6 +11,18 @@ export class Provider {
 
 	init(): Promise<Provider> {
 		return Promise.resolve(this);
+	}
+
+	getLoginHint(): ?string {
+		return localStorage.getItem(`${CACHED_OAUTH_LOGIN_HINT}.${this.constructor.key}`);
+	}
+
+	setLoginHint(value: string) {
+		localStorage.setItem(`${CACHED_OAUTH_LOGIN_HINT}.${this.constructor.key}`, value);
+	}
+
+	invalidateLoginHint() {
+		localStorage.removeItem(`${CACHED_OAUTH_LOGIN_HINT}.${this.constructor.key}`);
 	}
 
 	read(): Promise<string> { throw new Error('unimplemented'); }

--- a/lib/modules/backupAndRestore/providers/Provider.js
+++ b/lib/modules/backupAndRestore/providers/Provider.js
@@ -1,7 +1,5 @@
 /* @flow */
 
-import { CACHED_OAUTH_LOGIN_HINT } from '../../../constants/localStorage';
-
 /* eslint-disable no-unused-vars */
 export class Provider {
 	static key = 'abstract';
@@ -9,20 +7,8 @@ export class Provider {
 	static notifyBackupDone = true;
 	static supportsAutomaticBackups = false;
 
-	init(): Promise<Provider> {
+	init({ loginHintStorage }: {| loginHintStorage: * |}): Promise<Provider> {
 		return Promise.resolve(this);
-	}
-
-	getLoginHint(): ?string {
-		return localStorage.getItem(`${CACHED_OAUTH_LOGIN_HINT}.${this.constructor.key}`);
-	}
-
-	setLoginHint(value: string) {
-		localStorage.setItem(`${CACHED_OAUTH_LOGIN_HINT}.${this.constructor.key}`, value);
-	}
-
-	invalidateLoginHint() {
-		localStorage.removeItem(`${CACHED_OAUTH_LOGIN_HINT}.${this.constructor.key}`);
 	}
 
 	read(): Promise<string> { throw new Error('unimplemented'); }


### PR DESCRIPTION
As mentioned in #4376 , currently when there's more than one Google account logged in, RES does not remember which account it should use to backup to Google Drive, constantly asking you.

This PR fixes this issue by adding a `login_hint` field in the auth request. This requires an additional `https://www.googleapis.com/auth/userinfo.email` scope in the auth request.

The user's Google email address used to backup or restore for the first time is saved to local storage and re-used for subsequent backups or restores.

If the user logs out of the Google email address saved in local storage, then the local storage email address cache is invalidated and then re-written after the user re-authenticates with a Google account.

Relevant issue: Fixes #4376 
Tested in browser: Firefox 56, Chrome 61, Edge 40

~Outstanding Issue: Can someone help test this in Edge as I don't have ready access at present to this browser?~ Tested with Edge successfully.