### PR TITLE
Truncate user tags if too long. (#4500)

### DIFF
--- a/lib/css/modules/_userTagger.scss
+++ b/lib/css/modules/_userTagger.scss
@@ -131,6 +131,15 @@ a.voteWeight {
 		border-radius: 3px;
 		font-size: .9em;
 	}
+
+	&.truncateTag {
+		max-width: 25ch;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		display: inherit;
+		margin: 0 0 -3px 0;
+	}
 }
 
 #userTaggerTable th {

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -80,6 +80,13 @@ module.options = {
 		advanced: true,
 		dependsOn: options => options.trackVoteWeight.value,
 	},
+	truncateTag: {
+		title: 'userTaggerTruncateTagTitle',
+		type: 'boolean',
+		value: true,
+		description: 'userTaggerTruncateTagDesc',
+		advanced: true,
+	},
 };
 
 export const usernameRE = /(?:u|user)\/([\w\-]+)/;
@@ -158,9 +165,9 @@ export class Tag {
 				<a
 					class="userTagLink ${(text || color) ? 'hasTag' : 'RESUserTagImage'}"
 					${color && string._html`style="background-color: ${color}; color: ${bgToTextColorMap[color]} !important;"`}
-					title="set a tag"
+					title="${(text) ? text : 'set a tag'}"
 					href="javascript:void 0"
-				>${text}</a>
+				>${text && module.options.truncateTag.value ? text.length > 30 ? `${text.substr(0, 27)}...` : text : text}</a>
 			</span>
 		`;
 	}

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -163,11 +163,11 @@ export class Tag {
 		return string.html`
 			<span class="RESUserTag">
 				<a
-					class="userTagLink ${(text || color) ? 'hasTag' : 'RESUserTagImage'}"
+					class="userTagLink ${(text || color) ? 'hasTag' : 'RESUserTagImage'} ${module.options.truncateTag.value ? 'truncateTag' : ''}"
 					${color && string._html`style="background-color: ${color}; color: ${bgToTextColorMap[color]} !important;"`}
-					title="${(text) ? text : 'set a tag'}"
+					title="${text || 'set a tag'}"
 					href="javascript:void 0"
-				>${text && module.options.truncateTag.value ? text.length > 30 ? `${text.substr(0, 27)}...` : text : text}</a>
+				>${text}</a>
 			</span>
 		`;
 	}

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -2797,6 +2797,9 @@
 	"userTaggerVWNumberDesc": {
 		"message": "Show the number (i.e. [+6]) rather than [vw]"
 	},
+	"userTaggerTruncateTagDesc": {
+		"message": "Truncates long tags to 30 characters. Hovering over them reveals the full content."
+	},
 	"scrollOnCollapseDesc": {
 		"message": "Scrolls to next comment when a comment is collapsed."
 	},
@@ -3064,6 +3067,9 @@
 	},
 	"userTaggerVwNumberTitle": {
 		"message": "VW Number"
+	},
+	"userTaggerTruncateTagTitle": {
+		"message": "Truncate Tags"
 	},
 	"singleClickOpenOrderTitle": {
 		"message": "Open Order"


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: #4500 
Tested in browser:  Chrome, Firefox

I tried to use css but the max-width: 30ch; Did not seem to work well with anchor tags.
