### PR TITLE
showImages: Fix unloading media breaking resize events

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -645,7 +645,7 @@ function lazyUnload(media: ExpandoMediaElement, keepLoaded: boolean) {
 
 	if (/*:: media.restore && */ keepLoaded && media.state === mediaStates.UNLOADED) {
 		media.restore();
-		media.removeEventListener('mediaResize', stopEventPropagation);
+		media.removeEventListener('mediaResize', stopEventPropagation, true);
 	} else if (/*:: media.unload && */ !keepLoaded && media.state !== mediaStates.UNLOADED) {
 		media.unload();
 		media.addEventListener('mediaResize', stopEventPropagation, true);


### PR DESCRIPTION
The `stopEventPropagation` handler was not removed when restoring media.