### PR TITLE
Fix commentPreview getting stuck with top-level textarea contents

### DIFF
--- a/lib/modules/commentPreview.js
+++ b/lib/modules/commentPreview.js
@@ -10,7 +10,9 @@ import * as Modules from '../core/modules';
 import {
 	checkKeysForEvent,
 	currentSubreddit,
+	downcast,
 	isPageType,
+	string,
 } from '../utils';
 import * as CommentTools from './commentTools';
 import * as KeyboardNav from './keyboardNav';
@@ -135,10 +137,14 @@ module.go = () => {
 		$(this).find('.livePreview').hide();
 	});
 
-	if (!isWiki) {
-		$(document.body).on('focus', CommentTools.commentTextareaSelector, attachPreview);
-	} else {
+	if (isWiki) {
 		attachWikiPreview();
+		addBigEditorButton(document.querySelector('.markhelp'));
+	} else {
+		$(document.body).on('focus', CommentTools.commentTextareaSelector, e => {
+			addBigEditorButton(e.target);
+			attachPreview(e.target);
+		});
 	}
 };
 
@@ -240,88 +246,96 @@ function markdownToHTML(md) {
 	}
 }
 
-function makeBigEditorButton() {
-	return $('<button type="button" class="RESBigEditorPop" tabIndex="3"><span class="res-icon res-icon-12">&#xF0A4;</span> big editor</button>');
+function addBigEditorButton(ele) {
+	if (!module.options.enableBigEditor.value) return;
+
+	if (ele.hasAttribute('res-bigEditorButton-initialized')) return;
+	ele.setAttribute('res-bigEditorButton-initialized', '');
+
+	const bigEditorButton = string.html`
+		<button type="button" class="RESBigEditorPop" tabIndex="3">
+			<span class="res-icon res-icon-12">&#xF0A4;</span> big editor
+		</button>
+	`;
+
+	if (isBan || isWiki) {
+		ele.after(bigEditorButton);
+	} else {
+		const container = downcast(ele.closest('.usertext-edit'), HTMLElement);
+		const bottom = container.querySelector('.bottom-area');
+		bottom.prepend(bigEditorButton);
+	}
 }
 
-function attachPreview() {
-	if (this.hasAttribute('commentPreview-initialized')) return;
-	this.setAttribute('commentPreview-initialized', true);
-
-	const $this = $(this);
-	const $usertextContainer = $this.closest('.usertext-edit, #banned');
-
-	if (module.options.enableBigEditor.value) {
-		if (isBan) {
-			makeBigEditorButton().insertAfter($this);
-		} else {
-			makeBigEditorButton().prependTo($usertextContainer.find('.bottom-area'));
-		}
+function attachPreview(ele) {
+	switch (ele.getAttribute('res-commentPreview-state')) {
+		case 'disabled':
+			// previously disabled
+			return;
+		case 'enabled':
+			// previously enabled
+			break;
+		default:
+			if (
+				!module.options.enableForComments.value && ele.closest('.commentarea, .message') ||
+				!module.options.enableForPosts.value && (isPageType('submit') || ele.closest('.link')) ||
+				!module.options.enableForSubredditConfig.value && (/^\/r\/[\-\w.]+\/about\/edit/i).test(location.pathname) ||
+				!module.options.enableForBanMessages.value && isBan
+			) {
+				// avoid repeating this (potentially expensive) check
+				ele.setAttribute('res-commentPreview-state', 'disabled');
+				return;
+			} else {
+				ele.setAttribute('res-commentPreview-state', 'enabled');
+			}
+			break;
 	}
 
-	if (
-		!module.options.enableForComments.value && $this.closest('.commentarea, .message').length ||
-		!module.options.enableForPosts.value && (isPageType('submit') || $this.closest('.link').length) ||
-		!module.options.enableForSubredditConfig.value && (/^\/r\/[\-\w.]+\/about\/edit/i).test(location.pathname) ||
-		!module.options.enableForBanMessages.value && (/^\/r\/[\-\w.]+\/about\/banned/i).test(location.pathname)
-	) {
-		return;
-	}
+	const container = downcast(ele.closest('.usertext-edit, #banned'), HTMLElement);
+	const preview = container.querySelector('.livePreview') || container.appendChild(makePreviewBox());
+	const contents = preview.querySelector('.RESDialogContents');
 
-	const $preview = makePreviewBox();
+	$(ele)
+		.off('input')
+		.on('input', e => onTextareaInput(e, preview, contents));
 
-	$usertextContainer.append($preview);
-
-	const $contents = $preview.find('.RESDialogContents');
-
-	if (module.options.sidebarPreview.value && $this.attr('name') === 'description') {
-		const $sideMd = $('.side .usertext-body .md:first');
-
-		if ($sideMd.length) {
-			$contents.push($sideMd[0]);
-		}
-	}
-
-	$this.on('input', e => onTextareaInput($preview, $contents, e));
-
-	setTimeout(() => $this.trigger('input'), 1);
+	// trigger initial render in case the textarea already has text in it
+	// e.g. if it was copied from the top-level textarea into a comment reply
+	setTimeout(() => $(ele).trigger('input'), 1);
 }
 
 function attachWikiPreview() {
-	if (module.options.enableBigEditor.value) {
-		makeBigEditorButton().insertAfter('.markhelp');
-	}
+	if (!module.options.enableForWiki.value) return;
 
-	if (isPageType('wiki') && module.options.enableForWiki.value) {
-		const preview = makePreviewBox();
-		preview.find('.md').addClass('wiki');
-		preview.insertAfter($('#editform > br').first());
+	const preview = makePreviewBox();
+	preview.querySelector('.md').classList.add('wiki');
+	document.querySelector('#editform > br').after(preview);
+	const contents = preview.querySelector('.RESDialogContents');
 
-		const contents = preview.find('.RESDialogContents');
-		$('#wiki_page_content').on('input', e => onTextareaInput(preview, contents, e));
-	}
+	$('#wiki_page_content').on('input', e => onTextareaInput(e, preview, contents));
 }
 
-const onTextareaInput = _.debounce((preview, contents, event) => {
-	const $textarea = $(event.target);
-	const markdownText = $textarea.val();
+const onTextareaInput = _.debounce((e, preview, contents) => {
+	const markdownText = downcast(e.target, HTMLTextAreaElement).value;
 
 	if (markdownText.length > 0) {
-		preview.show();
+		preview.style.display = '';
 		// SnuOwnd created this HTML from markdown so it is safe.
-		contents.html(markdownToHTML(markdownText));
+		contents.innerHTML = markdownToHTML(markdownText);
 	} else {
-		preview.hide();
-		contents.html('');
+		preview.style.display = 'none';
+		contents.innerHTML = '';
 	}
 }, 250);
 
 function makePreviewBox() {
-	const $previewBox = $('<div style="display: none" class="RESDialogSmall livePreview"><h3>Live Preview</h3><div class="md RESDialogContents"></div></div>');
-	const urlHashLink = SettingsNavigation.makeUrlHashLink(module.moduleID, undefined, ' ', 'gearIcon');
-	$previewBox.find('h3').append(urlHashLink);
-
-	return $previewBox;
+	return string.html`
+		<div style="display: none" class="RESDialogSmall livePreview">
+			<h3>Live Preview</h3>
+			${string.safe(SettingsNavigation.makeUrlHashLink(module.moduleID, undefined, ' ', 'gearIcon'))}
+			<div class="md RESDialogContents"></div>
+		</div>
+	`;
 }
 
 let bigTextTarget;


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: https://www.reddit.com/r/Enhancement/comments/75zy7i/live_preview_locks_to_first_reply_never_updates/
Tested in browser: Chrome 62

Reddit appears to clone to the top-level textarea, so if we've already added a preview box there, initialization would bail out and no listeners would be added for the child textarea.