### PR TITLE
Small language fix

### DIFF
--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -3954,7 +3954,7 @@
 		"message": "Show gallery as 'slideshow' when the total number of pieces is larger than this number. (0 for no limit)"
 	},
 	"showImagesConvertGifstoGfycatTitle": {
-		"message": "Convert Gifsto Gfycat"
+		"message": "Convert Gifs to Gfycat"
 	},
 	"showImagesConvertGifstoGfycatDesc": {
 		"message": "Convert Gif links to Gfycat links."


### PR DESCRIPTION
Relevant issue: Previously was "Convert Gifsto Gfycat" fixed to "Convert Gifs to Gfycat"
Tested in browser: Not tested
