### PR TITLE
Update exec-loader for ES6 imports

### DIFF
--- a/lib/core/metadata/index.js
+++ b/lib/core/metadata/index.js
@@ -1,6 +1,8 @@
 /* @flow */
 
-export {
+import packageInfo from 'exec-loader?cache!./packageInfo';
+
+export const {
 	announcementsSubreddit,
 	name,
 	version,
@@ -11,4 +13,4 @@ export {
 	updatedURL,
 	homepageURL,
 	gitDescription,
-} from 'exec-loader?cache!./packageInfo';
+} = packageInfo;

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "eslint-plugin-import": "2.8.0",
     "eslint-plugin-no-useless-assign": "1.0.2",
     "eslint-plugin-prefer-spread": "1.0.3",
-    "exec-loader": "3.0.0",
+    "exec-loader": "4.0.0",
     "extricate-loader": "2.0.0",
     "file-loader": "1.1.5",
     "firefox-extension-deploy": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3596,9 +3596,9 @@ evp_bytestokey@^1.0.0:
   dependencies:
     create-hash "^1.1.1"
 
-exec-loader@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/exec-loader/-/exec-loader-3.0.0.tgz#cfaee3a07866afa836448f74774479bcebb65fab"
+exec-loader@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/exec-loader/-/exec-loader-4.0.0.tgz#b6880d5da30c6c7cc1414b02a94bf57772bb98ae"
   dependencies:
     loader-utils "^1.1.0"
 


### PR DESCRIPTION
Tested in browser: Chrome 64