### PR TITLE
UserTagger preset tags

### DIFF
--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -50,6 +50,7 @@ export type ModuleOption<Ctx> =
 	| EnumOption<Ctx>
 	| KeycodeOption<Ctx>
 	| ListOption<Ctx>
+	| SelectOption<Ctx>
 	| TableOption<Ctx, any>
 	| ButtonOption<Ctx>
 	| ColorOption<Ctx>
@@ -110,6 +111,17 @@ export type ListOption<Ctx> = {|
 
 type ListType = 'subreddits';
 
+export type SelectOption<Ctx> = {|
+	type: 'select',
+	value: string,
+	values: Array<{
+		name: string,
+		value: string,
+		style: string,
+	}>,
+	...CommonOptionProps<Ctx>,
+|};
+
 export type TableOption<Ctx, V: $ReadOnlyArray<any>> = {|
 	type: 'table',
 	addRowText?: string,
@@ -119,7 +131,7 @@ export type TableOption<Ctx, V: $ReadOnlyArray<any>> = {|
 	...CommonOptionProps<Ctx>,
 |};
 
-type TableField = TextField | BooleanField | ListField | PasswordField | KeycodeField | TextareaField | EnumField | ColorField;
+type TableField = TextField | BooleanField | ListField | PasswordField | KeycodeField | TextareaField | EnumField | ColorField | SelectField;
 
 type TextField = {|
 	type: 'text',
@@ -175,6 +187,18 @@ type ColorField = {|
 	type: 'color',
 	key: string,
 	name: string,
+|};
+
+type SelectField = {|
+	type: 'select',
+	key: string,
+	name: string,
+	value: string,
+	values: Array<{
+		name: string,
+		value: string,
+		style: string,
+	}>,
 |};
 
 export type ButtonOption<Ctx> = {|

--- a/lib/css/modules/_hover.scss
+++ b/lib/css/modules/_hover.scss
@@ -68,7 +68,7 @@
 	}
 }
 
-.fieldPair {
+.fieldPair:not([hidden]) {
 	display: flex;
 	margin-bottom: 12px;
 

--- a/lib/css/modules/_userTagger.scss
+++ b/lib/css/modules/_userTagger.scss
@@ -145,7 +145,11 @@ a.voteWeight {
 }
 
 #userTaggerPresetTags .RESUserTag {
-	margin-bottom: 4px;
+	margin: 0 4px 4px 0;
+}
+
+#userTaggerPresetSaveAs {
+	margin-left: auto;
 }
 
 #userTaggerTable th {

--- a/lib/css/modules/_userTagger.scss
+++ b/lib/css/modules/_userTagger.scss
@@ -144,6 +144,10 @@ a.voteWeight {
 	}
 }
 
+#userTaggerPreset .RESUserTag {
+	margin-bottom: 4px;
+}
+
 #userTaggerTable th {
 	cursor: pointer;
 	user-select: none;

--- a/lib/css/modules/_userTagger.scss
+++ b/lib/css/modules/_userTagger.scss
@@ -144,7 +144,7 @@ a.voteWeight {
 	}
 }
 
-#userTaggerPreset .RESUserTag {
+#userTaggerPresetTags .RESUserTag {
 	margin-bottom: 4px;
 }
 

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -795,8 +795,10 @@ function stageCurrentModuleOptions() {
 					const tempArray = input.value.split(',');
 					// convert the internal values of this array into their respective types (int, bool, bool, bool)
 					optionValue = [parseInt(tempArray[0], 10), (tempArray[1] === 'true'), (tempArray[2] === 'true'), (tempArray[3] === 'true'), (tempArray[4] === 'true')];
-				} else if (input.getAttribute('class') && input.getAttribute('class').includes('select') && input.selectedOptions) {
-					optionValue = input.selectedOptions[0].value;
+				} else if (input instanceof HTMLSelectElement) {
+					if (input.selectedIndex >= 0) {
+						optionValue = input.options[input.selectedIndex].value;
+					}
 				} else {
 					optionValue = input.value;
 				}
