### PR TITLE
Adding Comment Navigator feature - "Auto-IAmA"

### DIFF
--- a/lib/modules/commentNavigator.js
+++ b/lib/modules/commentNavigator.js
@@ -219,7 +219,7 @@ module.go = () => {
 	}
 };
 
-let currentCategory = isCurrentSubreddit('IAmA') ? 'IAmA' : '';
+let currentCategory = isCurrentSubreddit('IAmA', 'casualiama') ? 'IAmA' : '';
 
 function onScroll() {
 	const category = currentCategory;
@@ -302,8 +302,11 @@ export function toggleNavigator() {
 }
 
 export function refreshCurrentCategoryPosts() {
-	_posts[currentCategory] = sortTypes[currentCategory] ? sortTypes[currentCategory].getPosts() : sortTypes[currentCategory];
-	resetNavigator(currentCategory);
+	if (currentCategory) {
+		if (!_posts[currentCategory] || currentCategory === 'highlighted') {
+			_posts[currentCategory] = sortTypes[currentCategory].getPosts();
+		}
+	}
 }
 
 function resetNavigator(category) {

--- a/lib/modules/commentNavigator.js
+++ b/lib/modules/commentNavigator.js
@@ -13,6 +13,7 @@ import {
 	scrollToElement,
 	string,
 	waitForEvent,
+	isCurrentSubreddit,
 } from '../utils';
 import * as Floater from './floater';
 import * as UserInfo from './userInfo';
@@ -28,6 +29,13 @@ module.options = {
 		value: false,
 		description: 'commentNavigatorShowByDefaultDesc',
 		title: 'commentNavigatorShowByDefaultTitle',
+	},
+	autoNavigateByIama: {
+		type: 'boolean',
+		value: true,
+		description: 'commentNavigatorAutoNavigateByIamaUserDesc',
+		title: 'commentNavigatorAutoNavigateByIamaUserTitle',
+		dependsOn: options => options.showByDefault.value,
 	},
 	openOnHighlightUser: {
 		type: 'boolean',
@@ -214,7 +222,11 @@ module.go = () => {
 	});
 
 	if (module.options.showByDefault.value) {
-		commentNav();
+		if (module.options.autoNavigateByIama.value && isCurrentSubreddit('IAmA')) {
+			showNavigator('IAmA', true);
+		} else {
+			commentNav();
+		}
 	}
 };
 
@@ -236,14 +248,14 @@ function onScroll() {
 	}
 }
 
