### PR TITLE
Firefox: open new tabs in the same container

### DIFF
--- a/firefox/background.entry.js
+++ b/firefox/background.entry.js
@@ -28,13 +28,14 @@ addListener('download', ({ url, filename }) => {
 	chrome.downloads.download({ url, filename });
 });
 
-// Firefox doesn't support openerTabId
-addListener('openNewTabs', ({ urls, focusIndex }, { index: currentIndex }) => {
+// Firefox doesn't support openerTabId, and needs cookieStoreId to open in correct container
+addListener('openNewTabs', ({ urls, focusIndex }, { index: currentIndex, cookieStoreId }) => {
 	urls.forEach((url, i) => {
 		chrome.tabs.create({
 			url,
 			active: i === focusIndex,
 			index: ++currentIndex,
+			cookieStoreId,
 		});
 	});
 });


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: https://www.reddit.com/r/Enhancement/comments/78iyos/new_ushiftu_shortcut_opens_a_user_profile_in_a/
Tested in browser: Firefox 56, Firefox 58.0a1 (2017-10-22)