### PR TITLE
Add /attribution_link in YouTube host

### DIFF
--- a/lib/modules/hosts/youtube.js
+++ b/lib/modules/hosts/youtube.js
@@ -18,6 +18,11 @@ export default new Host('youtube', {
 		if (searchParams.has('v')) return [searchParams.get('v'), searchParams];
 		//   watch/embed/v
 		if ((/watch|embed|v/i).exec(split[0])) return [split[1], searchParams];
+		//   attribution_link
+		if (split[0] === 'attribution_link' && searchParams.has('u')) {
+			const videoID = new URLSearchParams(searchParams.get('u').split('?')[1]);
+			if (videoID.has('v')) return [videoID.get('v'), searchParams];
+		}
 	},
 	handleLink(href, [path, searchParams]) {
 		const url = new URL(`https://www.youtube.com/embed/${path}`);

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -20,7 +20,7 @@ export class Thing {
 	static thingsContainer(body: HTMLElement = document.body): HTMLElement {
 		return (
 			body.querySelector('.sitetable') ||
-            _.last(Array.from(body.querySelectorAll('.search-result-listing')))
+			_.last(Array.from(body.querySelectorAll('.search-result-listing')))
 		);
 	}
 


### PR DESCRIPTION
Tested in browser: Chrome 62, Firefox 56

YouTube URLs with "/attribution_link" do not get an expando. 

# Example

This particular example is from the /r/videos subreddit. Post: https://www.reddit.com/r/videos/comments/7ce3ws/

## Post URL

`https://www.youtube.com/attribution_link?a=iAZ-qdJA3J0&u=%2Fwatch%3Fv%3D2a0DQWmVmL4%26feature%3Dshare`

When clicked, this URL should redirect to: `https://www.youtube.com/watch?v=2a0DQWmVmL4&feature=share` but that doesn't matter to the host detection.

## Pathname

/attribution_link

## Query string

| Key | Value |
|---|---|
| a | iAZ-qdJA3J0 |
| u | /watch?v=2a0DQWmVmL4&feature=share |

# Changes

## Before:

![image](https://user-images.githubusercontent.com/7132646/32698366-3f6d24e6-c76a-11e7-8062-f64789d3eb54.png)

## After:

![image](https://user-images.githubusercontent.com/7132646/32698369-4788d08a-c76a-11e7-9ccc-4d78224c077e.png)

If you need to find an example post for testing or whatnot, you can run this code in the console to jump to one:

`(() => { let v = document.querySelectorAll('a.title[href*="attrib"]'); v.length ? (v[0].scrollIntoView(), console.log('Scrolled into view')) : console.log('Keep scrolling'); })();`