### PR TITLE
Add shift+o and shift+p shortcuts from the go menu to switch profile …

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -9,6 +9,7 @@ import {
 	click,
 	downcast,
 	currentSubreddit,
+	currentUserProfile,
 	filterMap,
 	getPercentageVisibleYAxis,
 	hashKeyArray,
@@ -756,6 +757,28 @@ module.options = {
 		description: 'keyboardNavPrevPageDesc',
 		title: 'keyboardNavPrevPageTitle',
 		callback: prevPage,
+		goMode: true,
+	},
+	overviewLegacy: {
+		type: 'keycode',
+		value: [79, false, false, true, false], // shift+o
+		description: 'keyboardNavOverviewLegacyDesc',
+		title: 'keyboardNavOverviewLegacyTitle',
+		callback() {
+			const currentUser = currentUserProfile();
+			if (currentUser) navigateTo(false, `/user/${currentUser}/overview`);
+		},
+		goMode: true,
+	},
+	profileView: {
+		type: 'keycode',
+		value: [80, false, false, true, false], // shift+p
+		description: 'keyboardNavProfileViewDesc',
+		title: 'keyboardNavProfileViewTitle',
+		callback() {
+			const currentUser = currentUserProfile();
+			if (currentUser) navigateTo(false, `/user/${currentUser}`);
+		},
 		goMode: true,
 	},
 	toggleCommentNavigator: {

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -761,6 +761,7 @@ module.options = {
 	},
 	overviewLegacy: {
 		type: 'keycode',
+		include: ['d2x', 'profile'],
 		value: [79, false, false, true, false], // shift+o
 		description: 'keyboardNavOverviewLegacyDesc',
 		title: 'keyboardNavOverviewLegacyTitle',
@@ -772,6 +773,7 @@ module.options = {
 	},
 	profileView: {
 		type: 'keycode',
+		include: ['d2x', 'profile'],
 		value: [80, false, false, true, false], // shift+p
 		description: 'keyboardNavProfileViewDesc',
 		title: 'keyboardNavProfileViewTitle',

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -879,6 +879,18 @@
 	"keyboardNavPrevPageDesc": {
 		"message": "Go to previous page (link list pages only)."
 	},
+	"keyboardNavOverviewLegacyTitle": {
+		"message": "Legacy Profile"
+	},
+	"keyboardNavOverviewLegacyDesc": {
+		"message": "Go to legacy (overview) profile (profile pages only)."
+	},
+	"keyboardNavProfileViewTitle": {
+		"message": "New Profile"
+	},
+	"keyboardNavProfileViewDesc": {
+		"message": "Go to new profile (profile pages only)."
+	},
 	"keyboardNavToggleCommentNavigatorTitle": {
 		"message": "Toggle Comment Navigator"
 	},


### PR DESCRIPTION
Two new keyboard shortcuts from the go menu:

If on a user page:
* `shift+o`: switch to the overveiw (legacy) format (`../user/overview`)
* `shift+p`: switch to the new profile page (`../user`)