### PR TITLE
Hide pinned reddit videos

### DIFF
--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -30,6 +30,11 @@ img {
 	}
 }
 
+// Hide pinned Reddit-hosted videos
+.res-showImages-hidePinnedRedditVideos {
+	.pinnable-content.pinned { display: none; }
+}
+
 // Place inline expandos so that they don't impact the line height
 .res-freetext-expando {
 	display: inline-block;

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -433,6 +433,13 @@ module.options = {
 		value: true,
 		description: 'showImagesAutoplayVideoDesc',
 	},
+	hidePinnedRedditVideos: {
+		title: 'showImagesHidePinnedRedditVideosTitle',
+		type: 'boolean',
+		value: false,
+		description: 'showImagesHidePinnedRedditVideosDesc',
+		bodyClass: true,
+	},
 	...Object.values(siteModules).reduce((options, siteModule) => {
 		// Ignore default
 		if (genericHosts.includes(siteModule)) return options;

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -4268,6 +4268,12 @@
 	"showImagesAutoplayVideoDesc": {
 		"message": "Autoplay inline videos."
 	},
+	"showImagesHidePinnedRedditVideosTitle": {
+		"message": "Hide pinned reddit videos"
+	},
+	"showImagesHidePinnedRedditVideosDesc": {
+		"message": "Hide pinned Reddit-hosted videos when scrolling on comments page."
+	},
 	"showImagesHostToggleDesc": {
 		"message": "Display expandos for this host."
 	},


### PR DESCRIPTION
Option added to the showImages module to hide pinned Reddit-hosted videos on comment pages. 

Relevant issue: #4644
Tested in browser: Firefox 58
