### PR TITLE
Fix right margin on hidden user names (round 2)

### DIFF
--- a/lib/modules/usernameHider.js
+++ b/lib/modules/usernameHider.js
@@ -136,6 +136,9 @@ const hideUsername = _.memoize((user = loggedInUser()) => {
 			background-color: inherit;
 			border-radius: inherit;
 			padding: inherit;
+		}
+
+		a.author${userHref}::after {
 			margin-right: 0.5em;
 		}
 


### PR DESCRIPTION
I messed up a little with #4446: I actually added a margin to some instances of the hidden user name where there shouldn't be one (like in the top header). I just moved the margin rule out so that it only affects `a.author` — this seems to fix the main thing i was worried about before, without breaking anything else.

Tested in browser: Firefox 59
