### PR TITLE
Fix userTagger vote click when downvoting after upvoting

### DIFF
--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -517,7 +517,7 @@ async function handleVoteClick(arrow) {
 		down = 1;
 		if ($otherArrow.hasClass('upmod')) {
 			// also removing an upvote
-			down = -1;
+			up = -1;
 		}
 	} else if ($this.hasClass('downmod')) {
 		// removing a downvote directly


### PR DESCRIPTION
Discovered while working on a feature with similar code for vote tracking #4560 

Actual: When upvoting then downvoting a post, it was counting as a negative downvote and incrementing the total vote weight. (up = 0, down = -1)

Expected: (up = -1, down = 1)

Tested in browser: Firefox