### PR TITLE
CommentNav tweaks

### DIFF
--- a/lib/css/modules/_commentNavigator.scss
+++ b/lib/css/modules/_commentNavigator.scss
@@ -43,11 +43,9 @@
 #REScommentNavBox {
 	clear: both;
 	float: right;
-	width: 80px;
+	width: 50px;
 	margin-top: 5px;
 	padding: 3px;
-	border: 1px solid gray;
-	background-color: #fff;
 	opacity: .3;
 	user-select: none;
 	transition: opacity .5s ease-in;

--- a/lib/css/modules/_nightMode.scss
+++ b/lib/css/modules/_nightMode.scss
@@ -706,7 +706,6 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 	.usertext-edit textarea,
 	.RESDialogSmall,
 	.c-close,
-	#REScommentNavBox,
 	#BigEditor #BigText,
 	#liveupdate-statusbar,
 	#liveupdate-statusbar.complete,
@@ -1396,6 +1395,21 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 			&-action {
 				border-bottom-color: #404040;
 			}
+		}
+	}
+
+	#REScommentNavBox {
+		#commentNavBy {
+			background-color: #707070;
+		}
+
+		#commentNavUp,
+		#commentNavDown {
+			color: #434343;
+		}
+
+		#commentNavPostCount {
+			color: #9f9f9f;
 		}
 	}
 

--- a/lib/modules/commentNavigator.js
+++ b/lib/modules/commentNavigator.js
@@ -302,9 +302,16 @@ function installEntryElement() {
 export async function updateFromSelected(selected = SelectedEntry.selectedThing) {
 	const posts = await currentPosts();
 
-	// Non-linear comment categories are not sorted by distance from top,
-	// so do not disturb the selection by automatically updating
-	if (!sortTypes[currentCategory].nonlinear && posts.includes(selected)) {
+	if (
+		posts.includes(selected) &&
+		(
+			// Non-linear comment categories are not sorted by distance from top,
+			// so do not disturb the selection by automatically updating
+			!sortTypes[currentCategory].nonlinear ||
+			// But allow change if `selected` is adjecent to `lastNavigatedTo`
+			Math.abs(posts.indexOf(lastNavigatedTo) - posts.indexOf(selected)) <= 1
+		)
+	) {
 		lastNavigatedTo = selected;
 	}
 

--- a/lib/modules/commentNavigator.js
+++ b/lib/modules/commentNavigator.js
@@ -191,7 +191,7 @@ function getCategories() {
 				title,
 			}))
 	).then(v =>
-		v.filter(entry => entry.size)
+		v.filter(({ size, selected }) => selected || size)
 	);
 }
 


### PR DESCRIPTION
Keeps the commentNav `popular` sort a little less annoying when used along with other keyboard navigation.

Makes the widget a less intrusive, especially in dark mode:
![image](https://user-images.githubusercontent.com/1748521/36153674-5e0f4f88-10cf-11e8-88b2-295121f1b05c.png)
