### PR TITLE
Give hidden user names the same right margin as non-hidden ones

### DIFF
--- a/lib/modules/usernameHider.js
+++ b/lib/modules/usernameHider.js
@@ -136,6 +136,7 @@ const hideUsername = _.memoize((user = loggedInUser()) => {
 			background-color: inherit;
 			border-radius: inherit;
 			padding: inherit;
+			margin-right: 0.5em;
 		}
 
 		.commentingAsUser a${userHref}::after {


### PR DESCRIPTION
Hey there. I noticed that if you tag yourself (which i started doing so i could find my comments more easily), and you have user-name hiding enabled, the normal margin between the name and the tag is missing:

<img width="224" alt="screen shot 2017-10-05 at 22 15 47" src="https://user-images.githubusercontent.com/122095/31261640-260ac01a-aa1b-11e7-9a8e-e3d571edb3e5.png">

Simply copying the `margin-right` value from reddit's own `a.author` rule seems to fix it.

Tested in browser: Firefox 56
