### PR TITLE
watcher: Use utils.getViewportSize when determining sort order

### DIFF
--- a/lib/utils/watchers.js
+++ b/lib/utils/watchers.js
@@ -1,8 +1,7 @@
 /* @flow */
 
-import _ from 'lodash';
 import { sortBy, map, flow } from 'lodash/fp';
-import { Thing, isPageType, observe, downcast, forEachChunked } from './';
+import { Thing, isPageType, observe, downcast, forEachChunked, getViewportSize } from './';
 
 type WatcherOptions = {| immediate?: boolean |};
 
@@ -119,11 +118,11 @@ export function initObservers() {
 export function newSitetable(siteTable: HTMLElement) {
 	let sorter;
 	if (document.contains(siteTable)) {
-		const viewportHeight = _.once(() => document.documentElement.clientHeight);
+		const viewportHeight = getViewportSize();
 		sorter = sortBy(([element]) => {
 			const fromTop = element.getBoundingClientRect().top;
 			return element.offsetParent ?
-					(fromTop >= 0 ? fromTop : -fromTop + viewportHeight()) :
+					(fromTop >= 0 ? fromTop : -fromTop + viewportHeight) :
 					Infinity;
 		});
 	}


### PR DESCRIPTION
It's more accurate. Also, since it's memoized, calling it at this stage avoids it causing a reflow when otherwise invoked at a later stage in the init.
