### PR TITLE
Tagging/filtering for RES saved comments

### DIFF
--- a/lib/modules/saveComments.js
+++ b/lib/modules/saveComments.js
@@ -14,6 +14,7 @@ import {
 	string,
 	watchForThings,
 	Thing,
+	loggedInUser,
 } from '../utils';
 import { Storage, i18n } from '../environment';
 import * as KeyboardNav from './keyboardNav';
@@ -28,6 +29,21 @@ module.category = 'commentsCategory';
 module.exclude = [
 	'submit',
 ];
+module.options = {
+	enableCommentSaveOnReply: {
+		title: 'commentSaveOnReplySwitch',
+		type: 'boolean',
+		value: false,
+		description: 'commentSaveOnReplySwitchDesc',
+	},
+	enableInlinePreviousComment: {
+		title: 'enableShowPreviousSwitch',
+		dependsOn: options => options.enableCommentSaveOnReply.value,
+		type: 'boolean',
+		value: false,
+		description: 'enableShowPreviousSwitchDesc',
+	},
+};
 
 const savedRe = /\/user\/([\-\w]+)\/saved\/?/i;
 
@@ -39,10 +55,14 @@ const savedCommentStorage = Storage.wrapBlob('RESmodules.saveComments.savedComme
 |} => { throw new Error('Saved comment not found'); });
 let savedCommentIDs;
 
+
 module.beforeLoad = async () => {
 	savedCommentIDs = new Set(Object.keys(await savedCommentStorage.getAll()));
 
 	watchForThings(['comment'], addSaveLinkToComment);
+	if (module.options.enableCommentSaveOnReply.value) {
+		watchForThings(['comment'], addReplyListener);
+	}
 };
 
 module.go = async () => {
@@ -54,7 +74,124 @@ module.go = async () => {
 	}
 };
 
+// Comment save on reply implementation
+function addReplyListener(thing: Thing) {
+	const isMine = loggedInUser() === thing.getAuthor();
+	if (!isMine) {
+		const replyButton = thing.element.querySelector('a.access-required[data-event-action=comment]');
+		replyButton.addEventListener('click', saveCommentHandler, false);
+	}
+}
+
+function addPreviousCommentButton(thing) {
+	// Add a button to the button list to view
+	// the previous versions of the comment
+	const buttonsLists = thing.element.querySelector('ul.buttons');
+	const template = string.html`
+    <li>
+        <a href="#" class="noCtrlF">${i18n('commentSaveOnReplyButton')}</a>
+    </li>`;
+	const link = template.querySelector('a');
+	link.addEventListener('click', loadPreviousCommentHandler, false);
+	buttonsLists.appendChild(template);
+}
+
+function saveCommentHandler() {
+	const commentThing = Thing.from(this);
+	if (commentThing) {
+		saveComment(commentThing, true);
+		addSaveLinkToComment(commentThing, true);
+	}
+}
+
+function hidePreviousCommentHandler(event) {
+	event.preventDefault();
+	const commentArea = Thing.from(this);
+	if (commentArea) {
+		const md = commentArea.element.getElementsByClassName('md')[0];
+		const prev = md.getElementsByClassName('res-comment-saved-text')[0];
+		md.removeChild(prev);
+		updateButton(this, true);
+	}
+}
+
+async function loadPreviousCommentHandler(event: Event) {
+	event.preventDefault();
+	const commentThing = Thing.from(this);
+	if (commentThing) {
+		const commentElement = commentThing.element;
+		const comment = await getComment(getId(commentThing));
+
+		if (comment === null) {
+			notFound(this);
+		} else {
+			showPreviousComment(comment.comment, commentElement);
+			updateButton(this, false);
+		}
+	}
+}
+
+function notFound(button) {
+	button.removeEventListener('click', loadPreviousCommentHandler, false);
+	button.addEventListener('click', event => { event.preventDefault(); }, false);
+	const commentArea = Thing.from(button);
+	if (commentArea) {
+		const md = commentArea.element.getElementsByClassName('md')[0];
+		const div = string.html`
+            <div>
+                <p><mark>${i18n('commentSaveOnReplyNotFound')} </mark></p>
+            </div>`;
+		div.classList.add('res-comment-saved-text');
+		md.appendChild(div);
+	}
+}
+// @flow
+function showPreviousComment(comment, commentElement) {
+	// displays the comment under the current comment
+	if (comment !== null && comment !== undefined) {
+		const div = string.html`
+            <div>
+                <p><mark>${i18n('commentSaveOnReplyTitle')}: </mark></p>${string.safe(comment)}
+            </div>`;
+		div.classList.add('res-comment-saved-text');
+		const commentArea = commentElement.getElementsByClassName('md')[0];
+		commentArea.appendChild(div);
+	}
+}
+
+function updateButton(button, removed) {
+	// removed is a bool for whether or not the preview was just removed
+	// takes the <a> element when clicked
+	if (removed) {
+		button.textContent = i18n('commentSaveOnReplyButton');
+		button.removeEventListener('click', hidePreviousCommentHandler, false);
+		button.addEventListener('click', loadPreviousCommentHandler, false);
+	} else {
+		button.textContent = i18n('commentSaveOnReplyHideButton');
+		button.removeEventListener('click', loadPreviousCommentHandler, false);
+		button.addEventListener('click', hidePreviousCommentHandler, false);
+	}
+}
+
+async function getComment(id) {
+	const savedComments = await savedCommentStorage.getAll();
+	const comment = savedComments[id];
+
+	if (comment === undefined) {
+		return null;
+	} else {
+		return comment;
+	}
+}
+
+// end comment save on reply implementation
+
 function getId(thing) {
+	if (thing.isDeleted()) {
+		const reportForm = thing.element.querySelector('div.reportform');
+		const id = [...reportForm.classList].filter(c => c !== 'reportform')[0];
+		return id.split('_').slice(-1)[0];
+	}
 	return thing.getFullname().split('_').slice(-1)[0];
 }
 
