### PR TITLE
Remove other favicons to prevent Chrome from switching to them

### DIFF
--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -194,6 +194,9 @@ function updateFaviconBadge(count) {
 const setupFaviconBadge = _.once(() => {
 	if (!module.options.showUnreadCountInFavicon.value) return false;
 
+	// remove other icons, since Chrome (bizarrely) switches to one of them if RES changes the favicon
+	for (const e of document.head.querySelectorAll('link[rel="icon"]')) e.remove();
+
 	const favicon = new Favico();
 
 	if (module.options.resetFaviconOnLeave.value) {


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: https://www.reddit.com/r/Enhancement/comments/7i99t5/orange_icon_on_browser_tab_with_res_enabled/
Tested in browser: Chrome 64