### PR TITLE
Cache: Rename to LRUCache, and make typing stricter

### DIFF
--- a/browser/background.js
+++ b/browser/background.js
@@ -13,7 +13,7 @@ import cssOffSmall from '../images/css-off-small.png';
 import cssOn from '../images/css-on.png';
 import cssOnSmall from '../images/css-on-small.png';
 import { getLocaleDictionary } from '../locales';
-import { Cache } from '../lib/utils/Cache';
+import { LRUCache } from '../lib/utils/Cache';
 import { keyedMutex } from '../lib/utils/async';
 import { createMessageHandler } from './utils/messaging';
 import { apiToPromise } from './utils/api';
@@ -113,11 +113,12 @@ addListener('storage-cas', keyedMutex(async ([key, oldValue, newValue]) => {
 	return true;
 }, ([key]) => key));
 
-const cache = new Cache(512);
+const cache = new LRUCache(512);
 addListener('XHRCache', ([operation, key, value]) => {
 	switch (operation) {
 		case 'set':
-			return cache.set(key, value);
+			cache.set(key, value);
+			break;
 		case 'check':
 			return cache.get(key, value);
 		case 'delete':

--- a/lib/utils/Cache.js
+++ b/lib/utils/Cache.js
@@ -37,7 +37,7 @@ export class LRUCache<K, V> {
 		return this;
 	}
 
-	delete(key: K): bool {
+	delete(key: K): boolean {
 		return this.map.delete(key);
 	}
 

--- a/lib/utils/Cache.js
+++ b/lib/utils/Cache.js
@@ -15,7 +15,7 @@ export class LRUCache<K, V> {
 		this.capacity = capacity;
 	}
 
-	get(key: K, maxAge: number = Infinity): ?V {
+	get(key: K, maxAge: number = Infinity): V | void {
 		const now = Date.now();
 		const entry = this.map.get(key);
 		if (entry && (now - entry.createTime < maxAge)) {

--- a/lib/utils/Cache.js
+++ b/lib/utils/Cache.js
@@ -1,32 +1,49 @@
 /* @flow */
 
-export class Cache<K, V> extends Map<K, $FlowIgnore> {
+type CacheV<V> = {
+	value: V;
+	createTime: number;
+	hitTime: number;
+};
+
+export class LRUCache<K, V> {
+	map: Map<K, CacheV<V>>;
 	capacity: number;
 
 	constructor(capacity: number) {
-		super();
+		this.map = new Map();
 		this.capacity = capacity;
 	}
 
-	get(key: K, maxAge?: number = Infinity): V | void {
+	get(key: K, maxAge: number = Infinity): ?V {
 		const now = Date.now();
-		const entry = super.get(key);
+		const entry = this.map.get(key);
 		if (entry && (now - entry.createTime < maxAge)) {
 			entry.hitTime = now;
 			return entry.value;
 		}
 	}
 
-	set(key: K, value: V): $FlowIgnore {
+	set(key: K, value: V): this {
 		const now = Date.now();
-		super.set(key, { value, createTime: now, hitTime: now });
+		this.map.set(key, { value, createTime: now, hitTime: now });
 
-		if (this.size > this.capacity) {
-			// evict least-recently used (hit)
-			Array.from(this.entries())
+		if (this.map.size > this.capacity) {
+			// Evict least-recently used (hit)
+			Array.from(this.map.entries())
 				.sort(([, a], [, b]) => b.hitTime - a.hitTime)
 				.slice((this.capacity / 2) | 0)
-				.forEach(([key]) => this.delete(key));
+				.forEach(([key]) => this.map.delete(key));
 		}
+
+		return this;
+	}
+
+	delete(key: K): bool {
+		return this.map.delete(key);
+	}
+
+	clear(): void {
+		this.map.clear();
 	}
 }

--- a/lib/utils/Cache.js
+++ b/lib/utils/Cache.js
@@ -1,13 +1,11 @@
 /* @flow */
 
-type CacheV<V> = {
-	value: V;
-	createTime: number;
-	hitTime: number;
-};
-
 export class LRUCache<K, V> {
-	map: Map<K, CacheV<V>>;
+	map: Map<K, {
+		value: V,
+		createTime: number,
+		hitTime: number,
+	}>;
 	capacity: number;
 
 	constructor(capacity: number) {

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 export {
-	Cache,
+	LRUCache,
 } from './Cache';
 
 export {


### PR DESCRIPTION
Since the `LRUCache` doesn't need all of the methods of `Map`, and has some type differences, it seems to make more sense to use composition over inheritance.