### PR TITLE
showImages: Don't preload Wikipedia resources on handleLink

### DIFF
--- a/lib/modules/hosts/wikipedia.js
+++ b/lib/modules/hosts/wikipedia.js
@@ -52,16 +52,22 @@ export default new Host('wikipedia', {
 		});
 
 		// Clean up returned data
-		const $wikiData = $('<div>', { html: data.parse.text['*'] });
+		// `document.implementation.createHTMLDocument` won't preload linked resources
+		const cleanDoc = document.implementation.createHTMLDocument();
+		cleanDoc.body.innerHTML = data.parse.text['*'];
+
 		// Remove unwanted sections
-		$wikiData.find('.metadata, .hatnote, .mw-editsection, .mwe-math-mathml-inline, .reference, .references').remove();
+		for (const e of cleanDoc.querySelectorAll('.metadata, .hatnote, .mw-editsection, .mwe-math-mathml-inline, .reference, .references')) e.remove();
+
 		// Update all links to use the article's URL as baseURL
-		$wikiData.find('a').attr('href', (i, old) => new URL(old, `https://${language}.wikipedia.org/wiki/${article}`).href);
+		for (const e of cleanDoc.querySelectorAll('a')) {
+			e.href = new URL(e.getAttribute('href'), `https://${language}.wikipedia.org/wiki/${article}`).href;
+		}
 
 		return {
 			type: 'TEXT',
 			title: $('<div>', { html: data.parse.displaytitle || data.parse.title }).text(), // get title without html (jquery got quite unhappy when brackets appeared)
-			src: $wikiData[0].outerHTML,
+			src: cleanDoc.body.innerHTML,
 		};
 	},
 });


### PR DESCRIPTION
When parsed by jQuery it would start fetching images which quite often wouldn't be displayed.

Tested in browser: Chrome 63, Firefox 56