### PR TITLE
Use optional permissions in Firefox

### DIFF
--- a/chrome/beta/manifest.json
+++ b/chrome/beta/manifest.json
@@ -71,7 +71,7 @@
 	"optional_permissions": [
 		"downloads",
 
-		"https://api.twitter.com/*",
+		"https://api.twitter.com/1/statuses/oembed.json",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
 		"https://codepen.io/api/oembed",

--- a/chrome/beta/manifest.json
+++ b/chrome/beta/manifest.json
@@ -79,7 +79,6 @@
 		"https://xkcd.com/*/info.0.json",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
 		"https://content.googleapis.com/drive/v3/*",
-
 		"https://redditenhancementsuite.com/oauth",
 		"https://accounts.google.com/o/oauth2/v2/auth",
 		"https://www.dropbox.com/oauth2/authorize",

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -71,7 +71,7 @@
 	"optional_permissions": [
 		"downloads",
 
-		"https://api.twitter.com/*",
+		"https://api.twitter.com/1/statuses/oembed.json",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
 		"https://codepen.io/api/oembed",

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -79,7 +79,6 @@
 		"https://xkcd.com/*/info.0.json",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
 		"https://content.googleapis.com/drive/v3/*",
-
 		"https://redditenhancementsuite.com/oauth",
 		"https://accounts.google.com/o/oauth2/v2/auth",
 		"https://www.dropbox.com/oauth2/authorize",

--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -72,6 +72,10 @@
 		"https://xkcd.com/*/info.0.json",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
 		"https://content.googleapis.com/drive/v3/*",
+		"https://redditenhancementsuite.com/oauth",
+		"https://accounts.google.com/o/oauth2/v2/auth",
+		"https://www.dropbox.com/oauth2/authorize",
+		"https://login.live.com/oauth20_authorize.srf",
 
 		"https://api.photobucket.com/v2/media/fromurl",
 		"https://api.onedrive.com/*",

--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -64,7 +64,7 @@
 		"storage",
 		"unlimitedStorage",
 
-		"https://api.twitter.com/*",
+		"https://api.twitter.com/1/statuses/oembed.json",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
 		"https://codepen.io/api/oembed",

--- a/firefox/beta/manifest.json
+++ b/firefox/beta/manifest.json
@@ -72,7 +72,7 @@
 		"unlimitedStorage",
 		"downloads",
 
-		"https://api.twitter.com/*",
+		"https://api.twitter.com/1/statuses/oembed.json",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
 		"https://codepen.io/api/oembed",

--- a/firefox/beta/manifest.json
+++ b/firefox/beta/manifest.json
@@ -70,8 +70,9 @@
 		"history",
 		"storage",
 		"unlimitedStorage",
-		"downloads",
-
+		"downloads"
+	],
+	"optional_permissions": [
 		"https://api.twitter.com/1/statuses/oembed.json",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
@@ -79,6 +80,10 @@
 		"https://api.tumblr.com/v2/blog/*/posts",
 		"https://xkcd.com/*/info.0.json",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
-		"https://content.googleapis.com/drive/v3/*"
+		"https://content.googleapis.com/drive/v3/*",
+		"https://redditenhancementsuite.com/oauth",
+		"https://accounts.google.com/o/oauth2/v2/auth",
+		"https://www.dropbox.com/oauth2/authorize",
+		"https://login.live.com/oauth20_authorize.srf"
 	]
 }

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -72,7 +72,7 @@
 		"unlimitedStorage",
 		"downloads",
 
-		"https://api.twitter.com/*",
+		"https://api.twitter.com/1/statuses/oembed.json",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
 		"https://codepen.io/api/oembed",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -70,8 +70,9 @@
 		"history",
 		"storage",
 		"unlimitedStorage",
-		"downloads",
-
+		"downloads"
+	],
+	"optional_permissions": [
 		"https://api.twitter.com/1/statuses/oembed.json",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
@@ -79,6 +80,10 @@
 		"https://api.tumblr.com/v2/blog/*/posts",
 		"https://xkcd.com/*/info.0.json",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
-		"https://content.googleapis.com/drive/v3/*"
+		"https://content.googleapis.com/drive/v3/*",
+		"https://redditenhancementsuite.com/oauth",
+		"https://accounts.google.com/o/oauth2/v2/auth",
+		"https://www.dropbox.com/oauth2/authorize",
+		"https://login.live.com/oauth20_authorize.srf"
 	]
 }

--- a/lib/environment/background/permissions.js
+++ b/lib/environment/background/permissions.js
@@ -4,7 +4,7 @@ import { apiToPromise } from '../utils/api';
 import { addListener } from './messaging';
 
 addListener('permissions', ({ operation, permissions, origins }) => {
-	if (process.env.BUILD_TARGET === 'chrome') {
+	if (process.env.BUILD_TARGET === 'chrome' || process.env.BUILD_TARGET === 'firefox') {
 		switch (operation) {
 			case 'contains':
 				return apiToPromise(chrome.permissions.contains)({ permissions, origins });
@@ -13,7 +13,7 @@ addListener('permissions', ({ operation, permissions, origins }) => {
 			default:
 				throw new Error(`Invalid permissions operation: ${operation}`);
 		}
-	} else if (process.env.BUILD_TARGET === 'firefox' || process.env.BUILD_TARGET === 'edge') {
+	} else if (process.env.BUILD_TARGET === 'edge') {
 		return true;
 	}
 });

--- a/lib/modules/hosts/twitter.js
+++ b/lib/modules/hosts/twitter.js
@@ -8,7 +8,7 @@ import { ajax } from '../../environment';
 export default new Host('twitter', {
 	name: 'twitter',
 	domains: ['twitter.com'],
-	permissions: ['https://api.twitter.com/*'],
+	permissions: ['https://api.twitter.com/1/statuses/oembed.json'],
 	attribution: false,
 	detect: ({ href }) => (/^https?:\/\/(?:mobile\.)?twitter\.com\/(?:#!\/)?[\w]+\/status(?:es)?\/([\d]+)/i).exec(href),
 	async handleLink(href, [, id]) {


### PR DESCRIPTION
Tested in browser: ~~Firefox 55~~

Can't work until https://bugzilla.mozilla.org/show_bug.cgi?id=1398833 or similar is fixed. (e.g. https://bugzilla.mozilla.org/show_bug.cgi?id=1392624 also deals with propagating the user interaction bit)

Firefox currently requires permissions to be requested synchronously from inside an event handler. But content scripts (where our event handlers are) can't use the permissions API, only the background page and extension-generated pages (popups, options UI, etc.) can. And the content script can only communicate with these pages asynchronously.