### PR TITLE
[WIP] Integrate RES userinfo hover-card with new reddit-hovercards

### DIFF
--- a/lib/css/modules/_userInfo.scss
+++ b/lib/css/modules/_userInfo.scss
@@ -1,12 +1,21 @@
-#authorInfoToolTip {
-	.blueButton {
-		float: right;
-		margin-left: 8px;
-		margin-top: 12px;
+.author-tooltip {
+	h3, .res-tags {
+		display: inline-block;
+	}
+	.res-tags {
+		margin-left: .5em;
+		line-height: 26px;
+    	vertical-align: top;
 	}
 
-	.redButton {
-		float: right;
-		margin-left: 8px;
+	.author-tooltip__link-list {
+		a.blue, a.red {
+			background: #fff;
+			border: 0;
+			cursor: pointer;
+		}
+		a.red {
+			color: rgb(255, 87, 87);
+		}
 	}
 }

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -107,31 +107,28 @@ module.go = () => {
 		//author-tooltip 
 		const addedNode = downcast(mutation.addedNodes[0], HTMLElement);
 		if (addedNode.classList.contains('author-tooltip')){
-			setTimeout(() => { renderHoverCardInfo(addedNode) }, 500);
-			
+			setTimeout(() => { renderHoverCardInfo(addedNode); }, 500); // Need better way to await reddit data load
 		}
 	});
 };
 
-
 async function renderHoverCardInfo(hoverCard) {
 	const authorLink = hoverCard.querySelector('.author-tooltip__profile-link');
-	const header = hoverCard.querySelector('.author-tooltip__head');
-	const links = hoverCard.querySelector('.author-tooltip__link-list');
-
 	const [, username] = UserTagger.usernameRE.exec(authorLink.href);
-
-	applyUserTag(hoverCard, header, links, username);
-
+	applyResData(hoverCard, username);
 }
 
