### PR TITLE
[WIP] Subreddit vote tracking

### DIFF
--- a/lib/css/modules/_subredditVoteTracker.scss
+++ b/lib/css/modules/_subredditVoteTracker.scss
@@ -2,7 +2,6 @@
 	margin-left: 0.5em;
 }
 
-
 .RESSubredditVotes .up {
 	color: #FF8B60;
 }

--- a/lib/css/modules/_subredditVoteTracker.scss
+++ b/lib/css/modules/_subredditVoteTracker.scss
@@ -1,0 +1,12 @@
+.RESSubredditVotes {
+	margin-left: 0.5em;
+}
+
+
+.RESSubredditVotes .up {
+	color: #FF8B60;
+}
+
+.RESSubredditVotes .down {
+	color: #9494FF;
+}

--- a/lib/css/res.scss
+++ b/lib/css/res.scss
@@ -36,6 +36,7 @@
 @import 'modules/submitIssue';
 @import 'modules/subredditInfo';
 @import 'modules/subredditManager';
+@import 'modules/subredditVoteTracker';
 @import 'modules/tableTools';
 @import 'modules/temporaryDropdownLinks';
 @import 'modules/troubleshooter';

--- a/lib/modules/subredditVoteTracker.js
+++ b/lib/modules/subredditVoteTracker.js
@@ -1,0 +1,222 @@
+/* @flow */
+
+import _ from 'lodash';
+import { $ } from '../vendor';
+import { Module } from '../core/module';
+
+import { Storage } from '../environment';
+import {
+	Thing,
+	batch,
+	loggedInUser,
+	string,
+	watchForElements,
+} from '../utils';
+
+export const module: Module<*> = new Module('subredditVoteTracker');
+
+module.moduleName = 'subredditVoteTrackerName';
+module.category = 'subredditsCategory';
+module.description = 'subredditVoteTrackerDesc';
+module.options = {
+	trackVoteRatio: {
+		title: 'subredditVoteTrackerTrackVoteRatioTitle',
+		type: 'boolean',
+		value: true,
+		description: 'subredditVoteTrackerTrackVoteRatioDesc',
+	},
+	renderVoteRatio: {
+		title: 'subredditVoteTrackerVRNumberTitle',
+		type: 'boolean',
+		value: true,
+		description: 'subredditVoteTrackerVRNumberDesc',
+		dependsOn: options => options.trackVoteRatio.value,
+	},
+};
+
+export const vrStorage = Storage.wrapPrefix('subredditvote.', () => (({}: any): {|
+	votesDown?: number,
+	votesUp?: number,
+|}), subreddit => subreddit);
+
+const getVRBatched = batch(async subreddits => {
+	const voteratios = await vrStorage.getMultipleNullable(subreddits);
+	return subreddits.map(subreddit => voteratios[subreddit]);
+}, { size: Infinity, delay: 0 });
+
+module.beforeLoad = () => {
+	watchForElements(['siteTable'], subredditSelector, applyToSubreddit);
+};
+
+module.go = () => {
+	// // If we're on the dashboard, add a tab to it...
+	// if (isCurrentSubreddit('dashboard')) {
+	//	 addDashboardFunctionality();
+	// }
+
+	if (module.options.trackVoteRatio.value && loggedInUser()) {
+		attachVoteHandler();
+	}
+};
+
+export const subredditSelector = 'p.tagline a.subreddit, p.parent a.subreddit';
+
+export async function applyToSubreddit(element: *, {
+	renderVoteRatio = module.options.trackVoteRatio.value,
+}: {|
+	renderVoteRatio?: boolean,
+|} = {}) {
+	const subreddit = Thing.checkedFrom(element).getSubreddit();
+
+	// Get tags immediately so that it can be rendered at once without having to wait for storage
+	// since in most cases there's no applied tag
+	const vr = SubredditVoteRatio.getUnfilled(subreddit);
+	vr.add(element, { renderVoteRatio });
+	await vr.fill();
+}
+
+export const subredditVotes: Map<string, SubredditVoteRatio> = new Map();
+
+export class SubredditVoteRatio {
+	static async getStored(): Promise<Array<SubredditVoteRatio>> {
+		return Object.entries(await vrStorage.getAll())
+			.map(([k, v]) => {
+				const subVR = SubredditVoteRatio.getUnfilled(k);
+				subVR.load(v);
+				return subVR;
+			});
+	}
+
+	static getUnfilled(id: string): SubredditVoteRatio {
+		let subVR = subredditVotes.get(id);
+		if (!subVR) {
+			subVR = new SubredditVoteRatio(id);
+			subredditVotes.set(id, subVR);
+		}
+		return subVR;
+	}
+
+	static async get(id: string): Promise<SubredditVoteRatio> {
+		const subVR = SubredditVoteRatio.getUnfilled(id);
+		await subVR.fill();
+		return subVR;
+	}
+
+	id: string;
+	votesUp: number = 0;
+	votesDown: number = 0;
+
+	instances: Array<{
+		element: HTMLElement,
+		vr?: HTMLElement,
+	}> = [];
+
+	constructor(id: $PropertyType<this, 'id'> = '~dummy') {
+		this.id = id;
+	}
+
+	fill = _.once(async () => {
+		const data = await getVRBatched(this.id);
+		if (data) this.load(data);
+	});
+
+	load(data: *) {
+		if (data.votesUp !== undefined) this.votesUp = data.votesUp;
+		if (data.votesDown !== undefined) this.votesDown = data.votesDown;
+		for (const instance of this.instances) this.render(instance);
+	}
+
+	extract() {
+		return {
+			votesDown: this.votesDown,
+			votesUp: this.votesUp,
+		};
+	}
+
+	save() {
+		const base = (new SubredditVoteRatio()).extract();
+		const data = this.extract();
+		vrStorage.set(this.id, _.pickBy(data, (v, k) => base[k] !== v));
+	}
+
+	add(element: HTMLAnchorElement, { renderVoteRatio = false }: {| renderVoteRatio?: boolean |} = {}) {
+		const instance = { element, renderVoteRatio };
+		this.instances.push(instance);
+		this.render(instance);
+	}
+
+	render(instance: *) {
+		if (instance.vr) instance.vr.remove();
+		if (instance.renderVoteRatio) {
+			instance.vr = string.html`
+				<span class="RESSubredditVotes">(<span class="${this.votesUp > 0 ? 'up' : 'neutral'}">${this.votesUp}</span>|<span class="${this.votesDown > 0 ? 'down' : 'neutral'}">${this.votesDown}</span>)</span>
+			`;
+			instance.element.after(instance.vr);
+		}
+	}
+}
+
+function attachVoteHandler() {
+	// hand-rolled delegated listener because jQuery doesn't support useCapture
+	// which is necessary so we run before reddit's handler
+	document.body.addEventListener('click', (e: MouseEvent) => {
+		if (e.button !== 0) return;
+		if (e.target.classList.contains('arrow')) {
+			handleVoteClick(e.target);
+		}
+	}, true);
+}
+
+async function handleVoteClick(arrow) {
+	const $this = $(arrow);
+	const $otherArrow = $this.siblings('.arrow');
+
+	// Stop if the post is archived (unvotable)
+	if ($this.hasClass('archived')) {
+		return;
+	}
+
+	// there are 6 possibilities here:
+	// 1) no vote yet, click upmod
+	// 2) no vote yet, click downmod
+	// 3) already upmodded, undoing
+	// 4) already downmodded, undoing
+	// 5) upmodded before, switching to downmod
+	// 6) downmodded before, switching to upmod
+
+	// classes are changed AFTER this event is triggered
+	let up = 0;
+	let down = 0;
+	if ($this.hasClass('up')) {
+		// adding an upvote
+		up = 1;
+		if ($otherArrow.hasClass('downmod')) {
+			// also removing a downvote
+			down = -1;
+		}
+	} else if ($this.hasClass('upmod')) {
+		// removing an upvote directly
+		up = -1;
+	} else if ($this.hasClass('down')) {
+		// adding a downvote
+		down = 1;
+		if ($otherArrow.hasClass('upmod')) {
+			// also removing an upvote
+			up = -1;
+		}
+	} else if ($this.hasClass('downmod')) {
+		// removing a downvote directly
+		down = -1;
+	}
+
+	// must load votes object _after_ checking the DOM, so that classes will not be changed
+	const thing = Thing.checkedFrom(arrow);
+	const subreddit = thing.getSubreddit();
+	const subVR = subreddit && await SubredditVoteRatio.get(subreddit);
+	if (!subVR) throw new Error('No votes for subreddit');
+	subVR.load({
+		votesUp: subVR.votesUp + up,
+		votesDown: subVR.votesDown + down,
+	});
+	subVR.save();
+}

