### PR TITLE
Prepare workaround for potential extension CSS precedence change

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -13,6 +13,7 @@
 module.use_strict=true
 
 module.name_mapper='^exec-loader\(\?cache\)?!\(.+\)$'->'\2'
+module.name_mapper.extension='scss'->'<PROJECT_ROOT>/flow/stub/scss.js'
 
 esproposal.export_star_as=enable
 

--- a/browser/foreground.js
+++ b/browser/foreground.js
@@ -28,6 +28,8 @@ export {
 
 addInterceptor('extensionId', () => chrome.runtime.id);
 
+addInterceptor('getUrl', path => chrome.extension.getURL(path));
+
 addInterceptor('isPrivateBrowsing', () => chrome.extension.inIncognitoContext);
 
 const _set = apiToPromise((items, callback) => chrome.storage.local.set(items, callback));

--- a/chrome/beta/manifest.json
+++ b/chrome/beta/manifest.json
@@ -52,11 +52,11 @@
 		"js": [
 			"{{../../lib/main.entry.js}}"
 		],
-		"css": [
-			"{{../../lib/css/res.scss}}"
-		],
 		"run_at": "document_start"
 	}],
+	"web_accessible_resources": [
+		"{{../../lib/css/res.scss}}"
+	],
 	"permissions": [
 		"https://*.reddit.com/*",
 		"cookies",

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -52,11 +52,11 @@
 		"js": [
 			"{{../lib/main.entry.js}}"
 		],
-		"css": [
-			"{{../lib/css/res.scss}}"
-		],
 		"run_at": "document_start"
 	}],
+	"web_accessible_resources": [
+		"{{../lib/css/res.scss}}"
+	],
 	"permissions": [
 		"https://*.reddit.com/*",
 		"cookies",

--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -52,11 +52,11 @@
 			"{{./edge.entry.js}}",
 			"{{../lib/main.entry.js}}"
 		],
-		"css": [
-			"{{../lib/css/res.scss}}"
-		],
 		"run_at": "document_start"
 	}],
+	"web_accessible_resources": [
+		"{{../lib/css/res.scss}}"
+	],
 	"permissions": [
 		"https://*.reddit.com/*",
 		"cookies",

--- a/firefox/beta/manifest.json
+++ b/firefox/beta/manifest.json
@@ -56,11 +56,11 @@
 		"js": [
 			"{{../../lib/main.entry.js}}"
 		],
-		"css": [
-			"{{../../lib/css/res.scss}}"
-		],
 		"run_at": "document_start"
 	}],
+	"web_accessible_resources": [
+		"{{../../lib/css/res.scss}}"
+	],
 	"permissions": [
 		"https://*.reddit.com/*",
 		"cookies",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -56,11 +56,11 @@
 		"js": [
 			"{{../lib/main.entry.js}}"
 		],
-		"css": [
-			"{{../lib/css/res.scss}}"
-		],
 		"run_at": "document_start"
 	}],
+	"web_accessible_resources": [
+		"{{../lib/css/res.scss}}"
+	],
 	"permissions": [
 		"https://*.reddit.com/*",
 		"cookies",

--- a/flow/stub/scss.js
+++ b/flow/stub/scss.js
@@ -1,0 +1,3 @@
+/* @flow */
+
+export default ('': string);

--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import { RES_DISABLED_KEY } from '../constants/sessionStorage';
+import { injectCss } from '../css';
 import { _loadI18n } from '../environment/i18n';
 import * as Modules from './modules';
 import { _loadModuleOptions } from './options/options';
@@ -30,6 +31,8 @@ export function init() {
 // DOM / browser state
 
 const sourceLoaded = new Promise(resolve => (start = resolve));
+
+sourceLoaded.then(() => injectCss());
 
 // Edge has weird bugs with MutationObservers
 // so just make a best effort at divining when the head and body are ready

--- a/lib/css/index.js
+++ b/lib/css/index.js
@@ -1,0 +1,12 @@
+/* @flow */
+
+import { getExtensionUrl } from '../environment/getUrl';
+
+import cssPath from './res.scss';
+
+export function injectCss() {
+	const link = document.createElement('link');
+	link.rel = 'stylesheet';
+	link.href = getExtensionUrl(cssPath);
+	(document.head || document.documentElement).prepend(link);
+}

--- a/lib/environment/getUrl.js
+++ b/lib/environment/getUrl.js
@@ -1,0 +1,7 @@
+/* @flow */
+
+import { sendSynchronous } from '../../browser';
+
+export function getExtensionUrl(path: string): string {
+	return sendSynchronous('getUrl', path);
+}

--- a/lib/environment/index.js
+++ b/lib/environment/index.js
@@ -3,6 +3,7 @@
 export { addURLToHistory, isURLVisited } from './history';
 export { ajax } from './ajax';
 export { download } from './download';
+export { getExtensionUrl } from './getUrl';
 export { getExtensionId } from './id';
 export { i18n } from './i18n';
 export { isPrivateBrowsing } from './privateBrowsing';


### PR DESCRIPTION
Tested in browser: Chrome 64, Firefox 55, Edge 16

This change may be backed out of Chromium; it does make !important rules more powerful, but it makes non-!important rules much less useful.

Won't be merged until shortly before 64 goes stable (probably).