@@ -77,11 +214,17 @@ const saveElement = (e => () => e().cloneNode(true))(_.once(() => {
 		</li>
 	`;
 }));
-
-function addSaveLinkToComment(thing) {
+function addSaveLinkToComment(thing, update = false) {
 	const sibling = thing.element.querySelector('ul.buttons .comment-save-button');
 	if (!sibling) return;
+	if (update) {
+		const old = sibling.nextSibling;
+		if (old && old.parentElement) old.parentElement.removeChild(old);
+	}
 	sibling.after(savedCommentIDs.has(getId(thing)) ? unsaveElement() : saveElement());
+	if (module.options.enableInlinePreviousComment.value && savedCommentIDs.has(getId(thing))) {
+		addPreviousCommentButton(thing);
+	}
 }
 
 function getCommentContent(thing) {
@@ -90,7 +233,7 @@ function getCommentContent(thing) {
 	return content.html();
 }
 
-function saveComment(thing: Thing) {
+function saveComment(thing: Thing, autoSaved = false) {
 	const id = getId(thing);
 	if (savedCommentIDs.has(id)) throw new Error('comment already saved!');
 
@@ -102,6 +245,7 @@ function saveComment(thing: Thing) {
 		username: thing.getAuthor() || '[deleted]',
 		comment: getCommentContent(thing),
 		timeSaved: new Date().toString(),
+		auto: autoSaved,
 	});
 	savedCommentIDs.add(id);
 }

--- a/lib/modules/saveComments.js
+++ b/lib/modules/saveComments.js
@@ -52,9 +52,9 @@ const savedCommentStorage = Storage.wrapBlob('RESmodules.saveComments.savedComme
 	username: string,
 	comment: string,
 	timeSaved: string,
+    tags: Array<string>,
 |} => { throw new Error('Saved comment not found'); });
 let savedCommentIDs;
-
 
 module.beforeLoad = async () => {
 	savedCommentIDs = new Set(Object.keys(await savedCommentStorage.getAll()));
@@ -68,6 +68,7 @@ module.beforeLoad = async () => {
 module.go = async () => {
 	if (savedRe.test(location.pathname)) {
 		await drawSavedComments();
+		createFilterTextInput();
 		switchTab(location.hash);
 	} else if (isPageType('profile')) {
 		addTabs({ onSavedPage: false });
@@ -99,7 +100,7 @@ function addPreviousCommentButton(thing) {
 function saveCommentHandler() {
 	const commentThing = Thing.from(this);
 	if (commentThing) {
-		saveComment(commentThing, true);
+		saveComment(commentThing);
 		addSaveLinkToComment(commentThing, true);
 	}
 }
@@ -186,6 +187,79 @@ async function getComment(id) {
 
 // end comment save on reply implementation
 
+// Comment tagging/filtering implementation
+
+function createFilterTextInput() {
+	const input = string.html`
+    <input placeholder="Filter comments">
+    `;
+	input.addEventListener('keyup', filterHandler);
+	const menuArea = document.querySelector('div.menuarea');
+	menuArea.appendChild(string.html`<div class="spacer"></div>`);
+	menuArea.appendChild(input);
+}
+
+async function filterHandler() {
+	const text = this.value;
+	const words = text.split(', ').filter((x: string) => x !== '');
+	const commentList = [...document.querySelector('div.res-saveComments-list').children];
+	const savedComments = await savedCommentStorage.getAll();
+	for (const comment of commentList) {
+		const href = comment.querySelector('a').getAttribute('href');
+		const hrefSplit = href.split('/').filter((x: string) => x !== '');
+		const id = hrefSplit[hrefSplit.length - 1];
+		const commentData = savedComments[id];
+		if (commentData !== null && commentData !== undefined) {
+			const tags = commentData.tags;
+			const existsInTags = (x: string) => tags.includes(x);
+			if (words.length === 0 || tags !== undefined && words.every(existsInTags)) {
+				comment.style.display = '';
+			} else {
+				comment.style.display = 'none';
+			}
+		}
+	}
+}
+
+function showTagInput(thing: Thing) {
+	// Called when saving a comment
+	const buttons = thing.element.querySelector('ul.buttons');
+	const input = createTagInput(getId(thing));
+	buttons.appendChild(input);
+}
+
+function createTagInput(id) {
+	const input = document.createElement('input');
+	input.setAttribute('placeholder', 'Enter tags');
+	input.addEventListener('keyup', (event: Event) => {
+		if (event.key === 'Enter') {
+			const tags = input.value.split(', ');
+			updateTags(id, tags);
+			if (input instanceof HTMLInputElement && input.parentElement instanceof HTMLElement) {
+				input.parentElement.removeChild(input);
+			}
+		}
+	});
+
+	return input;
+}
+
+async function updateTags(id, tags) {
+	const savedComment = await getComment(id);
+	if (savedComment !== null && savedComment !== undefined) {
+		savedCommentStorage.delete(id);
+		savedCommentStorage.set(id, {
+			href: savedComment.href,
+			username: savedComment.username,
+			comment: savedComment.comment,
+			timeSaved: savedComment.timeSaved,
+			tags,
+		});
+	}
+}
+
+// End comment tagging/filtering implementation
+
 function getId(thing) {
 	if (thing.isDeleted()) {
 		const reportForm = thing.element.querySelector('div.reportform');
@@ -204,6 +278,7 @@ const saveElement = (e => () => e().cloneNode(true))(_.once(() => {
 	$(document.body).on('click', 'li.saveComments', ({ currentTarget }: Event) => {
 		const thing = Thing.checkedFrom(currentTarget);
 		saveComment(thing);
+		showTagInput(thing);
 		currentTarget.remove();
 		addSaveLinkToComment(thing);
 	});
@@ -233,7 +308,7 @@ function getCommentContent(thing) {
 	return content.html();
 }
 
-function saveComment(thing: Thing, autoSaved = false) {
+function saveComment(thing: Thing) {
 	const id = getId(thing);
 	if (savedCommentIDs.has(id)) throw new Error('comment already saved!');
 
@@ -245,7 +320,7 @@ function saveComment(thing: Thing, autoSaved = false) {
 		username: thing.getAuthor() || '[deleted]',
 		comment: getCommentContent(thing),
 		timeSaved: new Date().toString(),
-		auto: autoSaved,
+		tags: [],
 	});
 	savedCommentIDs.add(id);
 }
@@ -314,19 +389,20 @@ const savedCommentsTemplate = ({ comments, keyNavTip, moduleDescription }) => st
 			</div>
 		`)}
 		<div class="res-saveComments-list">
-			${comments.map(({ id, link, username, dateTime, date, timeAgo, body }) => string._html`
+			${comments.map(({ id, link, username, dateTime, date, timeAgo, body, tags }) => string._html`
 				<div class="entry res-savedComment">
 					<div class="savedCommentHeader">
 						<a href="${link}">
 							<b>${username}</b>
 							- saved <date title="${dateTime}" datetime="${date}">${timeAgo}</date> ago
-						</a>
+						</a><span class="tags-display" id="${id}">${drawTags(tags.join(', '))}</span>
 					</div>
 					<div class="savedCommentBody md">${string.safe(body)}</div>
 					<div class="savedCommentFooter">
 						<ul class="flat-list buttons">
 							<li><a href="${link}">permalink</a></li>
 							<li><a class="unsaveComment" href="#" data-unsaveID="${id}">unsave-RES</a></li>
+                <li><a class="editTags" href="#" data-commentId="${id}">edit tags</a></li>
 						</ul>
 					</div>
 				</div>
@@ -335,11 +411,14 @@ const savedCommentsTemplate = ({ comments, keyNavTip, moduleDescription }) => st
 	</div>
 `;
 
+const drawTags = tagString => (tagString !== '') ? ` - tagged: ${tagString}` : '';
+
 async function drawSavedComments() {
 	const savedComments = await savedCommentStorage.getAll();
 
-	const comments = Object.entries(savedComments).map(([id, { comment, href, username, timeSaved }]) => {
+	const comments = Object.entries(savedComments).map(([id, { comment, href, username, timeSaved, tags }]) => {
 		const date = new Date(timeSaved);
+		const tagArray = (tags !== null && tags !== undefined) ? tags : [];
 		return {
 			id,
 			link: href,
@@ -348,6 +427,7 @@ async function drawSavedComments() {
 			dateTime: formatDateTime(date),
 			timeAgo: formatDateDiff(date),
 			body: comment.replace(/<(script|iframe|video)(.|\s)*?\/(script|iframe|video)>/g, ''),
+			tags: tagArray,
 		};
 	});
 
@@ -368,6 +448,31 @@ async function drawSavedComments() {
 		e.preventDefault();
 		unsaveComment($(e.target).attr('data-unsaveID'));
 		$(e.target).text('removed');
+	});
+	$saveCommentsContent.on('click', '.editTags', async (e: Event) => {
+		e.preventDefault();
+		const id = $(e.target).attr('data-commentId');
+		const input = createTagInput(id);
+		const comment = await getComment(id);
+		if (comment !== null && comment !== undefined && comment.tags !== null) {
+			input.value = comment.tags.join(', ');
+		}
+
+		const buttonBar: HTMLElement = (e.target.parentElement: any);
+		buttonBar.appendChild(input);
+		buttonBar.removeChild(e.target);
+		const button = e.target;
+
+		$(input).on('keyup', (e: Event) => {
+			if (e.key === 'Enter') {
+				buttonBar.appendChild(button);
+
+				const tagDisplay = document.querySelector(`.tags-display#${id}`);
+				if (e.target instanceof HTMLInputElement) {
+					tagDisplay.textContent = drawTags(e.target.value);
+				}
+			}
+		});
 	});
 }
 

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -261,6 +261,30 @@
 	"hideCommentsOnHeaderDoubleClickTitle": {
 		"message": "Hide Comments On Header Double Click"
 	},
