### PR TITLE
add "Hide all child comments" functionality to keyboard navigation

### DIFF
--- a/lib/modules/hideChildComments.js
+++ b/lib/modules/hideChildComments.js
@@ -81,7 +81,6 @@ const addToggleAllButton = _.once(thing => {
 
 	toggle(initialHide ? 'hide' : 'show');
 
-
 	li.appendChild(a);
 	menu.appendChild(li);
 });
@@ -126,7 +125,7 @@ function addToggleChildrenButton(comment) {
 }
 
 export function toggleAll() {
-	const button = document.querySelector('a.res-toggleAllChildren');
+	const button = toggleAllButton;
 	if (!button) throw new Error('Toggle all button not found');
 	button.click();
 }

--- a/lib/modules/hideChildComments.js
+++ b/lib/modules/hideChildComments.js
@@ -34,7 +34,7 @@ module.include = [
 	'comments',
 ];
 
-let initialHide;
+let initialHide, toggleAllButton;
 
 module.beforeLoad = () => {
 	initialHide = module.options.automatic.value &&
@@ -77,8 +77,10 @@ const addToggleAllButton = _.once(thing => {
 		e.preventDefault();
 		toggle(a.getAttribute('action'));
 	});
+	toggleAllButton = a;
 
 	toggle(initialHide ? 'hide' : 'show');
+
 
 	li.appendChild(a);
 	menu.appendChild(li);
@@ -121,6 +123,12 @@ function addToggleChildrenButton(comment) {
 
 	li.appendChild(a);
 	menu.appendChild(li);
+}
+
+export function toggleAll() {
+	const button = document.querySelector('a.res-toggleAllChildren');
+	if (!button) throw new Error('Toggle all button not found');
+	button.click();
 }
 
 export function toggle(thing: *) {

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -596,6 +596,16 @@ module.options = {
 			HideChildComments.toggle(selected);
 		},
 	},
+	showAllChildComments: {
+		type: 'keycode',
+		requiresModule: HideChildComments,
+		value: [67, false, false, true, false], // shift-c
+		description: 'keyboardNavShowAllChildCommentsDesc',
+		title: 'keyboardNavShowAllChildCommentsTitle',
+		callback(selected = getSelected()) {
+			HideChildComments.toggleAll(selected);
+		},
+	},
 	followPermalink: {
 		type: 'keycode',
 		include: ['comments', 'commentsLinklist', 'inbox'],

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -602,8 +602,8 @@ module.options = {
 		value: [67, false, false, true, false], // shift-c
 		description: 'keyboardNavShowAllChildCommentsDesc',
 		title: 'keyboardNavShowAllChildCommentsTitle',
-		callback(selected = getSelected()) {
-			HideChildComments.toggleAll(selected);
+		callback() {
+			HideChildComments.toggleAll();
 		},
 	},
 	followPermalink: {

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -765,6 +765,12 @@
 	"keyboardNavShowChildCommentsDesc": {
 		"message": "Show/hide the child comments tree (comment pages only)."
 	},
+	"keyboardNavShowAllChildCommentsTitle": {
+		"message": "Show all child comments"
+	},
+	"keyboardNavShowAllChildCommentsDesc": {
+		"message": "Show/hide all child comments on the page (comment pages only)."
+	},
 	"keyboardNavFollowPermalinkTitle": {
 		"message": "Follow Permalink"
 	},


### PR DESCRIPTION
uses shift-C as the command


Relevant issue: fixes #4677 
Tested in browser: Chrome
