### PR TITLE
Use CSS transforms on expando media resize for 60 FPS experience

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1707,16 +1707,19 @@ function setMediaMaxSize(media) {
 	if (maxHeight) media.style.maxHeight = `${maxHeight}px`;
 }
 
-function addDragListener({ media, element, atShiftKey, onStart, onMove }: {|
+function addDragListener({ media, element, atShiftKey, onStart, onMove, onEnd }: {|
 	media: HTMLElement,
 	element: HTMLElement,
 	atShiftKey: boolean,
 	onStart?: (x: number, y: number) => void,
 	onMove: (x: number, y: number, moveX: number, moveY: number) => void,
+	onEnd?: (x: number, y: number, moveX: number, moveY: number) => void,
 |}) {
-	let isActive, hasMoved, lastX, lastY;
+	let isActive, isStopped, hasMoved, startX, startY, lastX, lastY;
 
 	const handleMove = frameThrottle((e: MouseEvent) => {
+		if (isStopped) return;
+
 		const movementX = e.clientX - lastX;
 		const movementY = e.clientY - lastY;
 
@@ -1749,10 +1752,14 @@ function addDragListener({ media, element, atShiftKey, onStart, onMove }: {|
 	}
 
 	function stop() {
+		isStopped = true;
+
 		media.classList.remove('res-media-dragging');
 
 		document.removeEventListener('mousemove', handleMove);
 		document.removeEventListener('mouseup', stop);
+
+		if (onEnd) onEnd(lastX, lastY, lastX - startX, lastY - startY);
 
 		// `handleClick` is only invoked if the mouse target is `element`
 		// `setTimeout` is necessary since `mouseup` is emitted before `click`
@@ -1763,9 +1770,11 @@ function addDragListener({ media, element, atShiftKey, onStart, onMove }: {|
 		if (e.button !== 0) return;
 
 		({ clientX: lastX, clientY: lastY } = e);
+		({ clientX: startX, clientY: startY } = e);
 
 		hasMoved = false;
 		isActive = false;
+		isStopped = false;
 
 		document.addEventListener('mousemove', handleMove);
 		document.addEventListener('mouseup', stop);
@@ -1795,10 +1804,20 @@ function makeMediaZoomable(media, element, dragInitiater = element, absoluteSizi
 		element: dragInitiater,
 		atShiftKey: false,
 		onStart(x, y) {
+			element.style.transformOrigin = 'top left';
 			({ left, top, width: initialWidth } = element.getBoundingClientRect());
 			initialDiagonal = getDiagonal(x, y);
 		},
 		onMove(x, y, deltaX, deltaY) {
+			if (absoluteSizing) {
+				const { width, height } = element.getBoundingClientRect();
+				temporarilyResizeMedia(element, width + deltaX, height + deltaY);
+			} else {
+				const newWidth = getDiagonal(x, y) / initialDiagonal * initialWidth;
+				temporarilyResizeMedia(element, newWidth);
+			}
+		},
+		onEnd(x, y, deltaX, deltaY) {
 			if (absoluteSizing) {
 				const { width, height } = element.getBoundingClientRect();
 				resizeMedia(element, width + deltaX, height + deltaY);
@@ -2189,10 +2208,25 @@ export function resizeMedia(ele: HTMLElement, newWidth: number, newHeight?: numb
 		ele.style.height = `${((height / width) * newWidth).toFixed(2)}px`;
 	}
 
+	ele.style.transform = '';
 	ele.style.width = `${newWidth}px`;
 	ele.style.maxWidth = ele.style.maxHeight = 'none';
 
 	ele.dispatchEvent(new CustomEvent('mediaResize', { bubbles: true }));
+}
+
+export function temporarilyResizeMedia(ele: HTMLElement, newWidth: number, newHeight?: number): void {
+	// ele should always be grippable, so ignore resizes that are too tiny
+	if (newWidth < 20) return;
+
+	const computedStyles = getComputedStyle(ele);
+	if (typeof newHeight === 'number') {
+		const height = parseInt(computedStyles.height, 10);
+		ele.style.transform = `scale(${newHeight / height})`;
+	} else {
+		const width = parseInt(computedStyles.width, 10);
+		ele.style.transform = `scale(${newWidth / width})`;
+	}
 }
 
 function rotateMedia(ele, rotationState) {


### PR DESCRIPTION
**The problem:** Resizing media causes thousands of reflows, DOM events etc. On all low- and mid- range devices (and even on my Core i5 Surface Pro on Firefox) performance of resizing is far from buttery smooth.

**Solution:** When still dragging, use CSS transforms to resize the media. That makes it full 60 FPS experience. Quite an improvement over 7.5 FPS I was getting.

However, this solution causes image container to be updated only after resizing ends, and not during it. So, some people might not like this behavior. In that case, this more GPU/CPU-friendly solution may be applied based on some internal performance measurements we would do or simply on some setting we could create.

What do you think?