### PR TITLE
Storage refactoring/minor cleanup

### DIFF
--- a/browser/foreground.js
+++ b/browser/foreground.js
@@ -60,10 +60,10 @@ addInterceptor('storage', keyedMutex(async ([operation, key, value]) => {
 		case 'setMultiple':
 			return _set(value);
 		case 'patch':
-			return set(key, Object.assign(await get(key) || {}, value));
-		case 'patchDeep':
 			const extended = extendDeep(await get(key) || {}, value);
 			return set(key, extended);
+		case 'patchShallow':
+			return set(key, Object.assign(await get(key) || {}, value));
 		case 'deletePath':
 			try {
 				const stored = await get(key) || {};

--- a/browser/foreground.js
+++ b/browser/foreground.js
@@ -65,16 +65,13 @@ addInterceptor('storage', keyedMutex(async ([operation, key, value]) => {
 		case 'patchShallow':
 			return set(key, Object.assign(await get(key) || {}, value));
 		case 'deletePath':
-			try {
-				const stored = await get(key) || {};
-				value.split(',').reduce((obj, key, i, { length }) => {
-					if (i < length - 1) return obj[key];
-					delete obj[key];
-				}, stored);
-				return set(key, stored);
-			} catch (e) {
-				throw new Error(`Failed to delete path: ${value} on key: ${key} - error: ${e}`);
-			}
+			const stored = await get(key);
+			value.reduce((obj, key, i, { length }) => {
+				if (!obj) return;
+				if (i < length - 1) return obj[key];
+				delete obj[key];
+			}, stored);
+			return set(key, stored);
 		case 'delete':
 			return _delete(key);
 		case 'has':

--- a/browser/foreground.js
+++ b/browser/foreground.js
@@ -48,7 +48,7 @@ addInterceptor('storage', keyedMutex(async ([operation, key, value]) => {
 			return get(key, null);
 		case 'getAll':
 			return _get(null);
-		case 'batch':
+		case 'getMultiple':
 			const defaults = {};
 			// key is an array here
 			for (const k of key) {

--- a/browser/foreground.js
+++ b/browser/foreground.js
@@ -64,13 +64,15 @@ addInterceptor('storage', keyedMutex(async ([operation, key, value]) => {
 			return set(key, extended);
 		case 'patchShallow':
 			return set(key, Object.assign(await get(key) || {}, value));
-		case 'deletePath':
+		case 'deletePaths':
 			const stored = await get(key);
-			value.reduce((obj, key, i, { length }) => {
-				if (!obj) return;
-				if (i < length - 1) return obj[key];
-				delete obj[key];
-			}, stored);
+			for (const path of value) {
+				path.reduce((obj, key, i, { length }) => {
+					if (!obj) return;
+					if (i < length - 1) return obj[key];
+					delete obj[key];
+				}, stored);
+			}
 			return set(key, stored);
 		case 'delete':
 			return _delete(key);

--- a/browser/foreground.js
+++ b/browser/foreground.js
@@ -60,6 +60,8 @@ addInterceptor('storage', keyedMutex(async ([operation, key, value]) => {
 		case 'setMultiple':
 			return _set(value);
 		case 'patch':
+			return set(key, Object.assign(await get(key) || {}, value));
+		case 'patchDeep':
 			const extended = extendDeep(await get(key) || {}, value);
 			return set(key, extended);
 		case 'deletePath':

--- a/lib/core/modules/modules.js
+++ b/lib/core/modules/modules.js
@@ -12,7 +12,7 @@ import type { OpaqueModuleId } from '../module';
 const moduleContext = (require: any).context('../../modules', false, /\.js$/);
 
 const modulePrefsStorage = Storage.wrapBlob('RES.modulePrefs',
-	(): boolean => { throw new Error('default module enabled state should never be accessed'); });
+	(): boolean => { throw new Error('Default module enabled state should never be accessed'); });
 
 const enabled = {};
 

--- a/lib/core/modules/modules.js
+++ b/lib/core/modules/modules.js
@@ -11,6 +11,9 @@ import type { OpaqueModuleId } from '../module';
 
 const moduleContext = (require: any).context('../../modules', false, /\.js$/);
 
+const modulePrefsStorage = Storage.wrapBlob('RES.modulePrefs',
+	(): boolean => { throw new Error('default module enabled state should never be accessed'); });
+
 const enabled = {};
 
 const modules = flow(
@@ -27,7 +30,7 @@ if (process.env.NODE_ENV === 'development') {
 }
 
 export async function _loadModulePrefs() {
-	const storedPrefs = await Storage.get('RES.modulePrefs') || {};
+	const storedPrefs = await modulePrefsStorage.getAll();
 
 	for (const id in modules) {
 		if (modules[id].alwaysEnabled) {
@@ -44,7 +47,7 @@ export function setEnabled(opaqueId: OpaqueModuleId, enable: boolean) {
 	const module = get(opaqueId);
 	// set enabled state of module
 	enabled[module.moduleID] = enable;
-	Storage.patch('RES.modulePrefs', { [module.moduleID]: enable });
+	modulePrefsStorage.set(module.moduleID, enable);
 	module.onToggle(enable);
 }
 

--- a/lib/core/options/options.js
+++ b/lib/core/options/options.js
@@ -7,15 +7,13 @@ import { Storage } from '../../environment';
 import type { OpaqueModuleId } from '../module';
 import { filterMap } from '../../utils';
 
-function getKey(module) {
-	return `RESoptions.${module.moduleID}`;
-}
+const moduleOptionsStorage = Storage.wrapPrefix('RESoptions.', () => ({}));
 
 export async function _loadModuleOptions() {
-	const allOptions = await Storage.getMultiple(Modules.all().map(mod => getKey(mod)));
+	const allOptions = await moduleOptionsStorage.getMultipleNullable(Modules.all().map(mod => mod.moduleID));
 
 	for (const mod of Modules.all()) {
-		_initOptions(mod, allOptions[getKey(mod)]);
+		_initOptions(mod, allOptions[mod.moduleID]);
 	}
 }
 
@@ -51,7 +49,7 @@ const _initOptions = _.memoize((module, storedOptions) => {
 export const loadRaw = flow(
 	(opaqueId: OpaqueModuleId) => Modules.get(opaqueId),
 	_.memoize(
-		module => Storage.get(getKey(module)),
+		module => moduleOptionsStorage.get(module.moduleID),
 		module => module.moduleID
 	)
 );
@@ -70,7 +68,7 @@ export function set(opaqueId: OpaqueModuleId, optionKey: string, value: mixed) {
 
 	// save value to module options and storage
 	module.options[optionKey].value = value;
-	Storage.patch(getKey(module), { [optionKey]: { value } });
+	moduleOptionsStorage.patch(module.moduleID, { [optionKey]: { value } });
 
 	if (module.options[optionKey].onChange) {
 		// Intentionally do not pass in the new value

--- a/lib/core/options/options.js
+++ b/lib/core/options/options.js
@@ -12,7 +12,7 @@ function getKey(module) {
 }
 
 export async function _loadModuleOptions() {
-	const allOptions = await Storage.batch(Modules.all().map(mod => getKey(mod)));
+	const allOptions = await Storage.getMultiple(Modules.all().map(mod => getKey(mod)));
 
 	for (const mod of Modules.all()) {
 		_initOptions(mod, allOptions[getKey(mod)]);

--- a/lib/environment/storage.js
+++ b/lib/environment/storage.js
@@ -15,15 +15,15 @@ export function getMultiple<T: string>(keys: T[]): Promise<{ [key: T]: any | nul
 	return sendSynchronous('storage', ['getMultiple', keys]);
 }
 
-export function set(key: string, value: mixed) {
+export function set(key: string, value: mixed): Promise<void> {
 	return sendSynchronous('storage', ['set', key, value]);
 }
 
-export function setMultiple(valueMap: { +[key: string]: mixed }) {
+export function setMultiple(valueMap: { +[key: string]: mixed }): Promise<void> {
 	return sendSynchronous('storage', ['setMultiple', null, valueMap]);
 }
 
-function _delete(keys: string | string[]) {
+function _delete(keys: string | string[]): Promise<void> {
 	return sendSynchronous('storage', ['delete', keys]);
 }
 export { _delete as delete };
@@ -36,7 +36,7 @@ export function keys(): Promise<string[]> {
 	return sendSynchronous('storage', ['keys']);
 }
 
-export function clear() {
+export function clear(): Promise<void> {
 	return sendSynchronous('storage', ['clear']);
 }
 
@@ -46,22 +46,22 @@ export function clear() {
  * i.e. `deletePath('userTaggerStorageKey', 'username', 'tag')`
  * will `delete userTaggerStoredValue.username.tag`
  */
-function deletePath(key: string, ...path: string[]) {
+function deletePath(key: string, ...path: string[]): Promise<void> {
 	return sendSynchronous('storage', ['deletePath', key, path.join(',')]);
-}
-
-/*
- * Shallowly patches an object in storage, like Object.assign().
- */
-function patch(key: string, value: { [key: string]: mixed }) {
-	return sendSynchronous('storage', ['patch', key, value]);
 }
 
 /*
  * Deeply patches an object in storage, like extendDeep().
  */
-function patchDeep(key: string, value: { [key: string]: mixed }) {
-	return sendSynchronous('storage', ['patchDeep', key, value]);
+function patch(key: string, value: { [key: string]: mixed }): Promise<void> {
+	return sendSynchronous('storage', ['patch', key, value]);
+}
+
+/*
+ * Shallowly patches an object in storage, like Object.assign().
+ */
+function patchShallow(key: string, value: { [key: string]: mixed }): Promise<void> {
+	return sendSynchronous('storage', ['patchShallow', key, value]);
 }
 
 function compareAndSet(key: string, oldValue: mixed, newValue: mixed): Promise<boolean> {
@@ -86,7 +86,11 @@ class Wrapper<T> {
 	}
 
 	patch(value: $Shape<T>): Promise<void> {
-		return patchDeep(this._key(), (value: any));
+		return patch(this._key(), (value: any));
+	}
+
+	patchShallow(value: $Shape<T>): Promise<void> {
+		return patchShallow(this._key(), (value: any));
 	}
 
 	compareAndSet(oldValue: T, newValue: T): Promise<boolean> {
@@ -163,7 +167,11 @@ class PrefixWrapper<T> {
 	}
 
 	patch(key: string, value: $Shape<T>): Promise<void> {
-		return patchDeep(this._keyGen(key), (value: any));
+		return patch(this._keyGen(key), (value: any));
+	}
+
+	patchShallow(key: string, value: $Shape<T>): Promise<void> {
+		return patchShallow(this._keyGen(key), (value: any));
 	}
 
 	deletePath(key: string, ...path: string[]): Promise<void> {
@@ -223,11 +231,15 @@ class BlobWrapper<T> {
 	}
 
 	set(key: string, value: T): Promise<void> {
-		return patch(this._rootKey, { [key]: value });
+		return patchShallow(this._rootKey, { [key]: value });
 	}
 
 	patch(key: string, value: $Shape<T>): Promise<void> {
-		return patchDeep(this._rootKey, { [key]: value });
+		return patch(this._rootKey, { [key]: value });
+	}
+
+	patchShallow(key: string, value: $Shape<T>): Promise<void> {
+		return patchShallow(this._rootKey, { [key]: value });
 	}
 
 	deletePath(key: string, ...path: string[]): Promise<void> {
@@ -237,7 +249,7 @@ class BlobWrapper<T> {
 	delete(keys: string | string[]): Promise<void> {
 		// storage ignores keys with value undefined
 		const toDelete = _.transform([].concat(keys), (acc, key) => { acc[key] = undefined; }, {});
-		return patch(this._rootKey, toDelete);
+		return patchShallow(this._rootKey, toDelete);
 	}
 
 	has(key: string): Promise<boolean> {

--- a/lib/environment/storage.js
+++ b/lib/environment/storage.js
@@ -126,7 +126,7 @@ class PrefixWrapper<T> {
 		return get(this._keyGen(key)).then(val => (val === null ? this._default() : val));
 	}
 
-	getNullable(key: string): Promise<?T> {
+	getNullable(key: string): Promise<T | null> {
 		return get(this._keyGen(key));
 	}
 
@@ -193,7 +193,7 @@ class BlobWrapper<T> {
 		));
 	}
 
-	getNullable(key: string): Promise<?T> {
+	getNullable(key: string): Promise<T | null> {
 		return get(this._rootKey).then(val => (
 			(val === null || val[key] === undefined) ? null : val[key]
 		));

--- a/lib/environment/storage.js
+++ b/lib/environment/storage.js
@@ -23,29 +23,6 @@ export function setMultiple(valueMap: { +[key: string]: mixed }) {
 	return sendSynchronous('storage', ['setMultiple', null, valueMap]);
 }
 
-export function compareAndSet(key: string, oldValue: mixed, newValue: mixed): Promise<boolean> {
-	return sendMessage('storage-cas', [key, oldValue, newValue]);
-}
-
-function patch(key: string, value: { [key: string]: mixed }) {
-	return sendSynchronous('storage', ['patch', key, value]);
-}
-
-function patchDeep(key: string, value: { [key: string]: mixed }) {
-	return sendSynchronous('storage', ['patchDeep', key, value]);
-}
-export { patchDeep as patch };
-
-/*
- * Deletes a property on a value in storage.
- * Path components may not contain ','
- * i.e. `deletePath('userTaggerStorageKey', 'username', 'tag')`
- * will `delete userTaggerStoredValue.username.tag`
- */
-export function deletePath(key: string, ...path: string[]) {
-	return sendSynchronous('storage', ['deletePath', key, path.join(',')]);
-}
-
 function _delete(keys: string | string[]) {
 	return sendSynchronous('storage', ['delete', keys]);
 }
@@ -61,6 +38,34 @@ export function keys(): Promise<string[]> {
 
 export function clear() {
 	return sendSynchronous('storage', ['clear']);
+}
+
+/*
+ * Deletes a property on a value in storage.
+ * Path components may not contain ','
+ * i.e. `deletePath('userTaggerStorageKey', 'username', 'tag')`
+ * will `delete userTaggerStoredValue.username.tag`
+ */
+function deletePath(key: string, ...path: string[]) {
+	return sendSynchronous('storage', ['deletePath', key, path.join(',')]);
+}
+
+/*
+ * Shallowly patches an object in storage, like Object.assign().
+ */
+function patch(key: string, value: { [key: string]: mixed }) {
+	return sendSynchronous('storage', ['patch', key, value]);
+}
+
+/*
+ * Deeply patches an object in storage, like extendDeep().
+ */
+function patchDeep(key: string, value: { [key: string]: mixed }) {
+	return sendSynchronous('storage', ['patchDeep', key, value]);
+}
+
+function compareAndSet(key: string, oldValue: mixed, newValue: mixed): Promise<boolean> {
+	return sendMessage('storage-cas', [key, oldValue, newValue]);
 }
 
 class Wrapper<T> {

--- a/lib/environment/storage.js
+++ b/lib/environment/storage.js
@@ -42,12 +42,11 @@ export function clear(): Promise<void> {
 
 /*
  * Deletes a property on a value in storage.
- * Path components may not contain ','
  * i.e. `deletePath('userTaggerStorageKey', 'username', 'tag')`
  * will `delete userTaggerStoredValue.username.tag`
  */
 function deletePath(key: string, ...path: string[]): Promise<void> {
-	return sendSynchronous('storage', ['deletePath', key, path.join(',')]);
+	return sendSynchronous('storage', ['deletePath', key, path]);
 }
 
 /*

--- a/lib/environment/storage.js
+++ b/lib/environment/storage.js
@@ -27,12 +27,14 @@ export function compareAndSet(key: string, oldValue: mixed, newValue: mixed): Pr
 	return sendMessage('storage-cas', [key, oldValue, newValue]);
 }
 
-/*
- * Deeply extends a value in storage.
- */
-export function patch(key: string, value: { [key: string]: mixed }) {
+function patch(key: string, value: { [key: string]: mixed }) {
 	return sendSynchronous('storage', ['patch', key, value]);
 }
+
+function patchDeep(key: string, value: { [key: string]: mixed }) {
+	return sendSynchronous('storage', ['patchDeep', key, value]);
+}
+export { patchDeep as patch };
 
 /*
  * Deletes a property on a value in storage.
@@ -79,7 +81,7 @@ class Wrapper<T> {
 	}
 
 	patch(value: $Shape<T>): Promise<void> {
-		return patch(this._key(), (value: any));
+		return patchDeep(this._key(), (value: any));
 	}
 
 	compareAndSet(oldValue: T, newValue: T): Promise<boolean> {
@@ -156,11 +158,7 @@ class PrefixWrapper<T> {
 	}
 
 	patch(key: string, value: $Shape<T>): Promise<void> {
-		return patch(this._keyGen(key), (value: any));
-	}
-
-	compareAndSet(key: string, oldValue: T, newValue: T): Promise<boolean> {
-		return compareAndSet(this._keyGen(key), oldValue, newValue);
+		return patchDeep(this._keyGen(key), (value: any));
 	}
 
 	deletePath(key: string, ...path: string[]): Promise<void> {
@@ -178,4 +176,74 @@ class PrefixWrapper<T> {
 
 export function wrapPrefix<T>(prefix: string, defaultValue: () => T, destructiveKeyMapper: (key: string) => string = x => x): PrefixWrapper<T> {
 	return new PrefixWrapper(prefix, defaultValue, destructiveKeyMapper);
+}
+
+class BlobWrapper<T> {
+	_rootKey: string;
+	_default: () => T;
+
+	constructor(rootKey: string, def: () => T) {
+		this._rootKey = rootKey;
+		this._default = def;
+	}
+
+	get(key: string): Promise<T> {
+		return get(this._rootKey).then(val => (
+			(val === null || val[key] === undefined) ? this._default() : val[key]
+		));
+	}
+
+	getNullable(key: string): Promise<?T> {
+		return get(this._rootKey).then(val => (
+			(val === null || val[key] === undefined) ? null : val[key]
+		));
+	}
+
+	getAll(): Promise<{ [key: string]: T }> {
+		return get(this._rootKey).then(val => (val === null ? {} : val));
+	}
+
+	async getMultiple(keys: string[]): Promise<{ [key: string]: T }> {
+		const rawValues = (await get(this._rootKey)) || {};
+		return _.transform(keys, (acc, key) => {
+			acc[key] = rawValues[key] === undefined ? this._default() : rawValues[key];
+		}, {});
+	}
+
+	async getMultipleNullable(keys: string[]): Promise<{ [key: string]: T | null }> {
+		const rawValues = (await get(this._rootKey)) || {};
+		return _.transform(keys, (acc, key) => {
+			acc[key] = rawValues[key] === undefined ? null : rawValues[key];
+		}, {});
+	}
+
+	set(key: string, value: T): Promise<void> {
+		return patch(this._rootKey, { [key]: value });
+	}
+
+	patch(key: string, value: $Shape<T>): Promise<void> {
+		return patchDeep(this._rootKey, { [key]: value });
+	}
+
+	deletePath(key: string, ...path: string[]): Promise<void> {
+		return deletePath(this._rootKey, key, ...path);
+	}
+
+	delete(keys: string | string[]): Promise<void> {
+		// storage ignores keys with value undefined
+		const toDelete = _.transform([].concat(keys), (acc, key) => { acc[key] = undefined; }, {});
+		return patch(this._rootKey, toDelete);
+	}
+
+	has(key: string): Promise<boolean> {
+		return get(this._rootKey).then(val => (val !== null && val[key] !== undefined));
+	}
+
+	clear(): Promise<void> {
+		return _delete(this._rootKey);
+	}
+}
+
+export function wrapBlob<T>(rootKey: string, defaultValue: () => T): BlobWrapper<T> {
+	return new BlobWrapper(rootKey, defaultValue);
 }

--- a/lib/environment/storage.js
+++ b/lib/environment/storage.js
@@ -23,30 +23,8 @@ export function setMultiple(valueMap: { +[key: string]: mixed }): Promise<void> 
 	return sendSynchronous('storage', ['setMultiple', null, valueMap]);
 }
 
-function _delete(keys: string | string[]): Promise<void> {
-	return sendSynchronous('storage', ['delete', keys]);
-}
-export { _delete as delete };
-
-export function has(key: string): Promise<boolean> {
-	return sendSynchronous('storage', ['has', key]);
-}
-
-export function keys(): Promise<string[]> {
-	return sendSynchronous('storage', ['keys']);
-}
-
-export function clear(): Promise<void> {
-	return sendSynchronous('storage', ['clear']);
-}
-
-/*
- * Deletes a property on a value in storage.
- * i.e. `deletePath('userTaggerStorageKey', 'username', 'tag')`
- * will `delete userTaggerStoredValue.username.tag`
- */
-function deletePaths(key: string, paths: string[][]): Promise<void> {
-	return sendSynchronous('storage', ['deletePaths', key, paths]);
+function compareAndSet(key: string, oldValue: mixed, newValue: mixed): Promise<boolean> {
+	return sendMessage('storage-cas', [key, oldValue, newValue]);
 }
 
 /*
@@ -63,8 +41,30 @@ function patchShallow(key: string, value: { [key: string]: mixed }): Promise<voi
 	return sendSynchronous('storage', ['patchShallow', key, value]);
 }
 
-function compareAndSet(key: string, oldValue: mixed, newValue: mixed): Promise<boolean> {
-	return sendMessage('storage-cas', [key, oldValue, newValue]);
+/*
+ * Deletes a property on a value in storage.
+ * i.e. `deletePath('userTaggerStorageKey', 'username', 'tag')`
+ * will `delete userTaggerStoredValue.username.tag`
+ */
+function deletePaths(key: string, paths: string[][]): Promise<void> {
+	return sendSynchronous('storage', ['deletePaths', key, paths]);
+}
+
+function _delete(keys: string | string[]): Promise<void> {
+	return sendSynchronous('storage', ['delete', keys]);
+}
+export { _delete as delete };
+
+export function has(key: string): Promise<boolean> {
+	return sendSynchronous('storage', ['has', key]);
+}
+
+export function keys(): Promise<string[]> {
+	return sendSynchronous('storage', ['keys']);
+}
+
+export function clear(): Promise<void> {
+	return sendSynchronous('storage', ['clear']);
 }
 
 class Wrapper<T> {

--- a/lib/environment/storage.js
+++ b/lib/environment/storage.js
@@ -11,8 +11,8 @@ export function getAll(): Promise<{ [key: string]: mixed }> {
 	return sendSynchronous('storage', ['getAll']);
 }
 
-export function batch<T: string>(keys: T[]): Promise<{ [key: T]: any | null }> {
-	return sendSynchronous('storage', ['batch', keys]);
+export function getMultiple<T: string>(keys: T[]): Promise<{ [key: T]: any | null }> {
+	return sendSynchronous('storage', ['getMultiple', keys]);
 }
 
 export function set(key: string, value: mixed) {
@@ -137,15 +137,15 @@ class PrefixWrapper<T> {
 		}, {});
 	}
 
-	async batch(keys: string[]): Promise<{ [key: string]: T }> {
-		const rawValues = await batch(keys.map(k => this._keyGen(k)));
+	async getMultiple(keys: string[]): Promise<{ [key: string]: T }> {
+		const rawValues = await getMultiple(keys.map(k => this._keyGen(k)));
 		return _.transform(rawValues, (acc, v, k) => {
 			acc[k.slice(this._prefix.length)] = (v === null ? this._default() : v);
 		}, {});
 	}
 
-	async batchNullable(keys: string[]): Promise<{ [key: string]: ?T }> {
-		const rawValues = await batch(keys.map(k => this._keyGen(k)));
+	async getMultipleNullable(keys: string[]): Promise<{ [key: string]: T | null }> {
+		const rawValues = await getMultiple(keys.map(k => this._keyGen(k)));
 		return _.transform(rawValues, (acc, v, k) => {
 			acc[k.slice(this._prefix.length)] = v;
 		}, {});

--- a/lib/environment/storage.js
+++ b/lib/environment/storage.js
@@ -45,8 +45,8 @@ export function clear(): Promise<void> {
  * i.e. `deletePath('userTaggerStorageKey', 'username', 'tag')`
  * will `delete userTaggerStoredValue.username.tag`
  */
-function deletePath(key: string, ...path: string[]): Promise<void> {
-	return sendSynchronous('storage', ['deletePath', key, path]);
+function deletePaths(key: string, paths: string[][]): Promise<void> {
+	return sendSynchronous('storage', ['deletePaths', key, paths]);
 }
 
 /*
@@ -88,16 +88,12 @@ class Wrapper<T> {
 		return patch(this._key(), (value: any));
 	}
 
-	patchShallow(value: $Shape<T>): Promise<void> {
-		return patchShallow(this._key(), (value: any));
-	}
-
 	compareAndSet(oldValue: T, newValue: T): Promise<boolean> {
 		return compareAndSet(this._key(), oldValue, newValue);
 	}
 
 	deletePath(...path: string[]): Promise<void> {
-		return deletePath(this._key(), ...path);
+		return deletePaths(this._key(), [path]);
 	}
 
 	delete(): Promise<void> {
@@ -169,12 +165,8 @@ class PrefixWrapper<T> {
 		return patch(this._keyGen(key), (value: any));
 	}
 
-	patchShallow(key: string, value: $Shape<T>): Promise<void> {
-		return patchShallow(this._keyGen(key), (value: any));
-	}
-
 	deletePath(key: string, ...path: string[]): Promise<void> {
-		return deletePath(this._keyGen(key), ...path);
+		return deletePaths(this._keyGen(key), [path]);
 	}
 
 	delete(keys: string | string[]): Promise<void> {
@@ -237,18 +229,12 @@ class BlobWrapper<T> {
 		return patch(this._rootKey, { [key]: value });
 	}
 
-	patchShallow(key: string, value: $Shape<T>): Promise<void> {
-		return patchShallow(this._rootKey, { [key]: value });
-	}
-
 	deletePath(key: string, ...path: string[]): Promise<void> {
-		return deletePath(this._rootKey, key, ...path);
+		return deletePaths(this._rootKey, [[key, ...path]]);
 	}
 
 	delete(keys: string | string[]): Promise<void> {
-		// storage ignores keys with value undefined
-		const toDelete = _.transform([].concat(keys), (acc, key) => { acc[key] = undefined; }, {});
-		return patchShallow(this._rootKey, toDelete);
+		return deletePaths(this._rootKey, [].concat(keys).map(k => [k]));
 	}
 
 	has(key: string): Promise<boolean> {

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -92,7 +92,7 @@ const subscriptionStorage = Storage.wrapBlob('RESmodules.newCommentCount.subscri
 	updateTime: number,
 	url: string,
 	title: string,
-|} => { throw new Error('default subscription should never be accessed'); });
+|} => { throw new Error('Subscription not found'); });
 
 module.beforeLoad = () => {
 	updateToggleSubscriptionButton();

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -85,16 +85,14 @@ const entryStorage = Storage.wrapPrefix('newCommentCount.', (): {|
 	throw new Error('Default value should never be retrieved');
 });
 
-const subscriptionStorage = Storage.wrap('RESmodules.newCommentCount.subscriptions', ({}: {
-	[id: string]: {|
-		count: number,
-		subscriptionDate: number,
-		editedTime: number,
-		updateTime: number,
-		url: string,
-		title: string,
-	|},
-}));
+const subscriptionStorage = Storage.wrapBlob('RESmodules.newCommentCount.subscriptions', (): {|
+	count: number,
+	subscriptionDate: number,
+	editedTime: number,
+	updateTime: number,
+	url: string,
+	title: string,
+|} => { throw new Error('default subscription should never be accessed'); });
 
 module.beforeLoad = () => {
 	updateToggleSubscriptionButton();
@@ -216,7 +214,7 @@ const updateToggleSubscriptionButton = mutex(async () => {
 	if (!currentId) throw new Error('No currentId');
 
 	const $button = getToggleSubscriptionButton();
-	const subscriptions = await subscriptionStorage.get();
+	const subscriptions = await subscriptionStorage.getAll();
 	if (currentId in subscriptions) {
 		// Unsubscribe.
 		$button
@@ -258,18 +256,18 @@ const updateToggleSubscriptionButton = mutex(async () => {
 
 function subscribe(id, newCommentCount, newEditedTime) {
 	const now = Date.now();
-	return subscriptionStorage.patch({ [id]: {
+	return subscriptionStorage.set(id, {
 		count: newCommentCount,
 		subscriptionDate: now,
 		updateTime: now,
 		editedTime: newEditedTime,
 		url: location.href.replace(location.hash, ''),
 		title: document.title,
-	} });
+	});
 }
 
 function unsubscribe(id) {
-	return subscriptionStorage.deletePath(id);
+	return subscriptionStorage.delete(id);
 }
 
 function stopTracking(id) {
@@ -279,13 +277,13 @@ function stopTracking(id) {
 async function checkSubscriptions() {
 	const now = Date.now();
 
-	for (const [id, subscription] of Object.entries(await subscriptionStorage.get())) {
+	for (const [id, subscription] of Object.entries(await subscriptionStorage.getAll())) {
 		const { subscriptionDate, updateTime } = subscription;
 		// If it's been subscriptionLength days since we've subscribed, we're going to delete this subscription...
 		if ((now - subscriptionDate) > (DAY * parseInt(module.options.subscriptionLength.value, 10))) {
 			unsubscribe(id);
 		} else if ((now - updateTime) > (5 * MINUTE)) {
-			subscriptionStorage.patch({ [id]: { updateTime: now } });
+			subscriptionStorage.patch(id, { updateTime: now });
 			checkThread(id, subscription);
 		}
 	}
@@ -296,7 +294,7 @@ async function checkThread(id, subscription) {
 	const { count, editedTime, url, title } = subscription;
 
 	if (newCount > count) {
-		subscriptionStorage.patch({ [id]: { count: newCount } });
+		subscriptionStorage.patch(id, { count: newCount });
 
 		const notification = await Notifications.showNotification({
 			header: 'New comments',
@@ -312,7 +310,7 @@ async function checkThread(id, subscription) {
 		$(notification.element).find('.RESNotificationContent').append(button);
 	}
 	if (module.options.notifyEditedPosts.value && newEditedTime > editedTime) {
-		subscriptionStorage.patch({ [id]: { editedTime: newEditedTime } });
+		subscriptionStorage.patch(id, { editedTime: newEditedTime });
 
 		const notification = await Notifications.showNotification({
 			header: 'Post edited',
@@ -347,7 +345,7 @@ function createButton(id, type) {
 				.html('<span class="res-icon">&#xF03B;</span> renew')
 				.attr('title', `renew for ${module.options.subscriptionLength.value} days`);
 			action = async () => {
-				await subscriptionStorage.patch({ [id]: { subscriptionDate: Date.now() } });
+				await subscriptionStorage.patch(id, { subscriptionDate: Date.now() });
 
 				Notifications.showNotification({
 					notificationID: 'newCommentCountRenew',
@@ -363,7 +361,7 @@ function createButton(id, type) {
 				.attr('title', 'delete from list')
 				.addClass('deleteIcon');
 			action = async () => {
-				const { [id]: { title } } = await subscriptionStorage.get();
+				const { title } = await subscriptionStorage.get(id);
 				return Alert.open(`Are you sure you want to unsubscribe from post: "${title}"?`, { cancelable: true })
 					.then(() => unsubscribe(id));
 			};
@@ -420,7 +418,7 @@ async function drawSubscriptionsTable(sortMethod, descending) {
 	currentSortMethod = sortMethod || currentSortMethod;
 	isDescending = (descending === undefined) ? isDescending : !!descending;
 	$('#newCommentsTable tbody').html('');
-	const thisCounts = filterMap(Object.entries(await subscriptionStorage.get()), ([id, commentCount]) => {
+	const thisCounts = filterMap(Object.entries(await subscriptionStorage.getAll()), ([id, commentCount]) => {
 		const match = new URL(commentCount.url).pathname.match(regexes.subreddit);
 		if (match) {
 			return [{

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -128,7 +128,7 @@ module.afterLoad = () => {
 };
 
 const getEntryBatched = batch(async ids => {
-	const entries = await entryStorage.batchNullable(ids);
+	const entries = await entryStorage.getMultipleNullable(ids);
 	return ids.map(id => entries[id]);
 }, { size: Infinity, delay: 0 });
 

--- a/lib/modules/saveComments.js
+++ b/lib/modules/saveComments.js
@@ -31,16 +31,16 @@ module.exclude = [
 
 const savedRe = /\/user\/([\-\w]+)\/saved\/?/i;
 
-const savedCommentStorage = Storage.wrap('RESmodules.saveComments.savedComments', ({}: { [commentId: string]: {|
+const savedCommentStorage = Storage.wrapBlob('RESmodules.saveComments.savedComments', (): {|
 	href: string,
 	username: string,
 	comment: string,
 	timeSaved: string,
-|} }));
+|} => { throw new Error('default saved comment should never be accessed'); });
 let savedCommentIDs;
 
 module.beforeLoad = async () => {
-	savedCommentIDs = new Set(Object.keys(await savedCommentStorage.get()));
+	savedCommentIDs = new Set(Object.keys(await savedCommentStorage.getAll()));
 
 	watchForThings(['comment'], addSaveLinkToComment);
 };
@@ -97,13 +97,11 @@ function saveComment(thing: Thing) {
 	const permaLink = thing.getCommentPermalink();
 	if (!permaLink) throw new Error('Comment lacks permalink');
 
-	savedCommentStorage.patch({
-		[id]: {
-			href: permaLink.href,
-			username: thing.getAuthor() || '[deleted]',
-			comment: getCommentContent(thing),
-			timeSaved: new Date().toString(),
-		},
+	savedCommentStorage.set(id, {
+		href: permaLink.href,
+		username: thing.getAuthor() || '[deleted]',
+		comment: getCommentContent(thing),
+		timeSaved: new Date().toString(),
 	});
 	savedCommentIDs.add(id);
 }
@@ -194,7 +192,7 @@ const savedCommentsTemplate = ({ comments, keyNavTip, moduleDescription }) => st
 `;
 
 async function drawSavedComments() {
-	const savedComments = await savedCommentStorage.get();
+	const savedComments = await savedCommentStorage.getAll();
 
 	const comments = Object.entries(savedComments).map(([id, { comment, href, username, timeSaved }]) => {
 		const date = new Date(timeSaved);
@@ -230,7 +228,7 @@ async function drawSavedComments() {
 }
 
 function unsaveComment(id) {
-	savedCommentStorage.deletePath(id);
+	savedCommentStorage.delete(id);
 	savedCommentIDs.delete(id);
 }
 

--- a/lib/modules/saveComments.js
+++ b/lib/modules/saveComments.js
@@ -36,7 +36,7 @@ const savedCommentStorage = Storage.wrapBlob('RESmodules.saveComments.savedComme
 	username: string,
 	comment: string,
 	timeSaved: string,
-|} => { throw new Error('default saved comment should never be accessed'); });
+|} => { throw new Error('Saved comment not found'); });
 let savedCommentIDs;
 
 module.beforeLoad = async () => {

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -14,7 +14,7 @@ import {
 	niceKeyCode,
 	Alert,
 } from '../utils';
-import { i18n, Storage } from '../environment';
+import { i18n } from '../environment';
 import * as About from './about';
 import * as CommandLine from './commandLine';
 import * as Menu from './menu';
@@ -904,8 +904,6 @@ export function open(moduleIdOrCategory?: string) {
 
 	RESConsoleContainer.classList.remove('slideOut');
 	RESConsoleContainer.classList.add('slideIn');
-
-	Storage.set('RESConsole.hasOpenedConsole', true);
 
 	$(document.body).on('keyup', handleEscapeKey);
 	$(window)

--- a/lib/modules/troubleshooter.js
+++ b/lib/modules/troubleshooter.js
@@ -203,6 +203,17 @@ async function testEnvironment() {
 		domain.delete('1');
 		rows.push(`prefix.get(): ${(await domain.get('1'): any)}`);
 		rows.push(`prefix.has(): ${(await domain.has('1'): any)}`, '');
+
+		rand = Math.random();
+		const blob = Storage.wrapBlob(testKey, () => 'default');
+		rows.push(`blob.set(): ${rand}`);
+		blob.set('1', rand);
+		rows.push(`blob.get(): ${(await blob.get('1'): any)}`);
+		rows.push(`blob.has(): ${(await blob.has('1'): any)}`);
+		rows.push('blob.delete()');
+		blob.delete('1');
+		rows.push(`blob.get(): ${(await blob.get('1'): any)}`);
+		rows.push(`blob.has(): ${(await blob.has('1'): any)}`, '');
 	} catch (e) {
 		rows.push('', `Errored: ${e}`);
 		console.error(e);

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -100,7 +100,7 @@ export const tagStorage = Storage.wrapPrefix('tag.', () => (({}: any): {|
 |}), user => user.toLowerCase());
 
 const getTagBatched = batch(async users => {
-	const tags = await tagStorage.batchNullable(users);
+	const tags = await tagStorage.getMultipleNullable(users);
 	return users.map(user => tags[user.toLowerCase()]);
 }, { size: Infinity, delay: 0 });
 


### PR DESCRIPTION
Tested in browser: Chrome 64; existing integration tests exercise module enabled state / options

Primarily adding `Storage.wrapBlob`, and not exporting some complex storage operations at the root (you should probably use a wrapper instead)