### PR TITLE
 commentNavigator: Use filteReddit cases

### DIFF
--- a/lib/modules/commandLine.js
+++ b/lib/modules/commandLine.js
@@ -153,7 +153,7 @@ async function cmdLineHelper(val) {
 	}
 }
 
-function cmdLineSubmit(e) {
+async function cmdLineSubmit(e) {
 	e.preventDefault();
 	cmdLineShowError(false);
 
@@ -161,7 +161,7 @@ function cmdLineSubmit(e) {
 	const command = splitWords[0];
 	const val = splitWords.slice(1).join(' ');
 
-	const error = executeCommand(command, val, e);
+	const error = await executeCommand(command, val, e);
 	if (error) {
 		cmdLineShowError(error);
 	} else if (error !== false) {
@@ -185,7 +185,7 @@ export function registerCommand<T>(
 	commandPredicate: RegExp | string | (cmd: string, val: string) => false | void | T,
 	description: string | string[] | false,
 	getTip: (cmd: string, val: string, predResult: T) => string | false | void | Promise<string>,
-	executeCommand: (cmd: string, val: string, predResult: T, e: KeyboardEvent) => string | false | void
+	executeCommand: (cmd: string, val: string, predResult: T, e: KeyboardEvent) => string | false | void | Promise<string | void>
 ) {
 	commands.push({
 		commandPredicate,

--- a/lib/modules/commentNavigator.js
+++ b/lib/modules/commentNavigator.js
@@ -6,6 +6,7 @@ import { $ } from '../vendor';
 import { Module } from '../core/module';
 import {
 	Thing,
+	asyncFilter,
 	downcast,
 	filterMap,
 	loggedInUser,
@@ -14,7 +15,9 @@ import {
 	string,
 	isCurrentSubreddit,
 	empty,
+	watchForThings,
 } from '../utils';
+import * as Cases from './filteReddit/cases';
 import * as Floater from './floater';
 import * as UserInfo from './userInfo';
 import * as SelectedEntry from './selectedEntry';
@@ -61,45 +64,53 @@ module.go = () => {
 	});
 };
 
+	// `getPosts` is memoized. Keep up to date by reseting it when new comments loads
+	watchForThings(['comment'], () => clearCurrentPosts());
+};
+
 const sortTypes: {
 	[string]: {|
 		title: string,
-		getPosts: () => Array<HTMLElement> | NodeList<*>,
+		getElements?: () => Array<HTMLElement> | NodeList<*>,
+		conditions?: *, // Used in conjunction with filteReddit
 		nonlinear?: boolean,
 		disabled?: () => boolean,
 	|},
 } = {
+	custom: {
+		title: 'Navigate custom category',
+		conditions: { type: 'false' }, // Must be updated by `updateCustomCategory`
+	},
 	comment: {
 		title: 'Navigate comments',
-		getPosts: () => Array.from(document.querySelectorAll('.entry'))
-			.filter(e => { const t = Thing.checkedFrom(e); return t.isComment() && t.isVisible(); }),
+		conditions: { type: 'true' },
 	},
 	submitter: {
 		title: 'Navigate comments made by the post submitter',
-		getPosts: () => document.querySelectorAll('.noncollapsed a.author.submitter'),
+		getElements: () => document.querySelectorAll('.noncollapsed a.author.submitter'),
 	},
 	moderator: {
 		title: 'Navigate comments made by moderators',
-		getPosts: () => document.querySelectorAll('.noncollapsed a.author.moderator'),
+		getElements: () => document.querySelectorAll('.noncollapsed a.author.moderator'),
 	},
 	friend: {
 		title: 'Navigate comments made by users on your friends list',
-		getPosts: () => document.querySelectorAll('.noncollapsed a.author.friend'),
+		getElements: () => document.querySelectorAll('.noncollapsed a.author.friend'),
 	},
 	me: {
 		title: 'Navigate comments made by you',
-		getPosts: () => {
+		getElements: () => {
 			const loggedIn = loggedInUser();
 			return loggedIn ? document.querySelectorAll(`.noncollapsed a.author[href$="/user/${loggedIn}"]`) : [];
 		},
 	},
 	admin: {
 		title: 'Navigate comments made by reddit admins',
-		getPosts: () => document.querySelectorAll('.noncollapsed a.author.admin'),
+		getElements: () => document.querySelectorAll('.noncollapsed a.author.admin'),
 	},
 	highlighted: {
 		title: 'Navigate comments made by highlighted user',
-		getPosts() {
+		getElements() {
 			const highlightedUserSelector = Object.keys(UserInfo.highlightedUsers)
 				.map(key => `.noncollapsed .author.id-t2_${key}`)
 				.join(', ');
@@ -108,15 +119,15 @@ const sortTypes: {
 	},
 	tagged: {
 		title: 'Navigate comments made by tagged users',
-		getPosts: () => document.querySelectorAll('.noncollapsed .tagline .userTagLink.hasTag'),
+		getElements: () => document.querySelectorAll('.noncollapsed .tagline .userTagLink.hasTag'),
 	},
 	gilded: {
 		title: 'Navigate through gilded comments',
-		getPosts: () => document.querySelectorAll('.noncollapsed .gilded-icon'),
+		getElements: () => document.querySelectorAll('.noncollapsed .gilded-icon'),
 	},
 	IAmA: {
 		title: 'Navigate through questions that have been answered by the submitter (most useful in /r/IAmA)',
-		getPosts() {
+		getElements() {
 			const submitterPosts = document.querySelectorAll('.noncollapsed a.author.submitter');
 			const parents = Array.from(submitterPosts)
 				.map(post => $(post).closest('.comment').parent().closest('.comment').get(0))
@@ -126,15 +137,15 @@ const sortTypes: {
 	},
 	images: {
 		title: 'Navigate through comments with images',
-		getPosts: () => document.querySelectorAll('.expando-button.image'),
+		getElements: () => document.querySelectorAll('.expando-button.image'),
 	},
 	videos: {
 		title: 'Navigate through comments with videos',
-		getPosts: () => document.querySelectorAll('.expando-button.video'),
+		getElements: () => document.querySelectorAll('.expando-button.video'),
 	},
 	popular: {
 		title: 'Navigate through comments in order of highest vote total',
-		getPosts() {
+		getElements() {
 			return flow(
 				() => Thing.things(),
 				filter(thing => thing.isComment()),
@@ -152,33 +163,53 @@ const sortTypes: {
 	},
 	new: {
 		title: 'Navigate through new comments (Reddit Gold users only)',
-		getPosts: () => document.querySelectorAll('.new-comment'),
+		getElements: () => document.querySelectorAll('.new-comment'),
 		disabled: () => !document.body.querySelector('.gold-accent.comment-visits-box'),
 	},
 	upvoted: {
 		title: 'Navigate through comments you upvoted',
-		getPosts: () => document.querySelectorAll('.upmod'),
+		getElements: () => document.querySelectorAll('.upmod'),
 	},
 };
 
-function getCategories() {
-	return Object.entries(sortTypes)
-		.filter(([, { disabled }]) => !disabled || !disabled())
-		.map(([category, { title }]) => ({
-			category,
-			selected: category === currentCategory,
-			size: getPosts(category).length,
-			title,
-		}))
-		.filter(entry => entry.size);
+export function updateCustomConditions(conditions: *) {
+	sortTypes.custom.conditions = conditions;
 }
 
-const getPosts = _.memoize((category: Category) => Array.from(sortTypes[category].getPosts()).filter(e => e.offsetParent));
+function getCategories() {
+	return Promise.all(
+		Object.entries(sortTypes)
+			.filter(([, { disabled }]) => !disabled || !disabled())
+			.map(async ([category, { title }]) => ({
+				category,
+				selected: category === currentCategory,
+				size: (await getPosts(category)).length,
+				title,
+			}))
+	).then(v =>
+		v.filter(entry => entry.size)
+	);
+}
+
+const _memoized = _.memoize((category: Category): Promise<HTMLElement[]> => {
+	const { getElements, conditions } = sortTypes[category];
+	if (getElements) {
+		return Promise.resolve(Array.from(getElements()));
+	} else if (conditions) {
+		const cased = Cases.fromConditions(conditions);
+		return asyncFilter(Thing.visibleThings(), /*:: async */ thing => cased.evaluate(thing)).then(v => v.map(thing => thing.element));
+	} else {
+		throw new Error('Neither conditions or getElements available');
+	}
+});
+const getPosts = (category: Category) => _memoized(category).then(v => v.filter(e => Thing.checkedFrom(e).isVisible()));
 const currentPosts = () => getPosts(currentCategory);
+const clearCurrentPosts = () => _memoized.cache.delete(currentCategory);
 
 type Category = $Keys<typeof sortTypes>;
 let currentCategory: Category = isCurrentSubreddit('IAmA', 'casualiama') ? 'IAmA' : 'comment';
-let index = 0;
+let index: number = 0;
+let length: number = 0;
 let isOpen = false;
 
 const commentNav = _.once(() => {
@@ -198,10 +229,11 @@ const commentNav = _.once(() => {
 
 	const select = downcast(box.querySelector('#commentNavBy'), HTMLSelectElement);
 
-	select.addEventListener('focus', () => {
+	select.addEventListener('focus', async () => {
 		empty(select);
+		const categories = await getCategories();
 		select.append(
-			...getCategories().map(({ category, selected, size }) => string.html`
+			...categories.map(({ category, selected, size }) => string.html`
 				<option ${selected && 'selected'} value="${category}"">${category}<span> (${size})</span></option>
 			`)
 		);
@@ -223,8 +255,8 @@ const commentNav = _.once(() => {
 
 	function refresh() {
 		up.disabled = index <= 0;
-		down.disabled = index >= currentPosts().length - 1;
-		postCount.textContent = currentPosts().length ? `${index + 1}/${currentPosts().length}` : 'none';
+		down.disabled = index >= length - 1;
+		postCount.textContent = length ? `${index + 1}/${length}` : 'none';
 	}
 
 	function open() { isOpen = true; box.hidden = false; }
@@ -245,10 +277,11 @@ function installEntryElement() {
 		.appendTo('.commentarea .panestack-title')
 		.get(0);
 
-	commentNavToggle.addEventListener('mouseenter', () => {
+	commentNavToggle.addEventListener('mouseenter', async () => {
 		const choices = commentNavToggle.querySelector('.res-commentNavToggle-choices');
 		empty(choices);
-		choices.append(...getCategories().map(({ category, title, size }) => {
+		const categories = await getCategories();
+		choices.append(...categories.map(({ category, title, size }) => {
 			const element = string.html`
 				<div class="res-commentNavToggle-type noCtrlF" title="${title}" category="${category}">${category} (${size})</div>
 			`;
@@ -258,19 +291,19 @@ function installEntryElement() {
 	});
 }
 
-function refreshIndex() {
+async function refreshIndex() {
 	// Non-linear comment categories are not sorted by distance from top,
 	// so the most matching comment cannot determined by the algorithm below
 	if (sortTypes[currentCategory].nonlinear) return;
 
+	const posts = await currentPosts();
 	setIndex(
-		currentPosts().findIndex(post => post.getBoundingClientRect().top >= getHeaderOffset())
+		posts.findIndex(post => post.getBoundingClientRect().top >= getHeaderOffset()),
+		posts.length
 	);
 }
 
 export function setCategory(category: Category, keepClosest: boolean = false) {
-	getPosts.cache.clear();
-
 	currentCategory = category;
 	commentNav().select.value = category;
 
@@ -297,10 +330,11 @@ export function moveDown() { move(index + 1); }
 let recentMove = false;
 const refreshMoveTimer = _.debounce(() => { recentMove = false; }, 1000);
 
-function move(to) {
-	setIndex(to);
+async function move(to) {
+	const posts = await currentPosts();
+	setIndex(to, posts.length);
 
-	const element = currentPosts()[index];
+	const element = posts[index];
 	if (element) {
 		scrollToElement(element, null, { scrollStyle: 'top' });
 		SelectedEntry.select(Thing.checkedFrom(element));
@@ -310,10 +344,12 @@ function move(to) {
 	refreshMoveTimer();
 }
 
-function setIndex(to) {
-	if (!currentPosts().length) index = 0;
+function setIndex(to, _length) {
+	length = _length;
+
+	if (!length) index = 0;
 	else if (to <= 0) index = 0;
-	else if (to >= currentPosts().length - 1) index = currentPosts().length - 1;
+	else if (to >= length - 1) index = length - 1;
 	else index = to;
 
 	commentNav().refresh();

--- a/lib/modules/commentNavigator.js
+++ b/lib/modules/commentNavigator.js
@@ -1,15 +1,13 @@
 /* @flow */
 
 import _ from 'lodash';
-import { flow, filter, map } from 'lodash/fp';
+import { flow, map } from 'lodash/fp';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
 import {
 	Thing,
-	asyncFilter,
 	downcast,
 	filterMap,
-	loggedInUser,
 	string,
 	isCurrentSubreddit,
 	empty,
@@ -74,6 +72,7 @@ const sortTypes: {
 	[string]: {|
 		title: string,
 		getElements?: () => Array<HTMLElement> | NodeList<*>,
+		getThings?: () => Promise<Array<Thing>>,
 		conditions?: *, // Used in conjunction with filteReddit
 		nonlinear?: boolean,
 		disabled?: () => boolean,
@@ -89,26 +88,23 @@ const sortTypes: {
 	},
 	submitter: {
 		title: 'Navigate comments made by the post submitter',
-		getElements: () => document.querySelectorAll('.noncollapsed a.author.submitter'),
+		conditions: { type: 'userAttr', attr: 'submitter' },
 	},
 	moderator: {
 		title: 'Navigate comments made by moderators',
-		getElements: () => document.querySelectorAll('.noncollapsed a.author.moderator'),
+		conditions: { type: 'userAttr', attr: 'moderator' },
 	},
 	friend: {
 		title: 'Navigate comments made by users on your friends list',
-		getElements: () => document.querySelectorAll('.noncollapsed a.author.friend'),
+		conditions: { type: 'userAttr', attr: 'friend' },
 	},
 	me: {
 		title: 'Navigate comments made by you',
-		getElements: () => {
-			const loggedIn = loggedInUser();
-			return loggedIn ? document.querySelectorAll(`.noncollapsed a.author[href$="/user/${loggedIn}"]`) : [];
-		},
+		conditions: { type: 'userAttr', attr: 'me' },
 	},
 	admin: {
 		title: 'Navigate comments made by reddit admins',
-		getElements: () => document.querySelectorAll('.noncollapsed a.author.admin'),
+		conditions: { type: 'userAttr', attr: 'admin' },
 	},
 	highlighted: {
 		title: 'Navigate comments made by highlighted user',
@@ -129,28 +125,20 @@ const sortTypes: {
 	},
 	IAmA: {
 		title: 'Navigate through questions that have been answered by the submitter (most useful in /r/IAmA)',
-		getElements() {
-			const submitterPosts = document.querySelectorAll('.noncollapsed a.author.submitter');
-			const parents = Array.from(submitterPosts)
-				.map(post => $(post).closest('.comment').parent().closest('.comment').get(0))
-				.filter(x => x);
-			return _.uniq(parents);
-		},
+		getThings: async () => filterMap(await getPosts('submitter'), thing => thing.parent ? [thing.parent] : undefined),
 	},
 	images: {
 		title: 'Navigate through comments with images',
-		getElements: () => document.querySelectorAll('.expando-button.image'),
+		conditions: { type: 'hasExpando', types: ['image'] },
 	},
 	videos: {
 		title: 'Navigate through comments with videos',
-		getElements: () => document.querySelectorAll('.expando-button.video'),
+		conditions: { type: 'hasExpando', types: ['video'] },
 	},
 	popular: {
 		title: 'Navigate through comments in order of highest vote total',
-		getElements() {
+		async getThings() {
 			return flow(
-				() => Thing.things(),
-				filter(thing => thing.isComment()),
 				filterMap(thing => {
 					const score = thing.getScore();
 					if (typeof score === 'number') {
@@ -158,8 +146,8 @@ const sortTypes: {
 					}
 				}),
 				arr => arr.sort((a, b) => b[0] - a[0]),
-				map(([, thing]) => thing.element)
-			)();
+				map(([, thing]) => thing),
+			)(await getPosts('comment'));
 		},
 		nonlinear: true,
 	},
@@ -170,7 +158,7 @@ const sortTypes: {
 	},
 	upvoted: {
 		title: 'Navigate through comments you upvoted',
-		getElements: () => document.querySelectorAll('.upmod'),
+		conditions: { type: 'voteType', kind: 'upvote' },
 	},
 };
 
@@ -193,23 +181,29 @@ function getCategories() {
 	);
 }
 
-const _memoized = _.memoize((category: Category): Promise<Thing[]> => {
-	const { getElements, conditions } = sortTypes[category];
-	if (getElements) {
-		return Promise.resolve(_.uniq(Array.from(getElements()).map(e => Thing.checkedFrom(e))));
-	} else if (conditions) {
-		const cased = Cases.fromConditions(conditions);
-		return asyncFilter(Thing.things().filter(thing => thing.isComment()), /*:: async */ thing => cased.evaluate(thing));
+const _memoized = _.memoize(async (category: Category): Promise<Thing[]> => {
+	const { getElements, getThings, conditions } = sortTypes[category];
+
+	let things = [];
+
+	if (getThings) {
+		things = _.uniq(await getThings());
+	} else if (getElements) {
+		things = _.uniq(Array.from(getElements()).map(e => Thing.checkedFrom(e)));
 	} else {
-		throw new Error('Neither conditions or getElements available');
+		things = Thing.things().filter(thing => thing.isComment());
 	}
+
+	return Cases.filterThings(things, conditions);
 });
-const getPosts = (category: Category) => _memoized(category).then(v => v.filter(thing => !thing.isFiltered() && !thing.isCollapsed() && thing.isVisible()));
+const getPosts = (category: Category) => _memoized(category).then(v =>
+	v.filter(thing => !thing.isFiltered() && !thing.isCollapsed() && thing.isVisible())
+);
 const currentPosts = () => getPosts(currentCategory);
 let lastNavigatedTo: ?Thing = null;
 
 type Category = $Keys<typeof sortTypes>;
-let currentCategory: Category = isCurrentSubreddit('IAmA', 'casualiama') ? 'IAmA' : 'comment';
+let currentCategory: Category = isCurrentSubreddit('IAmA', 'casualiama') ? 'IAmA' : 'popular';
 let isOpen = false;
 
 const commentNav = _.once(() => {
@@ -324,22 +318,25 @@ export function toggle(focus: boolean = false, open: boolean = !isOpen) {
 }
 
 export async function move(change: 'up' | 'down' | 'top') {
-	const all = Thing.things();
-	const lastNavigatedToIndex = all.indexOf(lastNavigatedTo);
-	const selectedIndex = all.indexOf(SelectedEntry.selectedThing);
+	if (!sortTypes[currentCategory].nonlinear) {
+		const all = Thing.things();
+		const lastNavigatedToIndex = all.indexOf(lastNavigatedTo);
+		const selectedIndex = all.indexOf(SelectedEntry.selectedThing);
 
-	if (
-		// Return to the last navigated to post if currently moved it beyond in the opposite direction
-		change === 'down' && selectedIndex < lastNavigatedToIndex ||
-		change === 'up' && selectedIndex > lastNavigatedToIndex
-	) {
-		moveTo(lastNavigatedTo);
-	} else {
-		const posts = await currentPosts();
-		if (change === 'top') moveTo(posts[0]);
-		else if (change === 'down') moveTo(posts[posts.indexOf(lastNavigatedTo) + 1]);
-		else if (change === 'up') moveTo(posts[posts.indexOf(lastNavigatedTo) - 1]);
+		if (
+			// Return to the last navigated to post if currently moved it beyond in the opposite direction
+			change === 'down' && selectedIndex < lastNavigatedToIndex ||
+			change === 'up' && selectedIndex > lastNavigatedToIndex
+		) {
+			moveTo(lastNavigatedTo);
+			return;
+		}
 	}
+
+	const posts = await currentPosts();
+	if (change === 'top') moveTo(posts[0]);
+	else if (change === 'down') moveTo(posts[posts.indexOf(lastNavigatedTo) + 1]);
+	else if (change === 'up') moveTo(posts[posts.indexOf(lastNavigatedTo) - 1]);
 }
 
 function moveTo(thing: ?Thing) {

--- a/lib/modules/commentNavigator.js
+++ b/lib/modules/commentNavigator.js
@@ -210,7 +210,7 @@ const commentNav = _.once(() => {
 	const box = string.html`
 		<div id="REScommentNavBox">
 			<select id="commentNavBy">
-				<option value="${currentCategory}">${currentCategory}</option>
+				<option selected value="${currentCategory}">${currentCategory}</option>
 			</select>
 			<hr style="margin-bottom: 0">
 			<div id="commentNavButtons">
@@ -228,7 +228,7 @@ const commentNav = _.once(() => {
 		const categories = await getCategories();
 		select.append(
 			...categories.map(({ category, selected, size }) => string.html`
-				<option ${selected && 'selected'} value="${category}"">${category}<span> (${size})</span></option>
+				<option ${selected && 'selected'} value="${category}">${category}<span> (${size})</span></option>
 			`)
 		);
 	}, true);

--- a/lib/modules/commentNavigator.js
+++ b/lib/modules/commentNavigator.js
@@ -10,8 +10,6 @@ import {
 	downcast,
 	filterMap,
 	loggedInUser,
-	getHeaderOffset,
-	scrollToElement,
 	string,
 	isCurrentSubreddit,
 	empty,
@@ -55,18 +53,22 @@ module.go = () => {
 	}
 
 	WheelBrowse.setCallback(wheelBrowseWidget => {
-		wheelBrowseWidget.addEventListener('click', toggle);
+		wheelBrowseWidget.addEventListener('click', () => { toggle(); });
 
 		return direction => {
-			if (direction === 'up') moveUp();
-			else moveDown();
+			if (direction === 'up') move('up');
+			else move('down');
 		};
 	});
 };
 
+const initialize = _.once(() => {
 	// `getPosts` is memoized. Keep up to date by reseting it when new comments loads
-	watchForThings(['comment'], () => clearCurrentPosts());
-};
+	watchForThings(['comment'], () => { _memoized.cache.clear(); });
+
+	SelectedEntry.addListener(updateFromSelected, 'beforePaint');
+	updateFromSelected();
+});
 
 const sortTypes: {
 	[string]: {|
@@ -191,25 +193,23 @@ function getCategories() {
 	);
 }
 
-const _memoized = _.memoize((category: Category): Promise<HTMLElement[]> => {
+const _memoized = _.memoize((category: Category): Promise<Thing[]> => {
 	const { getElements, conditions } = sortTypes[category];
 	if (getElements) {
-		return Promise.resolve(Array.from(getElements()));
+		return Promise.resolve(_.uniq(Array.from(getElements()).map(e => Thing.checkedFrom(e))));
 	} else if (conditions) {
 		const cased = Cases.fromConditions(conditions);
-		return asyncFilter(Thing.visibleThings(), /*:: async */ thing => cased.evaluate(thing)).then(v => v.map(thing => thing.element));
+		return asyncFilter(Thing.things().filter(thing => thing.isComment()), /*:: async */ thing => cased.evaluate(thing));
 	} else {
 		throw new Error('Neither conditions or getElements available');
 	}
 });
-const getPosts = (category: Category) => _memoized(category).then(v => v.filter(e => Thing.checkedFrom(e).isVisible()));
+const getPosts = (category: Category) => _memoized(category).then(v => v.filter(thing => !thing.isFiltered() && !thing.isCollapsed() && thing.isVisible()));
 const currentPosts = () => getPosts(currentCategory);
-const clearCurrentPosts = () => _memoized.cache.delete(currentCategory);
+let lastNavigatedTo: ?Thing = null;
 
 type Category = $Keys<typeof sortTypes>;
 let currentCategory: Category = isCurrentSubreddit('IAmA', 'casualiama') ? 'IAmA' : 'comment';
-let index: number = 0;
-let length: number = 0;
 let isOpen = false;
 
 const commentNav = _.once(() => {
@@ -244,24 +244,24 @@ const commentNav = _.once(() => {
 	});
 
 	const postCount = box.querySelector('#commentNavPostCount');
-	postCount.addEventListener('click', () => move(index));
+	postCount.addEventListener('click', () => moveTo(lastNavigatedTo));
 	const up = downcast(box.querySelector('#commentNavUp'), HTMLButtonElement);
-	up.addEventListener('click', moveUp);
+	up.addEventListener('click', () => move('up'));
 	const down = downcast(box.querySelector('#commentNavDown'), HTMLButtonElement);
-	down.addEventListener('click', moveDown);
+	down.addEventListener('click', () => move('down'));
 
 	Floater.addElement(box, { separate: true });
-	window.addEventListener('scroll', _.debounce(() => { if (!recentMove) refreshIndex(); }, 300));
 
-	function refresh() {
-		up.disabled = index <= 0;
-		down.disabled = index >= length - 1;
-		postCount.textContent = length ? `${index + 1}/${length}` : 'none';
+	function refresh(index, length, lastNavigatedToIndex) {
+		up.disabled = lastNavigatedToIndex <= 0;
+		down.disabled = lastNavigatedToIndex >= length - 1;
+		postCount.textContent = length ? `${lastNavigatedToIndex === index ? '' : '~'}${lastNavigatedToIndex + 1}/${length}` : 'none';
 	}
 
 	function open() { isOpen = true; box.hidden = false; }
 	function close() { isOpen = false; box.hidden = true; }
 
+	initialize();
 	isOpen = true;
 
 	return {
@@ -291,66 +291,61 @@ function installEntryElement() {
 	});
 }
 
-async function refreshIndex() {
-	// Non-linear comment categories are not sorted by distance from top,
-	// so the most matching comment cannot determined by the algorithm below
-	if (sortTypes[currentCategory].nonlinear) return;
-
+export async function updateFromSelected(selected = SelectedEntry.selectedThing) {
 	const posts = await currentPosts();
-	setIndex(
-		posts.findIndex(post => post.getBoundingClientRect().top >= getHeaderOffset()),
-		posts.length
-	);
+
+	// Non-linear comment categories are not sorted by distance from top,
+	// so do not disturb the selection by automatically updating
+	if (!sortTypes[currentCategory].nonlinear && posts.includes(selected)) {
+		lastNavigatedTo = selected;
+	}
+
+	commentNav().refresh(posts.indexOf(selected), posts.length, posts.indexOf(lastNavigatedTo));
 }
 
-export function setCategory(category: Category, keepClosest: boolean = false) {
+export function setCategory(category: Category, keepSelected: boolean = false) {
 	currentCategory = category;
+	lastNavigatedTo = null;
+
 	commentNav().select.value = category;
 
-	if (keepClosest) {
-		refreshIndex();
-	} else {
-		move(0);
-	}
+	_memoized.cache.delete(currentCategory);
+
+	if (!keepSelected) move('top');
 }
 
-export function toggle() {
-	if (isOpen) {
+export function toggle(focus: boolean = false, open: boolean = !isOpen) {
+	if (!open) {
 		commentNav().close();
 	} else {
 		commentNav().open();
-		commentNav().select.focus();
-		refreshIndex();
+		if (focus) commentNav().select.focus();
 	}
 }
 
-export function moveUp() { move(index - 1); }
-export function moveDown() { move(index + 1); }
+export async function move(change: 'up' | 'down' | 'top') {
+	const all = Thing.things();
+	const lastNavigatedToIndex = all.indexOf(lastNavigatedTo);
+	const selectedIndex = all.indexOf(SelectedEntry.selectedThing);
 
-let recentMove = false;
-const refreshMoveTimer = _.debounce(() => { recentMove = false; }, 1000);
-
-async function move(to) {
-	const posts = await currentPosts();
-	setIndex(to, posts.length);
-
-	const element = posts[index];
-	if (element) {
-		scrollToElement(element, null, { scrollStyle: 'top' });
-		SelectedEntry.select(Thing.checkedFrom(element));
+	if (
+		// Return to the last navigated to post if currently moved it beyond in the opposite direction
+		change === 'down' && selectedIndex < lastNavigatedToIndex ||
+		change === 'up' && selectedIndex > lastNavigatedToIndex
+	) {
+		moveTo(lastNavigatedTo);
+	} else {
+		const posts = await currentPosts();
+		if (change === 'top') moveTo(posts[0]);
+		else if (change === 'down') moveTo(posts[posts.indexOf(lastNavigatedTo) + 1]);
+		else if (change === 'up') moveTo(posts[posts.indexOf(lastNavigatedTo) - 1]);
 	}
-
-	recentMove = true;
-	refreshMoveTimer();
 }
 
-function setIndex(to, _length) {
-	length = _length;
+function moveTo(thing: ?Thing) {
+	if (!thing) return;
 
-	if (!length) index = 0;
-	else if (to <= 0) index = 0;
-	else if (to >= length - 1) index = length - 1;
-	else index = to;
-
-	commentNav().refresh();
+	lastNavigatedTo = thing;
+	// Force selection to run callbacks in case `thing` is already selected
+	SelectedEntry.select(thing, { scrollStyle: 'top' }, true);
 }

--- a/lib/modules/commentNavigator.js
+++ b/lib/modules/commentNavigator.js
@@ -14,6 +14,7 @@ import {
 	watchForThings,
 } from '../utils';
 import * as Cases from './filteReddit/cases';
+import * as CommandLine from './commandLine';
 import * as Floater from './floater';
 import * as UserInfo from './userInfo';
 import * as SelectedEntry from './selectedEntry';
@@ -58,6 +59,19 @@ module.go = () => {
 			else move('down');
 		};
 	});
+
+	const getMatchingCategory = async val => val && (await getCategories()).find(({ category }) => category.startsWith(val));
+	CommandLine.registerCommand('nav', 'nav [sortType] - open the comment navigator',
+		async (command, val) => {
+			const { category: matchingCategory = '' } = await getMatchingCategory(val) || {};
+			return `navigate comments by [(${(await getCategories()).map(({ category }) => matchingCategory === category ? `<b>${category}</b>` : category).join('|')})]`;
+		},
+		async (command, val) => {
+			const { category: matchingCategory = '' } = await getMatchingCategory(val) || {};
+			if (matchingCategory) setCategory(matchingCategory);
+			toggle(false, true);
+		}
+	);
 };
 
 const initialize = _.once(() => {

--- a/lib/modules/filteReddit/LineFilter.js
+++ b/lib/modules/filteReddit/LineFilter.js
@@ -8,10 +8,12 @@ import {
 	downcast,
 	frameThrottle,
 } from '../../utils';
+import * as CommentNavigator from '../commentNavigator';
 import * as Hover from '../hover';
 import * as FilteReddit from '../filteReddit';
 import * as SettingsConsole from '../settingsConsole';
 import * as Cases from './cases';
+import * as Modules from './../../core/modules';
 import { Filter } from './Filter';
 
 export class LineFilter extends Filter {
@@ -184,6 +186,7 @@ export class LineFilter extends Filter {
 		function addButton(container, text, groupName, action) {
 			const button = string.html`<button class="res-filterline-filter-hover-button" action="${action}">${text}</button>`;
 			const group = downcast(container.querySelector(`[group=${groupName}]`), HTMLElement);
+			group.hidden = false;
 			const buttons = downcast(group.querySelector('.res-filterline-filter-hover-buttons'), HTMLElement);
 			buttons.appendChild(button);
 			return waitForEvent(button, 'click');
@@ -235,6 +238,15 @@ export class LineFilter extends Filter {
 		if (this.state !== false) addButton(body, 'Hide matching posts', 'state-actions', 'state-false').then(() => { this.update(false); }).then(redraw);
 		if (this.state !== true) addButton(body, 'Show only matching posts', 'state-actions', 'state-true').then(() => { this.update(true); }).then(redraw);
 
+		if (Modules.isRunning(CommentNavigator)) {
+			addButton(body, 'Navigate by', 'state-actions', 'navigate-by').then(() => {
+				this.update(null);
+				CommentNavigator.updateCustomConditions(getConditions());
+				CommentNavigator.setCategory('custom');
+				card.close();
+			});
+		}
+
 		await this.updatePromise;
 
 		const uncertainMatches = filterline.getFiltered()
@@ -248,20 +260,20 @@ export class LineFilter extends Filter {
 
 		if (allMatching.length) {
 			body.appendChild(string.html`
-				<div class="res-filterline-filter-hover-group" group="match-actions">
+				<div class="res-filterline-filter-hover-group" group="hidden-actions" hidden>
 					For posts (${allMatching.length}) hidden by filter:
 					<div class="res-filterline-filter-hover-buttons"></div>
 				</div>
 			`);
 
 			// TODO Make togglable, auto-apply matching things on subsequent pages
-			addButton(body, 'Highlight', 'match-actions', 'highlight').then(() => {
+			addButton(body, 'Highlight', 'hidden-actions', 'highlight').then(() => {
 				for (const e of document.querySelectorAll('.res-filterline-highlight-match')) e.classList.remove('res-filterline-highlight-match');
 				for (const thing of allMatching) thing.element.classList.add('res-filterline-highlight-match');
 			});
 
 			if (filterline.thingType === 'post') {
-				addButton(body, 'Permanently hide', 'match-actions', 'native-hide').then(() => { filterline.hide(allMatching); });
+				addButton(body, 'Permanently hide', 'hidden-actions', 'native-hide').then(() => { filterline.hide(allMatching); });
 			}
 		}
 

--- a/lib/modules/filteReddit/cases.js
+++ b/lib/modules/filteReddit/cases.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import _ from 'lodash';
-import { fastAsync } from '../../utils';
+import { asyncFilter, fastAsync } from '../../utils';
 import { Case } from './Case';
 import * as postCases from './postCases';
 import * as commentCases from './commentCases';
@@ -234,7 +234,12 @@ export function populatePrimitives(types: Array<*> = ['post', 'comment', 'browse
 	if (types.includes('browse')) fill(browseCases, 'browse');
 }
 
-export const fromConditions = (conditions: *) => Case.fromConditions(conditions);
+export function filterThings(things: *, conditions: *) {
+	if (!conditions) return things;
+	const cased = Case.fromConditions(conditions);
+	return asyncFilter(things, /*:: async */ thing => cased.evaluate(thing));
+}
+
 export const remove = (type: string) => { delete available[type]; };
 export const has = (type: string) => available.hasOwnProperty(type);
 export const get = (type: string) => has(type) ? available[type] : Inert;

--- a/lib/modules/filteReddit/cases.js
+++ b/lib/modules/filteReddit/cases.js
@@ -234,6 +234,7 @@ export function populatePrimitives(types: Array<*> = ['post', 'comment', 'browse
 	if (types.includes('browse')) fill(browseCases, 'browse');
 }
 
+export const fromConditions = (conditions: *) => Case.fromConditions(conditions);
 export const remove = (type: string) => { delete available[type]; };
 export const has = (type: string) => available.hasOwnProperty(type);
 export const get = (type: string) => has(type) ? available[type] : Inert;

--- a/lib/modules/hideChildComments.js
+++ b/lib/modules/hideChildComments.js
@@ -102,6 +102,8 @@ function addToggleChildrenButton(comment) {
 			a.setAttribute('data-text', 'hide child comments');
 			a.setAttribute('action', 'hide');
 		}
+
+		comment.element.classList.toggle('res-children-hidden', action === 'hide');
 	}
 
 	const li = document.createElement('li');

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -789,7 +789,7 @@ module.options = {
 		value: [78, false, false, false, false], // N
 		description: 'keyboardNavToggleCommentNavigatorDesc',
 		title: 'keyboardNavToggleCommentNavigatorTitle',
-		callback: CommentNavigator.toggle,
+		callback() { CommentNavigator.toggle(true); },
 	},
 	commentNavigatorMoveUp: {
 		type: 'keycode',
@@ -797,7 +797,7 @@ module.options = {
 		value: [38, false, false, true, false], // shift+up arrow
 		description: 'keyboardNavCommentNavigatorMoveUpDesc',
 		title: 'keyboardNavCommentNavigatorMoveUpTitle',
-		callback() { CommentNavigator.moveUp(); },
+		callback() { CommentNavigator.move('up'); },
 	},
 	commentNavigatorMoveDown: {
 		type: 'keycode',
@@ -805,7 +805,7 @@ module.options = {
 		value: [40, false, false, true, false], // shift+down arrow
 		description: 'keyboardNavCommentNavigatorMoveDownDesc',
 		title: 'keyboardNavCommentNavigatorMoveDownTitle',
-		callback() { CommentNavigator.moveDown(); },
+		callback() { CommentNavigator.move('down'); },
 	},
 	focusOnSearchBox: {
 		type: 'keycode',

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -187,8 +187,8 @@ const runCallbacks = (() => {
 
 let oldSelected;
 
-export function select(newSelected: Thing, options: SelectOptions = { scrollStyle: 'none' }) {
-	if (newSelected === selectedThing) return;
+export function select(newSelected: Thing, options: SelectOptions = { scrollStyle: 'none' }, force: boolean = false) {
+	if (!force && newSelected === selectedThing) return;
 
 	oldSelected = selectedThing;
 

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -245,7 +245,7 @@ async function showUserInfo(card, username, thing) {
 	if (module.options.highlightButton.value) {
 		$body.find('#highlightUser').on('click', ({ target }: Event) => {
 			const userid = target.getAttribute('data-userid');
-			toggleUserHighlight(target, userid);
+			toggleUserHighlight(target, userid, thing);
 		});
 	}
 	if (module.options.gildComments.value && thing && thing.isComment()) {
@@ -289,7 +289,7 @@ function hideAuthorInfo() {
 	Hover.infocard(module.moduleID).close();
 }
 
-function toggleUserHighlight(authorInfoToolTipHighlight, userid) {
+function toggleUserHighlight(authorInfoToolTipHighlight, userid, thing) {
 	if (highlightedUsers[userid]) {
 		highlightedUsers[userid].remove();
 		delete highlightedUsers[userid];
@@ -301,6 +301,8 @@ function toggleUserHighlight(authorInfoToolTipHighlight, userid) {
 
 	if (Modules.isRunning(CommentNavigator) && CommentNavigator.module.options.openOnHighlightUser.value) {
 		CommentNavigator.setCategory('highlighted', true);
+		if (thing) CommentNavigator.updateFromSelected(thing);
+		CommentNavigator.toggle(false, true);
 	}
 }
 

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -38,12 +38,12 @@ export class Thing {
 		});
 	}
 
-	static things(): Thing[] {
-		return Array.from(things);
-	}
-
 	static thingElements(): HTMLElement[] {
 		return Array.from(document.querySelectorAll(Thing.bodyThingSelector));
+	}
+
+	static things(): Thing[] {
+		return Thing.thingElements().map(e => Thing.checkedFrom(e));
 	}
 
 	static visibleThingElements(): HTMLElement[] {

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -554,6 +554,7 @@ export class Thing {
 	}
 
 	isVisible(): boolean {
+		// TODO Check whether hideChildComments hides it
 		return (
 			!(this.isFiltered() && !this.element.classList.contains('res-thing-has-visible-child')) &&
 			!this.isInCollapsed()

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -550,11 +550,12 @@ export class Thing {
 
 	isInCollapsed(): boolean {
 		const parent_ = this.getParent();
-		return !!(parent_ && parent_.getClosest(function() { return this.isCollapsed(); }));
+		return !!(parent_ && parent_.getClosest(function() {
+			return this.isCollapsed() || this.element.classList.contains('res-children-hidden');
+		}));
 	}
 
 	isVisible(): boolean {
-		// TODO Check whether hideChildComments hides it
 		return (
 			!(this.isFiltered() && !this.element.classList.contains('res-thing-has-visible-child')) &&
 			!this.isInCollapsed()


### PR DESCRIPTION
- New ways to determine posts to browse: `getThings` and `conditions`.
- Adds a `navigate by` button to filter popups which sets conditions for posts to browse.
- Navigates to `Thing`s instead of elements
- More resilient to loading new comments (by keeping track of a `Thing` instead of an index)
- Set default navigation to browse popular comments 

![image](https://user-images.githubusercontent.com/1748521/35473264-e304f454-037d-11e8-81a8-5c128b6c9fe0.png)

Relevant issue: Closes #1327, closes #787
Tested in browser: Chrome 64