### PR TITLE
showImages inline expando button: Improve positioning

### DIFF
--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -30,6 +30,17 @@ img {
 	}
 }
 
+// Place inline expandos so that they don't impact the line height
+.res-freetext-expando {
+	display: inline-block;
+	height: 1em;
+	margin: 0 4px !important;
+	vertical-align: middle;
+
+	.expando-button { margin: calc(calc(1em * .5) - 50%) 0 0 0  !important; }
+	+ .res-expando-box { margin-top: 5px !important; }
+}
+
 .expando-button {
 	cursor: pointer;
 	user-select: none;
@@ -48,27 +59,6 @@ img {
 		background-image: url('../images/expandoButtons.png');
 		margin-right: 6px;
 		padding: 0;
-	}
-
-	.comment > .parent > &.linkImg,
-	&.commentImg {
-		vertical-align: middle !important;
-		float: none;
-		display: inline-block;
-		margin: 0 4px;
-
-		+ .res-expando-box {
-			margin-top: 3px;
-		}
-
-		// Override native
-		&.selftext.expanded {
-			margin-bottom: initial;
-		}
-	}
-
-	.comment > .parent > &.linkImg {
-		margin-left: 0;
 	}
 
 	&-duplicate {

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -891,10 +891,9 @@ export function getLinkExpando(link: HTMLAnchorElement): ?Expando {
 	if (expando instanceof Expando) return expando;
 }
 
-async function checkElementForMedia(element) {
-	if (scannedLinks.has(element)) return;
-	else scannedLinks.set(element, true);
+const inText = element => !!element.closest('.md, .search-result-footer');
 
+async function checkElementForMedia(element) {
 	const thing = Thing.from(element);
 
 	if (
@@ -906,13 +905,11 @@ async function checkElementForMedia(element) {
 		deferredLinks.delete(element);
 	}
 
-	const inText = !!$(element).closest('.md, .search-result-footer')[0];
-	const entryExpando = !inText && Expando.getEntryExpandoFrom(thing);
+	const entryExpando = !inText(element) && Expando.getEntryExpandoFrom(thing);
 	const nativeExpando = entryExpando instanceof Expando ? null : entryExpando;
 
 	if (module.options.hideNSFW.value && thing && thing.isNSFW()) {
 		if (nativeExpando) nativeExpando.detach();
-
 		return;
 	}
 
@@ -935,29 +932,21 @@ async function checkElementForMedia(element) {
 		element.removeAttribute('data-inbound-url');
 	}
 
-	if (nativeExpando) nativeExpando.detach();
-
 	const { lock = null, unlock = null } = mediaInfo.permissions;
 
-	const expando = new Expando(inText, lock, unlock);
+	const expando = new Expando(lock, unlock);
 	expandos.set(expando.button, expando);
 	scannedLinks.set(element, expando);
 
 	expando.button.setAttribute('data-host', mediaInfo.siteModule.moduleID);
 
-	if (!inText && thing && thing.getTitleElement()) {
-		$(expando.button).insertAfter(element.parentElement);
-		thing.entry.appendChild(expando.box);
-	} else {
-		$(element).add($(element).next('.keyNavAnnotation')).last()
-			.after(expando.box)
-			.after(expando.button);
-	}
-
 	expando.button.addEventListener('click', () => {
 		if (expando.unlock) expando.unlock();
 		expando.toggle({ scrollOnMoveError: true });
 	});
+
+	if (nativeExpando) nativeExpando.detach();
+	placeExpando(expando, element, thing);
 
 	if (thing) thingExpandoBuildListeners.fire(thing);
 
@@ -975,6 +964,17 @@ async function checkElementForMedia(element) {
 	}
 
 	if (thing) thingExpandoBuildListeners.fire(thing);
+}
+
+function placeExpando(expando, element, thing) {
+	if (!inText(element) && thing && thing.getTitleElement()) {
+		$(expando.button).insertAfter(element.parentElement);
+		thing.entry.appendChild(expando.box);
+	} else {
+		$(element).add($(element).next('.keyNavAnnotation')).last()
+			.after(expando.box)
+			.after($('<span class="res-freetext-expando">').append(expando.button));
+	}
 }
 
 async function completeExpando(expando, thing, mediaInfo) {
@@ -1011,7 +1011,7 @@ async function completeExpando(expando, thing, mediaInfo) {
 		}));
 	}
 
-	if (module.options.autoMaxHeight.value && thing && expando.inText) {
+	if (module.options.autoMaxHeight.value && thing && inText(expando.button)) {
 		thing.entry.addEventListener('mediaResize', updateParentHeight);
 	}
 
@@ -1019,7 +1019,7 @@ async function completeExpando(expando, thing, mediaInfo) {
 		let autoExpand;
 		let autoExpandFirstVisibleNonMutedInThing;
 
-		if (module.options.autoExpandSelfText.value && expando.inText && thing && thing.isSelfPost() && !isPageType('comments')) {
+		if (module.options.autoExpandSelfText.value && inText(expando.button) && thing && thing.isSelfPost() && !isPageType('comments')) {
 			const dontAutoExpandNSFW = !module.options.autoExpandSelfTextNSFW.value && thing.isNSFW();
 			autoExpand = !dontAutoExpandNSFW;
 			autoExpandFirstVisibleNonMutedInThing = module.options.autoExpandSelfTextFirstVisibleNonMuted.value;

--- a/lib/modules/showImages/expando.js
+++ b/lib/modules/showImages/expando.js
@@ -123,8 +123,7 @@ export class Expando {
 	generateMedia: ?() => ExpandoMediaElement;
 	onMediaAttach: ?() => void;
 
-	constructor(inText: boolean, lock: *, unlock: *) {
-		this.inText = inText;
+	constructor(lock: *, unlock: *) {
 		this.locked = !!lock;
 		if (lock) lock.then(() => { this.locked = false; this.updateButton(); });
 		this.unlock = unlock;
@@ -172,8 +171,7 @@ export class Expando {
 		this.button.className = [
 			'expando-button toggleImage',
 			mediaClass || 'expando-button-loading',
-			(this.open || this.expandWanted) ? 'expanded' : 'collapsed collapsedExpando',
-			this.inText ? 'commentImg' : 'linkImg',
+			this.open || this.expandWanted ? 'expanded' : 'collapsed collapsedExpando',
 		].join(' ');
 
 		if (!this.isPrimary()) {


### PR DESCRIPTION
- Sets the height of the button to match the line-height in order to avoid mismatched line-heights
- Makes it resist subreddit-style `float`.

![image](https://user-images.githubusercontent.com/1748521/31720669-79c8e88e-b417-11e7-94b9-386be96ebcbb.png)

Tested in: Firefox 58, Chrome 63