-async function applyUserTag(hoverCard, header, links, username) {
+async function applyResData(hoverCard, username) {
+	const header = hoverCard.querySelector('.author-tooltip__head');
+	const links = hoverCard.querySelector('.author-tooltip__link-list');
+	const $hoverCard = $(hoverCard);
+
 	const userTaggerEnabled = Modules.isRunning(UserTagger);
 	const userTag = userTaggerEnabled && await UserTagger.Tag.get(username);
 
 	let userHTML;
 	if (userTaggerEnabled) {
-		userHTML = `<div class="fieldPair"><div class="fieldPair-label">${i18n('userInfoUserTag')}</div> <div class="fieldPair-text" style="display:flex"><a class="author" style="display: none;" href="/u/${username}"/></div></div>`;
+		userHTML = `<a class="author" style="display: none;" href="/u/${username}"/>`;
 	}
 
 	if (userTag && userTag.link) {
@@ -140,21 +137,39 @@ async function applyUserTag(hoverCard, header, links, username) {
 	}
 
 	const tagger = document.createElement('div');
-	tagger.innerHTML = userHTML; 
-	header.insertBefore(tagger, header.querySelector('.author-tooltip__credentials-list'));
+	tagger.classList.add('res-tags');
+	tagger.innerHTML = userHTML; //author-tooltip__title
+	header.insertBefore(tagger, header.querySelector('h3').nextSibling);
 
 	if (userTag) {
-		const getButton = () => string.escape`<div class="${userTag.ignored ? 'redButton' : 'blueButton'}" id="ignoreUser">&empty; ${userTag.ignored ? i18n('userInfoUnignore') : i18n('userInfoIgnore')}</div>`;
+		const getButton = () => string.escape`<a class="${userTag.ignored ? 'red' : 'blue'}" id="ignoreUser">&empty; ${userTag.ignored ? i18n('userInfoUnignore') : i18n('userInfoIgnore')}</a>`;
 
-		$(hoverCard).on('click', '#ignoreUser', (e: Event) => {
-			if (e.target.classList.contains('blueButton')) userTag.ignore();
+		$hoverCard.on('click', '#ignoreUser', (e: Event) => {
+			if (e.target.classList.contains('blue')) userTag.ignore();
 			else userTag.unignore();
 			$(e.target).replaceWith(getButton());
 		});
 		const li = document.createElement('li');
 		li.innerHTML = getButton();
-
 		links.appendChild(li);
+	}
+
+	if (userTag) {
+		userTag.add(downcast($hoverCard.find('.author').get(0), HTMLAnchorElement), { renderTaggingIcon: true });
+	}
+
+	if (module.options.highlightButton.value) {
+		const isHighlight = !highlightedUsers[username];
+		userHTML = string.escape`<a class="${isHighlight ? 'blue' : 'red'}" id="highlightUser" data-userid="${username}">${isHighlight ? i18n('userInfoHighlight') : i18n('userInfoUnhighlight')}</a>`;
+		
+		const li = document.createElement('li');
+		li.innerHTML = userHTML;
+		links.appendChild(li);
+
+		$hoverCard.find('#highlightUser').on('click', ({ target }: Event) => {
+			const userid = target.getAttribute('data-userid');
+			toggleUserHighlight(target, userid);
+		});
 	}
 }
 
@@ -361,7 +376,7 @@ function toggleUserHighlight(authorInfoToolTipHighlight, userid) {
 
 function toggleUserHighlightButton(authorInfoToolTipHighlight, canHighlight) {
 	$(authorInfoToolTipHighlight)
-		.toggleClass('blueButton', canHighlight)
-		.toggleClass('redButton', !canHighlight)
+		.toggleClass('blue', canHighlight)
+		.toggleClass('red', !canHighlight)
 		.text(canHighlight ? i18n('userInfoHighlight') : i18n('userInfoUnhighlight'));
 }

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -14,6 +14,7 @@ import {
 	loggedInUser,
 	string,
 	Thing,
+	observe
 } from '../utils';
 import * as CommentNavigator from './commentNavigator';
 import * as Hover from './hover';
@@ -101,10 +102,64 @@ module.options = {
 export const highlightedUsers = {};
 
 module.go = () => {
-	if (module.options.hoverInfo.value) {
-		$(document.body).on('mouseover', UserTagger.usernameSelector, handleMouseOver);
-	}
+	observe(document.body, { childList: true }, mutation => {
+		if (!mutation.addedNodes.length) return;
+		//author-tooltip 
+		const addedNode = downcast(mutation.addedNodes[0], HTMLElement);
+		if (addedNode.classList.contains('author-tooltip')){
+			setTimeout(() => { renderHoverCardInfo(addedNode) }, 500);
+			
+		}
+	});
 };
+
+
+async function renderHoverCardInfo(hoverCard) {
+	const authorLink = hoverCard.querySelector('.author-tooltip__profile-link');
+	const header = hoverCard.querySelector('.author-tooltip__head');
+	const links = hoverCard.querySelector('.author-tooltip__link-list');
+
+	const [, username] = UserTagger.usernameRE.exec(authorLink.href);
+
+	applyUserTag(hoverCard, header, links, username);
+
+}
+
+async function applyUserTag(hoverCard, header, links, username) {
+	const userTaggerEnabled = Modules.isRunning(UserTagger);
+	const userTag = userTaggerEnabled && await UserTagger.Tag.get(username);
+
+	let userHTML;
+	if (userTaggerEnabled) {
+		userHTML = `<div class="fieldPair"><div class="fieldPair-label">${i18n('userInfoUserTag')}</div> <div class="fieldPair-text" style="display:flex"><a class="author" style="display: none;" href="/u/${username}"/></div></div>`;
+	}
+
+	if (userTag && userTag.link) {
+		const links = userTag.link.split(/\s/).reduce((acc, url) => acc + string.escape`<a target="_blank" rel="noopener noreferer" href="${url}">${url.replace(/^https?:\/\/(www\.)?/, '')}</a>`, '');
+		userHTML += `<div class="fieldPair"><div class="fieldPair-label">${i18n('userInfoLink')}</div> <div class="fieldPair-text">${links}</div></div>`;
+	}
+
+	const tagger = document.createElement('div');
+	tagger.innerHTML = userHTML; 
+	header.insertBefore(tagger, header.querySelector('.author-tooltip__credentials-list'));
+
+	if (userTag) {
+		const getButton = () => string.escape`<div class="${userTag.ignored ? 'redButton' : 'blueButton'}" id="ignoreUser">&empty; ${userTag.ignored ? i18n('userInfoUnignore') : i18n('userInfoIgnore')}</div>`;
+
+		$(hoverCard).on('click', '#ignoreUser', (e: Event) => {
+			if (e.target.classList.contains('blueButton')) userTag.ignore();
+			else userTag.unignore();
+			$(e.target).replaceWith(getButton());
+		});
+		const li = document.createElement('li');
+		li.innerHTML = getButton();
+
+		links.appendChild(li);
+	}
+}
+
+
+
 
 function handleMouseOver(e: Event) {
 	const authorLink = downcast(e.target, HTMLAnchorElement);


### PR DESCRIPTION
This is still in progress so code is still pretty dodgy.

Basic hover cards now look like
![image](https://user-images.githubusercontent.com/887397/32193695-fe3fa7d2-bdaf-11e7-9227-437e7e39c5eb.png)
V2 profile hover cards now look like
![image](https://user-images.githubusercontent.com/887397/32193721-128b7d4c-bdb0-11e7-8792-eb2f993440e5.png)

Overview of features;
* tagger next to name
* Ignore user button added
* Highlight user button added

Issues;
* current method of detecting hover cards being loaded isn't great
* No has gold / gift gold button currently (unsure where to fit this)
* Quick compose is gone - left with reddits built in message
* Friend is gone - is this the same as reddits follow?

Be great to get some early feedback on this (currently old code is just at bottom of file & my code is a bit of a copy & pastey mess)