--- a/lib/modules/subredditVoteTracker.js
+++ b/lib/modules/subredditVoteTracker.js
@@ -3,7 +3,6 @@
 import _ from 'lodash';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
-
 import { Storage } from '../environment';
 import {
 	Thing,


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: #4560 
Tested in browser: Firefox

It uses the same code as userTagger to track subreddit voting instead, and it only displays the vote ratio on pages where the subreddit name is visible e.g. frontpage, multi-reddit pages, old user pages. 

I already made some modifications to the code since it's only looking at vote ratios, but it could use some more work (see below)

<img width="1349" alt="screen shot 2017-12-22 at 2 46 23 pm" src="https://user-images.githubusercontent.com/1255633/34310689-eda32ee4-e726-11e7-939f-8cd3642bf2cb.png">

<img width="1079" alt="screen shot 2017-12-22 at 2 31 54 pm" src="https://user-images.githubusercontent.com/1255633/34310365-3fb52a2c-e725-11e7-8cfc-ffe2f7c003ca.png">

Screenshot above shows the frontpage with subreddit vote ratios. /r/pics previously has 1 upvoted post in addition to the one upvoted seen here.  

Possible to-do items that I can think of:
* Add module name/desc values into locales
* Add vote ratio to search results pages (selector: `.search-result .search-subreddit-link`)
* Add dashboard functionality similar to user tags page where you can sort by upvote/downvote
* Vote click handler on beta user profile pages (userTagger also needs this change)
* When clicking on vote ratio: open settings console to module OR option to modify vote ratio (currently: text only, does nothing)
* Show vote ratio on subreddit pages (this might depend on whether or not `.side .redditname` is visible in the sidebar which varies from sub to sub)
* Simplify/refactor code
