### PR TITLE
userTagger: move color back to parent element

### DIFF
--- a/lib/css/modules/_userTagger.scss
+++ b/lib/css/modules/_userTagger.scss
@@ -105,6 +105,7 @@ a.voteWeight {
 }
 
 .RESUserTag {
+	color: black;
 	display: inline-block;
 
 	// unselectable in comments/markdown for usability
@@ -121,8 +122,6 @@ a.voteWeight {
 }
 
 .userTagLink {
-	color: black;
-
 	&:hover { text-decoration: none !important; }
 
 	&.hasTag {


### PR DESCRIPTION
Tested in browser: Chrome 62

re #4382

Tags either get a specific color as an inline style (which works) or `color: "inherit"`, which makes them grey in taglines, since .RESUserTag (the parent) inherits the tagline color.

@larsjohnsen if reverting this line breaks something else, there are other ways I could fix this

