### PR TITLE
showImages: Make expando click snappier

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -961,6 +961,11 @@ async function checkElementForMedia(element) {
 
 	expando.button.setAttribute('data-host', mediaInfo.siteModule.moduleID);
 
+	// Start loading media early to make it snappier
+	expando.button.addEventListener('mousedown', () => {
+		if (!expando.media && expando.generateMedia) expando.generateMedia();
+	});
+
 	expando.button.addEventListener('click', () => {
 		if (expando.unlock) expando.unlock();
 		expando.toggle({ scrollOnMoveError: true });


### PR DESCRIPTION
By starting to load media on `mousedown`, the likelihood that it is ready on first paint after `click` significantly increases.

Tested in browser: Chrome 64