### PR TITLE
Use openerTabId with openNewTabs on Firefox

### DIFF
--- a/firefox/background.entry.js
+++ b/firefox/background.entry.js
@@ -28,13 +28,13 @@ addListener('download', ({ url, filename }) => {
 	chrome.downloads.download({ url, filename });
 });
 
-// Firefox doesn't support openerTabId, and needs cookieStoreId to open in correct container
-addListener('openNewTabs', ({ urls, focusIndex }, { index: currentIndex, cookieStoreId }) => {
+// Firefox needs cookieStoreId to open in correct container
+addListener('openNewTabs', ({ urls, focusIndex }, { id: tabId, cookieStoreId }) => {
 	urls.forEach((url, i) => {
 		chrome.tabs.create({
 			url,
 			active: i === focusIndex,
-			index: ++currentIndex,
+			openerTabId: tabId,
 			cookieStoreId,
 		});
 	});

--- a/firefox/beta/manifest.json
+++ b/firefox/beta/manifest.json
@@ -8,7 +8,7 @@
 	"applications": {
 		"gecko": {
 			"id": "jid1-xUfzOsOFlzSOXg@jetpack",
-			"strict_min_version": "55.0"
+			"strict_min_version": "57.0"
 		}
 	},
 	"icons": {

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -8,7 +8,7 @@
 	"applications": {
 		"gecko": {
 			"id": "jid1-xUfzOsOFlzSOXg@jetpack",
-			"strict_min_version": "55.0"
+			"strict_min_version": "57.0"
 		}
 	},
 	"icons": {


### PR DESCRIPTION
Relevant issue: fixes #4514 
Tested in browser: `Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:57.0) Gecko/20100101 Firefox/57.0`

Edit(erikdesjardins): fixes #4230
Edit(mc10): fixes #190