### PR TITLE
added custom lint rule for property name spaces

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -125,7 +125,7 @@
 		"no-restricted-globals": [2, "alert"],
 		"no-restricted-imports": [2, "jquery"], // import it from vendor/ instead
 		"no-restricted-modules": 0, // see import/no-nodejs-modules
-		"no-restricted-syntax": [2, "ForStatement"], // use for..of or Array.prototype methods
+		"no-restricted-syntax": [2, "ForStatement", "Property > Literal.key[raw=/ /]"], // use for..of or Array.prototype methods, no spaces in property names
 		"no-shadow": 0,
 		"no-sync": 0,
 		"no-tabs": 0,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -125,7 +125,16 @@
 		"no-restricted-globals": [2, "alert"],
 		"no-restricted-imports": [2, "jquery"], // import it from vendor/ instead
 		"no-restricted-modules": 0, // see import/no-nodejs-modules
-		"no-restricted-syntax": [2, "ForStatement", "Property > Literal.key[raw=/ /]"], // use for..of or Array.prototype methods, no spaces in property names
+		"no-restricted-syntax": [2, {
+			"selector": "ForStatement",
+			"message": "No C-style for-loops, use for..of or Array.prototype methods."
+		}, {
+			"selector": "AssignmentExpression[left.property.name='options'] > ObjectExpression > Property > Literal.key[value=/ /]",
+			"message": "No spaces in option names."
+		}, {
+			"selector": "Property[key.name='options'] > ObjectExpression > Property > Literal.key[value=/ /]",
+			"message": "No spaces in option names."
+		}],
 		"no-shadow": 0,
 		"no-sync": 0,
 		"no-tabs": 0,


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: fixes #4461 
Tested in browser: chrome

I added a `no-restricted-syntax` value with an AST selector that looks for object property names with spaces in them.

Running the lint there are ~60 errors thrown. Some of them seem reasonable, like test names.

Is there a good way to restrict this rule to only directories where we care about not having spaces in property names?
