### PR TITLE
WIP: Add Greasemonkey target

### DIFF
--- a/greasemonkey/header.js
+++ b/greasemonkey/header.js
@@ -1,0 +1,10 @@
+// ==UserScript==
+// @name        Reddit Enhancement Suite
+// @namespace	  https://redditenhancementsuite.com/
+// @description	community-driven unofficial browser extension for reddit
+// @include http://reddit.com/*
+// @include http://*.reddit.com/*
+// @include https://reddit.com/*
+// @include https://*.reddit.com/*
+// ==/UserScript==
+

--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import '../css/res.scss';
 import { RES_DISABLED_KEY } from '../constants/sessionStorage';
 import { _loadI18n } from '../environment';
 import {

--- a/lib/core/modules/modules.js
+++ b/lib/core/modules/modules.js
@@ -30,7 +30,8 @@ if (process.env.NODE_ENV === 'development') {
 }
 
 export async function _loadModulePrefs() {
-	const storedPrefs = await modulePrefsStorage.getAll();
+	// TODO greasemonkey: why was this change necessary? Our storage shim is wrong
+	const storedPrefs = (await modulePrefsStorage.getAll()) || {};
 
 	for (const [id, module] of Object.entries(modules)) {
 		if (module.alwaysEnabled) {

--- a/lib/environment/foreground/i18n.js
+++ b/lib/environment/foreground/i18n.js
@@ -4,6 +4,7 @@ import buildToken from 'exec-loader!../../../build/buildToken'; // eslint-disabl
 import { CACHED_LANG_KEY, CACHED_MESSAGES_KEY, CACHED_MESSAGES_TOKEN_KEY } from '../../constants/localStorage';
 import { rawLocale } from '../../utils/localization';
 import { sendMessage } from './messaging';
+import { getLocaleDictionary } from '../../../locales';
 
 let messages;
 
@@ -25,7 +26,8 @@ export async function _loadI18n(): Promise<void> {
 	// slow path: wait for background page to send new locales
 	// will be hit the first (ever) pageload on a new domain
 	// or after clearing localStorage
-	messages = await sendMessage('i18n', rawLocale());
+	// TODO greasemonkey: only use the direct path for greasemonkey
+	messages = getLocaleDictionary(rawLocale());
 
 	try { // Fails if remaining localStorage space is insufficient
 		localStorage.setItem(CACHED_MESSAGES_KEY, JSON.stringify(messages));

--- a/lib/environment/foreground/id.js
+++ b/lib/environment/foreground/id.js
@@ -1,5 +1,9 @@
 /* @flow */
 
 export function getExtensionId(): string {
-	return chrome.runtime.id;
+	if (typeof chrome !== "undefined") {
+		return chrome.runtime.id;
+	} else {
+		return "unknown";
+	}
 }

--- a/lib/environment/foreground/messaging.js
+++ b/lib/environment/foreground/messaging.js
@@ -3,7 +3,15 @@
 import { createMessageHandler } from '../utils/messaging';
 import { apiToPromise } from '../utils/api';
 
-const _sendMessage = apiToPromise(chrome.runtime.sendMessage);
+const _sendMessage = (() => {
+	if (typeof chrome === "undefined") {
+		return (...args) => {
+			console.log("sendMessage", args);
+			return new Promise((resolve, reject) => reject("not implemented"));
+		};
+	}
+	return apiToPromise(chrome.runtime.sendMessage);
+})();
 
 const {
 	_handleMessage,
@@ -11,7 +19,10 @@ const {
 	addListener,
 } = createMessageHandler(obj => _sendMessage(obj));
 
-chrome.runtime.onMessage.addListener((obj, sender, sendResponse) => _handleMessage(obj, sendResponse));
+if (typeof chrome !== "undefined") {
+	chrome.runtime.onMessage.addListener((obj, sender, sendResponse) =>
+		_handleMessage(obj, sendResponse));
+}
 
 export {
 	sendMessage,

--- a/lib/environment/foreground/privateBrowsing.js
+++ b/lib/environment/foreground/privateBrowsing.js
@@ -1,5 +1,5 @@
 /* @flow */
 
 export function isPrivateBrowsing(): boolean {
-	return chrome.extension.inIncognitoContext;
+	return chrome && chrome.extension.inIncognitoContext || false;
 }

--- a/lib/environment/foreground/storage.js
+++ b/lib/environment/foreground/storage.js
@@ -6,12 +6,49 @@ import { keyedMutex } from '../../utils/async';
 import { apiToPromise } from '../utils/api';
 import { sendMessage } from './messaging';
 
-const __set = apiToPromise((items, callback) => chrome.storage.local.set(items, callback));
+const __set = apiToPromise((items, callback) => {
+	if (typeof chrome !== "undefined") {
+		return chrome.storage.local.set(items, callback);
+	} else {
+		Object.keys(items).map(key => {
+			localStorage.setItem(key, JSON.stringify(items[key]));
+		});
+		callback();
+	}
+});
 const _set = (key, value) => __set({ [key]: value });
-const __get = apiToPromise((keys, callback) => chrome.storage.local.get(keys, callback));
+
+const __get = apiToPromise((keys, callback) => {
+	if (typeof chrome !== "undefined") {
+		return chrome.storage.local.get(keys, callback);
+	} else {
+		callback(Object.keys(keys)
+		 .reduce((a, i) => {
+			 let val = localStorage.getItem(i);
+			 val = val ? JSON.parse(val) : val;
+			 return Object.assign(a, { [i]: val });
+		 }));
+	}
+});
 const _get = async (key, defaultValue = null) => (await __get({ [key]: defaultValue }))[key];
-const _delete = apiToPromise((keys, callback) => chrome.storage.local.remove(keys, callback));
-const _clear = apiToPromise(callback => chrome.storage.local.clear(callback));
+
+const _delete = apiToPromise((keys, callback) => {
+	if (typeof chrome !== "undefined") {
+		return chrome.storage.local.remove(keys, callback);
+	} else {
+		keys.forEach(key => localStorage.removeItem(key));
+		callback();
+	}
+});
+
+const _clear = apiToPromise(callback => {
+	if (typeof chrome !== "undefined") {
+		return chrome.storage.local.clear(callback);
+	} else {
+		localStorage.clear();
+		callback();
+	}
+});
 
 const withLockOn = keyedMutex(<T>(key: string, fn: () => T): T => fn());
 
@@ -166,7 +203,9 @@ class PrefixWrapper<T> {
 	}
 
 	get(key: string): Promise<T> {
-		return get(this._keyGen(key)).then(val => (val === null ? this._default() : val));
+		// TODO greasemonkey: figure this bit out
+		//return get(this._keyGen(key)).then(val => (val === null ? this._default() : val));
+		return get(this._keyGen(key)).then(val => (!val ? this._default() : val));
 	}
 
 	getNullable(key: string): Promise<T | null> {

--- a/lib/environment/utils/api.js
+++ b/lib/environment/utils/api.js
@@ -4,7 +4,7 @@ export function apiToPromise(func: (...args: mixed[]) => void): (...args: mixed[
 	return (...args) =>
 		new Promise((resolve, reject) =>
 			func(...args, (...results) => {
-				if (chrome.runtime.lastError) {
+				if (typeof chrome !== "undefined" && chrome.runtime.lastError) {
 					reject(new Error(chrome.runtime.lastError.message));
 				} else {
 					resolve(results.length > 1 ? results : results[0]);

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "manifoldjs": "0.7.6",
     "nightwatch": "0.9.19",
     "node-sass": "4.7.2",
+    "null-loader": "^0.1.1",
     "nyc": "11.4.1",
     "opera-extension-deploy": "0.2.2",
     "postcss-loader": "2.1.0",
@@ -129,6 +130,7 @@
     "semver": "5.5.0",
     "sibling-loader": "1.2.0",
     "spawn-loader": "4.0.0",
+    "style-loader": "^0.20.2",
     "url-loader": "0.6.2",
     "webpack": "3.10.0",
     "zip-webpack-plugin": "2.1.0"

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -32,7 +32,7 @@ const browserConfig = {
 		target: 'firefox',
 		entry: 'firefox/manifest.json',
 		output: 'firefox',
-		sourcemap: false,
+		devtool: false,
 	},
 	firefoxbeta: {
 		target: 'firefox',
@@ -43,7 +43,7 @@ const browserConfig = {
 		target: 'greasemonkey',
 		entry: 'lib/foreground.entry.js',
 		output: 'greasemonkey',
-		sourcemap: 'inline-source-map',
+		devtool: 'inline-source-map',
 	},
 };
 
@@ -69,8 +69,8 @@ export default (env = {}) => {
 			filename: path.basename(conf.entry),
 		},
 		devtool: (() => {
+			if (typeof conf.devtool !== undefined) return conf.devtool;
 			if (!isProduction) return 'cheap-source-map';
-			if (typeof conf.sourcemap !== undefined) return conf.sourcemap;
 			return 'source-map';
 		})(),
 		bail: isProduction,


### PR DESCRIPTION
This isn't done, but I'm opening it up for discussion and feedback on the overall approach.

As of the latest release, [qutebrowser](https://github.com/qutebrowser/qutebrowser) now [supports Greasemonkey userscripts](https://github.com/qutebrowser/qutebrowser/pull/3040). Several other non-mainstream web browsers support userscripts as well. I thought it would be fun to try and port RES *back* to a Greasemonkey script.

Greasemonkey support was removed back in 2014 (#714) and I'm sure you guys aren't too eager to see it return. However, since the move to webpack, supporting Greasemonkey is much easier and more maintainable. I'd be happy to field support requests on this front, or we can call it officially unsupported (and maybe express that fact in the UI somewhere?).

Status: loads and many features work. There are some TODOs littered throughout, but the main ones are:

* [ ] Make locale loading use the old approach on non-Greasemonkey targets
* [ ] Figure out why my storage shim behaves differently from the Chrome version
* [ ] Finish shimming out background actions with browser equivalents (or no-ops)
* [ ] Document the limitations of the Greasemonkey target
* [ ] Fix source maps (they're messed up when the greasemonkey header is patched in, other targets still work)
* [ ] Test everything

Usage:

```shell
npm start greasemonkey # for development
npm run build greasemonkey # for actual use
ln -s $(pwd)/dist/greasemonkey/foreground.entry.js ~/.local/share/qutebrowser/greasemonkey/res.js
```

![](https://sr.ht/85u8.png)