### PR TITLE
Update Contributing doc to match new Chrome menus (Tools -> More tools)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,9 +57,9 @@ The default host and port (`localhost` and `4444`) should work for most local in
 
 ##### Chrome
 
-1. Go to `Menu->Tools->Extensions` and tick the `Developer Mode` checkbox.
+1. Go to `Menu->More tools->Extensions` and tick the `Developer Mode` checkbox.
 1. Click `Load unpacked extension` and select the `/dist/chrome` folder (not the `/chrome` folder).
-1. Any time you make changes, you must go back to the `Menu->Tools->Extensions` page and `Reload` the extension.
+1. Any time you make changes, you must go back to the `Menu->More tools->Extensions` page and `Reload` the extension.
 
 ##### Microsoft Edge
 


### PR DESCRIPTION
Relevant issue: None. Was going through Contributing doc as a new contributor and saw that the path to get to Chrome extensions had changed from Menu -> Tools -> Extensions to Menu -> More tools -> Extensions.

Tested in browser: Chrome
![image](https://user-images.githubusercontent.com/2118649/31805216-c1ec04b2-b524-11e7-912d-9a239b047566.png)

