### PR TITLE
Add user highlighting for current user

### DIFF
--- a/lib/modules/userHighlight.js
+++ b/lib/modules/userHighlight.js
@@ -4,8 +4,8 @@ import { Module } from '../core/module';
 import {
 	Alert,
 	addCSS,
-    hashCode,
-    loggedInUser,
+	hashCode,
+	loggedInUser,
 	watchForThings,
 } from '../utils';
 import { i18n } from '../environment';
@@ -213,8 +213,8 @@ module.beforeLoad = () => {
 	}
 
 	if (module.options.highlightFriend.value) {
-        highlight('friend', module.options.friendColor.value, module.options.friendColorHover.value);
-        highlightUser(loggedInUser()); // Also highlight "me"
+		highlight('friend', module.options.friendColor.value, module.options.friendColorHover.value);
+		highlightUser(loggedInUser()); // Also highlight "me"
 	}
 	if (module.options.highlightOP.value) {
 		highlight('submitter', module.options.OPColor.value, module.options.OPColorHover.value);

--- a/lib/modules/userHighlight.js
+++ b/lib/modules/userHighlight.js
@@ -19,6 +19,28 @@ module.category = 'usersCategory';
 module.description = 'userHighlightDesc';
 module.bodyClass = true;
 module.options = {
+	highlightSelf: {
+		title: 'userHighlightHighlightSelfTitle',
+		type: 'boolean',
+		value: false,
+		description: 'userHighlightHighlightSelfDesc',
+	},
+	selfColor: {
+		title: 'userHighlightSelfColorTitle',
+		type: 'color',
+		value: '#B8860B',
+		description: 'userHighlightSelfColorDesc',
+		advanced: true,
+		dependsOn: options => options.highlightSelf.value,
+	},
+	selfColorHover: {
+		title: 'userHighlightSelfColorHoverTitle',
+		type: 'color',
+		value: '#8A6508',
+		description: 'userHighlightSelfColorHoverDesc',
+		advanced: true,
+		dependsOn: options => options.highlightSelf.value,
+	},
 	highlightOP: {
 		title: 'userHighlightHighlightOPTitle',
 		type: 'boolean',
@@ -214,7 +236,6 @@ module.beforeLoad = () => {
 
 	if (module.options.highlightFriend.value) {
 		highlight('friend', module.options.friendColor.value, module.options.friendColorHover.value);
-		highlightUser(loggedInUser()); // Also highlight "me"
 	}
 	if (module.options.highlightOP.value) {
 		highlight('submitter', module.options.OPColor.value, module.options.OPColorHover.value);
@@ -227,6 +248,13 @@ module.beforeLoad = () => {
 	}
 	if (module.options.highlightAlum.value) {
 		highlight('alum', module.options.alumColor.value, module.options.alumColorHover.value);
+	}
+};
+
+module.go = () => {
+	const username = loggedInUser();
+	if (module.options.highlightSelf.value && username) {
+		highlight(`author[href$="/${username}"]`, module.options.selfColor.value, module.options.selfColorHover.value);
 	}
 };
 
@@ -390,7 +418,7 @@ function generateHoverColor(color) { // generate a darker color
 }
 
 function generateHoverColors() { // apply generateHoverColor on all option
-	const options = ['OPColor', 'adminColor', 'friendColor', 'modColor', 'firstCommentColor', 'alumColor'];
+	const options = ['selfColor', 'OPColor', 'adminColor', 'friendColor', 'modColor', 'firstCommentColor', 'alumColor'];
 	let error = false;
 	for (const option of options) {
 		const newColor = generateHoverColor(SettingsConsole.getOptionValue('userHighlight', option));

--- a/lib/modules/userHighlight.js
+++ b/lib/modules/userHighlight.js
@@ -4,7 +4,8 @@ import { Module } from '../core/module';
 import {
 	Alert,
 	addCSS,
-	hashCode,
+    hashCode,
+    loggedInUser,
 	watchForThings,
 } from '../utils';
 import { i18n } from '../environment';
@@ -212,7 +213,8 @@ module.beforeLoad = () => {
 	}
 
 	if (module.options.highlightFriend.value) {
-		highlight('friend', module.options.friendColor.value, module.options.friendColorHover.value);
+        highlight('friend', module.options.friendColor.value, module.options.friendColorHover.value);
+        highlightUser(loggedInUser()); // Also highlight "me"
 	}
 	if (module.options.highlightOP.value) {
 		highlight('submitter', module.options.OPColor.value, module.options.OPColorHover.value);

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -3614,6 +3614,24 @@
 	"redditUserInfoHideTitle": {
 		"message": "Hide Native Tooltip"
 	},
+	"userHighlightHighlightSelfTitle": {
+		"message": "Highlight Self"
+	},
+	"userHighlightHighlightSelfDesc": {
+		"message": "Highlight the logged in user's comments."
+	},
+	"userHighlightSelfColorTitle": {
+		"message": "Self Color"
+	},
+	"userHighlightSelfColorDesc": {
+		"message": "Color to use to highlight the logged in user."
+	},
+	"userHighlightSelfColorHoverTitle": {
+		"message": "Self Color Hover"
+	},
+	"userHighlightSelfColorHoverDesc": {
+		"message": "Color used to highlight the logged in user on hover."
+	},
 	"userHighlightHighlightOPTitle": {
 		"message": "Highlight OP"
 	},


### PR DESCRIPTION
Maybe ok for fixing #1666 ... "Me" also gets highlighted when the friends highlighting is active. That avoids having to create an extra option just for that.

Edit(erikdesjardins): fixes #1666