### PR TITLE
Disable voting keyboard shortcuts on archived posts

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1141,7 +1141,9 @@ function followLinkAndComments(background = false, selected = getSelected()) {
 function vote(way: 'downmod' | 'upmod', preventToggle = false, selected = getSelected()) {
 	const button = assertElement(way === 'upmod' ? selected.getUpvoteButton() : selected.getDownvoteButton());
 
-	if (NoParticipation.isVotingBlocked()) {
+	if (button.classList.contains('archived')) {
+		// do nothing
+	} else if (NoParticipation.isVotingBlocked()) {
 		NoParticipation.notifyNoVote();
 	} else if (!preventToggle || !button.classList.contains(way)) {
 		click(button);


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: https://www.reddit.com/r/Enhancement/comments/800v14/how_to_disable_upvote_shortcut_on_archived_posts/
Tested in browser: Chrome 66