### PR TITLE
gallery: Add button to switch from slideshow to filmstrip

### DIFF
--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -190,6 +190,7 @@ img {
 	clear: left; // Necessary on some custom stylesheets where .entry .flat-list has no height
 
 	.res-expando-box-inner {
+		width: 100%;
 		// Reset a few possible parent styles
 		font-style: normal; // Italics
 		font-weight: normal; // Bold
@@ -235,6 +236,8 @@ img {
 }
 
 .res-gallery {
+	width: 100%;
+
 	.res-gallery-title {
 		margin: 3px;
 		font-size: 15px;
@@ -258,6 +261,15 @@ img {
 		&[last-piece=true] .res-gallery-next,
 		&[first-piece=true] .res-gallery-previous {
 			transform: scaleX(-1);
+		}
+
+		.res-gallery-to-filmstrip {
+			margin-left: auto;
+			cursor: pointer;
+
+			&::before {
+				content: '𐁖';
+			}
 		}
 	}
 

--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -262,14 +262,16 @@ img {
 		&[first-piece=true] .res-gallery-previous {
 			transform: scaleX(-1);
 		}
+	}
 
-		.res-gallery-to-filmstrip {
-			margin-left: auto;
-			cursor: pointer;
+	&-to-filmstrip {
+		margin-left: auto;
+		cursor: pointer;
 
-			&::before {
-				content: '𐁖';
-			}
+		&::before {
+			content: '🎞';
+			display: block;
+			transform: rotate(90deg);
 		}
 	}
 

--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -190,7 +190,6 @@ img {
 	clear: left; // Necessary on some custom stylesheets where .entry .flat-list has no height
 
 	.res-expando-box-inner {
-		width: 100%;
 		// Reset a few possible parent styles
 		font-style: normal; // Italics
 		font-weight: normal; // Bold
@@ -236,8 +235,6 @@ img {
 }
 
 .res-gallery {
-	width: 100%;
-
 	.res-gallery-title {
 		margin: 3px;
 		font-size: 15px;
@@ -265,7 +262,7 @@ img {
 	}
 
 	&-to-filmstrip {
-		margin-left: auto;
+		margin-left: 5px;
 		cursor: pointer;
 
 		&::before {

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1202,6 +1202,7 @@ function generateGallery(options: GalleryMedia, context) {
 	const ctrlPrev = individualCtrl.querySelector('.res-gallery-previous');
 	const ctrlNext = individualCtrl.querySelector('.res-gallery-next');
 	const msgPosition = individualCtrl.querySelector('.res-gallery-position');
+	const ctrlToFilmstrip = individualCtrl.querySelector('.res-gallery-to-filmstrip');
 	const ctrlConcurrentIncrease = element.querySelector('.res-gallery-increase-concurrent');
 
 	const preloadCount = parseInt(module.options.galleryPreloadCount.value, 10) || 0;
@@ -1331,6 +1332,12 @@ function generateGallery(options: GalleryMedia, context) {
 		initialLoadPromise = changeSlideshowPiece(0);
 		ctrlPrev.addEventListener('click', () => { changeSlideshowPiece(-1); });
 		ctrlNext.addEventListener('click', () => { changeSlideshowPiece(1); });
+
+		waitForEvent(ctrlToFilmstrip, 'click').then(() => {
+			expandFilmstrip();
+			ctrlConcurrentIncrease.addEventListener('click', expandFilmstrip);
+			element.classList.remove('res-gallery-slideshow');
+		});
 	}
 
 	element.ready = initialLoadPromise;

--- a/lib/modules/showImages/templates.js
+++ b/lib/modules/showImages/templates.js
@@ -29,6 +29,7 @@ export const galleryTemplate = <T>({ title, caption, credits, src }: {| title?: 
 				<span class="res-gallery-position">1</span> of ${src.length}
 			</div>
 			<div class="res-step res-step-reverse res-gallery-next"></div>
+			<div class="res-gallery-to-filmstrip" title="View as filmstrip"></div>
 		</div>
 		<div class="res-gallery-pieces"></div>
 		<div class="res-gallery-below">


### PR DESCRIPTION
Useful for when a slideshow isn't suitable, like when there's a lot of text to each piece and the total height of the text and image exceeds the viewport height.

The `🎞` button to the right:
![image](https://user-images.githubusercontent.com/1748521/32294256-e5c04eea-bf45-11e7-8a58-522e230d2b46.png)

Edit: Changed character

Tested in browser: Chrome 63, Edge 16
