### PR TITLE
Adds Auto Switch to accountswitcher 

### DIFF
--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -3,7 +3,7 @@
 import _ from 'lodash';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
-import { Alert, formatDate, formatDateDiff, getUserInfo, loggedInUser } from '../utils';
+import { Alert, formatDate, formatDateDiff, getUserInfo, loggedInUser, isPageType, watchForThings} from '../utils';
 import { ajax, multicast, i18n } from '../environment';
 import * as BetteReddit from './betteReddit';
 import * as CommandLine from './commandLine';
@@ -59,6 +59,20 @@ module.options = {
 		value: false,
 		advanced: true,
 	},
+	autoSwitchOnPost: {
+		type: 'boolean',
+		description: 'accountSwitcherAutoSwitchOnPostDesc',
+		title: 'accountSwitcherAutoSwitchOnPostTitle',
+		value: false,
+		advanced: false,
+	},
+	autoSwitchOnComment: {
+		type: 'boolean',
+		description: 'accountSwitcherAutoSwitchOnCommentDesc',
+		title: 'accountSwitcherAutoSwitchOnCommentTitle',
+		value: false,
+		advanced: false,
+	},
 	showCurrentUserName: {
 		type: 'boolean',
 		value: false,
@@ -106,10 +120,18 @@ module.options = {
 	},
 };
 
-let userLink, $downArrow, $downArrowOverlay;
+let userLink, $downArrow, $downArrowOverlay, queryParameter;
 
 export let $accountMenu;
 
+module.beforeLoad = () => {
+	if(isPageType('comments') && module.options.autoSwitchOnPost.value) {
+		watchForThings(['post'], autoSwitcher);
+	}
+	if(isPageType('comments') && module.options.autoSwitchOnComment.value) {
+		watchForThings(['comment'], autoSwitcher);
+	}
+}
 module.go = () => {
 	userLink = document.querySelector('#header-bottom-right > span.user > a');
 	if (userLink) {
@@ -434,12 +456,42 @@ function _notifySwitchedAccountElsewhere() {
 		message,
 	});
 }
-
+function autoSwitcher(thing) {
+	if(thing.getAuthor() != loggedInUser() && window.location.search.indexOf('accountSwitcher=auto') == -1 ) {
+		switchTo(thing.getAuthor());
+		queryParameter = "auto"
+	}
+	if(window.location.search.indexOf('accountSwitcher=auto') > -1 && thing.getAuthor() == loggedInUser() && thing.isPost()) {
+		Notifications.showNotification({
+			moduleID: module.moduleID,
+			notificationID: 'auto-switched',
+			closeDelay: 4000,
+			optionKey: 'autoSwitchOnPost',
+			header: i18n('accountSwitcherAutoSwitchNotificationTitle'),
+			message: i18n('accountSwitcherAutoSwitchPostDesc', loggedInUser()),
+		});
+	}
+	if(window.location.search.indexOf('accountSwitcher=auto') > -1 && thing.getAuthor() == loggedInUser() && thing.isComment()) {
+		Notifications.showNotification({
+			moduleID: module.moduleID,
+			notificationID: 'auto-switched',
+			closeDelay: 4000,
+			optionKey: 'autoSwitchOnComment',
+			header: i18n('accountSwitcherAutoSwitchNotificationTitle'),
+			message: i18n('accountSwitcherAutoSwitchCommentDesc', loggedInUser()),
+		});
+	}
+}
 function manageAccounts() {
 	SettingsNavigation.loadSettingsPage(module.moduleID, 'accounts');
 }
 
 function reloadPage() {
 	NeverEndingReddit.resetReturnToPage();
-	location.reload();
+	if(queryParameter) {
+		window.location.href = window.location.pathname+"?"+$.param({'accountSwitcher':queryParameter})
+	}
+	else {
+		location.reload();
+	}
 }

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -1629,6 +1629,27 @@
 	"accountSwitcherReloadOtherTabsDesc": {
 		"message": "After switching accounts, automatically reload other tabs."
 	},
+	"accountSwitcherAutoSwitchOnPostTitle": {
+		"message": "Automatically Switch To Post OP"
+	},
+	"accountSwitcherAutoSwitchOnPostDesc": {
+		"message": "Automatically switch to alternative account if it's the OP of the post you are on."
+	},
+	"accountSwitcherAutoSwitchOnCommentTitle": {
+		"message": "Automatically Switch To Comment OP"
+	},
+	"accountSwitcherAutoSwitchOnCommentDesc": {
+		"message": "Automatically switch to alternative account if a comment from one of your alternative accounts is on the page"
+	},
+	"accountSwitcherAutoSwitchNotificationTitle": {
+		"message": "Account Switched"
+	},
+	"accountSwitcherAutoSwitchPostDesc": {
+		"message": "Your account has been switched to <b>$1</b> because it is the OP of this post"
+	},
+	"accountSwitcherAutoSwitchCommentDesc": {
+		"message": "Your account has been switched to <b>$1</b> because a comment by it was found on this post."
+	},
 	"accountSwitcherShowCurrentUserNameTitle": {
 		"message": "Show Current User Name"
 	},


### PR DESCRIPTION
Adds options to switch to an alt account if you are on a comment page that was created by one of your alt accounts or contains a comment created by one of your alt accounts. On switching accounts a query parameter is added to the URL on page refresh so that a notification is displayed to alert the user that their account has been switched.

Relevant issue: Fixes #4442 and #1686
Tested in browser: Chrome
