### PR TITLE
Allow option to prompt for password when switching accounts

### DIFF
--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -317,10 +317,12 @@ function findMatchingAccount(username, partialMatch) {
 async function switchTo(user) {
 	const account = findMatchingAccount(user);
 	if (!account) return;
-	const [username, password, requiresOtp] = account;
+	const [username, storedPassword, requiresOtp] = account;
 
-	// Don't await promise yet so that the OTP can be entered while logging out
+	// Don't await promise yet so that the password and OTP can be entered while logging out
 	const logoutPromise = loggedInUser() && ajax({ method: 'POST', url: '/logout' });
+
+	let password = storedPassword ? storedPassword : window.prompt(i18n('accountSwitcherPasswordPrompt', username));
 
 	let otp;
 	if (requiresOtp) {
@@ -336,7 +338,7 @@ async function switchTo(user) {
 		url: '/api/login',
 		data: {
 			user: username,
-			passwd: password ? password : window.prompt(i18n('accountSwitcherPasswordPrompt', username)),
+			passwd: password,
 			...otp,
 			rem: module.options.keepLoggedIn.value ? 'on' : 'off',
 		},

--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -336,7 +336,7 @@ async function switchTo(user) {
 		url: '/api/login',
 		data: {
 			user: username,
-			passwd: password,
+			passwd: password ? password : window.prompt(i18n('accountSwitcherPasswordPrompt', username)),
 			...otp,
 			rem: module.options.keepLoggedIn.value ? 'on' : 'off',
 		},

--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -322,7 +322,7 @@ async function switchTo(user) {
 	// Don't await promise yet so that the password and OTP can be entered while logging out
 	const logoutPromise = loggedInUser() && ajax({ method: 'POST', url: '/logout' });
 
-	let password = storedPassword ? storedPassword : window.prompt(i18n('accountSwitcherPasswordPrompt', username));
+	const password = storedPassword ? storedPassword : window.prompt(i18n('accountSwitcherPasswordPrompt', username));
 
 	let otp;
 	if (requiresOtp) {

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -123,7 +123,7 @@
 		"message": "Account Switcher"
 	},
 	"accountSwitcherDesc": {
-		"message": "Store username/password pairs and switch accounts instantly while browsing Reddit!\n\nIf you forget a password which is stored in Account Switcher, [you can recover them from RES settings](/r/Enhancement/wiki/faq/passwords). Be aware that RES offers very little protection for stored passwords, so be careful when sharing your computer or settings!"
+		"message": "Store username/password pairs and switch accounts instantly while browsing Reddit!\n\nIf you forget a password which is stored in Account Switcher, [you can recover them from RES settings](/r/Enhancement/wiki/faq/passwords). Be aware that RES offers very little protection for stored passwords, so be careful when sharing your computer or settings!\n\nLeave a password box blank to be prompted for a password every time you switch to that account."
 	},
 	"accountSwitcherAddAccount": {
 		"message": "+add account"
@@ -1742,6 +1742,9 @@
 	},
 	"accountSwitcherOptPrompt": {
 		"message": "Enter the 6 digit code from your authenticator app for $1"
+	},
+	"accountSwitcherPasswordPrompt": {
+		"message": "Enter the password for $1"
 	},
 	"backupAndRestoreProvidersFile": {
 		"message": "File"

--- a/tests/accountSwitcher.js
+++ b/tests/accountSwitcher.js
@@ -31,14 +31,16 @@ module.exports = {
 			return;
 		}
 
-		const username = 'this_username_is_too_long';
+		const password = 'this_is_the_wrong_password';
+		const username = 'this_username_is_too_long_anyway';
 
 		browser
 			.url('https://www.reddit.com/wiki/pages#res:settings/accountSwitcher')
 			.refresh() // get rid of update notification
 			.waitForElementVisible('#RESConsoleContainer')
 			.click('#optionContainer-accountSwitcher-accounts .addRowButton')
-			.setValue('#optionContainer-accountSwitcher-accounts input', [username])
+			.setValue('#optionContainer-accountSwitcher-accounts input[type=text]', [username])
+			.setValue('#optionContainer-accountSwitcher-accounts input[type=password]', [password])
 			.click('#moduleOptionsSave')
 
 			.url('https://en.reddit.com/r/RESIntegrationTests/wiki/pages')


### PR DESCRIPTION
Adds the ability to type in the password every time you switch to a different account, instead of having to store it in RES settings (which is not terribly secure, as a note in the module description warns.)

Based on an old [feature request](https://www.reddit.com/r/Enhancement/comments/13pkfn/feature_request_prompt_for_a_password_when/).

Tested in browser: Firefox 57.0.4