### PR TITLE
userTagger: Improve tagger alignment

### DIFF
--- a/lib/css/modules/_userTagger.scss
+++ b/lib/css/modules/_userTagger.scss
@@ -106,7 +106,8 @@ a.voteWeight {
 
 .RESUserTag {
 	color: black;
-	display: inline-block;
+	display: inline-flex;
+	height: 1.2em;
 
 	// unselectable in comments/markdown for usability
 	.md & {
@@ -122,23 +123,24 @@ a.voteWeight {
 }
 
 .userTagLink {
+	align-self: center;
+	height: 100%;
+
 	&:hover { text-decoration: none !important; }
 
 	&.hasTag {
 		padding: 0 4px;
-		line-height: normal;
 		border: 1px solid #c7c7c7;
 		border-radius: 3px;
 		font-size: .9em;
-	}
+		line-height: normal;
 
-	&.truncateTag {
-		max-width: 25ch;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-		display: inherit;
-		margin: 0 0 -3px 0;
+		&.truncateTag {
+			max-width: 25ch;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
 	}
 }
 


### PR DESCRIPTION
- Fixes height when there's color but no text
- Fixes some circumstances where it was misaligned with the username / voteweight.

Tested in browser: Firefox 57, Chrome 64
