### PR TITLE
Show nightModeAutomaticNightModeDenied message only when the user actually denied permission

### DIFF
--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -297,16 +297,24 @@ async function getNightModeTimes() {
 			} catch (err) {
 				console.warn('Failed to init automatic night mode:', err);
 
-				return Alert.open(i18n('nightModeAutomaticNightModeDenied', 'confirm'), { cancelable: true })
-					.then(() => {
-						// they clicked confirm, turn it off
-						Options.set(module, 'automaticNightMode', 'none');
+				switch (err.code) {
+					case err.PERMISSION_DENIED:
+						return Alert.open(i18n('nightModeAutomaticNightModeDenied', 'confirm'), { cancelable: true })
+							.then(() => {
+								// they clicked confirm, turn it off
+								Options.set(module, 'automaticNightMode', 'none');
 
-						return {
-							startingTime: new Date(0),
-							endingTime: new Date(0),
-						};
-					});
+								return {
+									startingTime: new Date(0),
+									endingTime: new Date(0),
+								};
+							});
+					case err.POSITION_UNAVAILABLE:
+					case err.TIMEOUT:
+					case err.UNKNOWN_ERROR:
+					default:
+						throw err;
+				}
 			}
 		case 'user':
 			return {


### PR DESCRIPTION
The problem was, that we were displaying the message about user denying location permission in case of ANY geolocation error. As a result, I - being in a high speed train at the moment - have received 865898 false alerts about denying location permission.

We need to decide how we should handle other kinds of errors. So far, I have just placed switch() in order to make it easy to implement.