### PR TITLE
Video duration, views and date for Vimeo and Gfycat

### DIFF
--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -325,45 +325,153 @@ function hideLink(clickedLink, action = clickedLink.getAttribute('action')) {
 }
 
 async function getVideoTimes(thing) {
-	const element = thing.element.querySelector('a.title[href*="youtube.com"], a.title[href*="youtu.be"]');
+	const element = thing.element.querySelector('a.title');
 	if (!element) return;
 	const link = downcast(element, HTMLAnchorElement);
 
-	const titleHasTimeRegex = /[\[|\(][0-9]*:[0-9]*[\]|\)]/;
-	const getYoutubeIDRegex = /\/?[&|\?]?v\/?=?([\w\-]{11})&?/i;
-	const getShortenedYoutubeIDRegex = /([\w\-]{11})&?/i;
-	const getYoutubeStartTimeRegex = /\[[\d]+:[\d]+\]/i;
+	switch (thing.getPostDomain()) {
+		case 'gfycat.com': {
+			const getGfycatIDRegex = /\/([A-Za-z]*)$/;
+			const match = getGfycatIDRegex.exec(link.href);
 
-	const isShortened = (/youtu\.be/i).test(link.href);
+			if (!match) return;
 
-	const match = isShortened ?
-		getShortenedYoutubeIDRegex.exec(link.href) :
-		getYoutubeIDRegex.exec(link.href);
+			const info = await getGfycatVideoInfo(match[1]);
 
-	if (!match) return;
+			applyVideoInfo(thing, link, info);
+			break;
+		}
+		case 'vimeo.com': {
+			const getVimeoIDAndHashRegex = /\/([0-9]*)(\/([a-f0-9]{1,}))?\/?$/;
+			const [, videoId] = getVimeoIDAndHashRegex.exec(link.href); // On index 3, there is private video hash
+			const info = await getVimeoVideoInfo(videoId);
 
-	const timeMatch = getYoutubeStartTimeRegex.exec(link.href);
-	const titleMatch = titleHasTimeRegex.test(link.textContent);
-	if (timeMatch && !titleMatch) {
-		link.textContent += ` (@${timeMatch[1]})`;
+			applyVideoInfo(thing, link, info);
+			break;
+		}
+		case 'youtube.com':
+		case 'youtu.be': {
+			const titleHasTimeRegex = /[\[|\(][0-9]*:[0-9]*[\]|\)]/;
+			const getYoutubeIDRegex = /\/?[&|\?]?v\/?=?([\w\-]{11})&?/i;
+			const getShortenedYoutubeIDRegex = /([\w\-]{11})&?/i;
+			const getYoutubeStartTimeRegex = /\[[\d]+:[\d]+\]/i;
+
+			const isShortened = (/youtu\.be/i).test(link.href);
+
+			const match = isShortened ?
+				getShortenedYoutubeIDRegex.exec(link.href) :
+				getYoutubeIDRegex.exec(link.href);
+
+			if (!match) return;
+
+			const timeMatch = getYoutubeStartTimeRegex.exec(link.href);
+			const titleMatch = titleHasTimeRegex.test(link.textContent);
+			if (timeMatch && !titleMatch) {
+				link.textContent += ` (@${timeMatch[1]})`;
+			}
+
+			const info = await getYouTubeVideoInfo(match[1]);
+
+			applyVideoInfo(thing, link, info);
+			break;
+		}
+		default:
 	}
-
-	const { info, duration, title } = await getVideoInfo(match[1]);
-
-	requestAnimationFrame(() => {
-		link.textContent += ` - ${info.join(' ')}`;
-		link.setAttribute('title', i18n('betteRedditVideoYouTubeTitle', title));
-
-		// Add native Reddit duration overlay on video thumbnail
-		const thumbnail = thing.element.querySelector('a.thumbnail');
-		const durationOverlay = document.createElement('div');
-		durationOverlay.className = 'duration-overlay';
-		durationOverlay.innerHTML = duration;
-		thumbnail.appendChild(durationOverlay);
-	});
 }
 
-const getVideoInfo = batch(async videoIds => {
+const applyVideoInfo = (thing, link, { info, duration, title }) => {
+	requestAnimationFrame(() => {
+		if (info && info.length) {
+			link.textContent += ` - ${info.join(' ')}`;
+		}
+
+		if (title) {
+			link.setAttribute('title', i18n('betteRedditVideoYouTubeTitle', title));
+		}
+
+		if (duration) {
+			// Add native Reddit duration overlay on video thumbnail
+			const thumbnail = thing.element.querySelector('a.thumbnail');
+			const durationOverlay = document.createElement('div');
+			durationOverlay.className = 'duration-overlay';
+			durationOverlay.innerHTML = duration;
+			thumbnail.appendChild(durationOverlay);
+		}
+	});
+};
+
+const secondsToTimestamp = totalSeconds => {
+	const durationSeconds = Math.floor(totalSeconds % 60);
+	const durationMinutes = Math.floor((totalSeconds - durationSeconds) / 60);
+	return `${durationMinutes ? `00${durationMinutes}`.slice(-2) : '0'}:${`00${durationSeconds}`.slice(-2)}`;
+};
+
+const getGfycatVideoInfo = async videoId => {
+	const {
+		gfyItem: {
+			frameRate,
+			createDate: rawUploaded, // 1512770721
+			numFrames,
+			views: viewed,
+			title,
+		},
+	} = await ajax({
+		// WARNING! This is Test API URL! Acquire token!
+		url: `https://api.gfycat.com/v1test/gfycats/${videoId}`,
+		type: 'json',
+		cacheFor: DAY,
+	});
+
+	const durationTotalSeconds = numFrames / frameRate;
+	const duration = secondsToTimestamp(durationTotalSeconds);
+
+	const info = [];
+
+	if (module.options.videoUploaded.value) {
+		const uploadedDate = new Date(rawUploaded * 1000);
+		info.push(`[${uploadedDate.getFullYear()}-${`00${uploadedDate.getMonth() + 1}`.slice(-2)}-${`00${uploadedDate.getDate()}`.slice(-2)}]`);
+	}
+
+	if (module.options.videoViewed.value) {
+		info.push(i18n('betteRedditVideoViewed', viewed));
+	}
+
+	return { duration, info, title };
+};
+
+const getVimeoVideoInfo = async videoId => {
+	const {
+		name: title,
+		duration: durationTotalSeconds,
+		created_time: uploaded, // 2016-01-05T19:28:00+00:00
+		stats: {
+			plays: viewed,
+		},
+	} = await ajax({
+		// WARNING! This will fail! Acquire token!
+		url: `https://api.vimeo.com/videos/${videoId}`,
+		type: 'json',
+		cacheFor: DAY,
+	});
+
+	const duration = secondsToTimestamp(durationTotalSeconds);
+
+	const info = [];
+
+	if (module.options.videoUploaded.value) {
+		info.push(`[${uploaded.match(/[^T]*/)}]`);
+	}
+
+	if (module.options.videoViewed.value) {
+		if (viewed !== null) {
+			info.push(i18n('betteRedditVideoViewed', viewed));
+		}
+	}
+
+	return { duration, info, title };
+};
+
+const getYouTubeVideoInfo = batch(async videoIds => {
 	const parts = ['id', 'contentDetails', 'snippet'];
 	if (module.options.videoViewed.value) parts.push('statistics');
 

--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -348,11 +348,18 @@ async function getVideoTimes(thing) {
 		link.textContent += ` (@${timeMatch[1]})`;
 	}
 
-	const { info, title } = await getVideoInfo(match[1]);
+	const { info, duration, title } = await getVideoInfo(match[1]);
 
 	requestAnimationFrame(() => {
-		link.textContent += ` - ${info}`;
+		link.textContent += ` - ${info.join(' ')}`;
 		link.setAttribute('title', i18n('betteRedditVideoYouTubeTitle', title));
+
+		// Add native Reddit duration overlay on video thumbnail
+		const thumbnail = thing.element.querySelector('a.thumbnail');
+		const durationOverlay = document.createElement('div');
+		durationOverlay.className = 'duration-overlay';
+		durationOverlay.innerHTML = duration;
+		thumbnail.appendChild(durationOverlay);
 	});
 }
 
@@ -380,19 +387,19 @@ const getVideoInfo = batch(async videoIds => {
 			.filter((time, i, { length }) => +time !== 0 || i >= length - 2)
 			.join(':');
 
-		let info = `[${duration}]`;
+		const info = [];
 
 		if (module.options.videoUploaded.value) {
 			const uploaded = snippet.publishedAt; // 2016-01-27T05:49:48.000Z
-			info += `[${uploaded.match(/[^T]*/)}]`;
+			info.push(`[${uploaded.match(/[^T]*/)}]`);
 		}
 
 		if (module.options.videoViewed.value) {
 			const viewed = statistics.viewCount;
-			info += i18n('betteRedditVideoViewed', viewed);
+			info.push(i18n('betteRedditVideoViewed', viewed));
 		}
 
-		return { id, info, title };
+		return { id, duration, info, title };
 	});
 
 	return videoIds.map(idFromBatch => results.find(({ id }) => id === idFromBatch));


### PR DESCRIPTION
Hey,
I implemented showing video duration, views and date for Vimeo and Gfycat. Hooray!

![obraz](https://user-images.githubusercontent.com/5426427/33798727-34cc37c4-dd1e-11e7-880f-1f0afbc16c33.png)

Gfycat is fully working and tested. Vimeo I had to do blindly based on their API sample.

**We're not done yet. I must ask you for a favor.** Would you please acquire official API tokens for Vimeo and Gfycat? You can do it here:
* [Acquire Vimeo API token](https://developer.vimeo.com/apps/new?source=getting-started)
* [Acquire Gfycat API token](https://developers.gfycat.com/api/#quick-start)

I don't like one thing about this - I did not find a way in both Vimeo and Gfycat API documentation to make calls for mutliple video at the time.

**Warning:** This Pull request contains #4584. I did not feel like implementing it twice and resolving conflicts ;)

Anyway, let me know what you think!