@@ -835,8 +837,10 @@ function stageCurrentModuleOptions() {
 							const tempArray = input.value.split(',');
 							// convert the internal values of this array into their respective types (int, bool, bool, bool)
 							optionValue = [parseInt(tempArray[0], 10), (tempArray[1] === 'true'), (tempArray[2] === 'true'), (tempArray[3] === 'true')];
-						} else if (input.getAttribute('class') && input.getAttribute('class').includes('select') && input.selectedOptions) {
-							optionValue = input.selectedOptions[0].value;
+						} else if (input instanceof HTMLSelectElement) {
+							if (input.selectedIndex >= 0) {
+								optionValue = input.options[input.selectedIndex].value;
+							}
 						} else {
 							optionValue = input.value;
 						}

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -449,7 +449,6 @@ function drawOptionInput(mod, optionName, optionObject, isTable) {
 				}
 				$thisOptionFormEle.append($thisOptionFormSubEle);
 			});
-
 			break;
 		default:
 			throw new Error(`modules.${mod.moduleID}.options.${optionName} has invalid type: ${optionObject.type}`);

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -795,7 +795,7 @@ function stageCurrentModuleOptions() {
 					const tempArray = input.value.split(',');
 					// convert the internal values of this array into their respective types (int, bool, bool, bool)
 					optionValue = [parseInt(tempArray[0], 10), (tempArray[1] === 'true'), (tempArray[2] === 'true'), (tempArray[3] === 'true'), (tempArray[4] === 'true')];
-				} else if (input.getAttribute('class') && input.getAttribute('class').includes('select')) {
+				} else if (input.getAttribute('class') && input.getAttribute('class').includes('select') && input.selectedOptions) {
 					optionValue = input.selectedOptions[0].value;
 				} else {
 					optionValue = input.value;
@@ -835,7 +835,7 @@ function stageCurrentModuleOptions() {
 							const tempArray = input.value.split(',');
 							// convert the internal values of this array into their respective types (int, bool, bool, bool)
 							optionValue = [parseInt(tempArray[0], 10), (tempArray[1] === 'true'), (tempArray[2] === 'true'), (tempArray[3] === 'true')];
-						} else if (input.getAttribute('class') && input.getAttribute('class').includes('select')) {
+						} else if (input.getAttribute('class') && input.getAttribute('class').includes('select') && input.selectedOptions) {
 							optionValue = input.selectedOptions[0].value;
 						} else {
 							optionValue = input.value;

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -447,7 +447,6 @@ function drawOptionInput(mod, optionName, optionObject, isTable) {
 				if ((optionObject.value === optionValue.value) || nullEqualsEmpty) {
 					$thisOptionFormSubEle.attr('selected', 'selected');
 				}
-				// console.log($thisOptionFormSubEle)
 				$thisOptionFormEle.append($thisOptionFormSubEle);
 			});
 

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -426,6 +426,32 @@ function drawOptionInput(mod, optionName, optionObject, isTable) {
 			}).val(niceKeyCode(optionObject.value));
 			$thisOptionFormEle = $('<div>').append(realOptionFormEle).append(thisKeyCodeDisplay);
 			break;
+		case 'select':
+			$thisOptionFormEle = $('<select>').attr({
+				id: optionName,
+				class: 'select',
+				value: optionObject.value,
+			});
+
+			optionObject.values.forEach((optionValue, index) => {
+				const thisId = `${optionName}-${index}`;
+				const $thisOptionFormSubEle = $('<option />', {
+					id: thisId,
+					class: 'select-option',
+					value: optionValue.value,
+					moduleID: mod.moduleID,
+					style: optionValue.style,
+				}).text(optionValue.name);
+				const nullEqualsEmpty = ((optionObject.value === null) && (optionValue.value === ''));
+				// we also need to check for null == '' - which are technically equal.
+				if ((optionObject.value === optionValue.value) || nullEqualsEmpty) {
+					$thisOptionFormSubEle.attr('selected', 'selected');
+				}
+				// console.log($thisOptionFormSubEle)
+				$thisOptionFormEle.append($thisOptionFormSubEle);
+			});
+
+			break;
 		default:
 			throw new Error(`modules.${mod.moduleID}.options.${optionName} has invalid type: ${optionObject.type}`);
 	}
