### PR TITLE
Fix settings layout to enhance clarity

### DIFF
--- a/lib/css/res.scss
+++ b/lib/css/res.scss
@@ -605,8 +605,8 @@ div.usertext-edit {
 
 .optionTitle {
 	font-size: 14px;
-	flex: 0 0 auto;
 	min-width: 200px;
+	flex: 0 0 20%;
 }
 
 .optionKey {
@@ -614,12 +614,14 @@ div.usertext-edit {
 	color: #999;
 }
 
-.optionDescription {
-	line-height: 1.5;
-}
-
 .optionSetting {
 	white-space: nowrap;
+	flex: 0 0 20%;
+}
+
+.optionDescription {
+	line-height: 1.5;
+	flex-grow: 1;
 }
 
 #RESConsoleContainer input[type=radio],


### PR DESCRIPTION
Settings, especially on non-English locales, tend to get messy. In Polish, often short setting names must be longer to make ANY sense. As a result, settings may look like this:

![obraz](https://user-images.githubusercontent.com/5426427/32986186-75b4a346-cccc-11e7-921e-f8e71e1425ff.png)

(and I couldn't be bothered to find the worst case)

After the fix, settings behave like so:

* Label takes 20%, but not less than 200px,
* Setting takes 20%, grows when necessary in some special cases
* Description takes whatever is left

and it looks like that:

![obraz](https://user-images.githubusercontent.com/5426427/32986188-a8647b90-cccc-11e7-9309-e37c5e6be70b.png)
