### PR TITLE
Change favicon notification colour

### DIFF
--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -197,7 +197,10 @@ const setupFaviconBadge = _.once(() => {
 	// remove other icons, since Chrome (bizarrely) switches to one of them if RES changes the favicon
 	for (const e of document.head.querySelectorAll('link[rel="icon"]')) e.remove();
 
-	const favicon = new Favico();
+	const favicon = new Favico({
+		bgColor : '#CCCCFF',
+		textColor : '#ff0',
+	});
 
 	if (module.options.resetFaviconOnLeave.value) {
 		// Prevent notification icon from showing up in bookmarks

--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -123,7 +123,7 @@ module.options = {
 		title: 'favicoNotificationTextColourTitle',
 		advanced: true,
 		type: 'color',
-		value: '#FFFFFF',
+		value: '#000000',
 	},
 };
 

--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -111,6 +111,20 @@ module.options = {
 		bodyClass: true,
 		dependsOn: options => !options.hideNewModMail.value,
 	},
+	favicoNotificationBGColour: {
+		description: 'favicoNotificationBGColourDesc',
+		title: 'favicoNotificationBGColourTitle',
+		advanced: true,
+		type: 'color',
+		value: '#CCCCFF',
+	},
+	favicoNotificationTextColour: {
+		description: 'favicoNotificationTextColourDesc',
+		title: 'favicoNotificationTextColourTitle',
+		advanced: true,
+		type: 'color',
+		value: '#FFFFFF',
+	},
 };
 
 module.go = () => {
@@ -198,8 +212,8 @@ const setupFaviconBadge = _.once(() => {
 	for (const e of document.head.querySelectorAll('link[rel="icon"]')) e.remove();
 
 	const favicon = new Favico({
-		bgColor : '#CCCCFF',
-		textColor : '#ff0',
+		bgColor: module.options.favicoNotificationBGColour.value,
+		textColor: module.options.favicoNotificationTextColour.value,
 	});
 
 	if (module.options.resetFaviconOnLeave.value) {

--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -60,6 +60,22 @@ module.options = {
 		type: 'boolean',
 		value: true,
 	},
+	faviconNotificationBGColor: {
+		description: 'faviconNotificationBGColorDesc',
+		title: 'faviconNotificationBGColorTitle',
+		advanced: true,
+		type: 'color',
+		value: '#5f99cf',
+		dependsOn: options => options.showUnreadCountInFavicon.value,
+	},
+	faviconNotificationTextColor: {
+		description: 'faviconNotificationTextColorDesc',
+		title: 'faviconNotificationTextColorTitle',
+		advanced: true,
+		type: 'color',
+		value: '#FFFFFF',
+		dependsOn: options => options.showUnreadCountInFavicon.value,
+	},
 	resetFaviconOnLeave: {
 		description: 'orangeredResetFaviconOnLeaveDesc',
 		title: 'orangeredResetFaviconOnLeaveTitle',
@@ -110,20 +126,6 @@ module.options = {
 		value: false,
 		bodyClass: true,
 		dependsOn: options => !options.hideNewModMail.value,
-	},
-	faviconNotificationBGColor: {
-		description: 'faviconNotificationBGColorDesc',
-		title: 'faviconNotificationBGColorTitle',
-		advanced: true,
-		type: 'color',
-		value: '#5f99cf',
-	},
-	faviconNotificationTextColor: {
-		description: 'faviconNotificationTextColorDesc',
-		title: 'faviconNotificationTextColorTitle',
-		advanced: true,
-		type: 'color',
-		value: '#FFFFFF',
 	},
 };
 

--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -116,14 +116,14 @@ module.options = {
 		title: 'faviconNotificationBGColorTitle',
 		advanced: true,
 		type: 'color',
-		value: '#CCCCFF',
+		value: '#5f99cf',
 	},
 	faviconNotificationTextColor: {
 		description: 'faviconNotificationTextColorDesc',
 		title: 'faviconNotificationTextColorTitle',
 		advanced: true,
 		type: 'color',
-		value: '#000000',
+		value: '#FFFFFF',
 	},
 };
 

--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -111,16 +111,16 @@ module.options = {
 		bodyClass: true,
 		dependsOn: options => !options.hideNewModMail.value,
 	},
-	favicoNotificationBGColour: {
-		description: 'favicoNotificationBGColourDesc',
-		title: 'favicoNotificationBGColourTitle',
+	faviconNotificationBGColor: {
+		description: 'faviconNotificationBGColorDesc',
+		title: 'faviconNotificationBGColorTitle',
 		advanced: true,
 		type: 'color',
 		value: '#CCCCFF',
 	},
-	favicoNotificationTextColour: {
-		description: 'favicoNotificationTextColourDesc',
-		title: 'favicoNotificationTextColourTitle',
+	faviconNotificationTextColor: {
+		description: 'faviconNotificationTextColorDesc',
+		title: 'faviconNotificationTextColorTitle',
 		advanced: true,
 		type: 'color',
 		value: '#000000',
@@ -212,8 +212,8 @@ const setupFaviconBadge = _.once(() => {
 	for (const e of document.head.querySelectorAll('link[rel="icon"]')) e.remove();
 
 	const favicon = new Favico({
-		bgColor: module.options.favicoNotificationBGColour.value,
-		textColor: module.options.favicoNotificationTextColour.value,
+		bgColor: module.options.faviconNotificationBGColor.value,
+		textColor: module.options.faviconNotificationTextColor.value,
 	});
 
 	if (module.options.resetFaviconOnLeave.value) {

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -1380,16 +1380,16 @@
 	"orangeredHideEmptyNewModMailDesc": {
 		"message": "Hide the new mod mail button when inbox is empty."
 	},
-	"favicoNotificationBGColourDesc": {
+	"faviconNotificationBGColorDesc": {
 		"message": "Change the background color of the notification in the favicon."
 	},
-	"favicoNotificationBGColourTitle": {
+	"faviconNotificationBGColorTitle": {
 		"message": "Favicon Notification Background Color"
 	},
-	"favicoNotificationTextColourDesc": {
+	"faviconNotificationTextColorDesc": {
 		"message": "Change the text color of the notification in the favicon."
 	},
-	"favicoNotificationTextColourTitle": {
+	"faviconNotificationTextColorTitle": {
 		"message": "Favicon Notification Text Color"
 	},
 	"pageNavName": {

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -1381,13 +1381,13 @@
 		"message": "Hide the new mod mail button when inbox is empty."
 	},
 	"faviconNotificationBGColorDesc": {
-		"message": "Change the background color of the notification in the favicon."
+		"message": "Change the background color of the notification on the favicon."
 	},
 	"faviconNotificationBGColorTitle": {
 		"message": "Favicon Notification Background Color"
 	},
 	"faviconNotificationTextColorDesc": {
-		"message": "Change the text color of the notification in the favicon."
+		"message": "Change the text color of the notification on the favicon."
 	},
 	"faviconNotificationTextColorTitle": {
 		"message": "Favicon Notification Text Color"

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -1380,6 +1380,18 @@
 	"orangeredHideEmptyNewModMailDesc": {
 		"message": "Hide the new mod mail button when inbox is empty."
 	},
+	"favicoNotificationBGColourDesc": {
+		"message": "Change the background color of the notification in the favicon."
+	},
+	"favicoNotificationBGColourTitle": {
+		"message": "Favicon Notification Background Color"
+	},
+	"favicoNotificationTextColourDesc": {
+		"message": "Change the text color of the notification in the favicon."
+	},
+	"favicoNotificationTextColourTitle": {
+		"message": "Favicon Notification Text Color"
+	},
 	"pageNavName": {
 		"message": "Page Navigator"
 	},


### PR DESCRIPTION
The current red notification doesnt work well with the orange background of the new favicon.

This changes to periwinkle to stay somewhat onbrand. Also adds the ability to customise for user preference.