### PR TITLE
Keyboard shortcut to navigate to author's profile

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -598,6 +598,22 @@ module.options = {
 		title: 'keyboardNavFollowSubredditNewTabTitle',
 		callback() { followSubreddit(true); },
 	},
+	followProfile: {
+		type: 'keycode',
+		include: ['linklist', 'comments', 'commentsLinklist', 'inbox', 'modqueue', 'search'],
+		value: [85, false, false, false, false], // u
+		description: 'keyboardNavFollowProfileDesc',
+		title: 'keyboardNavFollowProfileTitle',
+		callback() { followProfile(); },
+	},
+	followProfileNewTab: {
+		type: 'keycode',
+		include: ['linklist', 'comments', 'commentsLinklist', 'inbox', 'modqueue', 'search'],
+		value: [85, false, false, true, false], // shift-u
+		description: 'keyboardNavFollowProfileNewTabDesc',
+		title: 'keyboardNavFollowProfileNewTabTitle',
+		callback() { followProfile(true); },
+	},
 	goMode: {
 		type: 'keycode',
 		value: [71, false, false, false, false], // g
@@ -996,6 +1012,10 @@ function hideLink(selected = getSelected()) {
 function followSubreddit(newWindow = false, selected = getSelected()) {
 	const a = downcast(assertElement(selected.getSubredditLink()), HTMLAnchorElement);
 	navigateTo(newWindow, a.href);
+}
+
+function followProfile(newWindow = false, selected = getSelected()) {
+	navigateTo(newWindow, selected.getAuthorUrl());
 }
 
 function toggleChildren(selected = getSelected()) {

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -762,6 +762,18 @@
 	"keyboardNavFollowSubredditNewTabDesc": {
 		"message": "Go to subreddit of selected link in a new tab (link pages only)."
 	},
+	"keyboardNavFollowProfileTitle": {
+		"message": "Follow Profile"
+	},
+	"keyboardNavFollowProfileDesc": {
+		"message": "Go to profile of selected thing's author."
+	},
+	"keyboardNavFollowProfileNewTabTitle": {
+		"message": "Follow Profile New Tab"
+	},
+	"keyboardNavFollowProfileNewTabDesc": {
+		"message": "Go to profile of selected thing's author in a new tab."
+	},
 	"keyboardNavGoModeTitle": {
 		"message": "Go Mode"
 	},

--- a/tests/commentNavigator.js
+++ b/tests/commentNavigator.js
@@ -13,7 +13,7 @@ module.exports = {
 			.execute('document.querySelector(".footer").scrollIntoView()') // scroll to bottom
 			.keys(['n'])
 			.assert.visible('#REScommentNavBox')
-			.setValue('#commentNavBy', 'submitter')
+			.click('#commentNavBy [name="submitter"]')
 			.assert.containsText('#REScommentNavBox', '1/2')
 			.assert.visible('#thing_t1_dfqvawk')
 			.click('#commentNavDown')


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: https://www.reddit.com/r/Enhancement/comments/72i8hf/feature_request_keyboard_navigation_shortcut_to/
Tested in browser: Chrome 60

Potentially conflicts with the goMode shortcut (go to your own profile) for users that have disabled the prompt, but thanks to @larsjohnsen we now have the capability to deconflict it.