### PR TITLE
webpack: Replace env.production with argv.mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "preonce": "rimraf dist",
     "once": "webpack --progress --mode development --env.browsers",
     "prebuild": "rimraf dist",
-    "build": "webpack --progress --mode production --env.production --env.zip --env.browsers",
+    "build": "webpack --progress --mode production --env.zip --env.browsers",
     "manifoldjs-package": "manifoldjs -l debug -p edgeextension package dist/edgeextension/manifest",
     "autoi18n": "jscodeshift --parser flow --transform build/i18nTransformer.js",
     "postautoi18n": "eslint --fix lib/modules/*.js",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -38,7 +38,8 @@ const browserConfig = {
 	},
 };
 
-export default (env = {}) => {
+export default (env = {}, argv = {}) => {
+	const isProduction = argv.mode === 'production';
 	const browsers = (
 		typeof env.browsers !== 'string' ? ['chrome'] :
 		env.browsers === 'all' ? Object.keys(browserConfig) :
@@ -52,7 +53,7 @@ export default (env = {}) => {
 			filename: path.basename(conf.entry),
 		},
 		devtool: (() => {
-			if (!env.production) return 'cheap-source-map';
+			if (!isProduction) return 'cheap-source-map';
 			if (!conf.noSourcemap) return 'source-map';
 			return false;
 		})(),
@@ -79,11 +80,11 @@ export default (env = {}) => {
 								'transform-dead-code-elimination',
 								['transform-define', {
 									'process.env.BUILD_TARGET': conf.target,
-									'process.env.NODE_ENV': env.production ? 'production' : 'development',
+									'process.env.NODE_ENV': argv.mode,
 								}],
 								'lodash',
 							],
-							comments: !env.production,
+							comments: !isProduction,
 							babelrc: false,
 						},
 					},
@@ -98,7 +99,7 @@ export default (env = {}) => {
 							plugins: [
 								'transform-dead-code-elimination',
 								['transform-define', {
-									'process.env.NODE_ENV': env.production ? 'production' : 'development',
+									'process.env.NODE_ENV': argv.mode,
 								}],
 							],
 							compact: true,


### PR DESCRIPTION
This avoids the need to pass in `--env.production` to the `webpack` script.