### PR TITLE
Add npm-debug.log to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ## General ##
 node_modules/
+npm-debug.log
 
 # Browser extensions and certs
 *.crx


### PR DESCRIPTION
Some actions in the development process can cause a `npm-debug.log` file to be generated in the root directory. Add to `.gitignore` to not have this file accidentally committed. 
