### PR TITLE
filteReddit: Fix allowNSFW being ignored on comment page

### DIFF
--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -408,6 +408,7 @@ module.beforeLoad = fastAsync(function*() {
 	// start initializing filterline early
 	createFilterline(yield initialFilterlineState.get());
 
+	watchForThings(['post'], updateNsfwThingClass, { immediate: true });
 	watchForThings([thingType], registerThing, { immediate: true });
 });
 
@@ -429,8 +430,6 @@ module.go = () => {
 };
 
 function registerThing(thing) {
-	updateNsfwThingClass(thing);
-
 	if (
 		module.options.excludeOwnPosts.value && loggedInUser() &&
 		currentUserProfile() !== loggedInUser() &&


### PR DESCRIPTION
`registerThing` is only invoked for comments on comment pages.

Relevant issue: https://www.reddit.com/r/Enhancement/comments/7r26ku/filtereddit_is_not_working_correctly_since_the/
Tested in browser: Chrome 64