### PR TITLE
sourceSnudown: handle buttons without li.first

### DIFF
--- a/lib/modules/sourceSnudown.js
+++ b/lib/modules/sourceSnudown.js
@@ -37,7 +37,11 @@ function attachViewSourceButton(thing) {
 	// Link posts don't have any source
 	if (thing.isLinkPost()) return;
 
-	const buttons = thing.entry.querySelector('.flat-list.buttons > li.first');
+	const buttons =
+		// .first is the first button after NSFW/spoiler stamps
+		thing.entry.querySelector('.flat-list.buttons > li.first') ||
+		// but some pages (inbox) don't have the .first class
+		thing.entry.querySelector('.flat-list.buttons > li');
 	if (buttons) buttons.after(sourceButton());
 }
 


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: https://www.reddit.com/r/RESissues/comments/7rc3ps/res_510x_removed_the_source_button_from_the_inbox/
Tested in browser: Chrome 65