### PR TITLE
res-gallery-to-filmstrip: increase specificity and margin

### DIFF
--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -291,16 +291,16 @@ img {
 		&[first-piece=true] .res-gallery-previous {
 			transform: scaleX(-1);
 		}
-	}
 
-	&-to-filmstrip {
-		margin-left: 5px;
-		cursor: pointer;
+		.res-gallery-to-filmstrip {
+			margin-left: 1em;
+			cursor: pointer;
 
-		&::before {
-			content: '🎞';
-			display: block;
-			transform: rotate(90deg);
+			&::before {
+				content: '🎞';
+				display: block;
+				transform: rotate(90deg);
+			}
 		}
 	}
 


### PR DESCRIPTION
Should make it harder to accidentally click. (reddit's css was overriding the margin before, at least in comments)

Tested in browser: Chrome 64