+	"commentSaveOnReplySwitch": {
+		"message": "Enable comment save on reply"
+	},
+	"commentSaveOnReplySwitchDesc": {
+		"message": "Each time you reply to a comment a copy is saved locally"
+	},
+	"enableShowPreviousSwitch" : {
+		"message": "Add a button to every comment to show a previous version"
+	},
+	"enableShowPreviousSwitchDesc": {
+		"message": "Add a button to comments that will show a previous version of the comment (if available) inline."
+	},
+	"commentSaveOnReplyTitle": {
+		"message": "What the comment looked like when you replied"
+	},
+	"commentSaveOnReplyButton": {
+		"message": "previous version-RES"
+	},
+	"commentSaveOnReplyHideButton": {
+		"message": "(hide) previous version-RES"
+	},
+	"commentSaveOnReplyNotFound": {
+		"message": "No previous comments found."
+	},
 	"commentStyleName": {
 		"message": "Comment Style"
 	},


### PR DESCRIPTION
I implemented tagging/filtering for RES saved comments. The user is able to tag their comments after clicking the save-RES button. On the page of RES saved comments they can edit tags for each comment and filter comments by tag. This is still kind of a WIP (still needs module options and i18n keys) but I'd like some feedback if possible.

Note: I created this branch from my other branch.

Relevant issue: #4663 (I didn't get any feedback so if this feature isn't needed that's fine.)
Tested in browser: Chrome 63
