### PR TITLE
Don't add candystripe inside spoiler selfpost text

### DIFF
--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -18,10 +18,7 @@ img {
 	pointer-events: none;
 }
 
-.expando-button {
-	cursor: pointer;
-	user-select: none;
-
+.title ~ .expando-button {
 	.res-showImages-highlightSpoilerButton .thing.spoiler &::before {
 		@extend %expando-button-overlay;
 		background-image: linear-gradient(45deg, rgba(255, 130, 0, .3) 25%, transparent 25%, transparent 50%, rgba(255, 130, 0, .3) 50%, rgba(255, 130, 0, .3) 75%, transparent 75%, transparent);
@@ -31,6 +28,11 @@ img {
 		@extend %expando-button-overlay;
 		background-image: linear-gradient(45deg, rgba(255, 0, 0, .15) 25%, transparent 25%, transparent 50%, rgba(255, 0, 0, .15) 50%, rgba(255, 0, 0, .15) 75%, transparent 75%, transparent);
 	}
+}
+
+.expando-button {
+	cursor: pointer;
+	user-select: none;
 
 	&.image,
 	&.video-muted,


### PR DESCRIPTION
Made the selector stricter so that only expandos that are siblings of NSFW/spoiler post title divs will get candystripe.

Relevant issue: fixes #4016
Tested in browser: Chrome

