### PR TITLE
Remove now-unnecessary onedrive.live and 1drv permissions

### DIFF
--- a/chrome/beta/manifest.json
+++ b/chrome/beta/manifest.json
@@ -69,8 +69,6 @@
 	],
 	"optional_permissions": [
 		"https://api.twitter.com/*",
-		"https://onedrive.live.com/*",
-		"https://1drv.ms/*",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
 		"https://codepen.io/api/oembed",

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -69,8 +69,6 @@
 	],
 	"optional_permissions": [
 		"https://api.twitter.com/*",
-		"https://onedrive.live.com/*",
-		"https://1drv.ms/*",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
 		"https://codepen.io/api/oembed",

--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -66,8 +66,6 @@
 		"unlimitedStorage",
 
 		"https://api.twitter.com/*",
-		"https://onedrive.live.com/*",
-		"https://1drv.ms/*",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
 		"https://codepen.io/api/oembed",

--- a/firefox/beta/manifest.json
+++ b/firefox/beta/manifest.json
@@ -72,8 +72,6 @@
 		"downloads",
 
 		"https://api.twitter.com/*",
-		"https://onedrive.live.com/*",
-		"https://1drv.ms/*",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
 		"https://codepen.io/api/oembed",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -72,8 +72,6 @@
 		"downloads",
 
 		"https://api.twitter.com/*",
-		"https://onedrive.live.com/*",
-		"https://1drv.ms/*",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
 		"https://codepen.io/api/oembed",

--- a/lib/modules/hosts/onedrive.js
+++ b/lib/modules/hosts/onedrive.js
@@ -6,7 +6,6 @@ import { ajax } from '../../environment';
 
 export default new Host('onedrive', {
 	domains: ['onedrive.live.com', '1drv.ms'],
-	permissions: ['https://1drv.ms/*', 'https://onedrive.live.com/*'],
 	name: 'Microsoft OneDrive',
 	detect: () => true,
 	async handleLink(href) {


### PR DESCRIPTION
Tested in browser: Chrome 60, Edge 16

After #4203 we no longer need to use non-CORS endpoints.