### PR TITLE
ci: Remove now-unneeded `--` in yarn scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,18 +42,18 @@ matrix:
   include:
     - env: RES_JOB=lint_flow
       script:
-        - yarn run flow -- check --show-all-errors
+        - yarn run flow check --show-all-errors
         - yarn run eslint
         - yarn run sass-lint
         - yarn run i18n-lint
     - env: RES_JOB=test
       script:
         - yarn run coverage && yarn run report-coverage
-        - yarn run build -- chrome,firefox
-        - yarn run integration -- chrome --retries 2 && yarn run integration -- firefox --retries 2
+        - yarn run build chrome,firefox
+        - yarn run integration chrome --retries 2 && yarn run integration firefox --retries 2
     - env: RES_JOB=build_deploy
       script:
-        - yarn run build -- all
+        - yarn run build all
         - yarn run manifoldjs-package
       deploy:
         - provider: releases

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,4 +9,4 @@ install:
   - yarn install --frozen-lockfile
 test_script:
   - yarn test
-  - yarn run build -- all
+  - yarn run build all


### PR DESCRIPTION
In fact, a future version of `yarn` will actually pass `--` to scripts.
Delay this until `yarn` on Travis reaches v1.0.0, or if we switch back to version pinning for Yarn.