### PR TITLE
utils getViewportSize: Use window.visualViewport when available

### DIFF
--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -138,13 +138,20 @@ click.isProgrammaticEvent = (e: MouseEvent): boolean => e.clientX === 1 && e.cli
 export const getViewportSize = _.memoize((): { width: number, height: number } => {
 	waitForEvent(window, 'resize').then(() => { getViewportSize.cache.clear(); });
 
-	const viewportSizedElement = document.createElement('div');
-	viewportSizedElement.style.width = viewportSizedElement.style.height = '100%';
-	viewportSizedElement.style.position = 'fixed';
-	document.body.appendChild(viewportSizedElement);
-	const size = _.pick(viewportSizedElement.getBoundingClientRect(), ['height', 'width']);
-	viewportSizedElement.remove();
-	return size;
+	let visualViewport;
+
+	if (window.visualViewport) {
+		visualViewport = window.visualViewport;
+	} else {
+		const viewportSizedElement = document.createElement('div');
+		viewportSizedElement.style.width = viewportSizedElement.style.height = '100%';
+		viewportSizedElement.style.position = 'fixed';
+		document.body.appendChild(viewportSizedElement);
+		visualViewport = viewportSizedElement.getBoundingClientRect();
+		viewportSizedElement.remove();
+	}
+
+	return _.pick(visualViewport, ['height', 'width']);
 });
 
 export function elementInViewport(ele: Element): boolean {


### PR DESCRIPTION
[`visualViewport`](https://developers.google.com/web/updates/2017/09/visual-viewport-api) contains the same size data as `getBoundingClientRect`, but reflow is not necessary to obtain it.

Currently is `visualViewport` only available in Chrome.

Tested in browser: Firefox 59, Chrome 64, Edge 16