### PR TITLE
Don't add candystripe inside spoiler selfpost text

### DIFF
--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -18,10 +18,7 @@ img {
 	pointer-events: none;
 }
 
-.expando-button {
-	cursor: pointer;
-	user-select: none;
-
+.title ~ .expando-button {
 	.res-showImages-highlightSpoilerButton .thing.spoiler &::before {
 		@extend %expando-button-overlay;
 		background-image: linear-gradient(45deg, rgba(255, 130, 0, .3) 25%, transparent 25%, transparent 50%, rgba(255, 130, 0, .3) 50%, rgba(255, 130, 0, .3) 75%, transparent 75%, transparent);
@@ -31,6 +28,11 @@ img {
 		@extend %expando-button-overlay;
 		background-image: linear-gradient(45deg, rgba(255, 0, 0, .15) 25%, transparent 25%, transparent 50%, rgba(255, 0, 0, .15) 50%, rgba(255, 0, 0, .15) 75%, transparent 75%, transparent);
 	}
+}
+
+.expando-button {
+	cursor: pointer;
+	user-select: none;
 
 	&.image,
 	&.video-muted,

--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -330,6 +330,7 @@ async function toggleSubredditStyle(toggle, subreddit = currentSubreddit()) {
 
 		BodyClasses.toggle(toggle, 'res-srstyle-enabled');
 		BodyClasses.toggle(!toggle, 'res-srstyle-disabled');
+		BodyClasses.toggle(!toggle, 'no-subreddit-style');
 
 		// wait for nightmode to react to subreddit style toggle
 		// so `isNightmodeCompatible` check below is accurate

--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -303,7 +303,7 @@ const makeStyleToggle = _.once(() => {
 export async function toggleSubredditStyleIfNecessary() {
 	const subreddit = currentSubreddit();
 	if (!subreddit) {
-		BodyClasses.add('no-subreddit-style');
+		BodyClasses.add('res-srstyle-disabled');
 		return;
 	}
 
@@ -331,7 +331,6 @@ async function toggleSubredditStyle(toggle, subreddit = currentSubreddit()) {
 
 		BodyClasses.toggle(toggle, 'res-srstyle-enabled');
 		BodyClasses.toggle(!toggle, 'res-srstyle-disabled');
-		BodyClasses.toggle(!toggle, 'no-subreddit-style');
 
 		// wait for nightmode to react to subreddit style toggle
 		// so `isNightmodeCompatible` check below is accurate

--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -303,6 +303,7 @@ const makeStyleToggle = _.once(() => {
 export async function toggleSubredditStyleIfNecessary() {
 	const subreddit = currentSubreddit();
 	if (!subreddit) {
+		BodyClasses.toggle(!toggle, 'no-subreddit-style');
 		return;
 	}
 

--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -303,7 +303,7 @@ const makeStyleToggle = _.once(() => {
 export async function toggleSubredditStyleIfNecessary() {
 	const subreddit = currentSubreddit();
 	if (!subreddit) {
-		BodyClasses.toggle(!toggle, 'no-subreddit-style');
+		BodyClasses.add('no-subreddit-style');
 		return;
 	}
 

--- a/lib/modules/stylesheet.js
+++ b/lib/modules/stylesheet.js
@@ -227,7 +227,7 @@ function applyLoggedInUserClass() {
 		BodyClasses.add(`res-me-${name}`);
 	}
 }
-
+//NDK TODO: Going to need to apply classes?
 function applyBodyClasses() {
 	const addClasses = module.options.bodyClasses.value
 		.filter(row => shouldApply(row[3], row[1], row[2]))

--- a/lib/modules/stylesheet.js
+++ b/lib/modules/stylesheet.js
@@ -227,7 +227,7 @@ function applyLoggedInUserClass() {
 		BodyClasses.add(`res-me-${name}`);
 	}
 }
-//NDK TODO: Going to need to apply classes?
+
 function applyBodyClasses() {
 	const addClasses = module.options.bodyClasses.value
 		.filter(row => shouldApply(row[3], row[1], row[2]))


### PR DESCRIPTION
Made the selector stricter so that only expandos that are siblings of NSFW/spoiler post title divs will get candystripe.

Relevant issue: fixes #4016 
Tested in browser: Chrome
