### PR TITLE
NER: verify "next page" belongs to current user, fix "try again" link

### DIFF
--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -21,6 +21,7 @@ import * as Orangered from './orangered';
 import * as SelectedEntry from './selectedEntry';
 import * as SettingsConsole from './settingsConsole';
 import * as SettingsNavigation from './settingsNavigation';
+import { documentLoggedInUser, loggedInUser } from '../utils/user';
 
 export const module: Module<*> = new Module('neverEndingReddit');
 
@@ -380,6 +381,11 @@ async function loadPage(url: string) {
 			.replace(/<style(.|\s)*?>|<link(.|\s)*?>|<script(.|\s)*?\/script>/g, '');
 
 		const tempDiv = $('<div>').html(html).get(0);
+		const username = loggedInUser();
+		const tempUsername = documentLoggedInUser(tempDiv);
+		if (tempUsername !== username) {
+			throw Error('page loaded was not for current user')
+		}
 
 		// check for new mail
 		Orangered.updateFromPage(tempDiv);

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -14,6 +14,8 @@ import {
 	fastAsync,
 	newSitetable,
 	watchForElements,
+	documentLoggedInUser,
+	loggedInUser,
 } from '../utils';
 import * as Floater from './floater';
 import * as Notifications from './notifications';
@@ -21,7 +23,6 @@ import * as Orangered from './orangered';
 import * as SelectedEntry from './selectedEntry';
 import * as SettingsConsole from './settingsConsole';
 import * as SettingsNavigation from './settingsNavigation';
-import { documentLoggedInUser, loggedInUser } from '../utils/user';
 
 export const module: Module<*> = new Module('neverEndingReddit');
 
@@ -384,7 +385,7 @@ async function loadPage(url: string) {
 		const username = loggedInUser();
 		const tempUsername = documentLoggedInUser(tempDiv);
 		if (tempUsername !== username) {
-			throw Error('page loaded was not for current user')
+			throw new Error('page loaded was not for current user');
 		}
 
 		// check for new mail

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -445,8 +445,6 @@ const appendPage = fastAsync(function*(newSiteTable, pageHTML = newSiteTable.out
 });
 
 function endNER(text) {
-	nextPageURL = null;
-
 	$('<div>', {
 		class: 'NERPageMarker NERPageMarkerLast',
 		text,
@@ -463,4 +461,5 @@ function endNER(text) {
 		.appendTo(siteTable());
 
 	window.removeEventListener('scroll', handleScroll);
+	nextPageURL = null;	
 }

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -462,5 +462,5 @@ function endNER(text) {
 		.appendTo(siteTable());
 
 	window.removeEventListener('scroll', handleScroll);
-	nextPageURL = null;	
+	nextPageURL = null;
 }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -147,6 +147,7 @@ export {
 	getUserInfo,
 	isModeratorAnywhere,
 	loggedInUser,
+	documentLoggedInUser,
 	loggedInUserHash,
 } from './user';
 

--- a/lib/utils/user.js
+++ b/lib/utils/user.js
@@ -9,7 +9,7 @@ import * as string from './string';
 
 export const loggedInUser = _.once((): string | void => documentLoggedInUser(document));
 
-export const documentLoggedInUser = (document: Node): string | void => {
+export const documentLoggedInUser = (document: Document | Element): string | void => {
 	const link: ?HTMLAnchorElement = (document.querySelector('#header-bottom-right > span.user > a'): any);
 	if (!link || link.classList.contains('login-required')) return;
 	const profile = regexes.profile.exec(link.pathname);

--- a/lib/utils/user.js
+++ b/lib/utils/user.js
@@ -9,7 +9,7 @@ import * as string from './string';
 
 export const loggedInUser = _.once((): string | void => documentLoggedInUser(document));
 
-export const documentLoggedInUser = (document): string => {
+export const documentLoggedInUser = (document: Node): string | void => {
 	const link: ?HTMLAnchorElement = (document.querySelector('#header-bottom-right > span.user > a'): any);
 	if (!link || link.classList.contains('login-required')) return;
 	const profile = regexes.profile.exec(link.pathname);

--- a/lib/utils/user.js
+++ b/lib/utils/user.js
@@ -7,12 +7,14 @@ import { MINUTE } from './time';
 import { regexes } from './location';
 import * as string from './string';
 
-export const loggedInUser = _.once((): string | void => {
+export const loggedInUser = _.once((): string | void => documentLoggedInUser(document));
+
+export const documentLoggedInUser = (document): string => {
 	const link: ?HTMLAnchorElement = (document.querySelector('#header-bottom-right > span.user > a'): any);
 	if (!link || link.classList.contains('login-required')) return;
 	const profile = regexes.profile.exec(link.pathname);
 	return profile ? profile[1] : undefined;
-});
+};
 
 export const isModeratorAnywhere = _.once((): boolean => !!document.getElementById('modmail'));
 


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: #4219
Tested in browser:  Chrome 63.0.3239.84

"learn more" button on "could not load NER page" links to [wiki about NER](/r/Enhancement/wiki/faq/never_ending_reddit), which includes [troubleshooting steps for that error](/r/Enhancement/wiki/faq/never_ending_reddit#wiki_could_not_load_the_next_page.3A_page_loaded_was_not_for_current_user).

![ner-logged-out](https://user-images.githubusercontent.com/455632/34551193-2fc5af50-f0cc-11e7-9b9a-db1b9a4e5d7f.gif)

  