### PR TITLE
hideLink replacement: Collapse native expando manually

### DIFF
--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -20,6 +20,7 @@ import {
 	watchForElements,
 } from '../utils';
 import { ajax } from '../environment';
+import { Expando } from './showImages/expando';
 import { isSettingsUrl } from './settingsNavigation';
 import * as AccountSwitcher from './accountSwitcher';
 import * as SubredditManager from './subredditManager';
@@ -280,6 +281,10 @@ function hideLink(clickedLink, action = clickedLink.getAttribute('action')) {
 	const thing = Thing.checkedFrom(clickedLink);
 
 	if (action === 'hide') {
+		// Native expandos does not know that the post is being hidden, so collapse them manually
+		const expando = Expando.getEntryExpandoFrom(thing);
+		if (expando && expando.getTypes().includes('native')) expando.collapse();
+
 		if (timeout === null) $(thing.element).hide();
 		else hideTimer.set(clickedLink, setTimeout(() => $(thing.element).fadeOut(300), timeout));
 	}


### PR DESCRIPTION
Since it wouldn't be done otherwise, sometimes letting audio continue playing in the background.

Relevant issue: https://www.reddit.com/r/RESissues/comments/73ie7w/videos_keep_playing_after_hiding_the_post/
