### PR TITLE
showImages conserveMemory: Use IntersectionObserver

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -26,7 +26,6 @@ import {
 	CreateElement,
 	elementInViewport,
 	scrollToElement,
-	filterMap,
 	forEachChunked,
 	forEachSeq,
 	idleThrottle,
@@ -561,18 +560,6 @@ const resizeSources = {
 	USER_MOVE: 2,
 };
 
-function isWithinBuffer(ele) {
-	if (!ele.offsetParent) return false;
-
-	const bufferScreens = parseInt(module.options.bufferScreens.value, 10) || 2;
-	const viewportHeight = getViewportSize().height;
-	const maximumTop = viewportHeight * (bufferScreens + 1);
-	const minimumBottom = viewportHeight * bufferScreens * -1;
-
-	const { bottom, top } = ele.getBoundingClientRect();
-	return top <= maximumTop && bottom >= minimumBottom;
-}
-
 const checkDeferredLinks = frameThrottle(() => {
 	for (const [link, complete] of deferredLinks) {
 		const thing = Thing.from(link);
@@ -596,51 +583,62 @@ export const thingExpandoBuildListeners: * = $.Callbacks('unique');
  * @returns {void}
  */
 function enableConserveMemory() {
-	const refresh = _.throttle(frameThrottle(() => {
+	const rootMargin = `${100 * (parseInt(module.options.bufferScreens.value, 10) || 2)}%`;
+
+	const mediaMap = new WeakMap();
+	const ioMedia = new IntersectionObserver(entries => {
+		for (const entry of entries) {
+			const expando = downcast(mediaMap.get(entry.target), Expando);
+			if (expando.open && expando.media) lazyUnload(expando.media, entry.isIntersecting);
+		}
+	}, { rootMargin });
+
+	const buttonMap = new WeakMap();
+	const ioButton = new IntersectionObserver(entries => {
+		for (const entry of entries) {
+			const expando = downcast(buttonMap.get(entry.target), Expando);
+			if (!entry.isIntersecting && !expando.open) {
+				ioMedia.unobserve(expando.media);
+				ioButton.unobserve(expando.button);
+				expando.empty();
+			}
+		}
+	}, { rootMargin });
+
+	window.addEventListener('scroll', _.debounce(idleThrottle(() => {
 		// Running this can conflict with partially-ready expandos, as is the case
 		// while NER is ready-ing a new page
 		if (NeverEndingReddit.loadPromise) return;
 
 		const activeExpandos = Array.from(primaryExpandos.values());
-		const openExpandos = [];
 
-		// Empty collapsed when beyond buffer
 		for (const expando of activeExpandos) {
-			if (!expando.isAttached()) expando.destroy();
-			else if (expando.open) openExpandos.push(expando);
-			else if (expando.media && !isWithinBuffer(expando.button)) expando.empty();
+			if (expando.isAttached()) {
+				if (expando.media) {
+					if (expando.open) {
+						mediaMap.set(expando.media, expando);
+						ioMedia.observe(expando.media);
+					} else {
+						buttonMap.set(expando.button, expando);
+						ioButton.observe(expando.button);
+					}
+				}
+			} else {
+				expando.destroy();
+			}
 		}
-
-		// Unload expanded when beyond buffer
-		flow(
-			filterMap(expando => {
-				if (expando.media) return [{ media: expando.media, data: expando.media }];
-			}),
-			lazyUnload(isWithinBuffer)
-		)(openExpandos);
-	}), 150);
-
-	window.addEventListener('scroll', refresh);
-	// not using element-resize-detector because it sets the target to `position: relative`, breaking some stylesheets (/r/nba)
-	window.addEventListener('resize', refresh);
+	}), 1000));
 }
 
-const lazyUnload = _.curryRight(<T>(pieces: Array<{ media: ?ExpandoMediaElement, data: T }>, testKeepLoaded: (data: T) => boolean) => {
-	const actions: Array<() => void> = [];
+function lazyUnload(media: ExpandoMediaElement, keepLoaded: boolean) {
+	if (!media.unload || !media.restore) return;
 
-	for (const { media, data } of pieces) {
-		if (!media || !media.unload || !media.restore) continue;
-
-		const keepLoaded = testKeepLoaded(data);
-		if (/*:: media.restore && */ keepLoaded && media.state === mediaStates.UNLOADED) {
-			actions.push(media.restore);
-		} else if (/*:: media.unload && */ !keepLoaded && media.state !== mediaStates.UNLOADED) {
-			actions.push(media.unload);
-		}
+	if (/*:: media.restore && */ keepLoaded && media.state === mediaStates.UNLOADED) {
+		media.restore();
+	} else if (/*:: media.unload && */ !keepLoaded && media.state !== mediaStates.UNLOADED) {
+		media.unload();
 	}
-
-	for (const action of actions) action();
-});
+}
 
 let viewImagesButton;
 let autoExpandActive = false;
@@ -1306,17 +1304,15 @@ function generateGallery(options: GalleryMedia, context) {
 			const first = newIndex - preloadCount;
 			const last = newIndex + preloadCount;
 
-			flow(
-				filterMap(piece => {
-					if (piece.media) return [{ media: piece.media, data: piece }];
-				}),
-				lazyUnload(piece => {
-					const index = pieces.indexOf(piece);
-					if (last > pieces.length && last % pieces.length >= index) return true;
-					if (first < 0 && positiveModulo(first, pieces.length) <= index) return true;
-					return index >= first && index <= last;
-				})
-			)(pieces);
+			for (const [index, { media }] of pieces.entries()) {
+				if (!media) continue;
+
+				const keepLoaded = last > pieces.length && last % pieces.length >= index ||
+					first < 0 && positiveModulo(first, pieces.length) <= index ||
+					index >= first && index <= last;
+
+				lazyUnload(media, keepLoaded);
+			}
 		}
 
 		return preloadAhead();


### PR DESCRIPTION
Fixes:
- Image / video being slow to restore when scrolling fast / collapsing threads
- Forced reflow when refreshing

Tested in browser: Chrome 64, Firefox 58, Edge 16
