### PR TITLE
Applying a preset will prompt the user to reload (#2711)

### DIFF
--- a/lib/modules/presets.js
+++ b/lib/modules/presets.js
@@ -93,12 +93,10 @@ function confirmPreset(callback, optionName, option) {
 }
 
 function presetApplied(optionName, option) {
-	Notifications.showNotification({
-		moduleID: module.moduleID,
-		optionKey: optionName,
-		title: `Applied ${optionName} preset`,
-		message: `Applied preset: ${i18n(option.description)}\n<p>Reload page to see results.</p>`,
-	});
+	const shouldReload = confirm(`Applied preset: ${i18n(option.description)}\nYou must reload the page to see results.\n\nWould you like to reload now?`);
+	if (shouldReload) {
+		location.reload();
+	}
 }
 
 function presetCancelled(optionName) {

--- a/lib/modules/presets.js
+++ b/lib/modules/presets.js
@@ -83,7 +83,7 @@ module.loadDynamicOptions = () => {
 };
 
 function confirmPreset(callback, optionName, option) {
-	const confirmation = prompt(`Are you sure you want to apply the "${optionName}" preset? Type "yes" to continue.`);
+	const confirmation = prompt(`Are you sure you want to apply the "${i18n(option.title)}" preset? Type "yes" to continue.`);
 	if (/^"?yes"?$/.test(confirmation)) {
 		presetApplied(optionName, option);
 		callback();
@@ -93,7 +93,7 @@ function confirmPreset(callback, optionName, option) {
 }
 
 function presetApplied(optionName, option) {
-	const shouldReload = confirm(`Applied preset: ${optionName}\nYou must reload the page to see results.\n\nWould you like to reload now?`);
+	const shouldReload = confirm(`Applied preset: ${i18n(option.title)}\nYou must reload the page to see results.\n\nWould you like to reload now?`);
 	if (shouldReload) {
 		location.reload();
 	}

--- a/lib/modules/presets.js
+++ b/lib/modules/presets.js
@@ -85,14 +85,14 @@ module.loadDynamicOptions = () => {
 function confirmPreset(callback, optionName, option) {
 	const confirmation = prompt(`Are you sure you want to apply the "${i18n(option.title)}" preset? Type "yes" to continue.`);
 	if (/^"?yes"?$/.test(confirmation)) {
-		presetApplied(optionName, option);
+		presetApplied(option);
 		callback();
 	} else {
-		presetCancelled();
+		presetCancelled(optionName);
 	}
 }
 
-function presetApplied(optionName, option) {
+function presetApplied(option) {
 	const shouldReload = confirm(`Applied preset: ${i18n(option.title)}\nYou must reload the page to see results.\n\nWould you like to reload now?`);
 	if (shouldReload) {
 		location.reload();

--- a/lib/modules/presets.js
+++ b/lib/modules/presets.js
@@ -93,7 +93,7 @@ function confirmPreset(callback, optionName, option) {
 }
 
 function presetApplied(optionName, option) {
-	const shouldReload = confirm(`Applied preset: ${i18n(option.description)}\nYou must reload the page to see results.\n\nWould you like to reload now?`);
+	const shouldReload = confirm(`Applied preset: ${optionName}\nYou must reload the page to see results.\n\nWould you like to reload now?`);
 	if (shouldReload) {
 		location.reload();
 	}

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -105,7 +105,7 @@ function create() {
 	RESAdvOptionsSpan.setAttribute('title', i18n(SettingsNavigation.module.options.showAllOptions.description));
 
 	const RESAdvOptions: HTMLInputElement = (RESAdvOptionsSpan.querySelector('input'): any);
-	RESAdvOptions.addEventListener('change', function() {
+	RESAdvOptions.addEventListener('change', function () {
 		Options.set(SettingsNavigation, 'showAllOptions', this.checked);
 		updateAdvancedOptionsVisibility();
 	}, true);
@@ -114,14 +114,14 @@ function create() {
 	RESConsoleContainer.querySelector('#RESConfigPanelModulesList').appendChild(renderModulesSelector());
 
 	$(RESConsoleContainer).find('#RESConfigPanelModulesPane')
-		.on('click', '.moduleButton', function(e: Event) {
+		.on('click', '.moduleButton', function (e: Event) {
 			const id = $(this).data('module');
 			if (id) {
 				e.preventDefault();
 				showConfigOptions(Modules.get(id));
 			}
 		})
-		.on('click', '.categoryButton', function(e: Event) {
+		.on('click', '.categoryButton', function (e: Event) {
 			const id = $(this).data('category');
 			if (id) {
 				e.preventDefault();
@@ -154,36 +154,36 @@ function create() {
 			}
 			// not using .getElementById here due to a collision with reddit's elements (i.e. #modmail)
 			((RESConfigPanelOptions.querySelector(`[id="${captureKeyID}"]`): any): HTMLInputElement).value = keyArray.join(',');
-			((RESConfigPanelOptions.querySelector(`[id="${captureKeyID}-display"]`): any): HTMLInputElement).value = niceKeyCode(keyArray);
-			$keyCodeModal.css('display', 'none');
-			captureKey = false;
-		}
+	((RESConfigPanelOptions.querySelector(`[id="${captureKeyID}-display"]`): any): HTMLInputElement).value = niceKeyCode(keyArray);
+	$keyCodeModal.css('display', 'none');
+	captureKey = false;
+}
 	});
 
-	$(RESConsoleContent).on({
-		focus(e) {
-			// show dialog box to grab keycode, but display something nice...
-			const $target = $(e.target);
-			const { top, left } = $target.offset();
-			$keyCodeModal.css({
-				display: 'block',
-				top: top + $target.height(),
-				left,
-			});
-			captureKey = true;
-			captureKeyID = $target.attr('capturefor');
-		},
-		blur() {
-			$keyCodeModal.css('display', 'none');
-		},
-	}, '.keycode + input[type=text][displayonly]');
+$(RESConsoleContent).on({
+	focus(e) {
+		// show dialog box to grab keycode, but display something nice...
+		const $target = $(e.target);
+		const { top, left } = $target.offset();
+		$keyCodeModal.css({
+			display: 'block',
+			top: top + $target.height(),
+			left,
+		});
+		captureKey = true;
+		captureKeyID = $target.attr('capturefor');
+	},
+	blur() {
+		$keyCodeModal.css('display', 'none');
+	},
+}, '.keycode + input[type=text][displayonly]');
 
-	$keyCodeModal = $('<div>', {
-		id: 'keyCodeModal',
-		text: 'Press a key (or combination with shift, alt and/or ctrl) to assign this action.',
-	});
+$keyCodeModal = $('<div>', {
+	id: 'keyCodeModal',
+	text: 'Press a key (or combination with shift, alt and/or ctrl) to assign this action.',
+});
 
-	$keyCodeModal.appendTo(document.body);
+$keyCodeModal.appendTo(document.body);
 }
 
 function renderModulesSelector() {
@@ -228,7 +228,7 @@ function renderModulesSelector() {
 function updateSelectedModule(mod) {
 	const items = $(RESConsoleContainer).find('.moduleButton');
 
-	const selected = items.filter(function() {
+	const selected = items.filter(function () {
 		return $(this).data('module') === mod.moduleID;
 	});
 
@@ -279,34 +279,34 @@ function drawOptionInput(mod, optionName, optionObject, isTable) {
 			const { values = [], callback, text } = optionObject;
 			if (callback && text) values.push({ callback, text });
 			const buttonsContainer = $thisOptionFormEle = $('<div>', { id: optionName });
-			for (const optionObject of values) {
+			for (const option of values) {
 				let $thisOptionFormEle;
-				if (typeof optionObject.callback === 'string' || optionObject.callback.moduleID) {
+				if (typeof option.callback === 'string' || option.callback.moduleID) {
 					$thisOptionFormEle = $('<a>');
 				} else { // if (typeof optionObject.callback === 'function') {
 					$thisOptionFormEle = $('<button>');
 				}
 				$thisOptionFormEle.addClass('RESConsoleButton');
 				$thisOptionFormEle.attr('moduleID', mod.moduleID);
-				if (optionObject.text.tagName || optionObject.text.jquery) {
-					$thisOptionFormEle.append(optionObject.text);
-				} else if (typeof optionObject.text === 'string') {
-					$thisOptionFormEle.text(optionObject.text);
+				if (option.text.tagName || option.text.jquery) {
+					$thisOptionFormEle.append(option.text);
+				} else if (typeof option.text === 'string') {
+					$thisOptionFormEle.text(option.text);
 				} else {
 					$thisOptionFormEle.append(CreateElement.icon('F141'));
 				}
-				if (optionObject.callback.moduleID) {
-					$thisOptionFormEle.attr('href', SettingsNavigation.makeUrlHash(optionObject.callback.moduleID, optionObject.callback.optionKey));
-				} else if (typeof optionObject.callback === 'string') {
-					$thisOptionFormEle.attr('href', optionObject.callback);
+				if (option.callback.moduleID) {
+					$thisOptionFormEle.attr('href', SettingsNavigation.makeUrlHash(option.callback.moduleID, option.callback.optionKey));
+				} else if (typeof option.callback === 'string') {
+					$thisOptionFormEle.attr('href', option.callback);
 					$thisOptionFormEle.attr('target', '_blank');
 					$thisOptionFormEle.attr('rel', 'noopener noreferer');
-				} else if (typeof optionObject.callback === 'function') {
-					$thisOptionFormEle.click(async function() {
+				} else if (typeof option.callback === 'function') {
+					$thisOptionFormEle.click(async function () {
 						if (this.classList.contains('csspinner')) return;
 						this.classList.add('csspinner');
 						try {
-							await optionObject.callback(optionName, optionObject);
+							await option.callback(optionName, optionObject);
 						} catch (e) {
 							if (e.message) Alert.open(e.message);
 							console.error(e);
@@ -447,9 +447,9 @@ const drawSettingsConsole = _.once(() => {
 	const thisToggle = RESConsoleContainer.querySelector('.moduleToggle');
 	moduleToggle = thisToggle;
 
-	thisToggle.addEventListener('click', function() {
+	thisToggle.addEventListener('click', function () {
 		const moduleID = $(this).data('module');
-		const $moduleButton = $(RESConsoleContainer).find('.moduleButton').filter(function() {
+		const $moduleButton = $(RESConsoleContainer).find('.moduleButton').filter(function () {
 			return $(this).data('module') === moduleID;
 		});
 		const enabled = this.classList.contains('enabled');
@@ -587,7 +587,7 @@ function drawConfigOptions(mod) {
 				thisTable.appendChild(thisThead);
 				thisTbody.setAttribute('id', `tbody_${i}`);
 				if (thisOptions[i].value) {
-					thisOptions[i].value.forEach(function(thisValue, j) {
+					thisOptions[i].value.forEach(function (thisValue, j) {
 						const thisTR = document.createElement('tr');
 						$(thisTR).data('itemidx-orig', j);
 						thisOptions[i].fields.forEach((field, k) => {
@@ -620,7 +620,7 @@ function drawConfigOptions(mod) {
 						.get(0);
 					addRowButton.setAttribute('optionName', i);
 					addRowButton.setAttribute('moduleID', mod.moduleID);
-					addRowButton.addEventListener('click', function() {
+					addRowButton.addEventListener('click', function () {
 						const optionName = this.getAttribute('optionName');
 						const thisTbodyName = `tbody_${optionName}`;
 						const thisTbody = document.getElementById(thisTbodyName);
@@ -703,7 +703,7 @@ function drawConfigOptions(mod) {
 		thisTD = document.createElement('td');
 		const thisHandle = document.createElement('div');
 		$(thisHandle)
-		.addClass('res-icon-button res-icon handle')
+			.addClass('res-icon-button res-icon handle')
 			.html('&#xF0AA;')
 			.attr('title', 'drag and drop to move this row');
 
@@ -786,62 +786,62 @@ function stageCurrentModuleOptions() {
 				let notAllBlank = false;
 				const optionRow = Array.from(cells).map(cell => {
 					const inputs: NodeList<HTMLInputElement | HTMLTextAreaElement> = (cell.querySelectorAll('input[tableOption=true], textarea[tableOption=true]'): any);
-					let optionValue = null;
-					for (const input of inputs) {
-						if (/*:: input instanceof HTMLInputElement && */ input.getAttribute('type') === 'checkbox') {
-							optionValue = input.checked;
-						} else if (input.getAttribute('type') === 'radio') {
-							if (input.checked) {
-								optionValue = input.value;
-							}
-							// check if it's a keycode, in which case we need to parse it into an array...
-						} else if (input.getAttribute('class') && input.getAttribute('class').includes('keycode')) {
-							const tempArray = input.value.split(',');
-							// convert the internal values of this array into their respective types (int, bool, bool, bool)
-							optionValue = [parseInt(tempArray[0], 10), (tempArray[1] === 'true'), (tempArray[2] === 'true'), (tempArray[3] === 'true')];
-						} else {
+				let optionValue = null;
+				for (const input of inputs) {
+					if (/*:: input instanceof HTMLInputElement && */ input.getAttribute('type') === 'checkbox') {
+						optionValue = input.checked;
+					} else if (input.getAttribute('type') === 'radio') {
+						if (input.checked) {
 							optionValue = input.value;
 						}
-						if ((optionValue !== '') && (input.getAttribute('type') !== 'radio') &&
-								// If no keyCode is set, then discard the value
-								!(Array.isArray(optionValue) && isNaN(optionValue[0]))) {
-							notAllBlank = true;
-						}
+						// check if it's a keycode, in which case we need to parse it into an array...
+					} else if (input.getAttribute('class') && input.getAttribute('class').includes('keycode')) {
+						const tempArray = input.value.split(',');
+						// convert the internal values of this array into their respective types (int, bool, bool, bool)
+						optionValue = [parseInt(tempArray[0], 10), (tempArray[1] === 'true'), (tempArray[2] === 'true'), (tempArray[3] === 'true')];
+					} else {
+						optionValue = input.value;
 					}
-					return optionValue;
-				});
-
-				if (notAllBlank) {
-					return optionRow;
+					if ((optionValue !== '') && (input.getAttribute('type') !== 'radio') &&
+						// If no keyCode is set, then discard the value
+						!(Array.isArray(optionValue) && isNaN(optionValue[0]))) {
+						notAllBlank = true;
+					}
 				}
-			})
+				return optionValue;
+			});
+
+		if (notAllBlank) {
+			return optionRow;
+		}
+	})
 			.filter(optionRow => Array.isArray(optionRow) && (optionRow.length > 0));
 
-		const mod = Modules.get(moduleID);
+	const mod = Modules.get(moduleID);
 
-		if (typeof mod.options[optionName].sort === 'function') {
-			optionMulti.sort(mod.options[optionName].sort);
-		}
-
-		Options.stage.add(moduleID, optionName, optionMulti);
+	if (typeof mod.options[optionName].sort === 'function') {
+		optionMulti.sort(mod.options[optionName].sort);
 	}
 
-	$(panelOptionsDiv).find('.optionBuilder').each(function(i, builder) {
-		const moduleId = this.dataset.moduleId;
-		const optionName = this.dataset.optionName;
+	Options.stage.add(moduleID, optionName, optionMulti);
+}
 
-		const option = Modules.get(moduleId).options[optionName];
-		const config = option.cases;
+$(panelOptionsDiv).find('.optionBuilder').each(function (i, builder) {
+	const moduleId = this.dataset.moduleId;
+	const optionName = this.dataset.optionName;
 
-		const items = [];
-		$(builder).find('.builderItem').each(function() {
-			items.push(readBuilderItem(this, config));
-		});
-		Options.stage.add(moduleId, optionName, items);
+	const option = Modules.get(moduleId).options[optionName];
+	const config = option.cases;
+
+	const items = [];
+	$(builder).find('.builderItem').each(function () {
+		items.push(readBuilderItem(this, config));
 	});
+	Options.stage.add(moduleId, optionName, items);
+});
 
-	updateSaveButton();
-	updateDependsOn(currentModule);
+updateSaveButton();
+updateDependsOn(currentModule);
 }
 
 function saveCurrentModuleOptions() {
@@ -931,7 +931,7 @@ function handleBeforeUnload() {
 	}
 }
 
-export function close({ promptIfStagedOptions = true, resetUrl = true }: {| promptIfStagedOptions?: boolean, resetUrl?: boolean |} = {}) {
+export function close({ promptIfStagedOptions = true, resetUrl = true }: {| promptIfStagedOptions?: boolean, resetUrl?: boolean |} = { }) {
 	if (promptIfStagedOptions && Options.stage.isDirty()) {
 		const abandonChanges = confirm(abandonChangesConfirmation);
 		if (!abandonChanges) return;
@@ -969,12 +969,12 @@ export function close({ promptIfStagedOptions = true, resetUrl = true }: {| prom
 
 function openCategoryPanel(categories) {
 	const items = $(RESConsoleContainer).find('#RESConfigPanelModulesList .RESConfigPanelCategory');
-	let selected = items.filter(function() {
+	let selected = items.filter(function () {
 		const thisValue = $(this).data('category');
 		return categories.includes(thisValue);
 	});
 	if (selected.filter('.active').length === 0) { // if a category isn't already open
-		selected = selected.filter(function() { // select first category
+		selected = selected.filter(function () { // select first category
 			const thisValue = $(this).data('category');
 			return categories.indexOf(thisValue) === 0;
 		});
@@ -1052,7 +1052,7 @@ function makeOptionTableSortable(tableBody) {
 			// force a constant width for the columns since switching the
 			// row's positioning method to absolute means that the column
 			// width calulation ignores the other rows.
-			$item.find('>td').css('width', function() {
+			$item.find('>td').css('width', function () {
 				return $(this).width();
 			});
 			$item.css({
@@ -1085,7 +1085,7 @@ function drawOptionBuilder(options, mod, optionName) {
 	});
 	$addRowButton
 		.text(option.addItemText || '+add item')
-		.on('click', function() {
+		.on('click', function () {
 			const $newBody = drawBuilderItem(option.defaultTemplate(), option.cases);
 			$(this).siblings('.optionBuilder:first').trigger('change').append($newBody);
 			const firstText = $newBody.find('input[type=text], textarea')[0];
@@ -1104,7 +1104,7 @@ function drawBuilderItem(data, config) {
 		.addClass('res-icon-button res-icon builderControls builderTrailingControls')
 		.html('&#xF061;')
 		.attr('title', 'copy and share, or update your settings with a new version')
-		.on('click', function() {
+		.on('click', function () {
 			const data = readBuilderItem($(this).closest('.builderItem'), config);
 			const json = prompt(
 				'Copy this and share it, or paste a new version and update your settings',
@@ -1118,7 +1118,7 @@ function drawBuilderItem(data, config) {
 
 	const $deleteButton = drawDeleteButton()
 		.addClass('builderTrailingControls')
-		.on('click', function() {
+		.on('click', function () {
 			if (confirm('Are you sure you want remove this filter?')) {
 				$(this).trigger('change');
 				$(this).closest('.builderItem').trigger('change').remove();
@@ -1127,11 +1127,11 @@ function drawBuilderItem(data, config) {
 
 	const $header = $('<div class="builderItemControls" style="margin-bottom: 5px;">')
 		.append(
-			drawHandle(),
-			$('<textarea name="builderNote" rows="2" cols="40" placeholder="Write a description/note for this">').val(data.note),
-			$('<input type="hidden" name="version">').val(data.ver),
-			$editButton,
-			$deleteButton
+		drawHandle(),
+		$('<textarea name="builderNote" rows="2" cols="40" placeholder="Write a description/note for this">').val(data.note),
+		$('<input type="hidden" name="version">').val(data.ver),
+		$editButton,
+		$deleteButton
 		);
 
 	const $body = drawBuilderBlock(data.body, config);
@@ -1170,7 +1170,7 @@ function drawBuilderBlock(data, config) {
 
 	const $deleteButton = drawDeleteButton()
 		.addClass('builderTrailingControls')
-		.on('click', function() {
+		.on('click', function () {
 			if (confirm('Are you sure you want to delete this condition?')) {
 				$(this).trigger('change');
 				$(this).closest('.builderWrap').parent('li').remove();
@@ -1179,9 +1179,9 @@ function drawBuilderBlock(data, config) {
 
 	return $('<div class="builderWrap">')
 		.append(
-			drawHandle(),
-			$block,
-			$deleteButton
+		drawHandle(),
+		$block,
+		$deleteButton
 		);
 }
 
@@ -1332,7 +1332,7 @@ const builderFields = {
 				const name = config[key].name || key;
 				$('<option>').text(name).val(key).appendTo($addButton);
 			});
-			$addButton.on('change', function() {
+			$addButton.on('change', function () {
 				const type = $(this).val();
 				if (type !== '' && type in config) {
 					const newRowData = config[type].defaultTemplate();
@@ -1348,7 +1348,7 @@ const builderFields = {
 			return $rowWrapper.add($addButton);
 		},
 		read($elem, fieldConfig, config) {
-			return $elem.find('> li > .builderWrap > .builderBlock').map(function() {
+			return $elem.find('> li > .builderWrap > .builderBlock').map(function () {
 				return readBuilderBlock($(this), config);
 			}).get();
 		},

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -105,7 +105,7 @@ function create() {
 	RESAdvOptionsSpan.setAttribute('title', i18n(SettingsNavigation.module.options.showAllOptions.description));
 
 	const RESAdvOptions: HTMLInputElement = (RESAdvOptionsSpan.querySelector('input'): any);
-	RESAdvOptions.addEventListener('change', function () {
+	RESAdvOptions.addEventListener('change', function() {
 		Options.set(SettingsNavigation, 'showAllOptions', this.checked);
 		updateAdvancedOptionsVisibility();
 	}, true);
@@ -114,14 +114,14 @@ function create() {
 	RESConsoleContainer.querySelector('#RESConfigPanelModulesList').appendChild(renderModulesSelector());
 
 	$(RESConsoleContainer).find('#RESConfigPanelModulesPane')
-		.on('click', '.moduleButton', function (e: Event) {
+		.on('click', '.moduleButton', function(e: Event) {
 			const id = $(this).data('module');
 			if (id) {
 				e.preventDefault();
 				showConfigOptions(Modules.get(id));
 			}
 		})
-		.on('click', '.categoryButton', function (e: Event) {
+		.on('click', '.categoryButton', function(e: Event) {
 			const id = $(this).data('category');
 			if (id) {
 				e.preventDefault();
@@ -154,36 +154,36 @@ function create() {
 			}
 			// not using .getElementById here due to a collision with reddit's elements (i.e. #modmail)
 			((RESConfigPanelOptions.querySelector(`[id="${captureKeyID}"]`): any): HTMLInputElement).value = keyArray.join(',');
-	((RESConfigPanelOptions.querySelector(`[id="${captureKeyID}-display"]`): any): HTMLInputElement).value = niceKeyCode(keyArray);
-	$keyCodeModal.css('display', 'none');
-	captureKey = false;
-}
+			((RESConfigPanelOptions.querySelector(`[id="${captureKeyID}-display"]`): any): HTMLInputElement).value = niceKeyCode(keyArray);
+			$keyCodeModal.css('display', 'none');
+			captureKey = false;
+		}
 	});
 
-$(RESConsoleContent).on({
-	focus(e) {
-		// show dialog box to grab keycode, but display something nice...
-		const $target = $(e.target);
-		const { top, left } = $target.offset();
-		$keyCodeModal.css({
-			display: 'block',
-			top: top + $target.height(),
-			left,
-		});
-		captureKey = true;
-		captureKeyID = $target.attr('capturefor');
-	},
-	blur() {
-		$keyCodeModal.css('display', 'none');
-	},
-}, '.keycode + input[type=text][displayonly]');
+	$(RESConsoleContent).on({
+		focus(e) {
+			// show dialog box to grab keycode, but display something nice...
+			const $target = $(e.target);
+			const { top, left } = $target.offset();
+			$keyCodeModal.css({
+				display: 'block',
+				top: top + $target.height(),
+				left,
+			});
+			captureKey = true;
+			captureKeyID = $target.attr('capturefor');
+		},
+		blur() {
+			$keyCodeModal.css('display', 'none');
+		},
+	}, '.keycode + input[type=text][displayonly]');
 
-$keyCodeModal = $('<div>', {
-	id: 'keyCodeModal',
-	text: 'Press a key (or combination with shift, alt and/or ctrl) to assign this action.',
-});
+	$keyCodeModal = $('<div>', {
+		id: 'keyCodeModal',
+		text: 'Press a key (or combination with shift, alt and/or ctrl) to assign this action.',
+	});
 
-$keyCodeModal.appendTo(document.body);
+	$keyCodeModal.appendTo(document.body);
 }
 
 function renderModulesSelector() {
@@ -228,7 +228,7 @@ function renderModulesSelector() {
 function updateSelectedModule(mod) {
 	const items = $(RESConsoleContainer).find('.moduleButton');
 
-	const selected = items.filter(function () {
+	const selected = items.filter(function() {
 		return $(this).data('module') === mod.moduleID;
 	});
 
@@ -302,7 +302,7 @@ function drawOptionInput(mod, optionName, optionObject, isTable) {
 					$thisOptionFormEle.attr('target', '_blank');
 					$thisOptionFormEle.attr('rel', 'noopener noreferer');
 				} else if (typeof option.callback === 'function') {
-					$thisOptionFormEle.click(async function () {
+					$thisOptionFormEle.click(async function() {
 						if (this.classList.contains('csspinner')) return;
 						this.classList.add('csspinner');
 						try {
@@ -447,9 +447,9 @@ const drawSettingsConsole = _.once(() => {
 	const thisToggle = RESConsoleContainer.querySelector('.moduleToggle');
 	moduleToggle = thisToggle;
 
-	thisToggle.addEventListener('click', function () {
+	thisToggle.addEventListener('click', function() {
 		const moduleID = $(this).data('module');
-		const $moduleButton = $(RESConsoleContainer).find('.moduleButton').filter(function () {
+		const $moduleButton = $(RESConsoleContainer).find('.moduleButton').filter(function() {
 			return $(this).data('module') === moduleID;
 		});
 		const enabled = this.classList.contains('enabled');
@@ -587,7 +587,7 @@ function drawConfigOptions(mod) {
 				thisTable.appendChild(thisThead);
 				thisTbody.setAttribute('id', `tbody_${i}`);
 				if (thisOptions[i].value) {
-					thisOptions[i].value.forEach(function (thisValue, j) {
+					thisOptions[i].value.forEach(function(thisValue, j) {
 						const thisTR = document.createElement('tr');
 						$(thisTR).data('itemidx-orig', j);
 						thisOptions[i].fields.forEach((field, k) => {
@@ -620,7 +620,7 @@ function drawConfigOptions(mod) {
 						.get(0);
 					addRowButton.setAttribute('optionName', i);
 					addRowButton.setAttribute('moduleID', mod.moduleID);
-					addRowButton.addEventListener('click', function () {
+					addRowButton.addEventListener('click', function() {
 						const optionName = this.getAttribute('optionName');
 						const thisTbodyName = `tbody_${optionName}`;
 						const thisTbody = document.getElementById(thisTbodyName);
@@ -703,7 +703,7 @@ function drawConfigOptions(mod) {
 		thisTD = document.createElement('td');
 		const thisHandle = document.createElement('div');
 		$(thisHandle)
-			.addClass('res-icon-button res-icon handle')
+		.addClass('res-icon-button res-icon handle')
 			.html('&#xF0AA;')
 			.attr('title', 'drag and drop to move this row');
 
@@ -786,62 +786,62 @@ function stageCurrentModuleOptions() {
 				let notAllBlank = false;
 				const optionRow = Array.from(cells).map(cell => {
 					const inputs: NodeList<HTMLInputElement | HTMLTextAreaElement> = (cell.querySelectorAll('input[tableOption=true], textarea[tableOption=true]'): any);
-				let optionValue = null;
-				for (const input of inputs) {
-					if (/*:: input instanceof HTMLInputElement && */ input.getAttribute('type') === 'checkbox') {
-						optionValue = input.checked;
-					} else if (input.getAttribute('type') === 'radio') {
-						if (input.checked) {
+					let optionValue = null;
+					for (const input of inputs) {
+						if (/*:: input instanceof HTMLInputElement && */ input.getAttribute('type') === 'checkbox') {
+							optionValue = input.checked;
+						} else if (input.getAttribute('type') === 'radio') {
+							if (input.checked) {
+								optionValue = input.value;
+							}
+							// check if it's a keycode, in which case we need to parse it into an array...
+						} else if (input.getAttribute('class') && input.getAttribute('class').includes('keycode')) {
+							const tempArray = input.value.split(',');
+							// convert the internal values of this array into their respective types (int, bool, bool, bool)
+							optionValue = [parseInt(tempArray[0], 10), (tempArray[1] === 'true'), (tempArray[2] === 'true'), (tempArray[3] === 'true')];
+						} else {
 							optionValue = input.value;
 						}
-						// check if it's a keycode, in which case we need to parse it into an array...
-					} else if (input.getAttribute('class') && input.getAttribute('class').includes('keycode')) {
-						const tempArray = input.value.split(',');
-						// convert the internal values of this array into their respective types (int, bool, bool, bool)
-						optionValue = [parseInt(tempArray[0], 10), (tempArray[1] === 'true'), (tempArray[2] === 'true'), (tempArray[3] === 'true')];
-					} else {
-						optionValue = input.value;
+						if ((optionValue !== '') && (input.getAttribute('type') !== 'radio') &&
+								// If no keyCode is set, then discard the value
+								!(Array.isArray(optionValue) && isNaN(optionValue[0]))) {
+							notAllBlank = true;
+						}
 					}
-					if ((optionValue !== '') && (input.getAttribute('type') !== 'radio') &&
-						// If no keyCode is set, then discard the value
-						!(Array.isArray(optionValue) && isNaN(optionValue[0]))) {
-						notAllBlank = true;
-					}
-				}
-				return optionValue;
-			});
+					return optionValue;
+				});
 
-		if (notAllBlank) {
-			return optionRow;
-		}
-	})
+				if (notAllBlank) {
+					return optionRow;
+				}
+			})
 			.filter(optionRow => Array.isArray(optionRow) && (optionRow.length > 0));
 
-	const mod = Modules.get(moduleID);
+		const mod = Modules.get(moduleID);
 
-	if (typeof mod.options[optionName].sort === 'function') {
-		optionMulti.sort(mod.options[optionName].sort);
+		if (typeof mod.options[optionName].sort === 'function') {
+			optionMulti.sort(mod.options[optionName].sort);
+		}
+
+		Options.stage.add(moduleID, optionName, optionMulti);
 	}
 
-	Options.stage.add(moduleID, optionName, optionMulti);
-}
+	$(panelOptionsDiv).find('.optionBuilder').each(function(i, builder) {
+		const moduleId = this.dataset.moduleId;
+		const optionName = this.dataset.optionName;
 
-$(panelOptionsDiv).find('.optionBuilder').each(function (i, builder) {
-	const moduleId = this.dataset.moduleId;
-	const optionName = this.dataset.optionName;
+		const option = Modules.get(moduleId).options[optionName];
+		const config = option.cases;
 
-	const option = Modules.get(moduleId).options[optionName];
-	const config = option.cases;
-
-	const items = [];
-	$(builder).find('.builderItem').each(function () {
-		items.push(readBuilderItem(this, config));
+		const items = [];
+		$(builder).find('.builderItem').each(function() {
+			items.push(readBuilderItem(this, config));
+		});
+		Options.stage.add(moduleId, optionName, items);
 	});
-	Options.stage.add(moduleId, optionName, items);
-});
 
-updateSaveButton();
-updateDependsOn(currentModule);
+	updateSaveButton();
+	updateDependsOn(currentModule);
 }
 
 function saveCurrentModuleOptions() {
@@ -931,7 +931,7 @@ function handleBeforeUnload() {
 	}
 }
 
-export function close({ promptIfStagedOptions = true, resetUrl = true }: {| promptIfStagedOptions?: boolean, resetUrl?: boolean |} = { }) {
+export function close({ promptIfStagedOptions = true, resetUrl = true }: {| promptIfStagedOptions?: boolean, resetUrl?: boolean |} = {}) {
 	if (promptIfStagedOptions && Options.stage.isDirty()) {
 		const abandonChanges = confirm(abandonChangesConfirmation);
 		if (!abandonChanges) return;
@@ -969,12 +969,12 @@ export function close({ promptIfStagedOptions = true, resetUrl = true }: {| prom
 
 function openCategoryPanel(categories) {
 	const items = $(RESConsoleContainer).find('#RESConfigPanelModulesList .RESConfigPanelCategory');
-	let selected = items.filter(function () {
+	let selected = items.filter(function() {
 		const thisValue = $(this).data('category');
 		return categories.includes(thisValue);
 	});
 	if (selected.filter('.active').length === 0) { // if a category isn't already open
-		selected = selected.filter(function () { // select first category
+		selected = selected.filter(function() { // select first category
 			const thisValue = $(this).data('category');
 			return categories.indexOf(thisValue) === 0;
 		});
@@ -1052,7 +1052,7 @@ function makeOptionTableSortable(tableBody) {
 			// force a constant width for the columns since switching the
 			// row's positioning method to absolute means that the column
 			// width calulation ignores the other rows.
-			$item.find('>td').css('width', function () {
+			$item.find('>td').css('width', function() {
 				return $(this).width();
 			});
 			$item.css({
@@ -1085,7 +1085,7 @@ function drawOptionBuilder(options, mod, optionName) {
 	});
 	$addRowButton
 		.text(option.addItemText || '+add item')
-		.on('click', function () {
+		.on('click', function() {
 			const $newBody = drawBuilderItem(option.defaultTemplate(), option.cases);
 			$(this).siblings('.optionBuilder:first').trigger('change').append($newBody);
 			const firstText = $newBody.find('input[type=text], textarea')[0];
@@ -1104,7 +1104,7 @@ function drawBuilderItem(data, config) {
 		.addClass('res-icon-button res-icon builderControls builderTrailingControls')
 		.html('&#xF061;')
 		.attr('title', 'copy and share, or update your settings with a new version')
-		.on('click', function () {
+		.on('click', function() {
 			const data = readBuilderItem($(this).closest('.builderItem'), config);
 			const json = prompt(
 				'Copy this and share it, or paste a new version and update your settings',
@@ -1118,7 +1118,7 @@ function drawBuilderItem(data, config) {
 
 	const $deleteButton = drawDeleteButton()
 		.addClass('builderTrailingControls')
-		.on('click', function () {
+		.on('click', function() {
 			if (confirm('Are you sure you want remove this filter?')) {
 				$(this).trigger('change');
 				$(this).closest('.builderItem').trigger('change').remove();
@@ -1127,11 +1127,11 @@ function drawBuilderItem(data, config) {
 
 	const $header = $('<div class="builderItemControls" style="margin-bottom: 5px;">')
 		.append(
-		drawHandle(),
-		$('<textarea name="builderNote" rows="2" cols="40" placeholder="Write a description/note for this">').val(data.note),
-		$('<input type="hidden" name="version">').val(data.ver),
-		$editButton,
-		$deleteButton
+			drawHandle(),
+			$('<textarea name="builderNote" rows="2" cols="40" placeholder="Write a description/note for this">').val(data.note),
+			$('<input type="hidden" name="version">').val(data.ver),
+			$editButton,
+			$deleteButton
 		);
 
 	const $body = drawBuilderBlock(data.body, config);
@@ -1170,7 +1170,7 @@ function drawBuilderBlock(data, config) {
 
 	const $deleteButton = drawDeleteButton()
 		.addClass('builderTrailingControls')
-		.on('click', function () {
+		.on('click', function() {
 			if (confirm('Are you sure you want to delete this condition?')) {
 				$(this).trigger('change');
 				$(this).closest('.builderWrap').parent('li').remove();
@@ -1179,9 +1179,9 @@ function drawBuilderBlock(data, config) {
 
 	return $('<div class="builderWrap">')
 		.append(
-		drawHandle(),
-		$block,
-		$deleteButton
+			drawHandle(),
+			$block,
+			$deleteButton
 		);
 }
 
@@ -1332,7 +1332,7 @@ const builderFields = {
 				const name = config[key].name || key;
 				$('<option>').text(name).val(key).appendTo($addButton);
 			});
-			$addButton.on('change', function () {
+			$addButton.on('change', function() {
 				const type = $(this).val();
 				if (type !== '' && type in config) {
 					const newRowData = config[type].defaultTemplate();
@@ -1348,7 +1348,7 @@ const builderFields = {
 			return $rowWrapper.add($addButton);
 		},
 		read($elem, fieldConfig, config) {
-			return $elem.find('> li > .builderWrap > .builderBlock').map(function () {
+			return $elem.find('> li > .builderWrap > .builderBlock').map(function() {
 				return readBuilderBlock($(this), config);
 			}).get();
 		},


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: presets.cleanSlate should show prompt("Reload?") instead of notification (fixes #2711)
Tested in browser: Chrome and Firefox

This shows optionName instead of a blank field on the reload prompt. It should be fixed, but I wasn't able to figure out how to fix it.
