### PR TITLE
Don't notify No Participation when reverting vote

### DIFF
--- a/lib/modules/noParticipation.js
+++ b/lib/modules/noParticipation.js
@@ -206,7 +206,11 @@ function applyNoParticipationMode() {
 }
 
 function watchForVote() {
-	$(document.body).on('click', '.arrow', (e: Event) => notifyNoVote(e.target));
+	$(document.body).on('click', '.arrow', (e: Event) => {
+		if (e.target.classList.contains('up') || e.target.classList.contains('down')) {
+			notifyNoVote(e.target);
+		}
+	});
 }
 
 function revertVote(voteButtons) {


### PR DESCRIPTION
Manually reverting a vote shouldn't trigger the No Participation notification.