-function changeCategory() {
+function changeCategory(suppressAutoScroll: boolean = false) {
 	const index = commentNav().select.selectedIndex;
 	if (index === -1) {
 		return;
 	}
 	currentCategory = (commentNav().select.options.item(index).value: any);
 	if (currentCategory !== '') {
-		getPostsByCategory();
+		getPostsByCategory(suppressAutoScroll);
 		commentNav().buttons.style.display = 'block';
 	} else {
 		commentNav().buttons.style.display = 'none';
@@ -253,7 +265,7 @@ function changeCategory() {
 
 let isOpen = false;
 
-export function showNavigator(category: $Keys<typeof sortTypes> | '' = currentCategory) {
+export function showNavigator(category: $Keys<typeof sortTypes> | '' = currentCategory, suppressAutoScroll: boolean = false) {
 	isOpen = true;
 	commentNav().box.style.display = 'block';
 
@@ -265,7 +277,7 @@ export function showNavigator(category: $Keys<typeof sortTypes> | '' = currentCa
 		commentNav().select.selectedIndex = parseInt(category, 10);
 	}
 	$('#commentNavBy').focus();
-	changeCategory();
+	changeCategory(suppressAutoScroll);
 }
 
 export function hideNavigator() {
@@ -281,19 +293,21 @@ export function toggleNavigator() {
 	}
 }
 
-export function getPostsByCategory() {
+export function getPostsByCategory(suppressAutoScroll: boolean = false) {
 	if (currentCategory) {
 		if (!_posts[currentCategory] || currentCategory === 'highlighted') {
 			_posts[currentCategory] = sortTypes[currentCategory].getPosts();
 		}
-		resetNavigator(currentCategory);
+		resetNavigator(currentCategory, suppressAutoScroll);
 	}
 }
 
-function resetNavigator(category) {
+function resetNavigator(category, suppressAutoScroll: boolean = false) {
 	_nav[category] = 0;
 	if (_posts[category] && _posts[category].length) {
-		scrollToNavElement();
+		if (!suppressAutoScroll) {
+			scrollToNavElement();
+		}
 		commentNav().up.disabled = false;
 		commentNav().down.disabled = false;
 		commentNav().buttons.classList.remove('noNav');

--- a/lib/modules/commentNavigator.js
+++ b/lib/modules/commentNavigator.js
@@ -30,13 +30,6 @@ module.options = {
 		description: 'commentNavigatorShowByDefaultDesc',
 		title: 'commentNavigatorShowByDefaultTitle',
 	},
-	autoNavigateByIama: {
-		type: 'boolean',
-		value: true,
-		description: 'commentNavigatorAutoNavigateByIamaUserDesc',
-		title: 'commentNavigatorAutoNavigateByIamaUserTitle',
-		dependsOn: options => options.showByDefault.value,
-	},
 	openOnHighlightUser: {
 		type: 'boolean',
 		value: true,
@@ -222,15 +215,11 @@ module.go = () => {
 	});
 
 	if (module.options.showByDefault.value) {
-		if (module.options.autoNavigateByIama.value && isCurrentSubreddit('IAmA')) {
-			showNavigator('IAmA');
-		} else {
-			commentNav();
-		}
+		showNavigator();
 	}
 };
 
-let currentCategory = '';
+let currentCategory = isCurrentSubreddit('IAmA') ? 'IAmA' : '';
 
 function onScroll() {
 	const category = currentCategory;
@@ -248,22 +237,37 @@ function onScroll() {
 	}
 }
 
+function enableControls() {
+	commentNav().up.disabled = false;
+	commentNav().down.disabled = false;
+	commentNav().buttons.classList.remove('noNav');
+}
+
+function disableControls() {
+	commentNav().up.disabled = true;
+	commentNav().down.disabled = true;
+	commentNav().buttons.classList.add('noNav');
+}
+
 function changeCategory() {
 	const index = commentNav().select.selectedIndex;
 	if (index === -1) {
 		return;
 	}
-	const newCategory = (commentNav().select.options.item(index).value: any);
-	if (newCategory !== currentCategory) {
-		resetNavigator(newCategory);
+	const previousCategory = currentCategory;
+	currentCategory = (commentNav().select.options.item(index).value: any);
+	refreshCurrentCategoryPosts();
+	if (previousCategory !== currentCategory) {
+		resetNavigator(currentCategory);
 	}
-	if (newCategory !== '') {
-		getPostsByCategory();
+	if (currentCategory !== '') {
 		commentNav().buttons.style.display = 'block';
+		enableControls();
 	} else {
 		commentNav().buttons.style.display = 'none';
+		disableControls();
 	}
-	currentCategory = newCategory;
+
 	$('#commentNavBy').blur();
 }
 
@@ -297,26 +301,19 @@ export function toggleNavigator() {
 	}
 }
 
-export function getPostsByCategory() {
-	if (currentCategory) {
-		if (!_posts[currentCategory] || currentCategory === 'highlighted') {
-			_posts[currentCategory] = sortTypes[currentCategory].getPosts();
-		}
-	}
+export function refreshCurrentCategoryPosts() {
+	_posts[currentCategory] = sortTypes[currentCategory] ? sortTypes[currentCategory].getPosts() : sortTypes[currentCategory];
+	resetNavigator(currentCategory);
 }
 
 function resetNavigator(category) {
 	_nav[category] = 0;
 	if (_posts[category] && _posts[category].length) {
 		scrollToNavElement();
-		commentNav().up.disabled = false;
-		commentNav().down.disabled = false;
-		commentNav().buttons.classList.remove('noNav');
+		enableControls();
 	} else {
 		commentNav().postCount.textContent = 'none';
-		commentNav().up.disabled = true;
-		commentNav().down.disabled = true;
-		commentNav().buttons.classList.add('noNav');
+		disableControls();
 	}
 }
 

--- a/lib/modules/commentNavigator.js
+++ b/lib/modules/commentNavigator.js
@@ -223,7 +223,7 @@ module.go = () => {
 
 	if (module.options.showByDefault.value) {
 		if (module.options.autoNavigateByIama.value && isCurrentSubreddit('IAmA')) {
-			showNavigator('IAmA', true);
+			showNavigator('IAmA');
 		} else {
 			commentNav();
 		}
@@ -248,24 +248,28 @@ function onScroll() {
 	}
 }
 
-function changeCategory(suppressAutoScroll: boolean = false) {
+function changeCategory() {
 	const index = commentNav().select.selectedIndex;
 	if (index === -1) {
 		return;
 	}
-	currentCategory = (commentNav().select.options.item(index).value: any);
-	if (currentCategory !== '') {
-		getPostsByCategory(suppressAutoScroll);
+	const newCategory = (commentNav().select.options.item(index).value: any);
+	if (newCategory !== currentCategory) {
+		resetNavigator(newCategory);
+	}
+	if (newCategory !== '') {
+		getPostsByCategory();
 		commentNav().buttons.style.display = 'block';
 	} else {
 		commentNav().buttons.style.display = 'none';
 	}
+	currentCategory = newCategory;
 	$('#commentNavBy').blur();
 }
 
 let isOpen = false;
 
-export function showNavigator(category: $Keys<typeof sortTypes> | '' = currentCategory, suppressAutoScroll: boolean = false) {
+export function showNavigator(category: $Keys<typeof sortTypes> | '' = currentCategory) {
 	isOpen = true;
 	commentNav().box.style.display = 'block';
 
@@ -277,7 +281,7 @@ export function showNavigator(category: $Keys<typeof sortTypes> | '' = currentCa
 		commentNav().select.selectedIndex = parseInt(category, 10);
 	}
 	$('#commentNavBy').focus();
-	changeCategory(suppressAutoScroll);
+	changeCategory();
 }
 
 export function hideNavigator() {
@@ -293,21 +297,18 @@ export function toggleNavigator() {
 	}
 }
 
-export function getPostsByCategory(suppressAutoScroll: boolean = false) {
+export function getPostsByCategory() {
 	if (currentCategory) {
 		if (!_posts[currentCategory] || currentCategory === 'highlighted') {
 			_posts[currentCategory] = sortTypes[currentCategory].getPosts();
 		}
-		resetNavigator(currentCategory, suppressAutoScroll);
 	}
 }
 
-function resetNavigator(category, suppressAutoScroll: boolean = false) {
+function resetNavigator(category) {
 	_nav[category] = 0;
 	if (_posts[category] && _posts[category].length) {
-		if (!suppressAutoScroll) {
-			scrollToNavElement();
-		}
+		scrollToNavElement();
 		commentNav().up.disabled = false;
 		commentNav().down.disabled = false;
 		commentNav().buttons.classList.remove('noNav');

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -295,7 +295,7 @@ function toggleUserHighlight(authorInfoToolTipHighlight, userid) {
 		delete highlightedUsers[userid];
 		toggleUserHighlightButton(authorInfoToolTipHighlight, true);
 		if (Modules.isRunning(CommentNavigator) && CommentNavigator.module.options.openOnHighlightUser.value) {
-			CommentNavigator.getPostsByCategory(); // refresh informations
+			CommentNavigator.refreshCurrentCategoryPosts(); // refresh information
 		}
 	} else {
 		highlightedUsers[userid] = UserHighlight.highlightUser(userid);

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -234,12 +234,6 @@
 	"commentNavigatorOpenOnHighlightUserDesc": {
 		"message": "Display Comment Navigator when a user is highlighted."
 	},
-	"commentNavigatorAutoNavigateByIamaUserTitle": {
-		"message": "Auto-IAmA Mode"
-	},
-	"commentNavigatorAutoNavigateByIamaUserDesc": {
-		"message": "Automatically enable IAmA mode when viewing a post on /r/IAmA or /r/casualiama."
-	},
 	"commentPrevName": {
 		"message": "Live Preview"
 	},

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -234,6 +234,12 @@
 	"commentNavigatorOpenOnHighlightUserDesc": {
 		"message": "Display Comment Navigator when a user is highlighted."
 	},
+	"commentNavigatorAutoNavigateByIamaUserTitle": {
+		"message": "Auto-IAmA Mode"
+	},
+	"commentNavigatorAutoNavigateByIamaUserDesc": {
+		"message": "Automatically enable IAmA mode when viewing a post on /r/IAmA or /r/casualiama."
+	},
 	"commentPrevName": {
 		"message": "Live Preview"
 	},


### PR DESCRIPTION
Relevant issue: Adds feature and resolves #1442
Tested in browser: Firefox Developer Edition (Aurora, 57.0b8)

This change adds a setting, Auto-IAmA (`true` by default), which is dependent on Comment Navigator's `showByDefault`. When both are enabled, Comment Navigator appears automatically set to the IAmA setting when the user is browsing comments on r/IAmA or r/casualiama.

Notes:
- I had some issues running Flow check. I'm hoping someone can help if the Travis CI build fails.
- I hope my method of preventing auto-scroll-to-first-comment on page load is not too janky.
- Can someone confirm if I should just copy my new user facing strings as-is to the other localization files?