### PR TITLE
Filter newCommentCount: If not opened, use comment count in comparator

### DIFF
--- a/lib/modules/filteReddit/postCases/NewCommentCount.js
+++ b/lib/modules/filteReddit/postCases/NewCommentCount.js
@@ -9,7 +9,7 @@ export class NewCommentCount extends Case {
 	static text = 'New comment count';
 
 	static parseCriterion(input: *) { return { op: '>=', val: parseInt(input, 10) }; }
-	static async thingToCriterion(thing: *) { return String(await N.getNewCount(thing) || 0); }
+	static async thingToCriterion(thing: *) { return String((await N.hasEntry(thing) ? await N.getNewCount(thing) : thing.getCommentCount()) || 0); }
 
 	static defaultConditions = { op: '>', val: 0 };
 	static fields = ['has ', { type: 'select', options: 'COMPARISON', id: 'op' }, ' ', { type: 'number', id: 'val' }, ' new comments since last opened'];
@@ -28,7 +28,7 @@ export class NewCommentCount extends Case {
 	validator() { return parseInt(this.value.val, 10) >= 0; }
 
 	async evaluate(thing: *) {
-		const count = await N.getNewCount(thing) || 0;
+		const count = (await N.hasEntry(thing) ? await N.getNewCount(thing) : thing.getCommentCount()) || 0;
 		return numericalCompare(this.value.op, count, this.value.val);
 	}
 }


### PR DESCRIPTION
Tested in browser: Chrome 64