### PR TITLE
imgur: option to prefer gif over gifv (#1803)

### DIFF
--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -15,7 +15,7 @@ export default new Host('imgur', {
 			value: true,
 			type: 'boolean',
 		},
-		'Use GIF instead of GIFV': {
+		useGifOverGifv: {
 			title: 'imgurUseGifOverGifVTitle',
 			description: 'imgurUseGifOverGifVDesc',
 			value: false,
@@ -174,9 +174,10 @@ export default new Host('imgur', {
 		const baseUrl = 'https://imgur.com/';
 		const shareLinkPreferred = this.options.preferredImgurLink.value === 'share';
 		const resolutionSuffix = this.options.imgurImageResolution.value;
+		const useGif = this.options.useGifOverGifv.value;
 
 		const info = await getInfo();
-		const useGif = this.options['Use GIF instead of GIFV'].value;
+		
 
 		if (info.images && info.images.length) {
 			return _handleAlbum(href, info);

--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -15,6 +15,12 @@ export default new Host('imgur', {
 			value: true,
 			type: 'boolean',
 		},
+		'Use GIF instead of GIFV': {
+			title: 'imgurUseGifOverGifVTitle',
+			description: 'imgurUseGifOverGifVDesc',
+			value: false,
+			type: 'boolean',
+		},
 		preferredImgurLink: {
 			title: 'imgurPreferredImgurLinkTitle',
 			description: 'imgurPreferredImgurLinkDesc',
@@ -170,10 +176,11 @@ export default new Host('imgur', {
 		const resolutionSuffix = this.options.imgurImageResolution.value;
 
 		const info = await getInfo();
+		const useGif = this.options['Use GIF instead of GIFV'].value;
 
 		if (info.images && info.images.length) {
 			return _handleAlbum(href, info);
-		} else if (info.gifv) {
+		} else if (info.gifv && !useGif) {
 			return _handleGifv(info);
 		} else if (info.link) {
 			return _handleSingleImage(info);
@@ -187,7 +194,7 @@ export default new Host('imgur', {
 				title: info.title,
 				caption: info.description,
 				src: info.images.map(info => ({
-					...(info.gifv ?
+					...(info.gifv && !useGif ?
 							_handleGifv(info) :
 							_handleSingleImage(info)
 					),

--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -177,7 +177,6 @@ export default new Host('imgur', {
 		const useGif = this.options.useGifOverGifv.value;
 
 		const info = await getInfo();
-		
 
 		if (info.images && info.images.length) {
 			return _handleAlbum(href, info);

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -4022,6 +4022,12 @@
 	"imgurPreferResAlbumsDesc": {
 		"message": "Prefer RES support for imgur albums rather than reddit's built in support."
 	},
+	"imgurUseGifOverGifVTitle": {
+		"message": "Use GIFs instead of GIFV"
+	},
+	"imgurUseGifOverGifVDesc": {
+		"message": "Use GIFs in place of GIFV for imgur links"
+	},
 	"imgurPreferredImgurLinkTitle": {
 		"message": "Preferred Imgur Link"
 	},


### PR DESCRIPTION
- Add new imgur option to use gif in place of gifv for imgur links
- Update imgur host to use new option to either request gifv or gif

<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: fixes #1803
Tested in browser: Chrome
