### PR TITLE
bin/travisDeploy: Use `set -e` to exit on error

### DIFF
--- a/build/travisDeploy.sh
+++ b/build/travisDeploy.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
+set -e
 
 # Travis doesn't allow specifying a list of scripts for deployment as it does elsewhere,
 # so emulate that behaviour here.
 
-status=0
-
-yarn run deploy || status=1
-yarn run deploy-changelog || status=1
-
-exit $status
+yarn run deploy
+yarn run deploy-changelog


### PR DESCRIPTION
We probably don't need the changelog if the deploy failed.