### PR TITLE
followLinkAndCommentsNewTab no longer opens duped tabs.

### DIFF
--- a/lib/modules/singleClick.js
+++ b/lib/modules/singleClick.js
@@ -77,12 +77,12 @@ export function openTabs(thing: Thing, focused: boolean) {
 		const comments = thing.getCommentsLink().href;
 		// to avoid opening two of the same link, ensure
 		// the comments link is not the same as the post link.
-		if (comments != link) {
+		if (comments !== link) {
 			urls.push(comments);
 		}
 	} else if (module.options.openFrontpage.value) {
 		const frontpageLink = thing.getSubredditLink();
-		if (frontpageLink && frontpageLink != link) {
+		if (frontpageLink && frontpageLink !== link) {
 			urls.push(frontpageLink.href);
 		}
 	}

--- a/lib/modules/singleClick.js
+++ b/lib/modules/singleClick.js
@@ -70,7 +70,7 @@ module.go = () => {
 };
 
 export function openTabs(thing: Thing, focused: boolean) {
-	const link = thing.getPostLink().href;
+	const link = thing.getPostUrl();
 	const urls = [link];
 
 	if (thing.isLinkPost()) {

--- a/lib/modules/singleClick.js
+++ b/lib/modules/singleClick.js
@@ -75,10 +75,16 @@ export function openTabs(thing: Thing, focused: boolean) {
 
 	if (thing.isLinkPost()) {
 		const comments = thing.getCommentsLink().href;
-		urls.push(comments);
+		// to avoid opening two of the same link, ensure
+		// the comments link is not the same as the post link.
+		if (comments != link) {
+			urls.push(comments);
+		}
 	} else if (module.options.openFrontpage.value) {
 		const frontpageLink = thing.getSubredditLink();
-		if (frontpageLink) urls.push(frontpageLink.href);
+		if (frontpageLink && frontpageLink != link) {
+			urls.push(frontpageLink.href);
+		}
 	}
 
 	if (module.options.openOrder.value === 'commentsfirst') urls.reverse();

--- a/lib/modules/singleClick.js
+++ b/lib/modules/singleClick.js
@@ -82,7 +82,7 @@ export function openTabs(thing: Thing, focused: boolean) {
 		}
 	} else if (module.options.openFrontpage.value) {
 		const frontpageLink = thing.getSubredditLink();
-		if (frontpageLink && frontpageLink !== link) {
+		if (frontpageLink && frontpageLink.href !== link) {
 			urls.push(frontpageLink.href);
 		}
 	}

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -217,6 +217,10 @@ export class Thing {
 		return downcast(this.entry.querySelector('a.title, a.search-link'), HTMLAnchorElement);
 	}
 
+	getPostUrl(): string {
+		return this.element.dataset.url || this.getPostLink().href;
+	}
+
 	getCommentsLink(): HTMLAnchorElement {
 		return downcast(this.entry.querySelector('a.comments, a.search-comments'), HTMLAnchorElement);
 	}


### PR DESCRIPTION
Relevant issue: #4423 
Tested in browser: Chrome

This is a simple stopgap to address #4423, which may have some issues beyond the control of RES. The comments link will now only open once.