### PR TITLE
Make webpack module concatenation work

### DIFF
--- a/lib/core/modules/modules.js
+++ b/lib/core/modules/modules.js
@@ -11,7 +11,7 @@ import {
 import { Module } from '../module';
 import type { OpaqueModuleId } from '../module';
 
-const moduleContext = (require: any).context('../../modules', false, /\.js$/);
+import __modules from 'sibling-loader?import=module!../../modules/about'; // eslint-disable-line
 
 const modulePrefsStorage = Storage.wrapBlob('RES.modulePrefs',
 	(): boolean => { throw new Error('Default module enabled state should never be accessed'); });
@@ -19,9 +19,7 @@ const modulePrefsStorage = Storage.wrapBlob('RES.modulePrefs',
 const enabled = new Map();
 
 const modules = flow(
-	() => moduleContext.keys(),
-	map(moduleContext),
-	map(e => e.module),
+	() => Object.values(__modules),
 	map(mod => downcast(mod, Module)), // ensure that all modules are instances of `Module`
 	keyBy(mod => mod.moduleID)
 )();

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -67,14 +67,13 @@ import {
 	primaryExpandos,
 } from './showImages/expando';
 import type { ExpandoMediaElement } from './showImages/expando';
+import __hosts from 'sibling-loader?import=default!./hosts/default';
 
-const hostsContext = (require: any).context('./hosts', false, /\.js$/);
 const siteModules: { [string]: Host<any, any> } = flow(
-	map(hostsContext),
-	map(e => e.default),
+	() => Object.values(__hosts),
 	map(host => downcast(host, Host)), // ensure that all hosts are instances of `Host`
 	keyBy(host => host.moduleID)
-)(hostsContext.keys());
+)();
 export const genericHosts: Host<any, any>[] = [siteModules.default, siteModules.defaultVideo, siteModules.defaultAudio];
 
 export const module: Module<*> = new Module('showImages');

--- a/locales/index.js
+++ b/locales/index.js
@@ -1,14 +1,12 @@
 /* @flow */
 
 import _ from 'lodash';
-
-const localesContext = (require: any).context('./locales', false, /\.json$/);
-const validLocaleKeys = localesContext.keys();
+import locales from 'sibling-loader?import=default!./locales/en';
 
 const DEFAULT_TRANSIFEX_LOCALE = 'en';
 
-function localeNameToPath(localeName) {
-	return `./${localeName}.json`;
+function getLocale(locale) {
+	return locales[`${locale}.json`];
 }
 
 // `en-ca` -> `en_CA`
@@ -38,14 +36,7 @@ function redditLocaleToTransifexLocale(redditLocale) {
 	}
 }
 
-const getLocale = _.memoize(localeName => {
-	const path = localeNameToPath(localeName);
-	if (validLocaleKeys.includes(path)) {
-		return localesContext(path);
-	}
-});
-
-export const getLocaleDictionary = _.memoize((localeName: string): { [string]: string } => {
+export function getLocaleDictionary(localeName: string): { [string]: string } {
 	const transifexLocale = redditLocaleToTransifexLocale(localeName);
 
 	const mergedLocales = {
@@ -58,4 +49,4 @@ export const getLocaleDictionary = _.memoize((localeName: string): { [string]: s
 	};
 
 	return _.mapValues(mergedLocales, x => x.message);
-});
+}

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -3,8 +3,8 @@
 /* eslint-disable import/no-nodejs-modules */
 
 import path from 'path';
-import webpack from 'webpack';
 
+import webpack from 'webpack';
 import InertEntryPlugin from 'inert-entry-webpack-plugin';
 import LodashModuleReplacementPlugin from 'lodash-webpack-plugin';
 import ProgressBarPlugin from 'progress-bar-webpack-plugin';
@@ -75,7 +75,6 @@ export default (env = {}) => {
 								'transform-export-extensions',
 								'transform-class-properties',
 								['transform-object-rest-spread', { useBuiltIns: true }],
-								'transform-es2015-modules-commonjs',
 								'transform-flow-strip-types',
 								'transform-dead-code-elimination',
 								['transform-define', {
@@ -139,10 +138,10 @@ export default (env = {}) => {
 			}],
 		},
 		plugins: [
-			new webpack.optimize.ModuleConcatenationPlugin(),
 			new ProgressBarPlugin(),
 			new InertEntryPlugin(),
 			new LodashModuleReplacementPlugin(),
+			new webpack.optimize.ModuleConcatenationPlugin(),
 			(env.zip && !conf.noZip && new ZipPlugin({
 				path: path.join('..', 'zip'),
 				filename: conf.output,


### PR DESCRIPTION
re #4591, includes part of #4059
Tested in browser: Chrome 64

It doesn't really do anything if Babel is still converting everything to commonjs modules.

I had intentionally left the commonjs transform enabled because webpack used to generate massive `WEBPACK_IMPORTED_MODULE_...` identifiers for ES6 imports, making them a net negative, even with module concatenation (some execution time saved, but more spent to parse hundreds of KB of useless text). But it appears that was changed recently, so it is now actually a benefit. :tada: