### PR TITLE
Migrate text options saved as number to string

### DIFF
--- a/lib/core/migrate/migrate.js
+++ b/lib/core/migrate/migrate.js
@@ -594,6 +594,61 @@ const migrations = [
 		async go() {
 			await Migrators.moveOption('showImages', 'prefer RES albums', 'showImages', 'preferResAlbums');
 		},
+	}, {
+		versionNumber: '5.9.2-numbers-to-strings',
+		async go() {
+			function stringify(x) {
+				if (typeof x === 'number') return x.toString();
+				return x;
+			}
+
+			await Migrators.forceUpdateOption('betteReddit', 'hideLinkFadeDelay', stringify);
+			await Migrators.forceUpdateOption('commentDepth', 'defaultCommentDepth', stringify);
+			await Migrators.forceUpdateOption('commentDepth', 'defaultMinimumComments', stringify);
+			await Migrators.forceUpdateOption('commentStyle', 'commentIndent', stringify);
+			await Migrators.forceUpdateOption('context', 'defaultContext', stringify);
+			await Migrators.forceUpdateOption('dashboard', 'defaultPosts', stringify);
+			await Migrators.forceUpdateOption('dashboard', 'tagsPerPage', stringify);
+			await Migrators.forceUpdateOption('hover', 'openDelay', stringify);
+			await Migrators.forceUpdateOption('hover', 'fadeDelay', stringify);
+			await Migrators.forceUpdateOption('hover', 'fadeSpeed', stringify);
+			await Migrators.forceUpdateOption('hover', 'width', stringify);
+			await Migrators.forceUpdateOption('messageMenu', 'hoverDelay', stringify);
+			await Migrators.forceUpdateOption('messageMenu', 'fadeDelay', stringify);
+			await Migrators.forceUpdateOption('messageMenu', 'fadeSpeed', stringify);
+			await Migrators.forceUpdateOption('multiredditNavbar', 'hoverDelay', stringify);
+			await Migrators.forceUpdateOption('multiredditNavbar', 'fadeDelay', stringify);
+			await Migrators.forceUpdateOption('multiredditNavbar', 'fadeSpeed', stringify);
+			await Migrators.forceUpdateOption('neverEndingReddit', 'pauseAfterEvery', stringify);
+			await Migrators.forceUpdateOption('newCommentCount', 'cleanComments', stringify);
+			await Migrators.forceUpdateOption('newCommentCount', 'subscriptionLength', stringify);
+			await Migrators.forceUpdateOption('nightMode', 'nightModeOverrideHours', stringify);
+			await Migrators.forceUpdateOption('notifications', 'closeDelay', stringify);
+			await Migrators.forceUpdateOption('notifications', 'fadeOutLength', stringify);
+			await Migrators.forceUpdateOption('profileNavigator', 'hoverDelay', stringify);
+			await Migrators.forceUpdateOption('profileNavigator', 'fadeDelay', stringify);
+			await Migrators.forceUpdateOption('profileNavigator', 'fadeSpeed', stringify);
+			await Migrators.forceUpdateOption('showImages', 'browsePreloadCount', stringify);
+			await Migrators.forceUpdateOption('showImages', 'galleryPreloadCount', stringify);
+			await Migrators.forceUpdateOption('showImages', 'bufferScreens', stringify);
+			await Migrators.forceUpdateOption('showImages', 'selfTextMaxHeight', stringify);
+			await Migrators.forceUpdateOption('showImages', 'commentMaxHeight', stringify);
+			await Migrators.forceUpdateOption('showImages', 'filmstripLoadIncrement', stringify);
+			await Migrators.forceUpdateOption('showImages', 'useSlideshowWhenLargerThan', stringify);
+			await Migrators.forceUpdateOption('showImages', 'maxSimultaneousPlaying', stringify);
+			await Migrators.forceUpdateOption('showParent', 'hoverDelay', stringify);
+			await Migrators.forceUpdateOption('showParent', 'fadeDelay', stringify);
+			await Migrators.forceUpdateOption('showParent', 'fadeSpeed', stringify);
+			await Migrators.forceUpdateOption('styleTweaks', 'highlightTopLevelSize', stringify);
+			await Migrators.forceUpdateOption('subredditInfo', 'hoverDelay', stringify);
+			await Migrators.forceUpdateOption('subredditInfo', 'fadeDelay', stringify);
+			await Migrators.forceUpdateOption('subredditInfo', 'fadeSpeed', stringify);
+			await Migrators.forceUpdateOption('subredditManager', 'shortcutDropdownDelay', stringify);
+			await Migrators.forceUpdateOption('subredditManager', 'shortcutEditDropdownDelay', stringify);
+			await Migrators.forceUpdateOption('userInfo', 'hoverDelay', stringify);
+			await Migrators.forceUpdateOption('userInfo', 'fadeDelay', stringify);
+			await Migrators.forceUpdateOption('userInfo', 'fadeSpeed', stringify);
+		},
 	},
 
 ]; // ^^ Add new migrations ^^

--- a/lib/core/migrate/migrators.js
+++ b/lib/core/migrate/migrators.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import { Storage } from '../../environment';
 import * as Options from '../options';
 
-export async function updateOption(moduleID: string, optionName: string, formerDefaultValue: mixed, valueOrFunction?: mixed) {
+export async function updateOption(moduleID: string, optionName: string, formerDefaultValue: mixed, valueOrFunction: mixed) {
 	try {
 		const options = await Options.loadRaw(moduleID);
 		const option = options && options[optionName];
@@ -27,7 +27,7 @@ export async function updateOption(moduleID: string, optionName: string, formerD
 	}
 }
 
-export async function forceUpdateOption(moduleID: string, optionName: string, valueOrFunction?: mixed) {
+export async function forceUpdateOption(moduleID: string, optionName: string, valueOrFunction: mixed) {
 	// ☢ ☠ ☣  DANGER, WILL ROBINSON, DANGER ☠ ☣ ☢
 	// Make sure valueOrFunction doesn't destroy user settings!
 	try {


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: closes #4346
Tested in browser: Chrome 64

It's possible that some other options could have been saved as numbers, but this covers everything that could be broken by default (and other things should have more obviously broken when a user changed them).