### PR TITLE
Fix "Prominent comment" nightmode colour

### DIFF
--- a/lib/css/modules/_nightMode.scss
+++ b/lib/css/modules/_nightMode.scss
@@ -1651,6 +1651,7 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 	.Post__score,
 	.StyledHtml,
 	.Post__authorComment .StyledHtml,
+	.Post__prominentComment .StyledHtml,
 	.Post__commentContainer,
 	.ProfileVoiceAd__title,
 	.ProfileVoiceAd__description,


### PR DESCRIPTION
Relevant issue: #4530 
Tested in browser: Chrome 62.0.3202.75 (Official Build) (64-bit)

![](https://i.imgur.com/YBL3dZa.png)
