### PR TITLE
Add an option to hide other expandos on expando open

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -434,6 +434,12 @@ module.options = {
 		value: true,
 		description: 'showImagesAutoplayVideoDesc',
 	},
+	hideOtherExpandos: {
+		title: 'showImagesHideOtherExpandosTitle',
+		type: 'boolean',
+		value: false,
+		description: 'showImagesHideOtherExpandosDesc',
+	},
 	...Object.values(siteModules).reduce((options, siteModule) => {
 		// Ignore default
 		if (genericHosts.includes(siteModule)) return options;
@@ -967,6 +973,18 @@ async function checkElementForMedia(element) {
 	placeExpando(expando, element, thing);
 
 	if (thing) thingExpandoBuildListeners.fire(thing);
+
+	if (module.options.hideOtherExpandos.value) {
+		expando.onExpand(() => {
+			for (const [currentExpandoKey, currentExpando] of primaryExpandos) {
+				if (
+					!currentExpando.open ||
+					currentExpandoKey === expando.href
+				) continue;
+				currentExpando.collapse();
+			}
+		});
+	}
 
 	await lock;
 

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -4229,6 +4229,12 @@
 	"showImagesAutoplayVideoDesc": {
 		"message": "Autoplay inline videos."
 	},
+	"showImagesHideOtherExpandosTitle": {
+		"message": "Hide Other Expandos"
+	},
+	"showImagesHideOtherExpandosDesc": {
+		"message": "When opening expando, close all the other ones."
+	},
 	"showImagesHostToggleDesc": {
 		"message": "Display expandos for this host."
 	},


### PR DESCRIPTION
So, here's an idea.

When you browse Reddit using your keyboard, previously opened expandos close nicely as you select the next thing on the page. Mouse users need to do it manually, which is especially painful and necessary if you're browsing through videos.

This option may potentially conserve memory and help with a mess when browsing Reddit.