@@ -541,6 +567,7 @@ function drawConfigOptions(mod) {
 					niceDefaultOption = option.default ? 'on' : 'off';
 					break;
 				case 'enum':
+				case 'select':
 					const matchingOption = option.values.find(({ value }) => option.default === value);
 					niceDefaultOption = matchingOption && i18n(matchingOption.name);
 					break;
@@ -740,9 +767,9 @@ function stageCurrentModuleOptions() {
 	// first, go through inputs that aren't of a specialized type like table or builder
 	$(panelOptionsDiv)
 		.find('.optionContainer:not(.specialOptionType)')
-		.find('input, textarea')
+		.find('input, select, textarea')
 		.each((i, e) => {
-			const input: HTMLInputElement | HTMLTextAreaElement = (e: any);
+			const input: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement = (e: any);
 			// save values of any inputs onscreen, but skip ones with 'capturefor' - those are display only.
 			const notTokenPrefix = input.getAttribute('id') && !input.getAttribute('id').includes('token-input-');
 			if (notTokenPrefix && (input.getAttribute('type') !== 'button') &&
@@ -768,6 +795,8 @@ function stageCurrentModuleOptions() {
 					const tempArray = input.value.split(',');
 					// convert the internal values of this array into their respective types (int, bool, bool, bool)
 					optionValue = [parseInt(tempArray[0], 10), (tempArray[1] === 'true'), (tempArray[2] === 'true'), (tempArray[3] === 'true'), (tempArray[4] === 'true')];
+				} else if (input.getAttribute('class') && input.getAttribute('class').includes('select')) {
+					optionValue = input.selectedOptions[0].value;
 				} else {
 					optionValue = input.value;
 				}
@@ -792,7 +821,7 @@ function stageCurrentModuleOptions() {
 				const cells = row.querySelectorAll('td.hasTableOption');
 				let notAllBlank = false;
 				const optionRow = Array.from(cells).map(cell => {
-					const inputs: NodeList<HTMLInputElement | HTMLTextAreaElement> = (cell.querySelectorAll('input[tableOption=true], textarea[tableOption=true]'): any);
+					const inputs: NodeList<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement> = (cell.querySelectorAll('input[tableOption=true], select[tableOption=true], textarea[tableOption=true]'): any);
 					let optionValue = null;
 					for (const input of inputs) {
 						if (/*:: input instanceof HTMLInputElement && */ input.getAttribute('type') === 'checkbox') {
@@ -806,6 +835,8 @@ function stageCurrentModuleOptions() {
 							const tempArray = input.value.split(',');
 							// convert the internal values of this array into their respective types (int, bool, bool, bool)
 							optionValue = [parseInt(tempArray[0], 10), (tempArray[1] === 'true'), (tempArray[2] === 'true'), (tempArray[3] === 'true')];
+						} else if (input.getAttribute('class') && input.getAttribute('class').includes('select')) {
+							optionValue = input.selectedOptions[0].value;
 						} else {
 							optionValue = input.value;
 						}

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -794,10 +794,6 @@ function stageCurrentModuleOptions() {
 					const tempArray = input.value.split(',');
 					// convert the internal values of this array into their respective types (int, bool, bool, bool)
 					optionValue = [parseInt(tempArray[0], 10), (tempArray[1] === 'true'), (tempArray[2] === 'true'), (tempArray[3] === 'true'), (tempArray[4] === 'true')];
-				} else if (input instanceof HTMLSelectElement) {
-					if (input.selectedIndex >= 0) {
-						optionValue = input.options[input.selectedIndex].value;
-					}
 				} else {
 					optionValue = input.value;
 				}
@@ -836,10 +832,6 @@ function stageCurrentModuleOptions() {
 							const tempArray = input.value.split(',');
 							// convert the internal values of this array into their respective types (int, bool, bool, bool)
 							optionValue = [parseInt(tempArray[0], 10), (tempArray[1] === 'true'), (tempArray[2] === 'true'), (tempArray[3] === 'true')];
-						} else if (input instanceof HTMLSelectElement) {
-							if (input.selectedIndex >= 0) {
-								optionValue = input.options[input.selectedIndex].value;
-							}
 						} else {
 							optionValue = input.value;
 						}

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -418,7 +418,7 @@ function populateDialog(tag: Tag, card) {
 					`)}
 				</select>
 			</div>
-			<div class="fieldPair">
+			<div class="fieldPair" style="flex-wrap: wrap">
 				<label class="fieldPair-label" for="userTaggerPreview">Preview</label>
 				<span id="userTaggerPreview"></span>
 				<a id="userTaggerPresetSaveAs" title="save as preset" href="javascript:void 0">save as preset</a>

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -117,20 +117,20 @@ module.options = {
 		title: 'userTaggerShowPresetTagsTitle',
 		type: 'boolean',
 		value: true, // TO-DO: change to default false
-		description: 'userTaggerShowPresetTagsDescription',
+		description: 'userTaggerShowPresetTagsDesc',
 		advanced: true,
 	},
 	presetTags: {
 		title: 'userTaggerPresetTagsTitle',
 		type: 'table',
-		addRowText: 'userTaggerAddRowText',
+		addRowText: '+add preset',
 		fields: [{
 			key: 'text',
-			name: 'userTaggerPresetText',
+			name: 'text',
 			type: 'text',
 		}, {
 			key: 'color',
-			name: 'userTaggerPresetColor',
+			name: 'color',
 			type: 'select',
 			value: 'none',
 			values: Object.entries(bgToTextColorMap).map(([k, v]) => ({
@@ -139,7 +139,8 @@ module.options = {
 				style: `color: ${v}; background-color: ${k};`,
 			})),
 		}],
-		description: 'userTaggerPresetTagsDescription',
+		value: ([]: Array<[string, string]>),
+		description: 'userTaggerPresetTagsDesc',
 		advanced: true,
 	},
 };
@@ -407,11 +408,7 @@ function populateDialog(tag: Tag, card) {
 			color,
 		}));
 
-	const presetTags = module.options.presetTags.value
-		.map(([text, color]) => ({
-			text,
-			color,
-		}));
+	const presetTags = module.options.presetTags.value;
 
 	const body = string.html`
 		<form id="userTaggerToolTip">
@@ -454,7 +451,7 @@ function populateDialog(tag: Tag, card) {
 			<div class="fieldPair">
 				<label class="fieldPair-label" for="userTaggerPresetTags">Presets</label>
 				<span id="userTaggerPresetTags">
-					${presetTags.map(({ text, color }) => string._html`
+					${presetTags.map(([text, color]) => string._html`
 						<span class="RESUserTag">
 							<a
 								class="userTagLink hasTag"
@@ -520,9 +517,9 @@ function populateDialog(tag: Tag, card) {
 	}
 
 	elements.openLink.addEventListener('click', () => openNewTabs('none', ...elements.link.value.split(/\s/)));
-	elements.presetTag.addEventListener('click', e => {
+	elements.presetTag.addEventListener('click', (e: MouseEvent) => {
 		const preset = {
-			text: e.target.text,
+			text: e.target.innerText,
 			color: e.target.dataset.color,
 		};
 		const tagInfo = Object.assign(extract(), preset);

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -30,6 +30,30 @@ import * as SettingsNavigation from './settingsNavigation';
 
 export const module: Module<*> = new Module('userTagger');
 
+const bgToTextColorMap = {
+	none: 'inherit',
+	aqua: 'black',
+	black: 'white',
+	blue: 'white',
+	cornflowerblue: 'white',
+	fuchsia: 'white',
+	gray: 'white',
+	green: 'white',
+	lime: 'black',
+	maroon: 'white',
+	navy: 'white',
+	olive: 'white',
+	orange: 'white',
+	orangered: 'white',
+	pink: 'black',
+	purple: 'white',
+	red: 'white',
+	silver: 'black',
+	teal: 'white',
+	white: 'black',
+	yellow: 'black',
+};
+
 module.moduleName = 'userTaggerName';
 module.category = 'usersCategory';
 module.description = 'userTaggerDesc';
@@ -87,6 +111,35 @@ module.options = {
 		type: 'boolean',
 		value: true,
 		description: 'userTaggerTruncateTagDesc',
+		advanced: true,
+	},
+	showPresets: {
+		type: 'boolean',
+		value: true, // TO-DO: change to default false
+		description: 'userTaggerShowPresetsDescription',
+		title: 'userTaggerShowPresetsTitle',
+		advanced: true,
+	},
+	presets: {
+		type: 'table',
+		addRowText: 'userTaggerAddRowText',
+		fields: [{
+			key: 'text',
+			name: 'userTaggerPresetText',
+			type: 'text',
+		}, {
+			key: 'color',
+			name: 'userTaggerPresetColor',
+			type: 'select',
+			value: 'none',
+			values: Object.entries(bgToTextColorMap).map(([k, v]) => ({
+				name: k,
+				value: k,
+				style: `color: ${v}; background-color: ${k};`,
+			})),
+		}],
+		description: 'userTaggerPresetsDescription',
+		title: 'userTaggerPresetsTitle',
 		advanced: true,
 	},
 };
@@ -354,6 +407,12 @@ function populateDialog(tag: Tag, card) {
 			color,
 		}));
 
+	const presets = module.options.presets.value
+		.map(([text, color]) => ({
+			text,
+			color,
+		}));
+
 	const body = string.html`
 		<form id="userTaggerToolTip">
 			<div class="fieldPair">
@@ -392,6 +451,22 @@ function populateDialog(tag: Tag, card) {
 				<label class="fieldPair-label" for="userTaggerVotesDown" title="Downvotes you have given this redditor">Downvotes</label>
 				<input type="number" style="width: 50px;" id="userTaggerVotesDown" value="${tag.votesDown}">
 			</div>
+			<div class="fieldPair">
+				<label class="fieldPair-label" for="userTaggerPresets">Presets</label>
+				<span id="userTaggerPreset">
+					${presets.map(({ text, color }) => string._html`
+						<span class="RESUserTag">
+							<a
+								class="userTagLink hasTag"
+								${color && string._html`style="background-color: ${color}; color: ${bgToTextColorMap[color]} !important;"`}
+								title="use preset"
+								href="javascript:void 0"
+								data-color="${color}"
+							>${text}</a>
+						</span>
+					`)}
+				</span>
+			</div>
 			<div class="res-usertagger-footer">
 				<a href="/r/dashboard#userTaggerContents" target="_blank" rel="noopener noreferer">View tagged users</a>
 				<input type="submit" id="userTaggerSave" value="✓ save tag">
@@ -401,6 +476,7 @@ function populateDialog(tag: Tag, card) {
 
 	const elements = {
 		color: downcast(body.querySelector('#userTaggerColor'), HTMLSelectElement),
+		presetTag: downcast(body.querySelector('#userTaggerPreset'), HTMLElement),
 		link: downcast(body.querySelector('#userTaggerLink'), HTMLInputElement),
 		openLink: downcast(body.querySelector('.userTaggerOpenLink a'), HTMLAnchorElement),
 		preview: downcast(body.querySelector('#userTaggerPreview'), HTMLElement),
@@ -444,6 +520,19 @@ function populateDialog(tag: Tag, card) {
 	}
 
 	elements.openLink.addEventListener('click', () => openNewTabs('none', ...elements.link.value.split(/\s/)));
+	elements.presetTag.addEventListener('click', e => {
+		const preset = {
+			text: e.target.text,
+			color: e.target.dataset.color,
+		};
+		const tagInfo = Object.assign(extract(), preset);
+
+		e.preventDefault();
+		tag.load(tagInfo);
+		tag.save();
+		card.close();
+	});
+
 	$(body).on('change input click', updateTagPreview);
 	body.addEventListener('submit', e => {
 		e.preventDefault();
@@ -551,30 +640,6 @@ async function handleVoteClick(arrow) {
 	});
 	tag.save();
 }
-
-const bgToTextColorMap = {
-	none: 'inherit',
-	aqua: 'black',
-	black: 'white',
-	blue: 'white',
-	cornflowerblue: 'white',
-	fuchsia: 'white',
-	gray: 'white',
-	green: 'white',
-	lime: 'black',
-	maroon: 'white',
-	navy: 'white',
-	olive: 'white',
-	orange: 'white',
-	orangered: 'white',
-	pink: 'black',
-	purple: 'white',
-	red: 'white',
-	silver: 'black',
-	teal: 'white',
-	white: 'black',
-	yellow: 'black',
-};
 
 function getLinkBasedOnTagLocation(obj) {
 	const closestEntry = $(obj).closest('.entry');

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -113,14 +113,15 @@ module.options = {
 		description: 'userTaggerTruncateTagDesc',
 		advanced: true,
 	},
-	showPresets: {
+	showPresetTags: {
+		title: 'userTaggerShowPresetTagsTitle',
 		type: 'boolean',
 		value: true, // TO-DO: change to default false
-		description: 'userTaggerShowPresetsDescription',
-		title: 'userTaggerShowPresetsTitle',
+		description: 'userTaggerShowPresetTagsDescription',
 		advanced: true,
 	},
-	presets: {
+	presetTags: {
+		title: 'userTaggerPresetTagsTitle',
 		type: 'table',
 		addRowText: 'userTaggerAddRowText',
 		fields: [{
@@ -138,8 +139,7 @@ module.options = {
 				style: `color: ${v}; background-color: ${k};`,
 			})),
 		}],
-		description: 'userTaggerPresetsDescription',
-		title: 'userTaggerPresetsTitle',
+		description: 'userTaggerPresetTagsDescription',
 		advanced: true,
 	},
 };
@@ -407,7 +407,7 @@ function populateDialog(tag: Tag, card) {
 			color,
 		}));
 
-	const presets = module.options.presets.value
+	const presetTags = module.options.presetTags.value
 		.map(([text, color]) => ({
 			text,
 			color,
@@ -452,9 +452,9 @@ function populateDialog(tag: Tag, card) {
 				<input type="number" style="width: 50px;" id="userTaggerVotesDown" value="${tag.votesDown}">
 			</div>
 			<div class="fieldPair">
-				<label class="fieldPair-label" for="userTaggerPresets">Presets</label>
-				<span id="userTaggerPreset">
-					${presets.map(({ text, color }) => string._html`
+				<label class="fieldPair-label" for="userTaggerPresetTags">Presets</label>
+				<span id="userTaggerPresetTags">
+					${presetTags.map(({ text, color }) => string._html`
 						<span class="RESUserTag">
 							<a
 								class="userTagLink hasTag"
@@ -476,7 +476,7 @@ function populateDialog(tag: Tag, card) {
 
 	const elements = {
 		color: downcast(body.querySelector('#userTaggerColor'), HTMLSelectElement),
-		presetTag: downcast(body.querySelector('#userTaggerPreset'), HTMLElement),
+		presetTag: downcast(body.querySelector('#userTaggerPresetTags'), HTMLElement),
 		link: downcast(body.querySelector('#userTaggerLink'), HTMLInputElement),
 		openLink: downcast(body.querySelector('.userTaggerOpenLink a'), HTMLAnchorElement),
 		preview: downcast(body.querySelector('#userTaggerPreview'), HTMLElement),

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -3,6 +3,7 @@
 import _ from 'lodash';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
+import * as Options from '../core/options';
 import {
 	Alert,
 	CreateElement,
@@ -111,13 +112,6 @@ module.options = {
 		type: 'boolean',
 		value: true,
 		description: 'userTaggerTruncateTagDesc',
-		advanced: true,
-	},
-	showPresetTags: {
-		title: 'userTaggerShowPresetTagsTitle',
-		type: 'boolean',
-		value: true, // TO-DO: change to default false
-		description: 'userTaggerShowPresetTagsDesc',
 		advanced: true,
 	},
 	presetTags: {
@@ -427,6 +421,7 @@ function populateDialog(tag: Tag, card) {
 			<div class="fieldPair">
 				<label class="fieldPair-label" for="userTaggerPreview">Preview</label>
 				<span id="userTaggerPreview"></span>
+				<a id="userTaggerPresetSaveAs" title="save as preset" href="javascript:void 0">save as preset</a>
 			</div>
 			<div class="fieldPair res-usertag-ignore">
 				<label class="fieldPair-label" for="userTaggerIgnore">Ignore</label>
@@ -450,19 +445,7 @@ function populateDialog(tag: Tag, card) {
 			</div>
 			<div class="fieldPair">
 				<label class="fieldPair-label" for="userTaggerPresetTags">Presets</label>
-				<span id="userTaggerPresetTags">
-					${presetTags.map(([text, color]) => string._html`
-						<span class="RESUserTag">
-							<a
-								class="userTagLink hasTag"
-								${color && string._html`style="background-color: ${color}; color: ${bgToTextColorMap[color]} !important;"`}
-								title="use preset"
-								href="javascript:void 0"
-								data-color="${color}"
-							>${text}</a>
-						</span>
-					`)}
-				</span>
+				<span id="userTaggerPresetTags"></span>
 			</div>
 			<div class="res-usertagger-footer">
 				<a href="/r/dashboard#userTaggerContents" target="_blank" rel="noopener noreferer">View tagged users</a>
@@ -473,6 +456,7 @@ function populateDialog(tag: Tag, card) {
 
 	const elements = {
 		color: downcast(body.querySelector('#userTaggerColor'), HTMLSelectElement),
+		presetSaveAs: downcast(body.querySelector('#userTaggerPresetSaveAs'), HTMLAnchorElement),
 		presetTag: downcast(body.querySelector('#userTaggerPresetTags'), HTMLElement),
 		link: downcast(body.querySelector('#userTaggerLink'), HTMLInputElement),
 		openLink: downcast(body.querySelector('.userTaggerOpenLink a'), HTMLAnchorElement),
@@ -502,7 +486,7 @@ function populateDialog(tag: Tag, card) {
 
 	function extract() {
 		return {
-			color: elements.color.value === 'none' ? null : elements.color.value,
+			color: elements.color.value || null,
 			ignored,
 			link: elements.link.value || null,
 			text: elements.text.value || null,
@@ -516,19 +500,29 @@ function populateDialog(tag: Tag, card) {
 		elements.preview.appendChild(Tag.buildTagElement(extract()));
 	}
 
-	elements.openLink.addEventListener('click', () => openNewTabs('none', ...elements.link.value.split(/\s/)));
-	elements.presetTag.addEventListener('click', (e: MouseEvent) => {
-		const preset = {
-			text: e.target.innerText,
-			color: e.target.dataset.color,
-		};
-		const tagInfo = Object.assign(extract(), preset);
+	function buildPresetTagElement(text: string, color: string) {
+		const element = Tag.buildTagElement({ text, color });
+		element.addEventListener('click', () => {
+			tag.load({ text, color });
+			tag.save();
+			card.close();
+		});
+		return element;
+	}
 
-		e.preventDefault();
-		tag.load(tagInfo);
-		tag.save();
-		card.close();
-	});
+	function saveAsPreset() {
+		const { text, color } = extract();
+		if (text && color) {
+			elements.presetTag.append(buildPresetTagElement(text, color));
+			const newPresetTags = presetTags.concat([[text, color]]);
+			Options.stage.add(module.moduleID, 'presetTags', newPresetTags);
+			Options.stage.commit();
+		}
+	}
+
+	elements.openLink.addEventListener('click', () => openNewTabs('none', ...elements.link.value.split(/\s/)));
+	elements.presetTag.append(...presetTags.map(([text, color]) => buildPresetTagElement(text, color)));
+	elements.presetSaveAs.addEventListener('click', () => saveAsPreset());
 
 	$(body).on('change input click', updateTagPreview);
 	body.addEventListener('submit', e => {

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -443,7 +443,7 @@ function populateDialog(tag: Tag, card) {
 				<label class="fieldPair-label" for="userTaggerVotesDown" title="Downvotes you have given this redditor">Downvotes</label>
 				<input type="number" style="width: 50px;" id="userTaggerVotesDown" value="${tag.votesDown}">
 			</div>
-			<div class="fieldPair">
+			<div class="fieldPair" ${!presetTags.length && 'hidden'}>
 				<label class="fieldPair-label" for="userTaggerPresetTags">Presets</label>
 				<span id="userTaggerPresetTags"></span>
 			</div>
@@ -458,6 +458,7 @@ function populateDialog(tag: Tag, card) {
 		color: downcast(body.querySelector('#userTaggerColor'), HTMLSelectElement),
 		presetSaveAs: downcast(body.querySelector('#userTaggerPresetSaveAs'), HTMLAnchorElement),
 		presetTag: downcast(body.querySelector('#userTaggerPresetTags'), HTMLElement),
+		presetFieldPair: downcast(body.querySelector('#userTaggerPresetTags').parentElement, HTMLElement),
 		link: downcast(body.querySelector('#userTaggerLink'), HTMLInputElement),
 		openLink: downcast(body.querySelector('.userTaggerOpenLink a'), HTMLAnchorElement),
 		preview: downcast(body.querySelector('#userTaggerPreview'), HTMLElement),
@@ -513,10 +514,11 @@ function populateDialog(tag: Tag, card) {
 	function saveAsPreset() {
 		const { text, color } = extract();
 		if (text && color) {
+			elements.presetFieldPair.hidden = false;
 			elements.presetTag.append(buildPresetTagElement(text, color));
-			const newPresetTags = presetTags.concat([[text, color]]);
-			Options.stage.add(module.moduleID, 'presetTags', newPresetTags);
-			Options.stage.commit();
+			Options.set(module.moduleID, 'presetTags', [...presetTags, [text, color]]);
+		} else {
+			window.alert('Tag text must be specified in order to save as preset.');
 		}
 	}
 

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -2947,9 +2947,6 @@
 	"userTaggerTruncateTagDesc": {
 		"message": "Truncates long tags to 30 characters. Hovering over them reveals the full content."
 	},
-	"userTaggerShowPresetTagsDesc": {
-		"message": "Show preset tags when tagging a user."
-	},
 	"userTaggerPresetTagsDesc": {
 		"message": "Preset tags to be shown when tagging a user."
 	},
@@ -3226,9 +3223,6 @@
 	},
 	"userTaggerPresetTagsTitle": {
 		"message": "Preset Tags"
-	},
-	"userTaggerShowPresetTagsTitle": {
-		"message": "Show Preset Tags"
 	},
 	"singleClickOpenOrderTitle": {
 		"message": "Open Order"

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -2947,6 +2947,12 @@
 	"userTaggerTruncateTagDesc": {
 		"message": "Truncates long tags to 30 characters. Hovering over them reveals the full content."
 	},
+	"userTaggerShowPresetTagsDesc": {
+		"message": "Show preset tags when tagging a user."
+	},
+	"userTaggerPresetTagsDesc": {
+		"message": "Preset tags to be shown when tagging a user."
+	},
 	"scrollOnCollapseDesc": {
 		"message": "Scrolls to next comment when a comment is collapsed."
 	},
@@ -3217,6 +3223,12 @@
 	},
 	"userTaggerTruncateTagTitle": {
 		"message": "Truncate Tags"
+	},
+	"userTaggerPresetTagsTitle": {
+		"message": "Preset Tags"
+	},
+	"userTaggerShowPresetTagsTitle": {
+		"message": "Show Preset Tags"
 	},
 	"singleClickOpenOrderTitle": {
 		"message": "Open Order"


### PR DESCRIPTION
Relevant issue: resolves #1270 closes #1263
Tested in browser: Firefox

- [x] Select option field in core module
  - [x] Implement field functionality in settingsConsole
- [x] Ability to add/remove presets in userTagger options (table with text field and dropdown color field)
- [x] ~~Option to show/hide presets in dialog~~ (removed)
- [x] "Save as presets" button in tag dialog
  - [x] Bump button over if the preview tag text is too long (added flex-wrap)
- [x] Show presets in tag dialog 
  - [x] When preset tag is clicked in the dialog, it auto-saves that color/text option as the new tag and then closes the dialog
- [x] New strings for userTagger options in locales/en.json
- [x] Fix Flow type checking errors
- [ ] Test on other browsers: Chrome, Edge

Screenshots -

UserTagger options:
<img width="1020" alt="screen shot 2017-10-16 at 3 27 32 pm" src="https://user-images.githubusercontent.com/1255633/31680444-4f1e4b54-b342-11e7-99fa-4fbabfe40372.png">

A few presets:
<img width="825" alt="screen shot 2017-10-17 at 1 51 27 pm" src="https://user-images.githubusercontent.com/1255633/31680450-57369f94-b342-11e7-94c8-0380d1a88d25.png">

UserTagger dialog:
<img width="842" alt="screen shot 2017-10-17 at 6 24 55 am" src="https://user-images.githubusercontent.com/1255633/31680467-6297c9c6-b342-11e7-8a0c-ce6d09f58d2d.png">

~~Is calling it `preset` fine, or should it be called something else?~~ 

Changed it to `presetTags` to avoid any confusion with the existing `presets` module