### PR TITLE
Implement native Reddit duration overlay on video thumbnail

### DIFF
--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -354,12 +354,18 @@ async function getVideoTimes(thing) {
 		link.textContent += ` (@${time})`;
 	}
 
-	const { info, title } = await getVideoInfo(match[1]);
+	const { info, duration, title } = await getVideoInfo(match[1]);
 
 	requestAnimationFrame(() => {
-		link.textContent += ` - ${info}`;
-
+		link.textContent += ` - ${info.join(' ')}`;
 		link.setAttribute('title', i18n('betteRedditVideoYouTubeTitle', title));
+
+		// Add native Reddit duration overlay on video thumbnail
+		const thumbnail = thing.element.querySelector('a.thumbnail');
+		const durationOverlay = document.createElement('div');
+		durationOverlay.className = 'duration-overlay';
+		durationOverlay.innerHTML = duration;
+		thumbnail.appendChild(durationOverlay);
 	});
 }
 
@@ -387,19 +393,19 @@ const getVideoInfo = batch(async videoIds => {
 			.filter((time, i, { length }) => +time !== 0 || i >= length - 2)
 			.join(':');
 
-		let info = `[${duration}]`;
+		const info = [];
 
 		if (module.options.videoUploaded.value) {
 			const uploaded = snippet.publishedAt; // 2016-01-27T05:49:48.000Z
-			info += `[${uploaded.match(/[^T]*/)}]`;
+			info.push(`[${uploaded.match(/[^T]*/)}]`);
 		}
 
 		if (module.options.videoViewed.value) {
 			const viewed = statistics.viewCount;
-			info += i18n('betteRedditVideoViewed', viewed);
+			info.push(i18n('betteRedditVideoViewed', viewed));
 		}
 
-		return { id, info, title };
+		return { id, duration, info, title };
 	});
 
 	return videoIds.map(idFromBatch => results.find(({ id }) => id === idFromBatch));

--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -19,6 +19,7 @@ import {
 	watchForThings,
 	watchForElements,
 	fromSecondsToTime,
+	string,
 } from '../utils';
 import { _addHeaderId } from '../utils/dom';
 import { ajax, i18n } from '../environment';
@@ -346,26 +347,21 @@ async function getVideoTimes(thing) {
 	const timeMatch = getYoutubeStartTimeRegex.exec(link.href);
 	const titleMatch = titleHasTimeRegex.test(link.textContent);
 
+	let startTime;
 	if (timeMatch && !titleMatch) {
 		const seconds = fromYoutubeTimecodeToSeconds(timeMatch[1]);
-
-		const time = fromSecondsToTime(seconds);
-
-		link.textContent += ` (@${time})`;
+		startTime = fromSecondsToTime(seconds);
 	}
 
 	const { info, duration, title } = await getVideoInfo(match[1]);
 
 	requestAnimationFrame(() => {
-		link.textContent += ` - ${info.join(' ')}`;
+		if (info.length) link.textContent += ` - ${info.join(' ')}`;
 		link.setAttribute('title', i18n('betteRedditVideoYouTubeTitle', title));
 
 		// Add native Reddit duration overlay on video thumbnail
 		const thumbnail = thing.element.querySelector('a.thumbnail');
-		const durationOverlay = document.createElement('div');
-		durationOverlay.className = 'duration-overlay';
-		durationOverlay.innerHTML = duration;
-		thumbnail.appendChild(durationOverlay);
+		thumbnail.appendChild(string.html`<div class="duration-overlay">${duration}${startTime ? ` (@${startTime})` : ''}</div>`);
 	});
 }
 


### PR DESCRIPTION
Recently, Reddit started to show their video times on video thumbnail:

![obraz](https://user-images.githubusercontent.com/5426427/33798170-51dc489a-dd14-11e7-8572-91ba66c48e98.png)

So, I'm proposing to move RES's video duration to thumbnail as well:

![obraz](https://user-images.githubusercontent.com/5426427/33798181-6b22723e-dd14-11e7-81f9-c68f429d74f1.png)

(in this illustration, all video info options enabled: videoTimes, videoUploaded and videoViewed)