### PR TITLE
eslint: Mark as root config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+	"root": true,
 	"parser": "babel-eslint",
 	"plugins": [
 		"flowtype",


### PR DESCRIPTION
This prevents ESLint from looking for `eslintrc` files above this directory.