### PR TITLE
Adding keyboard shortcut to edit selected comment or self-post

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -573,7 +573,9 @@ module.options = {
 		description: 'keyboardNavEditDesc',
 		title: 'keyboardNavEditTitle',
 		mustBeLoggedIn: true,
-		callback: edit,
+		callback() {
+			click(getFirstElementInThingByQuery('.entry .edit-usertext', ASSERT, getSelected()));
+		},
 	},
 	followPermalink: {
 		type: 'keycode',
@@ -1111,12 +1113,6 @@ function reply(selected = getSelected()) {
 		// User cannot reply directly from this page, so go to where they can reply
 		getFirstElementInThingByQuery('.buttons a.comments, .buttons a.bylink', NOASSERT, selected)
 	));
-}
-
-function edit(selected = getSelected()) {
-	if (selected.isComment() || selected.isSelfPost()) {
-		click(getFirstElementInThingByQuery('.edit-usertext', ASSERT, selected));
-	}
 }
 
 function navigateTo(newWindow, href) {

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -566,6 +566,15 @@ module.options = {
 		mustBeLoggedIn: true,
 		callback: reply,
 	},
+	edit: {
+		type: 'keycode',
+		include: ['comments', 'profile'],
+		value: [69, false, false, false, false], // e
+		description: 'keyboardNavEditDesc',
+		title: 'keyboardNavEditTitle',
+		mustBeLoggedIn: true,
+		callback: edit,
+	},
 	followPermalink: {
 		type: 'keycode',
 		include: ['comments', 'commentsLinklist', 'inbox'],
@@ -1102,6 +1111,12 @@ function reply(selected = getSelected()) {
 		// User cannot reply directly from this page, so go to where they can reply
 		getFirstElementInThingByQuery('.buttons a.comments, .buttons a.bylink', NOASSERT, selected)
 	));
+}
+
+function edit(selected = getSelected()) {
+	if (selected.isComment() || selected.isSelfPost()) {
+		click(getFirstElementInThingByQuery('.edit-usertext', ASSERT, selected));
+	}
 }
 
 function navigateTo(newWindow, href) {

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -738,6 +738,12 @@
 	"keyboardNavReplyDesc": {
 		"message": "Reply to current comment (comment pages only)."
 	},
+	"keyboardNavEditTitle": {
+		"message": "Edit"
+	},
+	"keyboardNavEditDesc": {
+		"message": "Edit current comment or self-post."
+	},
 	"keyboardNavFollowPermalinkTitle": {
 		"message": "Follow Permalink"
 	},


### PR DESCRIPTION
This resolves #2466.
Tested in browser: Firefox Developer Edition (57.0b10).

Pressing 'e' triggers the edit button under a selected comment or self-post, currently enabled on comment and profile pages.

I am not all that familiar with the codebase, so I may have missed things. I hope it doesn't break existing functionality. Do the current integration tests support any way of testing features that require the user to be logged in?