### PR TITLE
Move requestIdleCallback shim to be Edge-specific

### DIFF
--- a/edge/edge.entry.js
+++ b/edge/edge.entry.js
@@ -77,3 +77,7 @@ if (!('isIntersecting' in IntersectionObserverEntry.prototype)) {
 			},
 		});
 }
+
+if (typeof requestIdleCallback === 'undefined') {
+	window.requestIdleCallback = fn => requestAnimationFrame(() => { requestAnimationFrame(fn); });
+}

--- a/lib/utils/async.js
+++ b/lib/utils/async.js
@@ -273,8 +273,6 @@ export function frameThrottle(callback) {
 /**
  * Returns a wrapper function, similar to _.throttle, that will only invoke the latest `callback` in the next upcoming idle period.
  *
- * For browsers that don't support requestIdleCallback, an approximation for "Don't do anything this frame" is provided.
- *
  * `callback` will be invoked with the arguments provided to the most recent call of the wrapper function.
  * @param {function(...*): void} callback
  * @returns {function(...*): void}
@@ -282,11 +280,6 @@ export function frameThrottle(callback) {
 export function idleThrottle<Fn:(...args: any) => void>(callback: Fn): Fn {
 	let args = [];
 	let queued = false;
-
-	// Firefox does not support `requestIdleCallback` from the extension environment
-	const requestIdle = process.env.BUILD_TARGET !== 'firefox' && window.requestIdleCallback ?
-		window.requestIdleCallback :
-		fn => requestAnimationFrame(() => { requestAnimationFrame(fn); });
 
 	function runCallback() {
 		queued = false;
@@ -299,6 +292,6 @@ export function idleThrottle<Fn:(...args: any) => void>(callback: Fn): Fn {
 		if (queued) return;
 		queued = true;
 
-		requestIdle(runCallback);
+		requestIdleCallback(runCallback);
 	}: any);
 }


### PR DESCRIPTION
Tested in browser: Chrome 60, Firefox 55

It appears that requestIdleCallback now works in extension context in Firefox