### PR TITLE
Contain subreddit list scrolling

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -32,7 +32,13 @@ rules:
   no-important: 0
   no-invalid-hex: 2
   no-mergeable-selectors: 2
-  no-misspelled-properties: 2
+  no-misspelled-properties:
+    - 2
+    -
+      extra-properties:
+        # necessary until a version of sass-lint is released that depends on
+        # known-css-properties >= 0.5.0
+        - overscroll-behavior-y
   no-qualifying-elements:
     - 2
     -

--- a/lib/css/modules/_subredditManager.scss
+++ b/lib/css/modules/_subredditManager.scss
@@ -21,6 +21,7 @@
 	background-color: #FAFAFA;
 	width: auto;
 	overflow-y: auto;
+	overscroll-behavior-y: contain;
 
 	tr {
 		border-bottom: 1px solid gray;


### PR DESCRIPTION
Currently when the user scrolls to the bottom of the subreddit list the whole page scrolls down, this moves this subreddit list up causing some confusion. [`overscroll-behavior`](https://wicg.github.io/overscroll-behavior/) is a new property to deal with this, it's supported in chrome as of 63 (the current stable release) and will be available in firefox come version 59