### PR TITLE
showImages clean-up

### DIFF
--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -604,7 +604,7 @@ body:not(.res-showImages-displayImageCaptions) {
 }
 
 // Extras for certain text expando's
-.res-media-host-wikipedia {
+.res-expando-box[data-host='wikipedia'] {
 	.md {
 		padding: 5px;
 		max-width: none;

--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -313,7 +313,7 @@ function hideLink(clickedLink, action = clickedLink.getAttribute('action')) {
 	if (action === 'hide') {
 		// Native expandos does not know that the post is being hidden, so collapse them manually
 		const expando = Expando.getEntryExpandoFrom(thing);
-		if (expando && expando.getTypes().includes('native')) expando.collapse();
+		if (expando && expando.types.includes('native')) expando.collapse();
 
 		if (timeout === null) $(thing.element).hide();
 		else hideTimer.set(clickedLink, setTimeout(() => $(thing.element).fadeOut(300), timeout));

--- a/lib/modules/filteReddit/postCases/Expando.js
+++ b/lib/modules/filteReddit/postCases/Expando.js
@@ -10,7 +10,7 @@ export class Expando extends Case {
 	static parseCriterion(input: string) { return { types: input.split(/[\s|]/).filter(Boolean) }; }
 	static thingToCriterion(thing: *) {
 		const expando = thing.isPost() ? E.getEntryExpandoFrom(thing) : E.getTextExpandosFrom(thing)[0];
-		return expando && expando.getTypes().join(' & ') || '';
+		return expando && expando.types.join(' & ') || '';
 	}
 
 	static defaultConditions = { types: [] };
@@ -26,9 +26,9 @@ export class Expando extends Case {
 	validator() { return ShowImages.matchesTypes(this.value.types); }
 
 	_matches(e: ?E) {
-		// Treat non-loaded expando as non-existing
-		if (!e || !e.isLoaded()) return false;
-		return ShowImages.matchesTypes(this.value.types, e.getTypes());
+		// Treat non-ready expando as non-existing
+		if (!e || !e.ready) return false;
+		return ShowImages.matchesTypes(this.value.types, e.types);
 	}
 
 	evaluate(thing: *) {

--- a/lib/modules/hosts/twitter.js
+++ b/lib/modules/hosts/twitter.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import _ from 'lodash';
 import { $ } from '../../vendor';
 import { Host } from '../../core/host';
 import { ajax } from '../../environment';
@@ -28,7 +29,7 @@ export default new Host('twitter', {
 			muted: true,
 			expandoClass: 'selftext',
 			generate: () => $dummy[0],
-			onAttach: () => { $dummy.replaceWith(html); },
+			onAttach: _.once(() => { $dummy.replaceWith(html); }),
 		};
 	},
 });

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -2013,7 +2013,7 @@ class Video extends Media {
 		this.video.addEventListener('pause', () => { this.element.classList.remove('playing'); });
 		this.video.addEventListener('play', () => { this.element.classList.add('playing'); });
 
-		this.video.addEventListener('loadedmetadata', () => { if (time !== this.video.currentTime) this.video.currentTime = this.time; });
+		this.video.addEventListener('loadedmetadata', () => { if (this.time !== this.video.currentTime) this.video.currentTime = this.time; });
 		this.video.playbackRate = playbackRate;
 
 		// Ignore events which might be meant for controls

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1540,7 +1540,8 @@ class Generic extends Media {
 
 		this.onAttach = options.onAttach;
 
-		this.element = options.generate();
+		this.element = document.createElement('div');
+		this.element.appendChild(options.generate());
 	}
 
 	// Always remove content, in case it contains audio or other unwanted things

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -66,7 +66,6 @@ import {
 	expandos,
 	primaryExpandos,
 } from './showImages/expando';
-import type { ExpandoMediaElement } from './showImages/expando';
 import __hosts from 'sibling-loader?import=default!./hosts/default';
 
 const siteModules: { [string]: Host<any, any> } = flow(
@@ -567,12 +566,6 @@ const modulesForHostname = _.memoize(hostname => {
 
 const deferredLinks: Map<HTMLElement, () => void> = new Map();
 
-const mediaStates = {
-	NONE: 0,
-	LOADED: 1,
-	UNLOADED: 2,
-};
-
 const checkDeferredLinks = frameThrottle(() => {
 	for (const [link, complete] of deferredLinks) {
 		if (!shouldLinkBeDeferred(link)) complete();
@@ -596,6 +589,7 @@ export const thingExpandoBuildListeners: * = $.Callbacks('unique'); // eslint-di
  */
 function enableConserveMemory() {
 	// Making elements fullscreen makes the intersectionobserver report that nothing is intersecting
+	// $FlowIssue `mozFullScreenElement` is not recognized
 	const fullscreenActive = () => !!(document.fullscreenElement || document.webkitFullscreenElement || document.mozFullScreenElement: any);
 
 	const rootMargin = `${100 * (parseInt(module.options.bufferScreens.value, 10) || 2)}%`;
@@ -604,8 +598,8 @@ function enableConserveMemory() {
 	const ioMedia = new IntersectionObserver(entries => {
 		if (fullscreenActive()) return;
 		for (const entry of entries) {
-			const expando = downcast(mediaMap.get(entry.target), Expando);
-			if (expando.open && expando.media) lazyUnload(expando.media, entry.isIntersecting);
+			const { open, media } = downcast(mediaMap.get(entry.target), Expando);
+			if (open && media) lazyUnload(media, entry.isIntersecting);
 		}
 	}, { rootMargin });
 
@@ -614,11 +608,10 @@ function enableConserveMemory() {
 		if (fullscreenActive()) return;
 		for (const entry of entries) {
 			const expando = downcast(buttonMap.get(entry.target), Expando);
-			if (!entry.isIntersecting && !expando.open) {
-				// $FlowIssue fixed for future Flow release
-				ioMedia.unobserve(expando.media);
-				// $FlowIssue fixed for future Flow release
-				ioButton.unobserve(expando.button);
+			const { media, open, button } = expando;
+			if (!entry.isIntersecting && !open) {
+				if (media) ioMedia.unobserve(media.element);
+				ioButton.unobserve(button);
 				expando.empty();
 			}
 		}
@@ -633,13 +626,14 @@ function enableConserveMemory() {
 
 		for (const expando of activeExpandos) {
 			if (expando.isAttached()) {
-				if (expando.media) {
-					if (expando.open) {
-						ioMedia.observe(expando.media);
-						mediaMap.set(expando.media, expando);
+				const { media, open, button } = expando;
+				if (media) {
+					if (open) {
+						ioMedia.observe(media.element);
+						mediaMap.set(media.element, expando);
 					} else {
-						ioButton.observe(expando.button);
-						buttonMap.set(expando.button, expando);
+						ioButton.observe(button);
+						buttonMap.set(button, expando);
 					}
 				}
 			} else {
@@ -652,15 +646,15 @@ function enableConserveMemory() {
 
 const stopEventPropagation = e => { e.stopImmediatePropagation(); };
 
-function lazyUnload(media: ExpandoMediaElement, keepLoaded: boolean) {
-	if (!media.unload || !media.restore) return;
-
-	if (/*:: media.restore && */ keepLoaded && media.state === mediaStates.UNLOADED) {
+function lazyUnload(media: Media, keepLoaded: boolean) {
+	if (keepLoaded && media.state === 'unloaded') {
 		media.restore();
-		media.removeEventListener('mediaResize', stopEventPropagation, true);
-	} else if (/*:: media.unload && */ !keepLoaded && media.state !== mediaStates.UNLOADED) {
+		media.element.removeEventListener('mediaResize', stopEventPropagation, true);
+		media.state = 'loaded';
+	} else if (!keepLoaded && media.state === 'loaded') {
 		media.unload();
-		media.addEventListener('mediaResize', stopEventPropagation, true);
+		media.element.addEventListener('mediaResize', stopEventPropagation, true);
+		media.state = 'unloaded';
 	}
 }
 
@@ -1096,17 +1090,17 @@ const retrieveExpandoOptions = _.memoize(async (thing, { siteModule, detectResul
 		mediaOptions: {
 			href,
 			muted: mediaOptions.type === 'GALLERY' ? mediaOptions.src.every(isMuted) : isMuted(mediaOptions),
-			moduleID: (siteModule && siteModule.moduleID) ? siteModule.moduleID : 'unknown',
+			moduleID: siteModule.moduleID,
 			buttonInfo: getMediaButtonInfo(mediaOptions),
 			...mediaOptions,
 		},
 		generateMedia() {
-			const element = generateMedia(mediaOptions, { href });
+			const media = generateMedia(mediaOptions, { href });
 			if (module.options.crossposts.value === 'withMetadata' && thing && thing.isCrosspost()) {
-				element.prepend(crosspostMetadataTemplate(thing.element.dataset));
+				media.element.prepend(crosspostMetadataTemplate(thing.element.dataset));
 			}
-			if (attribution) addSiteAttribution(siteModule, element);
-			return element;
+			if (attribution) addSiteAttribution(siteModule, media);
+			return media;
 		},
 		onMediaAttach() {
 			trackLoad();
@@ -1193,355 +1187,392 @@ function generateMedia(options: ExpandoMedia, context: {| href: string |}) {
 	if (options.credits) options.credits = $span.safeHtml(options.credits).html();
 	if (options.caption) options.caption = $span.safeHtml(options.caption).html();
 
-	let element;
+	let media;
 
 	switch (options.type) {
 		case 'GALLERY':
-			element = generateGallery(options, context);
+			media = new Gallery(options, context);
 			break;
 		case 'IMAGE':
-			element = generateImage(options, context);
+			media = new Image(options, context);
 			break;
 		case 'TEXT':
-			element = generateText(options);
+			media = new Text(options);
 			break;
 		case 'IFRAME':
-			element = generateIframe(options);
+			media = new Iframe(options);
 			break;
 		case 'VIDEO':
-			element = generateVideo(options, context);
+			media = new Video(options, context);
 			break;
 		case 'AUDIO':
-			element = generateAudio(options);
+			media = new Audio(options);
 			break;
 		case 'GENERIC_EXPANDO':
-			element = generateGeneric(options);
+			media = new Generic(options);
 			break;
 		default:
 			throw new Error(`Unreachable: invalid media type ${options.type}`);
 	}
 
-	return element;
+	return media;
 }
 
-function generateGallery(options: GalleryMedia, context) {
-	const element: ExpandoMediaElement = (galleryTemplate({
-		title: options.title,
-		caption: options.caption,
-		credits: options.credits,
-		src: options.src,
-	}): any);
+export class Media {
+	element: HTMLElement;
+	state: 'loaded' | 'unloaded' = 'loaded';
 
-	const piecesContainer = element.querySelector('.res-gallery-pieces');
-	const individualCtrl = element.querySelector('.res-gallery-individual-controls');
-	const ctrlPrev = individualCtrl.querySelector('.res-gallery-previous');
-	const ctrlNext = individualCtrl.querySelector('.res-gallery-next');
-	const msgPosition = individualCtrl.querySelector('.res-gallery-position');
-	const ctrlToFilmstrip = individualCtrl.querySelector('.res-gallery-to-filmstrip');
-	const ctrlConcurrentIncrease = element.querySelector('.res-gallery-increase-concurrent');
+	ready: ?Promise<void>;
 
-	const preloadCount = parseInt(module.options.galleryPreloadCount.value, 10) || 0;
+	expand(): void | Promise<void> {}
+	collapse(): ?boolean {} // Return `true` if media should be deleted
 
-	const filmstripLoadIncrement = parseInt(module.options.filmstripLoadIncrement.value, 10) || Infinity;
-	const slideshowWhenLargerThan = parseInt(module.options.useSlideshowWhenLargerThan.value, 10) || Infinity;
-	const filmstripActive = module.options.galleryAsFilmstrip.value &&
-		options.src.length < slideshowWhenLargerThan;
+	unload(): void {}
+	restore(): void {}
+}
 
-	const pieces: Array<{
-		generateMedia: () => ExpandoMediaElement,
-		media: ?ExpandoMediaElement,
-	}> = options.src.map(src => ({
-		generateMedia: () => generateMedia(src, context),
-		media: null,
-	}));
-	let lastRevealedPiece = null;
+class Gallery extends Media {
+	filmstripLoadIncrement = parseInt(module.options.filmstripLoadIncrement.value, 10) || Infinity;
+	preloadCount = parseInt(module.options.galleryPreloadCount.value, 10) || 0;
 
-	const rememberResizeWidth = module.options.galleryRememberWidth.value && !filmstripActive;
-	let lastResizedWidth;
+	individualCtrl;
+	msgPosition;
+	ctrlToFilmstrip;
+	ctrlConcurrentIncrease;
 
-	function rememberWidth(piece) {
-		const resizedElement = piece.media && piece.media.querySelector('.res-media-zoomable');
+	pieces: Array<{
+		generateMedia: () => Media,
+		media: ?Media,
+		wrapper: HTMLElement,
+	}>;
+
+	lastRevealedPiece = null;
+	filmstripActive: boolean;
+	rememberResizeWidth: boolean;
+	lastResizedWidth: number;
+
+	constructor(options: GalleryMedia, context) {
+		super();
+
+		this.element = galleryTemplate({
+			title: options.title,
+			caption: options.caption,
+			credits: options.credits,
+			src: options.src,
+		});
+
+		const piecesContainer = this.element.querySelector('.res-gallery-pieces');
+		this.individualCtrl = this.element.querySelector('.res-gallery-individual-controls');
+		const ctrlPrev = this.individualCtrl.querySelector('.res-gallery-previous');
+		const ctrlNext = this.individualCtrl.querySelector('.res-gallery-next');
+		this.msgPosition = this.individualCtrl.querySelector('.res-gallery-position');
+		this.ctrlToFilmstrip = this.individualCtrl.querySelector('.res-gallery-to-filmstrip');
+		this.ctrlConcurrentIncrease = this.element.querySelector('.res-gallery-increase-concurrent');
+
+		this.pieces = options.src.map(src => ({
+			generateMedia: () => generateMedia(src, context),
+			media: null,
+			wrapper: document.createElement('div'),
+		}));
+		piecesContainer.append(...this.pieces.map(({ wrapper }) => wrapper));
+
+		const slideshowWhenLargerThan = parseInt(module.options.useSlideshowWhenLargerThan.value, 10) || Infinity;
+		this.filmstripActive = module.options.galleryAsFilmstrip.value && this.pieces.length < slideshowWhenLargerThan;
+
+		if (this.filmstripActive || this.pieces.length === 1) {
+			this.ready = this.expandFilmstrip();
+			this.ctrlConcurrentIncrease.addEventListener('click', () => this.expandFilmstrip());
+		} else {
+			this.element.classList.add('res-gallery-slideshow');
+			this.ready = this.changeSlideshowPiece(0);
+			ctrlPrev.addEventListener('click', () => { this.changeSlideshowPiece(-1); });
+			ctrlNext.addEventListener('click', () => { this.changeSlideshowPiece(1); });
+
+			waitForEvent(this.ctrlToFilmstrip, 'click').then(() => {
+				this.expandFilmstrip();
+				this.ctrlConcurrentIncrease.addEventListener('click', () => this.expandFilmstrip());
+				this.element.classList.remove('res-gallery-slideshow');
+			});
+		}
+	}
+
+	shouldRememberResizeWidth() {
+		return module.options.galleryRememberWidth.value && !this.filmstripActive;
+	}
+
+	rememberWidth(piece) {
+		const resizedElement = piece.media && piece.media.element.querySelector('.res-media-zoomable');
 		// Only resized elements have style.width
 		const resizedWidth = resizedElement && parseInt(resizedElement.style.width, 10);
-		if (resizedWidth) lastResizedWidth = resizedWidth;
+		if (resizedWidth) this.lastResizedWidth = resizedWidth;
 	}
 
-	function restoreWidth(piece) {
-		if (!lastResizedWidth) return;
-		const resizeElement = piece.media && piece.media.querySelector('.res-media-zoomable');
-		if (resizeElement) resizeMedia(resizeElement, lastResizedWidth);
+	restoreWidth(piece) {
+		if (!this.lastResizedWidth) return;
+		const resizeElement = piece.media && piece.media.element.querySelector('.res-media-zoomable');
+		if (resizeElement) resizeMedia(resizeElement, this.lastResizedWidth);
 	}
 
-	function revealPiece(piece) {
-		if (rememberResizeWidth && lastRevealedPiece) rememberWidth(lastRevealedPiece);
-		lastRevealedPiece = piece;
+	revealPiece(piece) {
+		if (this.shouldRememberResizeWidth() && this.lastRevealedPiece) this.rememberWidth(this.lastRevealedPiece);
+		this.lastRevealedPiece = piece;
 
 		piece.media = piece.media || piece.generateMedia();
-		const { media } = piece;
-		if (!media.parentElement) {
-			const block = document.createElement('div');
-			block.appendChild(media);
-			piecesContainer.appendChild(block);
-		}
-		(media.parentElement: any).hidden = false;
-		if (rememberResizeWidth) restoreWidth(piece);
-		if (media.expand) media.expand();
+		const { media, wrapper } = piece;
+		if (!wrapper.contains(media.element)) wrapper.appendChild(media.element);
+		wrapper.hidden = false;
+		if (this.shouldRememberResizeWidth()) this.restoreWidth(piece);
+		media.expand();
 	}
 
-	function preloadAhead() {
-		const preloadFrom = pieces.indexOf((lastRevealedPiece: any));
-		const preloadTo = Math.min(preloadFrom + preloadCount + 1, pieces.length);
+	preloadAhead() {
+		const preloadFrom = this.pieces.indexOf(this.lastRevealedPiece);
+		const preloadTo = Math.min(preloadFrom + this.preloadCount + 1, this.pieces.length);
 
-		return preloadMedia(pieces.slice(preloadFrom, preloadTo));
+		return preloadMedia(this.pieces.slice(preloadFrom, preloadTo));
 	}
 
-	async function expandFilmstrip() {
-		const revealFrom = lastRevealedPiece ? pieces.indexOf(lastRevealedPiece) : 0;
-		const revealTo = Math.min(revealFrom + filmstripLoadIncrement, pieces.length);
+	async expandFilmstrip() {
+		const revealFrom = this.lastRevealedPiece ? this.pieces.indexOf(this.lastRevealedPiece) : 0;
+		const revealTo = Math.min(revealFrom + this.filmstripLoadIncrement, this.pieces.length);
 
-		ctrlConcurrentIncrease.hidden = true;
+		this.ctrlConcurrentIncrease.hidden = true;
 
 		// reveal new pieces
-		await forEachSeq(pieces.slice(revealFrom, revealTo), piece => {
-			revealPiece(piece);
+		await forEachSeq(this.pieces.slice(revealFrom, revealTo), piece => {
+			this.revealPiece(piece);
 			return piece.media && piece.media.ready;
 		});
 
-		if (revealTo < pieces.length) {
-			ctrlConcurrentIncrease.innerText = `Show next ${Math.min(filmstripLoadIncrement, pieces.length - revealTo)} pieces`;
-			ctrlConcurrentIncrease.hidden = false;
+		if (revealTo < this.pieces.length) {
+			this.ctrlConcurrentIncrease.innerText = `Show next ${Math.min(this.filmstripLoadIncrement, this.pieces.length - revealTo)} pieces`;
+			this.ctrlConcurrentIncrease.hidden = false;
 		}
 
-		return preloadAhead();
+		return this.preloadAhead();
 	}
 
-	function changeSlideshowPiece(step) {
-		const lastRevealedPieceIndex = lastRevealedPiece ? pieces.indexOf(lastRevealedPiece) : 0;
-		const previousMedia = lastRevealedPiece && lastRevealedPiece.media;
+	changeSlideshowPiece(step) {
+		const previous = this.lastRevealedPiece;
+		const previousIndex = previous ? this.pieces.indexOf(previous) : 0;
 
-		let newIndex = lastRevealedPieceIndex + step;
+		let newIndex = previousIndex + step;
 		// Allow wrap-around
-		newIndex = positiveModulo(newIndex, pieces.length);
+		newIndex = positiveModulo(newIndex, this.pieces.length);
 
-		individualCtrl.setAttribute('first-piece', String(newIndex === 0));
-		individualCtrl.setAttribute('last-piece', String(newIndex === pieces.length - 1));
-		msgPosition.innerText = String(newIndex + 1);
+		this.individualCtrl.setAttribute('first-piece', String(newIndex === 0));
+		this.individualCtrl.setAttribute('last-piece', String(newIndex === this.pieces.length - 1));
+		this.msgPosition.innerText = String(newIndex + 1);
 
-		revealPiece(pieces[newIndex]);
+		this.revealPiece(this.pieces[newIndex]);
 
-		if (previousMedia) {
-			const removeInstead = previousMedia.collapse && previousMedia.collapse();
+		if (previous) {
+			const { media, wrapper } = previous;
+			if (!media) throw new Error();
+			const removeInstead = media.collapse();
 			if (removeInstead) {
-				previousMedia.remove();
+				media.element.remove();
 			} else {
-				(previousMedia.parentElement: any).hidden = true;
+				wrapper.hidden = true;
 			}
 		}
 
 		if (module.options.conserveMemory.value) {
-			const first = newIndex - preloadCount;
-			const last = newIndex + preloadCount;
+			const first = newIndex - this.preloadCount;
+			const last = newIndex + this.preloadCount;
 
-			for (const [index, { media }] of pieces.entries()) {
+			for (const [index, { media }] of this.pieces.entries()) {
 				if (!media) continue;
 
-				const keepLoaded = last > pieces.length && last % pieces.length >= index ||
-					first < 0 && positiveModulo(first, pieces.length) <= index ||
+				const keepLoaded = last > this.pieces.length && last % this.pieces.length >= index ||
+					first < 0 && positiveModulo(first, this.pieces.length) <= index ||
 					index >= first && index <= last;
 
 				lazyUnload(media, keepLoaded);
 			}
 		}
 
-		return preloadAhead();
+		return this.preloadAhead();
 	}
+}
 
-	let initialLoadPromise;
-	if (filmstripActive || pieces.length === 1) {
-		initialLoadPromise = expandFilmstrip();
-		ctrlConcurrentIncrease.addEventListener('click', expandFilmstrip);
-	} else {
-		element.classList.add('res-gallery-slideshow');
-		initialLoadPromise = changeSlideshowPiece(0);
-		ctrlPrev.addEventListener('click', () => { changeSlideshowPiece(-1); });
-		ctrlNext.addEventListener('click', () => { changeSlideshowPiece(1); });
+class Image extends Media {
+	image: HTMLImageElement;
+	src: string;
 
-		waitForEvent(ctrlToFilmstrip, 'click').then(() => {
-			expandFilmstrip();
-			ctrlConcurrentIncrease.addEventListener('click', expandFilmstrip);
-			element.classList.remove('res-gallery-slideshow');
+	constructor({
+		title,
+		caption,
+		credits,
+		src,
+		href,
+	}: ImageMedia, context) {
+		super();
+
+		this.src = src;
+
+		this.element = imageTemplate({
+			title,
+			caption,
+			credits,
+			src,
+			href: href || context.href,
+			openInNewWindow: module.options.openInNewWindow.value,
 		});
+		this.image = downcast(this.element.querySelector('img.res-image-media'), HTMLImageElement);
+		const anchor = this.element.querySelector('a.res-expando-link');
+
+		this.ready = waitForEvent(this.image, 'load', 'error');
+
+		this.image.addEventListener('error', () => {
+			this.element.classList.add('res-media-load-error');
+		});
+
+		if (module.options.displayOriginalResolution.value) {
+			this.image.addEventListener('load', () => {
+				this.image.title = `${this.image.naturalWidth} × ${this.image.naturalHeight} px`;
+			});
+		}
+
+		setMediaMaxSize(this.image);
+		makeMediaZoomable(this.element, this.image);
+		const wrapper = setMediaControls(anchor, src, src);
+		makeMediaMovable(this.element, wrapper);
+		keepMediaVisible(wrapper);
+		makeMediaIndependent(wrapper);
 	}
 
-	element.ready = initialLoadPromise;
+	unload() {
+		this.image.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+	}
 
-	return element;
+	restore() {
+		this.image.src = this.src;
+	}
 }
 
-function generateImage(options: ImageMedia, context) {
-	const element: ExpandoMediaElement = (imageTemplate({
-		title: options.title,
-		caption: options.caption,
-		credits: options.credits,
-		src: options.src,
-		href: options.href || context.href,
-		openInNewWindow: module.options.openInNewWindow.value,
-	}): any);
-	const image: HTMLImageElement = (element.querySelector('img.res-image-media'): any);
-	const anchor = element.querySelector('a.res-expando-link');
+class Iframe extends Media {
+	loaded: boolean = false;
+	iframe: HTMLIFrameElement;
+	pauseCommand: ?string;
+	playCommand: ?string;
 
-	const transparentGif = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
-	element.state = mediaStates.NONE;
+	constructor({
+		embed,
+		embedAutoplay,
+		width = '640px',
+		height = '360px',
+		fixedRatio = false,
+		pause: pauseCommand,
+		play: playCommand,
+	}: IframeMedia) {
+		super();
 
-	image.addEventListener('error', () => {
-		element.classList.add('res-media-load-error');
-		image.title = '';
-	});
-	image.addEventListener('load', () => {
-		if (element.state === mediaStates.NONE) {
-			if (module.options.displayOriginalResolution.value && image.naturalWidth && image.naturalHeight) {
-				image.title = `${image.naturalWidth} × ${image.naturalHeight} px`;
-			}
+		this.pauseCommand = pauseCommand;
+		this.playCommand = playCommand;
 
-			element.state = mediaStates.LOADED;
-		}
-	});
+		this.element = iframeTemplate({
+			url: (module.options.autoplayVideo.value && embedAutoplay) ? embedAutoplay : embed,
+			width,
+			height,
+		});
+		this.iframe = downcast(this.element.querySelector('iframe'), HTMLIFrameElement);
+		const iframeWrapper = downcast(this.element.firstElementChild, HTMLElement);
+		const dragHandle = this.element.querySelector('.res-iframe-expando-drag-handle');
 
-	element.unload = () => {
-		element.state = mediaStates.UNLOADED;
+		makeMediaZoomable(this.element, this.iframe, dragHandle, !fixedRatio);
+		makeMediaMovable(this.element, iframeWrapper, dragHandle);
+		keepMediaVisible(iframeWrapper);
+		makeMediaIndependent(iframeWrapper);
+	}
 
-		image.src = transparentGif;
-	};
-	element.restore = () => {
-		element.state = mediaStates.LOADED;
-
-		image.src = options.src;
-	};
-
-	element.ready = waitForEvent(image, 'load', 'error');
-
-	setMediaMaxSize(image);
-	makeMediaZoomable(element, image);
-	const wrapper = setMediaControls(anchor, options.src, options.src);
-	makeMediaMovable(element, wrapper);
-	keepMediaVisible(wrapper);
-	makeMediaIndependent(wrapper);
-
-	return element;
-}
-
-function generateIframe(options: IframeMedia) {
-	const element: ExpandoMediaElement = (iframeTemplate({
-		url: (module.options.autoplayVideo.value && options.embedAutoplay) ? options.embedAutoplay : options.embed,
-		width: options.width || '640px',
-		height: options.height || '360px',
-	}): any);
-
-	const iframeNode = downcast(element.querySelector('iframe'), HTMLIFrameElement);
-	const iframeWrapper = downcast(element.firstElementChild, HTMLElement);
-	const dragHandle = element.querySelector('.res-iframe-expando-drag-handle');
-
-	let loaded = false;
-
-	element.expand = async () => {
-		if (module.options.autoplayVideo.value && options.play) {
-			if (!loaded) await waitForEvent(iframeNode, 'load');
-			loaded = true;
-
-			if (!iframeNode.offsetParent) {
-				// It may have been collapsed in the meanwhile
-				element.remove();
-				return;
-			}
+	async expand() {
+		if (module.options.autoplayVideo.value && this.playCommand) {
+			if (!this.loaded) await waitForEvent(this.iframe, 'load');
+			this.loaded = true;
 
 			try {
-				iframeNode.contentWindow.postMessage(options.play, '*');
+				this.iframe.contentWindow.postMessage(this.playCommand, '*');
 			} catch (e) {
-				console.error('Could not post "play" command to iframe', options.embed, e);
+				console.error('Could not post "play" command to iframe', this, e);
 			}
 		}
-	};
-	element.collapse = () => {
+	}
+
+	collapse() {
 		let removeInstead = true;
-		if (options.pause) {
+		if (this.pauseCommand) {
 			try {
-				iframeNode.contentWindow.postMessage(options.pause, '*');
+				this.iframe.contentWindow.postMessage(this.pauseCommand, '*');
 				removeInstead = false;
 			} catch (e) {
-				console.error('Could not post "pause" command to iframe', options.embed, e);
+				console.error('Could not post "pause" command to iframe', this, e);
 			}
 		}
 		return removeInstead;
-	};
-
-	makeMediaZoomable(element, iframeNode, dragHandle, !options.fixedRatio);
-	makeMediaMovable(element, iframeWrapper, dragHandle);
-	keepMediaVisible(iframeWrapper);
-	makeMediaIndependent(iframeWrapper);
-
-	return element;
+	}
 }
 
-function generateText(options: TextMedia) {
-	return ((textTemplate({
-		title: options.title,
-		credits: options.credits,
-		src: $('<span>').safeHtml(options.src).html(),
-	}): any): ExpandoMediaElement);
+class Text extends Media {
+	constructor({
+		title,
+		credits,
+		src,
+	}: TextMedia) {
+		super();
+
+		this.element = textTemplate({
+			title,
+			credits,
+			src: $('<span>').safeHtml(src).html(),
+		});
+	}
 }
 
-function generateVideo(options: VideoMedia, context) {
-	// Use default values for options not explicitly set
-	const filledOptions = {
-		autoplay: options.muted || module.options.autoplayVideo.value,
-		advancedControls: module.options.showVideoControls.value,
-		controls: true,
-		frameRate: 24,
-		loop: false,
-		muted: false,
-		openInNewWindow: module.options.openInNewWindow.value,
-		playbackRate: 1,
-		reversable: false,
-		reversed: false,
-		time: 0,
-		...options,
-	};
+class Audio extends Media {
+	autoplay: boolean;
+	audio: HTMLAudioElement;
 
-	return videoAdvanced(filledOptions, context);
-}
+	constructor({
+		autoplay = false,
+		loop,
+		sources,
+	}: AudioMedia) {
+		super();
 
-function generateAudio(options: AudioMedia) {
-	let {
-		autoplay,
-	} = options;
+		this.autoplay = autoplay;
 
-	const element: ExpandoMediaElement = (audioTemplate({
-		loop: options.loop,
-		sources: options.sources,
-	}): any);
-	const audio: HTMLAudioElement = (element.querySelector('audio'): any);
+		this.element = audioTemplate({
+			loop,
+			sources,
+		});
+		this.audio = downcast(this.element.querySelector('audio'), HTMLAudioElement);
+	}
 
-	element.collapse = () => {
+	collapse() {
 		// Audio is auto-paused when detached from DOM
-		if (!document.body.contains(audio)) return;
+		if (!document.body.contains(this.audio)) return;
 
-		autoplay = !audio.paused;
-		if (!audio.paused) audio.pause();
-	};
-	element.expand = () => { if (autoplay) audio.play(); };
+		this.autoplay = !this.audio.paused;
+		if (!this.audio.paused) this.audio.pause();
+	}
 
-	return element;
+	expand() {
+		if (this.autoplay) this.audio.play();
+	}
 }
 
-function generateGeneric(options: GenericMedia) {
-	const element: ExpandoMediaElement = (document.createElement('div'): any);
+class Generic extends Media {
+	constructor(options: GenericMedia) {
+		super();
 
-	element.appendChild(options.generate());
+		this.element = options.generate();
+	}
 
 	// Always remove content, in case it contains audio or other unwanted things
-	element.collapse = () => true;
-
-	return element;
+	collapse() {
+		return true;
+	}
 }
 
 const trackVisitNative = batch(async things => {
@@ -1651,18 +1682,18 @@ function addSiteAttribution(siteModule, media) {
 		logoUrl: siteModule.logo,
 		settingsLink: SettingsNavigation.makeUrlHash(module.moduleID, siteModuleOptionKey(siteModule)),
 	}));
-	const $replace = $('.res-expando-siteAttribution', media);
+	const $replace = $('.res-expando-siteAttribution', media.element);
 	if ($replace.length) {
 		$element.replaceAll($replace);
 	} else {
-		$element.addClass('res-expando-siteAttribution-generic').appendTo(media);
+		$element.addClass('res-expando-siteAttribution-generic').appendTo(media.element);
 	}
 }
 
 function keepMediaVisible(media) {
 	media.classList.add('res-media-keep-visible');
 
-	const basisLeft = _.once(() => (media.parentElement: any).getBoundingClientRect().left);
+	const basisLeft = _.once(() => downcast(media.parentElement, HTMLElement).getBoundingClientRect().left);
 	let isAligned = false;
 
 	media.addEventListener('mediaResize', ({ detail: { width: mediaWidth } }: any) => {
@@ -1795,7 +1826,7 @@ function addDragListener({ media, element, atShiftKey, onStart, onMove }: {|
 	element.addEventListener('mousedown', initiate);
 }
 
-function makeMediaZoomable(media, element, dragInitiater = element, absoluteSizing = false) {
+function makeMediaZoomable(media: HTMLElement, element: HTMLElement, dragInitiater: HTMLElement = element, absoluteSizing: boolean = false) {
 	if (!module.options.imageZoom.value) return;
 
 	element.classList.add('res-media-zoomable');
@@ -1828,7 +1859,7 @@ function makeMediaZoomable(media, element, dragInitiater = element, absoluteSizi
 	});
 }
 
-function makeMediaMovable(media, element, dragInitiater = element) {
+function makeMediaMovable(media: HTMLElement, element: HTMLElement, dragInitiater: HTMLElement = element) {
 	if (!module.options.imageMove.value) return;
 
 	element.classList.add('res-media-movable');
@@ -1843,7 +1874,7 @@ function makeMediaMovable(media, element, dragInitiater = element) {
 	});
 }
 
-function makeMediaIndependent(element) {
+function makeMediaIndependent(element: HTMLElement) {
 	const wrapper = document.createElement('div');
 	const independent = document.createElement('div');
 	$(element).replaceWith(wrapper);
@@ -1912,86 +1943,156 @@ const mutedVideoManager = _.once(() => {
 	};
 });
 
-function videoAdvanced(options, context) {
-	const {
+class Video extends Media {
+	video: HTMLVideoElement;
+	autoplay: boolean;
+	time: number;
+	frameRate: number;
+	useVideoManager: boolean;
+	muted: boolean;
+
+	constructor({
+		title,
+		caption,
+		credits,
+		controls = true,
 		fallback,
-		frameRate,
-		loop,
-		playbackRate,
-		advancedControls,
-		reversed,
-	} = options;
+		frameRate = 24,
+		href,
+		loop = false,
+		muted = false,
+		playbackRate = 1,
+		poster,
+		reversable = false,
+		reversed = false,
+		source,
+		sources,
+		time = 0,
+	}: VideoMedia, context) {
+		super();
 
-	let {
-		autoplay,
-		time,
-	} = options;
+		const advancedControls = module.options.showVideoControls.value;
+		this.useVideoManager = advancedControls && module.options.onlyPlayMutedWhenVisible.value && muted;
 
-	function formatPlaybackRate(value) {
-		return `${value.toFixed(2).replace('.', '.\u200B'/* zwsp */)}x`;
+		this.autoplay = muted || module.options.autoplayVideo.value;
+		this.time = time;
+		this.frameRate = frameRate;
+		this.muted = muted;
+
+		this.element = videoAdvancedTemplate({
+			title,
+			caption,
+			credits,
+			href: href || context.href,
+			source,
+			// Prevent poster from flashing before the video is ready when autoplaying
+			poster: this.autoplay && poster || '',
+			muted,
+			loop,
+			reversable,
+			controls,
+			advancedControls,
+			openInNewWindow: module.options.openInNewWindow.value,
+			formattedPlaybackRate: this.formatRateNumber(playbackRate),
+		});
+		this.video = downcast(this.element.querySelector('video'), HTMLVideoElement);
+		const container = this.element.querySelector('.video-advanced-container');
+
+		const msgError = this.element.querySelector('.video-advanced-error');
+		const displayError = (error: Error | ProgressEvent) => {
+			if (msgError.hidden) {
+				msgError.hidden = false;
+				$('<span>').text(`Could not play video: ${error.message ? String(error.message) : 'Unknown error'}`).appendTo(msgError);
+			}
+		};
+
+		const sourceElements = $(_.compact(sources.map(v => {
+			if (!this.video.canPlayType(v.type)) return null;
+			const source = document.createElement('source');
+			source.src = v.source;
+			source.type = v.type;
+			if (v.reverse) source.dataset.reverse = v.reverse;
+			return source;
+		}))).appendTo(this.video).get();
+
+		if (!sourceElements.length) {
+			if (fallback) {
+				return new Image({
+					type: 'IMAGE',
+					title,
+					caption,
+					credits,
+					src: fallback,
+				}, context);
+			} else {
+				displayError(new Error('No playable sources were found'));
+			}
+		}
+
+		const lastSource = sourceElements[sourceElements.length - 1];
+		lastSource.addEventListener('error', displayError);
+
+		if (reversed) this.reverse();
+
+		this.ready = Promise.race([waitForEvent(this.video, 'suspend'), waitForEvent(lastSource, 'error')]);
+
+		this.video.addEventListener('pause', () => { this.element.classList.remove('playing'); });
+		this.video.addEventListener('play', () => { this.element.classList.add('playing'); });
+
+		this.video.addEventListener('loadedmetadata', () => { if (time !== this.video.currentTime) this.video.currentTime = this.time; });
+		this.video.playbackRate = playbackRate;
+
+		// Ignore events which might be meant for controls
+		this.video.addEventListener('mousedown', (e: MouseEvent) => {
+			if (this.video.hasAttribute('controls')) {
+				const { height, top } = this.video.getBoundingClientRect();
+				let controlsBottomHeight = 0;
+				if (process.env.BUILD_TARGET === 'edge') controlsBottomHeight = 0.5 * height;
+				if (process.env.BUILD_TARGET === 'firefox') controlsBottomHeight = 40;
+				if ((height - controlsBottomHeight) < (e.clientY - top)) {
+					e.stopImmediatePropagation();
+				}
+			}
+		});
+
+		if (advancedControls) {
+			Promise.all([waitForEvent(this.element, 'mouseenter'), waitForEvent(this.video, 'loadedmetadata')])
+				.then(() => this.addAdvancedControls());
+		}
+
+		if (!loop && this.autoplay) {
+			waitForEvent(this.video, 'ended').then(() => this.stopAutoplay());
+		}
+
+		setMediaMaxSize(this.video);
+		makeMediaZoomable(this.element, this.video);
+		setMediaControls(this.video, undefined, sources[0].source);
+		makeMediaMovable(this.element, container);
+		keepMediaVisible(container);
+		makeMediaIndependent(container);
 	}
 
-	const useVideoManager = advancedControls && module.options.onlyPlayMutedWhenVisible.value && options.muted;
+	reverse() {
+		this.time = this.video.duration - this.video.currentTime;
+		if (isNaN(this.time)) this.time = 0;
 
-	// Poster is unnecessary, and will flash if loaded before the video is ready
-	if (autoplay) delete options.poster;
-
-	const element: ExpandoMediaElement = (document.createElement('div'): any);
-	const player = videoAdvancedTemplate({
-		title: options.title,
-		caption: options.caption,
-		credits: options.credits,
-		href: options.href || context.href,
-		source: options.source,
-		poster: options.poster,
-		muted: options.muted,
-		loop: options.loop,
-		reversable: options.reversable,
-		controls: options.controls,
-		advancedControls: options.advancedControls,
-		openInNewWindow: options.openInNewWindow,
-		formattedPlaybackRate: formatPlaybackRate(options.playbackRate),
-	});
-	element.appendChild(player);
-
-	const vid: HTMLVideoElement = (player.querySelector('video'): any);
-	const container: HTMLElement = (player.querySelector('.video-advanced-container'): any);
-
-	const msgError = element.querySelector('.video-advanced-error');
-
-	const sourceElements = $(_.compact(options.sources.map(v => {
-		if (!vid.canPlayType(v.type)) return null;
-		const source = document.createElement('source');
-		source.src = v.source;
-		source.type = v.type;
-		if (v.reverse) source.dataset.reverse = v.reverse;
-		return source;
-	}))).appendTo(vid).get();
-	if (!sourceElements.length) {
-		sourceErrorFallback(new Error('No playable sources were found'));
-		return element;
-	}
-
-	function reverse() {
-		time = vid.duration - vid.currentTime;
-		if (isNaN(time)) time = 0;
-
-		for (const v of vid.querySelectorAll('source')) {
+		for (const v of this.video.querySelectorAll('source')) {
 			// $FlowIssue
 			[v.src, v.dataset.reverse] = [v.dataset.reverse, v.src];
 		}
 
-		vid.load();
-		vid.play();
+		this.video.load();
+		this.video.play();
 
-		player.classList.toggle('reversed');
+		this.element.classList.toggle('reversed');
 	}
 
-	if (reversed) reverse();
+	formatRateNumber(value: number) {
+		return `${value.toFixed(2).replace('.', '.\u200B'/* zwsp */)}x`;
+	}
 
-	function setAdvancedControls() {
-		const ctrlContainer = player.querySelector('.video-advanced-controls');
-
+	addAdvancedControls() {
+		const ctrlContainer = this.element.querySelector('.video-advanced-controls');
 		const ctrlReverse = ctrlContainer.querySelector('.video-advanced-reverse');
 		const ctrlTogglePause = ctrlContainer.querySelector('.video-advanced-toggle-pause');
 		const ctrlSpeedDecrease = ctrlContainer.querySelector('.video-advanced-speed-decrease');
@@ -1999,7 +2100,7 @@ function videoAdvanced(options, context) {
 		const ctrlTimeDecrease = ctrlContainer.querySelector('.video-advanced-time-decrease');
 		const ctrlTimeIncrease = ctrlContainer.querySelector('.video-advanced-time-increase');
 
-		const progress = player.querySelector('.video-advanced-progress');
+		const progress = this.element.querySelector('.video-advanced-progress');
 		const indicatorPosition = progress.querySelector('.video-advanced-position');
 		const ctrlPosition = progress.querySelector('.video-advanced-position-thumb');
 
@@ -2007,20 +2108,20 @@ function videoAdvanced(options, context) {
 		const msgTime = ctrlContainer.querySelector('.video-advanced-time');
 
 		ctrlTogglePause.addEventListener('click', () => {
-			if (vid.paused) vid.play(); else vid.pause();
-			if (vid.paused) stopAutoplay();
+			if (this.video.paused) this.video.play(); else this.video.pause();
+			if (this.video.paused) this.stopAutoplay();
 		});
-		if (ctrlReverse) ctrlReverse.addEventListener('click', reverse);
+		if (ctrlReverse) ctrlReverse.addEventListener('click', () => this.reverse());
 
-		ctrlSpeedDecrease.addEventListener('click', () => { vid.playbackRate /= 1.1; });
-		ctrlSpeedIncrease.addEventListener('click', () => { vid.playbackRate *= 1.1; });
-		ctrlTimeDecrease.addEventListener('click', () => { vid.currentTime -= 1 / frameRate; });
-		ctrlTimeIncrease.addEventListener('click', () => { vid.currentTime += 1 / frameRate; });
+		ctrlSpeedDecrease.addEventListener('click', () => { this.video.playbackRate /= 1.1; });
+		ctrlSpeedIncrease.addEventListener('click', () => { this.video.playbackRate *= 1.1; });
+		ctrlTimeDecrease.addEventListener('click', () => { this.video.currentTime -= 1 / this.frameRate; });
+		ctrlTimeIncrease.addEventListener('click', () => { this.video.currentTime += 1 / this.frameRate; });
 
-		vid.addEventListener('ratechange', () => { msgSpeed.textContent = formatPlaybackRate(vid.playbackRate); });
-		vid.addEventListener('timeupdate', () => {
-			indicatorPosition.style.left = `${(vid.currentTime / vid.duration) * 100}%`;
-			msgTime.textContent = `${vid.currentTime.toFixed(2).replace('.', '.\u200B'/* zwsp */)}s`;
+		this.video.addEventListener('ratechange', () => { msgSpeed.textContent = this.formatRateNumber(this.video.playbackRate); });
+		this.video.addEventListener('timeupdate', () => {
+			indicatorPosition.style.left = `${(this.video.currentTime / this.video.duration) * 100}%`;
+			msgTime.textContent = this.formatRateNumber(this.video.currentTime);
 		});
 
 		progress.addEventListener('mousemove', (e: MouseEvent) => {
@@ -2032,119 +2133,53 @@ function videoAdvanced(options, context) {
 		});
 		ctrlPosition.addEventListener('click', (e: MouseEvent) => {
 			const percentage = (e.target.offsetLeft + e.target.clientWidth / 2) / progress.clientWidth;
-			vid.currentTime = vid.duration * percentage;
+			this.video.currentTime = this.video.duration * percentage;
 		});
 	}
 
-	if (advancedControls) {
-		Promise.all([waitForEvent(player, 'mouseenter'), waitForEvent(vid, 'loadedmetadata')])
-			.then(setAdvancedControls);
+	stopAutoplay() {
+		this.autoplay = false;
+		if (this.useVideoManager) mutedVideoManager().unobserve(this.video);
 	}
 
-	function sourceErrorFallback(error: Error | ProgressEvent) {
-		if (fallback) {
-			console.log('Could not play video', error);
-			const image = generateImage({
-				type: 'IMAGE',
-				title: options.title,
-				caption: options.caption,
-				credits: options.credits,
-				src: fallback,
-			}, context);
-			$(element).empty().append(image);
-		} else if (msgError.hidden) {
-			msgError.hidden = false;
-			$('<span>').text(`Could not play video: ${error.message ? String(error.message) : 'Unknown error'}`).appendTo(msgError);
-		}
-	}
-
-	const lastSource = sourceElements[sourceElements.length - 1];
-	lastSource.addEventListener('error', sourceErrorFallback);
-
-	vid.addEventListener('pause', () => { player.classList.remove('playing'); });
-	vid.addEventListener('play', () => { player.classList.add('playing'); });
-
-	vid.addEventListener('loadedmetadata', () => { if (time !== vid.currentTime) vid.currentTime = time; });
-	vid.playbackRate = playbackRate;
-
-	// Ignore events which might be meant for controls
-	vid.addEventListener('mousedown', (e: MouseEvent) => {
-		if (vid.hasAttribute('controls')) {
-			const { height, top } = vid.getBoundingClientRect();
-			let controlsBottomHeight = 0;
-			if (process.env.BUILD_TARGET === 'edge') controlsBottomHeight = 0.5 * height;
-			if (process.env.BUILD_TARGET === 'firefox') controlsBottomHeight = 40;
-			if ((height - controlsBottomHeight) < (e.clientY - top)) {
-				e.stopImmediatePropagation();
-			}
-		}
-	});
-
-	if (!loop && autoplay) {
-		waitForEvent(vid, 'ended').then(stopAutoplay);
-	}
-
-	function stopAutoplay() {
-		autoplay = false;
-		if (useVideoManager) mutedVideoManager().unobserve(vid);
-	}
-
-	function unload() {
+	_unload() {
 		// Video is auto-paused when detached from DOM
-		if (!document.body.contains(vid)) return;
+		if (!document.body.contains(this.video)) return;
 
-		if (!vid.paused) vid.pause();
+		if (!this.video.paused) this.video.pause();
 
-		time = vid.currentTime;
-		vid.setAttribute('src', ''); // vid.src has precedence over any child source element
-		vid.load();
+		this.time = this.video.currentTime;
+		this.video.setAttribute('src', ''); // this.video.src has precedence over any child source element
+		this.video.load();
 
-		if (useVideoManager) mutedVideoManager().unobserve(vid);
+		if (this.useVideoManager) mutedVideoManager().unobserve(this.video);
 	}
 
-	function restore() {
-		if (vid.hasAttribute('src')) {
-			vid.removeAttribute('src');
-			vid.load();
+	_restore() {
+		if (this.video.hasAttribute('src')) {
+			this.video.removeAttribute('src');
+			this.video.load();
 		}
 
-		if (autoplay) {
-			if (useVideoManager) mutedVideoManager().observe(vid);
-			else vid.play();
+		if (this.autoplay) {
+			if (this.useVideoManager) mutedVideoManager().observe(this.video);
+			else this.video.play();
 		}
 	}
 
-	element.collapse = unload;
-	element.expand = restore;
+	collapse = this._unload;
+	expand = this._restore;
 
-	element.state = mediaStates.NONE;
-
-	element.unload = () => {
-		if (element.state === mediaStates.UNLOADED) return;
-
+	unload() {
 		// If video has audio, it may be in use even if it is not visible
-		if (!options.muted && !vid.paused) return;
+		if (!this.muted && !this.video.paused) return;
 
-		element.state = mediaStates.UNLOADED;
-		unload();
-	};
-	element.restore = () => {
-		if (element.state === mediaStates.LOADED) return;
+		this._unload();
+	}
 
-		element.state = mediaStates.LOADED;
-		restore();
-	};
-
-	element.ready = Promise.race([waitForEvent(vid, 'suspend'), waitForEvent(lastSource, 'error')]);
-
-	setMediaMaxSize(vid);
-	makeMediaZoomable(element, vid);
-	setMediaControls(vid, undefined, options.sources[0].source);
-	makeMediaMovable(element, container);
-	keepMediaVisible(container);
-	makeMediaIndependent(container);
-
-	return element;
+	restore() {
+		this._restore();
+	}
 }
 
 export function moveMedia(ele: HTMLElement, deltaX: number, deltaY: number): void {

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1024,18 +1024,15 @@ async function completeExpando(expando, thing, mediaInfo) {
 	if (hideButton) hideButton.addEventListener('click', () => { expando.destroy(); });
 
 	if (thing && thing.isComment()) {
-		const $thing = $(thing.element);
 		expando.onExpand(_.once(() => {
 			let wasOpen;
 
-			// Execute expando toggle procedure when comment collapse / expand
-			$thing
-				.parents('.comment')
-				.addBack()
-				.find('> .entry .tagline > .expand, > .entry > .buttons .toggleChildren')
+			// Collapse / restore expandos when toggling comment visibility
+			$(thing.getParents().map(e => e.entry))
+				.find('.tagline > .expand, > .buttons .toggleChildren')
 				.click(() => {
-					if (expando.button.offsetParent) {
-						if (wasOpen) expando.expand();
+					if (thing.isVisible()) {
+						if (wasOpen && expando.media) expando.expand();
 					} else {
 						wasOpen = expando.open;
 						if (expando.open) expando.collapse();

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -969,7 +969,7 @@ async function checkElementForMedia(element) {
 
 	expando.button.addEventListener('click', () => {
 		if (expando.unlock) expando.unlock();
-		expando.toggle({ scrollOnMoveError: true });
+		expando.toggle();
 	});
 
 	if (nativeExpando) nativeExpando.detach();
@@ -1193,10 +1193,8 @@ export class Media {
 	onAttach: ?() => void;
 	isAttached(): boolean { return document.body.contains(this.element); }
 
-	supportsMoveInDOM = true;
-
 	expand(): void | Promise<void> {}
-	collapse(): ?boolean {} // Return `true` if media should be deleted
+	collapse(): void {} // Return `true` if media should be deleted
 
 	supportsUnload(): boolean { return false; }
 	state: 'loaded' | 'unloaded' = 'loaded';
@@ -1342,12 +1340,8 @@ class Gallery extends Media {
 		if (previous) {
 			const { media, wrapper } = previous;
 			if (!media) throw new Error();
-			const removeInstead = media.collapse();
-			if (removeInstead) {
-				media.element.remove();
-			} else {
-				wrapper.hidden = true;
-			}
+			media.collapse();
+			wrapper.hidden = true;
 		}
 
 		if (module.options.conserveMemory.value) {
@@ -1434,9 +1428,6 @@ class Iframe extends Media {
 	pauseCommand: ?string;
 	playCommand: ?string;
 
-	// iframe reloads when reattached after being moving in DOM / becoming parentless
-	supportsMoveInDOM = false;
-
 	constructor({
 		embed,
 		embedAutoplay,
@@ -1480,16 +1471,17 @@ class Iframe extends Media {
 	}
 
 	collapse() {
-		let removeInstead = true;
 		if (this.pauseCommand) {
 			try {
 				this.iframe.contentWindow.postMessage(this.pauseCommand, '*');
-				removeInstead = false;
+				return;
 			} catch (e) {
 				console.error('Could not post "pause" command to iframe', this, e);
 			}
 		}
-		return removeInstead;
+
+		// If we couldn't pause the iframe, remove it
+		this.element.remove();
 	}
 }
 
@@ -1553,7 +1545,7 @@ class Generic extends Media {
 
 	// Always remove content, in case it contains audio or other unwanted things
 	collapse() {
-		return true;
+		this.element.remove();
 	}
 }
 

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -2147,8 +2147,9 @@ class Video extends Media {
 	expand = this.restore;
 
 	supportsUnload() {
-		// If video has audio, it may be in use even if it is not visible
-		return !this.muted && !this.video.paused;
+		// Due to issues brougth about by with `pause` and `play` being asynchronous and conserveMemory and mutedVideoManager
+		// could end up in a race condition, only unload paused videoes
+		return this.video.paused;
 	}
 
 	unload() {

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -595,10 +595,14 @@ export const thingExpandoBuildListeners: * = $.Callbacks('unique'); // eslint-di
  * @returns {void}
  */
 function enableConserveMemory() {
+	// Making elements fullscreen makes the intersectionobserver report that nothing is intersecting
+	const fullscreenActive = () => !!(document.fullscreenElement || document.webkitFullscreenElement || document.mozFullScreenElement: any);
+
 	const rootMargin = `${100 * (parseInt(module.options.bufferScreens.value, 10) || 2)}%`;
 
 	const mediaMap = new WeakMap();
 	const ioMedia = new IntersectionObserver(entries => {
+		if (fullscreenActive()) return;
 		for (const entry of entries) {
 			const expando = downcast(mediaMap.get(entry.target), Expando);
 			if (expando.open && expando.media) lazyUnload(expando.media, entry.isIntersecting);
@@ -607,6 +611,7 @@ function enableConserveMemory() {
 
 	const buttonMap = new WeakMap();
 	const ioButton = new IntersectionObserver(entries => {
+		if (fullscreenActive()) return;
 		for (const entry of entries) {
 			const expando = downcast(buttonMap.get(entry.target), Expando);
 			if (!entry.isIntersecting && !expando.open) {

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -775,7 +775,7 @@ function mediaBrowse(selected, unselected, options) {
 
 function hasEntryAnyExpandedNonMuted(thing) {
 	return Expando.getTextExpandosFrom(thing).some(expando =>
-		expando.getTypes().includes('non-muted') && (expando.open || expando.expandWanted)
+		expando.types.includes('non-muted') && (expando.open || expando.expandWanted)
 	);
 }
 
@@ -808,10 +808,9 @@ function isExpandWanted(expando: Expando, {
 		if (primary && ignoreDuplicatesScope.contains(primary.button)) return false;
 	}
 
-	const expandoTypes = expando.getTypes();
-	const expandoIsNonMuted = expandoTypes.includes('non-muted');
+	const expandoIsNonMuted = expando.types.includes('non-muted');
 
-	const typeCriteriaOK = matchesTypes(autoExpandTypes, expandoTypes);
+	const typeCriteriaOK = matchesTypes(autoExpandTypes, expando.types);
 	const muteCriteriaOK = !(onlyExpandMuted && expandoIsNonMuted) ||
 		(autoExpandFirstVisibleNonMutedInThing && elementInViewport(expando.button) && !hasEntryAnyExpandedNonMuted(thing));
 
@@ -885,7 +884,7 @@ const generateSiteModuleLock = _.memoize(siteModule => {
 	};
 });
 
-function getMediaInfo(element, mediaUrl, thing) {
+function getMediaInfo(mediaUrl, thing) {
 	const matchingHosts = [
 		...modulesForHostname(mediaUrl.hostname),
 		...genericHosts,
@@ -895,15 +894,14 @@ function getMediaInfo(element, mediaUrl, thing) {
 		const detectResult = siteModule.detect(mediaUrl, thing);
 		if (detectResult) {
 			const permissions = generateSiteModuleLock(siteModule);
-			return { detectResult, siteModule, permissions, element, href: mediaUrl.href };
+			return { detectResult, siteModule, permissions, href: mediaUrl.href };
 		}
 	}
 }
 
-const scannedLinks: WeakMap<HTMLAnchorElement, boolean | Expando> = new WeakMap();
+const linksMap: WeakMap<HTMLAnchorElement, Expando> = new WeakMap();
 export function getLinkExpando(link: HTMLAnchorElement): ?Expando {
-	const expando = scannedLinks.get(link);
-	if (expando instanceof Expando) return expando;
+	return linksMap.get(link);
 }
 
 function shouldLinkBeDeferred(element) {
@@ -916,9 +914,6 @@ function shouldLinkBeDeferred(element) {
 const inText = element => !!element.closest('.md, .search-result-footer');
 
 async function checkElementForMedia(element) {
-	if (scannedLinks.has(element)) return;
-	else scannedLinks.set(element, true);
-
 	if (shouldLinkBeDeferred(element)) {
 		await new Promise(resolve => deferredLinks.set(element, resolve));
 		deferredLinks.delete(element);
@@ -943,7 +938,7 @@ async function checkElementForMedia(element) {
 	}
 
 	const mediaUrl = resolveMediaUrl(element, thing);
-	const mediaInfo = getMediaInfo(element, mediaUrl, thing);
+	const mediaInfo = getMediaInfo(mediaUrl, thing);
 
 	if (!mediaInfo) return;
 
@@ -958,11 +953,14 @@ async function checkElementForMedia(element) {
 
 	const { lock = null, unlock = null } = mediaInfo.permissions;
 
-	const expando = new Expando(lock, unlock);
+	const expando = new Expando(mediaInfo.href, lock, unlock);
 	expandos.set(expando.button, expando);
-	scannedLinks.set(element, expando);
+	linksMap.set(element, expando);
 
 	expando.button.setAttribute('data-host', mediaInfo.siteModule.moduleID);
+	expando.box.setAttribute('data-host', mediaInfo.siteModule.moduleID);
+
+	expando.onExpand(() => { trackMediaLoad(element, thing); });
 
 	// Start loading media early to make it snappier
 	expando.button.addEventListener('mousedown', () => {
@@ -989,7 +987,7 @@ async function checkElementForMedia(element) {
 
 		if (nativeExpando) nativeExpando.reattach();
 		expando.destroy();
-		scannedLinks.set(element, true);
+		linksMap.delete(element);
 	}
 
 	if (thing) thingExpandoBuildListeners.fire(thing);
@@ -1007,12 +1005,7 @@ function placeExpando(expando, element, thing) {
 }
 
 async function completeExpando(expando, thing, mediaInfo) {
-	const options = await retrieveExpandoOptions(thing, mediaInfo);
-
-	expando.href = options.href;
-	expando.generateMedia = options.generateMedia;
-	expando.mediaOptions = options.mediaOptions;
-	expando.onMediaAttach = options.onMediaAttach;
+	expando.initialize(await retrieveExpandoOptions(thing, mediaInfo));
 
 	const hideButton = thing && thing.getHideElement();
 	if (hideButton) hideButton.addEventListener('click', () => { expando.destroy(); });
@@ -1041,7 +1034,7 @@ async function completeExpando(expando, thing, mediaInfo) {
 		thing.entry.addEventListener('mediaResize', updateParentHeight);
 	}
 
-	if (!expando.expandWanted) {
+	if (!expando.open) {
 		let autoExpand;
 		let autoExpandFirstVisibleNonMutedInThing;
 
@@ -1051,15 +1044,15 @@ async function completeExpando(expando, thing, mediaInfo) {
 			autoExpandFirstVisibleNonMutedInThing = module.options.autoExpandSelfTextFirstVisibleNonMuted.value;
 		}
 
-		expando.expandWanted = isExpandWanted(expando, { thing, autoExpand, autoExpandFirstVisibleNonMutedInThing });
+		if (isExpandWanted(expando, { thing, autoExpand, autoExpandFirstVisibleNonMutedInThing })) {
+			expando.expand();
+		}
 	}
-
-	requestAnimationFrame(() => expando.initialize());
 
 	updateAutoExpandCount();
 }
 
-const retrieveExpandoOptions = _.memoize(async (thing, { siteModule, detectResult, element, href }) => {
+const retrieveExpandoOptions = _.memoize(async (thing, { siteModule, detectResult, href }) => {
 	let mediaOptions = await siteModule.handleLink(href, detectResult);
 
 	if (module.options.convertGifstoGfycat.value &&
@@ -1082,18 +1075,15 @@ const retrieveExpandoOptions = _.memoize(async (thing, { siteModule, detectResul
 		siteModule.domains.length && siteModule.attribution !== false;
 
 	const isMuted = media => media.muted || ['IMAGE', 'TEXT'].includes(media.type);
-
-	const trackLoad = _.once(() => trackMediaLoad(element, thing));
+	const muted = mediaOptions.type === 'GALLERY' ? mediaOptions.src.every(isMuted) : isMuted(mediaOptions);
 
 	return {
-		href, // Since mediaOptions.href may be overwritten
-		mediaOptions: {
-			href,
-			muted: mediaOptions.type === 'GALLERY' ? mediaOptions.src.every(isMuted) : isMuted(mediaOptions),
-			moduleID: siteModule.moduleID,
-			buttonInfo: getMediaButtonInfo(mediaOptions),
-			...mediaOptions,
-		},
+		types: [
+			mediaOptions.type,
+			muted ? 'muted' : 'non-muted',
+			...((mediaOptions.expandoClass || '').split(' ')),
+		].filter(v => v).map(s => s.toLowerCase()),
+		buttonInfo: getMediaButtonInfo(mediaOptions),
 		generateMedia() {
 			const media = generateMedia(mediaOptions, { href });
 			if (module.options.crossposts.value === 'withMetadata' && thing && thing.isCrosspost()) {
@@ -1101,10 +1091,6 @@ const retrieveExpandoOptions = _.memoize(async (thing, { siteModule, detectResul
 			}
 			if (attribution) addSiteAttribution(siteModule, media);
 			return media;
-		},
-		onMediaAttach() {
-			trackLoad();
-			if (mediaOptions.onAttach) mediaOptions.onAttach();
 		},
 	};
 }, (thing, { href }) => href);
@@ -1223,6 +1209,10 @@ export class Media {
 	state: 'loaded' | 'unloaded' = 'loaded';
 
 	ready: ?Promise<void>;
+
+	onAttach: ?() => void;
+
+	supportsMoveInDOM = true;
 
 	expand(): void | Promise<void> {}
 	collapse(): ?boolean {} // Return `true` if media should be deleted
@@ -1457,6 +1447,9 @@ class Iframe extends Media {
 	pauseCommand: ?string;
 	playCommand: ?string;
 
+	// iframe reloads when reattached after being moving in DOM / becoming parentless
+	supportsMoveInDOM = false;
+
 	constructor({
 		embed,
 		embedAutoplay,
@@ -1565,6 +1558,8 @@ class Audio extends Media {
 class Generic extends Media {
 	constructor(options: GenericMedia) {
 		super();
+
+		this.onAttach = options.onAttach;
 
 		this.element = options.generate();
 	}

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1211,6 +1211,7 @@ export class Media {
 	ready: ?Promise<void>;
 
 	onAttach: ?() => void;
+	isAttached(): boolean { return document.body.contains(this.element); }
 
 	supportsMoveInDOM = true;
 
@@ -1309,7 +1310,7 @@ class Gallery extends Media {
 
 		piece.media = piece.media || piece.generateMedia();
 		const { media, wrapper } = piece;
-		if (!wrapper.contains(media.element)) wrapper.appendChild(media.element);
+		if (!media.isAttached()) wrapper.appendChild(media.element);
 		wrapper.hidden = false;
 		if (this.shouldRememberResizeWidth()) this.restoreWidth(piece);
 		media.expand();
@@ -1544,7 +1545,7 @@ class Audio extends Media {
 
 	collapse() {
 		// Audio is auto-paused when detached from DOM
-		if (!document.body.contains(this.audio)) return;
+		if (!this.isAttached()) return;
 
 		this.autoplay = !this.audio.paused;
 		if (!this.audio.paused) this.audio.pause();
@@ -2139,7 +2140,7 @@ class Video extends Media {
 
 	_unload() {
 		// Video is auto-paused when detached from DOM
-		if (!document.body.contains(this.video)) return;
+		if (!this.isAttached()) return;
 
 		if (!this.video.paused) this.video.pause();
 

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -648,12 +648,12 @@ const stopEventPropagation = e => { e.stopImmediatePropagation(); };
 
 function lazyUnload(media: Media, keepLoaded: boolean) {
 	if (keepLoaded && media.state === 'unloaded') {
-		media.restore();
 		media.element.removeEventListener('mediaResize', stopEventPropagation, true);
+		media.restore();
 		media.state = 'loaded';
-	} else if (!keepLoaded && media.state === 'loaded') {
-		media.unload();
+	} else if (!keepLoaded && media.state === 'loaded' && media.supportsUnload()) {
 		media.element.addEventListener('mediaResize', stopEventPropagation, true);
+		media.unload();
 		media.state = 'unloaded';
 	}
 }
@@ -1206,7 +1206,6 @@ function generateMedia(options: ExpandoMedia, context: {| href: string |}) {
 
 export class Media {
 	element: HTMLElement;
-	state: 'loaded' | 'unloaded' = 'loaded';
 
 	ready: ?Promise<void>;
 
@@ -1218,6 +1217,8 @@ export class Media {
 	expand(): void | Promise<void> {}
 	collapse(): ?boolean {} // Return `true` if media should be deleted
 
+	supportsUnload(): boolean { return false; }
+	state: 'loaded' | 'unloaded' = 'loaded';
 	unload(): void {}
 	restore(): void {}
 }
@@ -1431,6 +1432,10 @@ class Image extends Media {
 		makeMediaMovable(this.element, wrapper);
 		keepMediaVisible(wrapper);
 		makeMediaIndependent(wrapper);
+	}
+
+	supportsUnload() {
+		return true;
 	}
 
 	unload() {
@@ -2138,7 +2143,15 @@ class Video extends Media {
 		if (this.useVideoManager) mutedVideoManager().unobserve(this.video);
 	}
 
-	_unload() {
+	collapse = this.unload;
+	expand = this.restore;
+
+	supportsUnload() {
+		// If video has audio, it may be in use even if it is not visible
+		return !this.muted && !this.video.paused;
+	}
+
+	unload() {
 		// Video is auto-paused when detached from DOM
 		if (!this.isAttached()) return;
 
@@ -2151,7 +2164,7 @@ class Video extends Media {
 		if (this.useVideoManager) mutedVideoManager().unobserve(this.video);
 	}
 
-	_restore() {
+	restore() {
 		if (this.video.hasAttribute('src')) {
 			this.video.removeAttribute('src');
 			this.video.load();
@@ -2161,20 +2174,6 @@ class Video extends Media {
 			if (this.useVideoManager) mutedVideoManager().observe(this.video);
 			else this.video.play();
 		}
-	}
-
-	collapse = this._unload;
-	expand = this._restore;
-
-	unload() {
-		// If video has audio, it may be in use even if it is not visible
-		if (!this.muted && !this.video.paused) return;
-
-		this._unload();
-	}
-
-	restore() {
-		this._restore();
 	}
 }
 

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1168,40 +1168,21 @@ function preloadMedia(pieces) {
 	});
 }
 
-function generateMedia(options: ExpandoMedia, context: {| href: string |}) {
+function generateMedia(options: ExpandoMedia, context: {| href: string |}): Media {
 	const $span = $('<span>');
 	if (options.credits) options.credits = $span.safeHtml(options.credits).html();
 	if (options.caption) options.caption = $span.safeHtml(options.caption).html();
 
-	let media;
-
 	switch (options.type) {
-		case 'GALLERY':
-			media = new Gallery(options, context);
-			break;
-		case 'IMAGE':
-			media = new Image(options, context);
-			break;
-		case 'TEXT':
-			media = new Text(options);
-			break;
-		case 'IFRAME':
-			media = new Iframe(options);
-			break;
-		case 'VIDEO':
-			media = new Video(options, context);
-			break;
-		case 'AUDIO':
-			media = new Audio(options);
-			break;
-		case 'GENERIC_EXPANDO':
-			media = new Generic(options);
-			break;
-		default:
-			throw new Error(`Unreachable: invalid media type ${options.type}`);
+		case 'GALLERY': return new Gallery(options, context);
+		case 'IMAGE': return new Image(options, context);
+		case 'TEXT': return new Text(options);
+		case 'IFRAME': return new Iframe(options);
+		case 'VIDEO': return new Video(options, context);
+		case 'AUDIO': return new Audio(options);
+		case 'GENERIC_EXPANDO': return new Generic(options);
+		default: throw new Error(`Unreachable: invalid media type ${options.type}`);
 	}
-
-	return media;
 }
 
 export class Media {

--- a/lib/modules/showImages/expando.js
+++ b/lib/modules/showImages/expando.js
@@ -9,6 +9,7 @@ import {
 	string,
 } from '../../utils';
 import type { Thing } from '../../utils';
+import type { Media } from '../showImages';
 
 export const expandos: WeakMap<Element, Expando> = new WeakMap();
 
@@ -18,20 +19,6 @@ export const primaryExpandos: Map<string /* href */, Expando> = new Map();
 type OnExpandCallback = () => void;
 
 type ExpandOptions = { scrollOnMoveError?: boolean };
-
-declare interface ExpandoMediaElement extends HTMLElement {
-	remove: () => void;
-	expand?: () => void | Promise<void>;
-	collapse?: () => ?boolean;
-	unload?: () => void;
-	restore?: () => void;
-	emitResizeEvent: () => void;
-	ready?: Promise<void>;
-	state?: number;
-	independent?: boolean;
-}
-
-export type { ExpandoMediaElement };
 
 type MediaOptions = {
 	moduleID: string,
@@ -120,9 +107,9 @@ export class Expando {
 	expandCallbacks: OnExpandCallback[] = [];
 
 	href: ?string;
-	media: ?ExpandoMediaElement;
+	media: ?Media;
 	mediaOptions: ?MediaOptions;
-	generateMedia: ?() => ExpandoMediaElement;
+	generateMedia: ?() => Media;
 	onMediaAttach: ?() => void;
 
 	constructor(lock: *, unlock: *) {
@@ -205,7 +192,7 @@ export class Expando {
 	setAsPrimary(force?: boolean = false) {
 		const primary = this.getPrimary();
 		if (!force && primary && primary.media) {
-			if (primary.mediaOptions && primary.mediaOptions.type === 'IFRAME' && document.body.contains(primary.media)) {
+			if (primary.mediaOptions && primary.mediaOptions.type === 'IFRAME' && document.body.contains(primary.media.element)) {
 				// iframe reloads when reattached after being moving in DOM / becoming parentless
 				throw new Error('Could not set as primary since iframe is active');
 			}
@@ -277,7 +264,7 @@ export class Expando {
 		if (this.media && this.media.collapse) {
 			const removeInstead = this.media.collapse();
 			if (removeInstead /*:: && this.media */) {
-				this.media.remove();
+				this.media.element.remove();
 			}
 		}
 
@@ -301,8 +288,8 @@ export class Expando {
 	attachMedia() {
 		if (!this.generateMedia) throw new Error('Cannot attach media without `generateMedia`');
 		this.media = this.media || this.generateMedia();
-		const wasAttached = !!this.media.offsetParent;
-		(this.box.firstElementChild: any).appendChild(this.media);
+		const wasAttached = !!this.media.element.offsetParent;
+		(this.box.firstElementChild: any).appendChild(this.media.element);
 		if (!wasAttached && this.onMediaAttach) this.onMediaAttach();
 	}
 
@@ -326,7 +313,7 @@ export class Expando {
 
 	empty() {
 		if (this.media) {
-			this.media.remove();
+			this.media.element.remove();
 			delete this.media;
 		}
 		if (this.button) {

--- a/lib/modules/showImages/expando.js
+++ b/lib/modules/showImages/expando.js
@@ -1,11 +1,9 @@
 /* @flow */
 
 import _ from 'lodash';
-import { $ } from '../../vendor';
 import {
 	click,
 	filterMap,
-	scrollToElement,
 	string,
 } from '../../utils';
 import type { Thing } from '../../utils';
@@ -17,8 +15,6 @@ export const expandos: WeakMap<Element, Expando> = new WeakMap();
 export const primaryExpandos: Map<string /* href */, Expando> = new Map();
 
 type OnExpandCallback = () => void;
-
-type ExpandOptions = { scrollOnMoveError?: boolean };
 
 export class Expando {
 	static expandoSelector = '.expando-button, .search-expando-button';
@@ -139,16 +135,12 @@ export class Expando {
 			this.open || this.expandWanted ? 'expanded' : 'collapsed collapsedExpando',
 		].join(' ');
 
-		if (!this.isPrimary()) {
-			this.button.classList.add('expando-button-duplicate');
-			title = [
-				title ? `${title}  (` : '',
-				'duplicate link',
-				title ? ')' : '',
-			].join('');
-		}
-
 		this.button.title = title;
+
+		if (this.ready && !this.isPrimary()) {
+			this.button.classList.add('expando-button-duplicate');
+			this.button.title += ' (duplicate link)';
+		}
 	}
 
 	getPrimary(): Expando | void {
@@ -156,22 +148,17 @@ export class Expando {
 	}
 
 	isPrimary(): boolean {
-		return this.getPrimary() === this || !this.getPrimary();
+		return this.getPrimary() === this;
 	}
 
 	setAsPrimary() {
-		const primary = this.getPrimary();
-		if (primary && primary.media) {
-			if (!primary.media.supportsMoveInDOM && primary.media.isAttached()) {
-				throw new Error('Media cannot be moved in DOM');
-			}
-
-			this.media = primary.media;
-		}
-
+		const lastPrimary = this.getPrimary();
 		primaryExpandos.set(this.href, this);
 
-		if (primary) primary.empty();
+		if (lastPrimary && lastPrimary !== this) {
+			this.media = lastPrimary.media;
+			lastPrimary.empty();
+		}
 	}
 
 	initialize(options: {| generateMedia: *, buttonInfo: *, types: * |}) {
@@ -186,26 +173,13 @@ export class Expando {
 		else this.updateButton();
 	}
 
-	toggle(options?: ExpandOptions) {
+	toggle() {
 		if (this.open) this.collapse();
-		else this.expand(options);
+		else this.expand();
 	}
 
-	expand({ scrollOnMoveError = false }: ExpandOptions = {}) {
-		try {
-			if (!this.isPrimary()) this.setAsPrimary();
-		} catch (e) {
-			// If another expando still is primary, scroll to it instead
-			const primary = this.getPrimary();
-			if (scrollOnMoveError && primary && !this.isPrimary()) {
-				primary.expand();
-				primary.scrollToButton(this.button);
-			} else {
-				console.log('Could not expand expando', e);
-			}
-
-			return;
-		}
+	expand() {
+		this.setAsPrimary();
 
 		if (!this.ready) {
 			this.expandWanted = true;
@@ -226,36 +200,15 @@ export class Expando {
 	}
 
 	collapse() {
-		if (!this.ready) {
-			this.expandWanted = false;
-			return;
-		}
+		this.box.hidden = true;
 
 		this.open = false;
+		this.expandWanted = false;
 		this.updateButton();
 
 		if (this.media) {
-			const removeInstead = this.media.collapse();
-			if (removeInstead /*:: && this.media */) {
-				this.media.element.remove();
-			}
+			this.media.collapse();
 		}
-
-		this.box.hidden = true;
-	}
-
-	scrollToButton(returnElement?: Element) {
-		const _returnElement = returnElement;
-		if (_returnElement) {
-			$('<span title="Restore position" class="res-expando-restore-position">')
-				.insertAfter(this.button)
-				.click(e => {
-					e.target.remove();
-					scrollToElement(_returnElement, null, { scrollStyle: 'middle' });
-				});
-		}
-
-		scrollToElement(this.button, null, { scrollStyle: 'top' });
 	}
 
 	attachMedia() {

--- a/lib/modules/showImages/expando.js
+++ b/lib/modules/showImages/expando.js
@@ -162,7 +162,7 @@ export class Expando {
 	setAsPrimary() {
 		const primary = this.getPrimary();
 		if (primary && primary.media) {
-			if (!primary.media.supportsMoveInDOM && document.body.contains(primary.media.element)) {
+			if (!primary.media.supportsMoveInDOM && primary.media.isAttached()) {
 				throw new Error('Media cannot be moved in DOM');
 			}
 

--- a/lib/modules/showImages/expando.js
+++ b/lib/modules/showImages/expando.js
@@ -20,19 +20,6 @@ type OnExpandCallback = () => void;
 
 type ExpandOptions = { scrollOnMoveError?: boolean };
 
-type MediaOptions = {
-	moduleID: string,
-	type: string,
-	attribution: boolean,
-	href: string,
-	muted: boolean,
-	expandoClass?: string,
-	buttonInfo: {
-		title: string,
-		mediaClass: string,
-	},
-};
-
 export class Expando {
 	static expandoSelector = '.expando-button, .search-expando-button';
 
@@ -65,13 +52,11 @@ export class Expando {
 					buttonPlaceholder.replaceWith(button);
 					boxPlaceholder.replaceWith(box);
 				},
-				getTypes() {
-					return [
-						'native',
-						this.button.classList.contains('selftext') ? 'selftext' : null,
-					].filter(v => v);
-				},
-				isLoaded() { return true; },
+				types: [
+					'native',
+					button.classList.contains('selftext') ? 'selftext' : null,
+				].filter(v => v),
+				ready: true,
 			}: any /* TODO: this is kinda dangerous, there should be a subclass instead */);
 
 			expandos.set(button, expando);
@@ -94,7 +79,9 @@ export class Expando {
 		return _.compact([...Expando.getTextExpandosFrom(thing), Expando.getEntryExpandoFrom(thing)]);
 	}
 
+	href: string;
 	inText: boolean;
+	ready: boolean = false;
 	locked: boolean;
 	unlock: ?() => {};
 
@@ -106,13 +93,21 @@ export class Expando {
 
 	expandCallbacks: OnExpandCallback[] = [];
 
-	href: ?string;
 	media: ?Media;
-	mediaOptions: ?MediaOptions;
 	generateMedia: ?() => Media;
-	onMediaAttach: ?() => void;
 
-	constructor(lock: *, unlock: *) {
+	types: string[] = [];
+
+	buttonInfo: {|
+		title: string,
+		mediaClass: string,
+	|} = {
+		title: 'Expando is not yet ready',
+		mediaClass: '',
+	};
+
+	constructor(href: *, lock: *, unlock: *) {
+		this.href = href;
 		this.locked = !!lock;
 		if (lock) lock.then(() => { this.locked = false; this.updateButton(); });
 		this.unlock = unlock;
@@ -130,31 +125,8 @@ export class Expando {
 		this.expandCallbacks.push(callback);
 	}
 
-	getTypes() {
-		if (this.mediaOptions) {
-			return [
-				this.mediaOptions.type,
-				this.mediaOptions.muted ? 'muted' : 'non-muted',
-				...((this.mediaOptions.expandoClass || '').split(' ')),
-			].filter(v => v).map(s => s.toLowerCase());
-		}
-
-		return [];
-	}
-
-	isLoaded() {
-		return !!this.mediaOptions;
-	}
-
 	updateButton() {
-		let title = '';
-		let mediaClass;
-
-		if (this.mediaOptions) {
-			({ mediaClass, title } = this.mediaOptions.buttonInfo);
-		} else {
-			title = 'Expando is not yet ready';
-		}
+		let { mediaClass, title } = this.buttonInfo;
 
 		if (this.locked) {
 			mediaClass = 'expando-button-requires-permission';
@@ -180,32 +152,34 @@ export class Expando {
 	}
 
 	getPrimary(): Expando | void {
-		if (typeof this.href === 'string') {
-			return primaryExpandos.get(this.href);
-		}
+		return primaryExpandos.get(this.href);
 	}
 
 	isPrimary(): boolean {
 		return this.getPrimary() === this || !this.getPrimary();
 	}
 
-	setAsPrimary(force?: boolean = false) {
+	setAsPrimary() {
 		const primary = this.getPrimary();
-		if (!force && primary && primary.media) {
-			if (primary.mediaOptions && primary.mediaOptions.type === 'IFRAME' && document.body.contains(primary.media.element)) {
-				// iframe reloads when reattached after being moving in DOM / becoming parentless
-				throw new Error('Could not set as primary since iframe is active');
+		if (primary && primary.media) {
+			if (!primary.media.supportsMoveInDOM && document.body.contains(primary.media.element)) {
+				throw new Error('Media cannot be moved in DOM');
 			}
 
 			this.media = primary.media;
 		}
 
-		if (this.href) primaryExpandos.set(this.href, this);
+		primaryExpandos.set(this.href, this);
 
 		if (primary) primary.empty();
 	}
 
-	initialize() {
+	initialize(options: {| generateMedia: *, buttonInfo: *, types: * |}) {
+		this.generateMedia = options.generateMedia;
+		this.buttonInfo = options.buttonInfo;
+		this.types = options.types;
+		this.ready = true;
+
 		if (!this.getPrimary()) this.setAsPrimary();
 
 		if (this.expandWanted) this.expand();
@@ -233,17 +207,16 @@ export class Expando {
 			return;
 		}
 
-		if (!this.mediaOptions) {
+		if (!this.ready) {
 			this.expandWanted = true;
 			this.updateButton();
 			return;
 		}
 
 		this.box.hidden = false;
-		this.box.classList.add(`res-media-host-${this.mediaOptions.moduleID}`);
 
-		if (!this.media || this.media.parentElement !== this.box) this.attachMedia();
-		if (this.media && this.media.expand) this.media.expand();
+		this.attachMedia();
+		if (this.media) this.media.expand();
 
 		this.open = true;
 		this.expandWanted = false;
@@ -253,7 +226,7 @@ export class Expando {
 	}
 
 	collapse() {
-		if (!this.mediaOptions) {
+		if (!this.ready) {
 			this.expandWanted = false;
 			return;
 		}
@@ -261,7 +234,7 @@ export class Expando {
 		this.open = false;
 		this.updateButton();
 
-		if (this.media && this.media.collapse) {
+		if (this.media) {
 			const removeInstead = this.media.collapse();
 			if (removeInstead /*:: && this.media */) {
 				this.media.element.remove();
@@ -288,9 +261,8 @@ export class Expando {
 	attachMedia() {
 		if (!this.generateMedia) throw new Error('Cannot attach media without `generateMedia`');
 		this.media = this.media || this.generateMedia();
-		const wasAttached = !!this.media.element.offsetParent;
 		(this.box.firstElementChild: any).appendChild(this.media.element);
-		if (!wasAttached && this.onMediaAttach) this.onMediaAttach();
+		if (/*:: this.media && */ this.media.onAttach) this.media.onAttach();
 	}
 
 	isAttached() {
@@ -308,7 +280,7 @@ export class Expando {
 			delete this.button;
 		}
 		this.empty();
-		if (this.href && primaryExpandos.get(this.href) === this) primaryExpandos.delete(this.href);
+		if (primaryExpandos.get(this.href) === this) primaryExpandos.delete(this.href);
 	}
 
 	empty() {

--- a/lib/modules/wheelBrowse.js
+++ b/lib/modules/wheelBrowse.js
@@ -50,10 +50,10 @@ function useLinklistBehavior() {
 
 		galleryPart.hidden = !(
 			media &&
-			media.classList.contains('res-gallery-slideshow') &&
+			media.element.classList.contains('res-gallery-slideshow') &&
 			( // Do not show the gallery scroll widget when at the end of the gallery
-				!(direction === 'down' && media.querySelector('[last-piece=true]')) &&
-				!(direction === 'up' && media.querySelector('[first-piece=true]'))
+				!(direction === 'down' && media.element.querySelector('[last-piece=true]')) &&
+				!(direction === 'up' && media.element.querySelector('[first-piece=true]'))
 			)
 		);
 	}
@@ -67,7 +67,7 @@ function useLinklistBehavior() {
 			if (target === wheelBrowseWidget) {
 				SelectedEntry.move(direction, { allowMediaBrowse: true, scrollStyle: 'top' });
 			} else if (target === galleryPart) {
-				const clicker = media && media.querySelector(direction === 'down' ? '.res-gallery-next' : '.res-gallery-previous');
+				const clicker = media && media.element.querySelector(direction === 'down' ? '.res-gallery-next' : '.res-gallery-previous');
 				if (clicker) clicker.click();
 				updateGalleryPart(direction);
 			}

--- a/tests/showImages.js
+++ b/tests/showImages.js
@@ -11,7 +11,7 @@ module.exports = {
 
 			.click('.expando-button')
 			.waitForElementVisible('.res-expando-box')
-			.assert.cssClassPresent('.res-expando-box', 'res-media-host-default')
+			.assert.attributeEquals('.res-expando-box', 'data-host', 'default')
 			.assert.attributeEquals('.res-expando-box img', 'src', 'http://fc04.deviantart.net/fs51/i/2009/278/e/6/THEN_by_SamSaxton.jpg')
 			.assert.attributeEquals('.res-expando-box a', 'href', 'http://fc04.deviantart.net/fs51/i/2009/278/e/6/THEN_by_SamSaxton.jpg')
 
@@ -42,7 +42,7 @@ module.exports = {
 			.assert.attributeEquals('.expando-button', 'data-host', 'defaultVideo')
 			.click('.expando-button')
 			.waitForElementVisible('.res-expando-box')
-			.assert.cssClassPresent('.res-expando-box', 'res-media-host-defaultVideo')
+			.assert.attributeEquals('.res-expando-box', 'data-host', 'defaultVideo')
 			.assert.attributeEquals('.res-expando-box video > source', 'src', 'http://mediadownloads.mlb.com/mlbam/mp4/2016/04/13/586892283/1460516257186/asset_1800K.mp4')
 			.end();
 	},
@@ -55,7 +55,7 @@ module.exports = {
 			.assert.attributeEquals('.expando-button', 'data-host', 'defaultAudio')
 			.click('.expando-button')
 			.waitForElementVisible('.res-expando-box')
-			.assert.cssClassPresent('.res-expando-box', 'res-media-host-defaultAudio')
+			.assert.attributeEquals('.res-expando-box', 'data-host', 'defaultAudio')
 			.assert.attributeEquals('.res-expando-box audio > source', 'src', 'https://wiki.teamfortress.com/w/images/8/85/Scout_stunballhit11.wav?t=20100625234511')
 			.end();
 	},
@@ -68,7 +68,7 @@ module.exports = {
 			.assert.attributeEquals('.expando-button', 'data-host', 'youtube')
 			.click('.expando-button')
 			.waitForElementVisible('.res-expando-box')
-			.assert.cssClassPresent('.res-expando-box', 'res-media-host-youtube')
+			.assert.attributeEquals('.res-expando-box', 'data-host', 'youtube')
 			.assert.attributeContains('.res-expando-box iframe', 'src', 'https://www.youtube.com/embed/iwGFalTRHDA')
 			.assert.visible('.res-iframe-expando-drag-handle', 'resize handle visible')
 			.end();
@@ -82,7 +82,7 @@ module.exports = {
 			.assert.attributeEquals('.expando-button', 'data-host', 'miiverse')
 			.click('.expando-button')
 			.waitForElementVisible('.res-expando-box')
-			.assert.cssClassPresent('.res-expando-box', 'res-media-host-miiverse')
+			.assert.attributeEquals('.res-expando-box', 'data-host', 'miiverse')
 			.end();
 	},
 	'gallery expando': browser => {
@@ -96,7 +96,7 @@ module.exports = {
 			.assert.attributeEquals('.expando-button', 'title', '2 items in gallery')
 			.click('.expando-button')
 			.waitForElementVisible('.res-expando-box')
-			.assert.cssClassPresent('.res-expando-box', 'res-media-host-imgur')
+			.assert.attributeEquals('.res-expando-box', 'data-host', 'imgur')
 			.assert.containsText('.res-expando-box', '1 of 2')
 			.assert.attributeEquals('.res-expando-box .res-gallery-pieces > div:not([hidden]) img', 'src', 'https://i.imgur.com/rXZWEIB.jpg')
 			.assert.attributeEquals('.res-expando-box .res-gallery-pieces > div:not([hidden]) a', 'href', 'https://imgur.com/rXZWEIB,eutVEAv#rXZWEIB')


### PR DESCRIPTION
- Convert media elements into classes
- Remove coupling between hosts and `Expando`
  - Removed `.res-expando-box` class `.res-media-host-${host}`
  - Added attribute `data-host=${host}` to it, as the button has

Tested in browser: Chrome 65
