### PR TITLE
stylesheets: display available customToggles

### DIFF
--- a/lib/modules/customToggles.js
+++ b/lib/modules/customToggles.js
@@ -140,3 +140,7 @@ export function toggleActive(key: string): boolean {
 	const toggle = toggles.get(key);
 	return !!toggle && toggle.enabled;
 }
+
+// Stage may have the most recent toggles, in case this is invoked while in settingsConsole
+export const getToggles = () => (Options.stage.get(module.moduleID) || module.options)
+	.toggle.value.map(([key, , text]) => ({ key, text }));

--- a/lib/modules/filteReddit/browseCases/Toggle.js
+++ b/lib/modules/filteReddit/browseCases/Toggle.js
@@ -3,7 +3,7 @@
 import { Case } from '../Case';
 import * as CustomToggles from '../../customToggles';
 
-const getOptions = () => CustomToggles.module.options.toggle.value.map(([key, , text]) => [text, key]);
+const getOptions = () => CustomToggles.getToggles().map(({ key, text }) => [text, key]);
 
 export class Toggle extends Case {
 	static text = 'Custom toggle';

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -377,6 +377,11 @@ function drawOptionInput(mod, optionName, optionObject, isTable) {
 				class: 'enum',
 			});
 
+			// Include existing value as option in case it is temporarily unavailable
+			if (optionObject.value && !_.find(optionObject.values, _.matchesProperty('value', optionObject.value))) {
+				optionObject.values.push({ name: `${optionObject.value} (not available)`, value: optionObject.value });
+			}
+
 			optionObject.values.forEach((optionValue, index) => {
 				const thisId = `${optionName}-${index}`;
 				const $thisOptionFormSubEle = $('<input>', {

--- a/lib/modules/stylesheet.js
+++ b/lib/modules/stylesheet.js
@@ -70,7 +70,9 @@ module.options = {
 		}, {
 			key: 'toggleKey',
 			name: 'toggleKey',
-			type: 'text',
+			type: 'enum',
+			get values() { return getToggles(); },
+			value: '',
 		}],
 	},
 	snippets: {
@@ -105,7 +107,9 @@ module.options = {
 		}, {
 			key: 'toggleKey',
 			name: 'toggleKey',
-			type: 'text',
+			type: 'enum',
+			get values() { return getToggles(); },
+			value: '',
 		}],
 	},
 	bodyClasses: {
@@ -140,7 +144,9 @@ module.options = {
 		}, {
 			key: 'toggleKey',
 			name: 'toggleKey',
-			type: 'text',
+			type: 'enum',
+			get values() { return getToggles(); },
+			value: '',
 		}],
 	},
 	subredditClass: {
@@ -323,4 +329,11 @@ function shouldApply(toggle, applyTo, applyList) {
 		default:
 			return true;
 	}
+}
+
+function getToggles() {
+	return [
+		{ name: 'No toggle needed', value: '' },
+		...CustomToggles.getToggles().map(({ key, text }) => ({ name: text, value: key })),
+	];
 }


### PR DESCRIPTION
There has been some confusion about what the `toggleName` column does, and entering the wrong text there prevents the snippet from working.

This changes the option from `text` to `enum`. The value remains the same.

![image](https://user-images.githubusercontent.com/1748521/35348910-cd3b391c-0139-11e8-867c-c246254a0dd5.png)

Tested in browser: Chrome 65