### PR TITLE
keyboardNav: Move to the previously selected thing

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -302,6 +302,13 @@ module.options = {
 		title: 'keyboardNavMoveToParentTitle',
 		callback() { SelectedEntry.move('toParent', { scrollStyle: module.options.nonLinearScrollStyle.value }); },
 	},
+	undoMove: {
+		type: 'keycode',
+		value: [90, false, true, false, false], // ctrl-z
+		description: 'keyboardNavUndoMoveDesc',
+		title: 'keyboardNavUndoMoveTitle',
+		callback() { SelectedEntry.move('previous', { scrollStyle: module.options.nonLinearScrollStyle.value }); },
+	},
 	showParents: {
 		type: 'keycode',
 		requiresModule: ShowParent,

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -179,10 +179,12 @@ const runCallbacks = (() => {
 	};
 })();
 
+let oldSelected;
+
 export function select(newSelected: Thing, options: SelectOptions = { scrollStyle: 'none' }) {
 	if (newSelected === selectedThing) return;
 
-	const oldSelected = selectedThing;
+	oldSelected = selectedThing;
 
 	options = {
 		...options,
@@ -261,6 +263,7 @@ const movers = {
 	downThread: (thing: Thing) => thing.getThreadTop().getNextSibling({ direction: 'down' }),
 	toTopComment: (thing: Thing) => thing.getThreadTop(),
 	toParent: (thing: Thing) => thing.getParent(),
+	previous: (/*:: thing: Thing */) => oldSelected,
 };
 
 let recentKeyMove = false;

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -564,6 +564,12 @@
 	"keyboardNavMoveToParentDesc": {
 		"message": "Move to parent (in comments)."
 	},
+	"keyboardNavUndoMoveTitle": {
+		"message": "Undo Move"
+	},
+	"keyboardNavUndoMoveDesc": {
+		"message": "Move to the previously selected thing."
+	},
 	"keyboardNavShowParentsTitle": {
 		"message": "Show Parents"
 	},


### PR DESCRIPTION
Shortcut: Ctrl+Z

I fairly often see something interesting just after starting to press the jump to the next comment thread-shortcut, so it's nice to have a way to quickly return to that position.

Tested in browser:  Chrome 63