### PR TITLE
Filter empty comment context navigation options

### DIFF
--- a/lib/modules/commentNavigator.js
+++ b/lib/modules/commentNavigator.js
@@ -168,7 +168,8 @@ function getCategories() {
 			selected: category === currentCategory,
 			size: getPosts(category).length,
 			title,
-		}));
+		}))
+		.filter(entry => entry.size);
 }
 
 const getPosts = _.memoize((category: Category) => Array.from(sortTypes[category].getPosts()).filter(e => e.offsetParent));


### PR DESCRIPTION
Relevant issue: https://github.com/honestbleeps/Reddit-Enhancement-Suite/issues/2147
Tested in browser: Chrone

Thought I'd try contributing by starting to tackle a smaller task.
I Took a look at #2147. Since it was filed, we now include the comment count pertaining to each filter. However, we still include all the filters with a count of (0). This PR filters those filters (ha!). 

Before:
https://i.imgur.com/2GKUmr9.gif

After:
https://i.imgur.com/2nOMRXH.gif

(GIFS too large to embed)

