### PR TITLE
Add support for Google Poly media host

### DIFF
--- a/lib/modules/hosts/poly.js
+++ b/lib/modules/hosts/poly.js
@@ -1,0 +1,23 @@
+/* @flow */
+
+import { Host } from '../../core/host';
+
+export default new Host('poly', {
+	name: 'Poly',
+
+	domains: [
+		'poly.google.com',
+	],
+
+	// Embed already contains attribution
+	attribution: false,
+
+	detect: ({ pathname }) => (/^\/view\/([a-zA-Z0-9-]+)\/?$/i).exec(pathname),
+
+	handleLink(href, [, id]) {
+		return {
+			type: 'IFRAME',
+			embed: `https://poly.google.com/view/${id}/embed`,
+		};
+	},
+});


### PR DESCRIPTION
A small, pretty straightforward implementation of a media host for Google's new Poly 3D model catalog.

As far as I know Poly doesn't have an API, but it's pretty straightforward to just embed the viewer with an iframe.

Tested in Chrome 62.

Try it out here: https://www.reddit.com/domain/poly.google.com/