### PR TITLE
Added upvoted sort type to the navigator sortTypes class

### DIFF
--- a/lib/modules/commentNavigator.js
+++ b/lib/modules/commentNavigator.js
@@ -154,6 +154,10 @@ const sortTypes: {
 		getPosts: () => document.querySelectorAll('.new-comment'),
 		disabled: () => !document.body.querySelector('.gold-accent.comment-visits-box'),
 	},
+	upvoted: {
+		title: 'Navigate through comments you upvoted',
+		getPosts: () => document.querySelectorAll('.upmod'),
+	},
 };
 
 function getCategory() {


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: fixes #4512 
Tested in browser: Chrome, Firefox

When you upvote something it changes css classes from 'up' to 'upmod'. I added a new sort type that gets all the upmod classes in  the commentNavigator class. I build it in chrome and firefox, and it behaved the same as the image and video navigator in my dev environment.

Let me know if there is anything I can do to improve the quality of my contribution.
