### PR TITLE
Update go-mode hotkey filter

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1184,8 +1184,14 @@ function navigateTo(newWindow, href) {
 
 const goModePanel = _.once(() => {
 	const goModes = filterMap(Object.entries(module.options), ([key, opt]) => {
-		if (!opt.goMode) return;
-		return [{ key, niceKeyCode: niceKeyCode(opt.value) }];
+		if (option.goMode && option.type === 'keycode' &&
+			option.callback &&
+			(!option.dependsOn || option.dependsOn(module.options)) &&
+			(!option.include || matchesPageLocation(option.include)) &&
+			(!option.mustBeLoggedIn || loggedInUser()) &&
+			(!option.requiresModule || Modules.isRunning(option.requiresModule))) {
+			return [{ key, niceKeyCode: niceKeyCode(option.value) }];
+		}
 	});
 
 	return $(string.html`

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -157,12 +157,6 @@ module.options = {
 		title: 'keyboardNavOnVoteCommentMoveDownTitle',
 		advanced: true,
 	},
-	useGoMode: {
-		type: 'boolean',
-		value: true,
-		description: 'keyboardNavUseGoModeDesc',
-		title: 'keyboardNavUseGoModeTitle',
-	},
 	followLinkNewTabFocus: {
 		type: 'boolean',
 		value: true,
@@ -655,145 +649,6 @@ module.options = {
 		title: 'keyboardNavFollowProfileNewTabTitle',
 		callback() { followProfile(true); },
 	},
-	goMode: {
-		type: 'keycode',
-		value: [71, false, false, false, false], // g
-		description: 'keyboardNavGoModeDesc',
-		title: 'keyboardNavGoModeTitle',
-		dependsOn: options => options.useGoMode.value,
-		callback() { if (module.options.useGoMode.value) toggleGoMode(); },
-	},
-	gotoInbox: {
-		type: 'keycode',
-		value: [73, false, false, false, false], // i
-		description: 'keyboardNavInboxDesc',
-		title: 'keyboardNavInboxTitle',
-		callback() { navigateTo(false, '/message/inbox/'); },
-		goMode: true,
-	},
-	gotoInboxNewTab: {
-		type: 'keycode',
-		value: [73, false, false, true, false], // shift+i
-		description: 'keyboardNavInboxNewTabDesc',
-		title: 'keyboardNavInboxNewTabTitle',
-		callback() { navigateTo(true, '/message/inbox/'); },
-		goMode: true,
-	},
-	gotoModmail: {
-		type: 'keycode',
-		value: [77, false, false, false, false], // m
-		description: 'keyboardNavModmailDesc',
-		title: 'keyboardNavModmailTitle',
-		callback() { navigateTo(false, '/message/moderator/'); },
-		goMode: true,
-	},
-	gotoModmailNewTab: {
-		type: 'keycode',
-		value: [77, false, false, true, false], // shift+m
-		description: 'keyboardNavModmailNewTabDesc',
-		title: 'keyboardNavModmailNewTabTitle',
-		callback() { navigateTo(true, '/message/moderator/'); },
-		goMode: true,
-	},
-	gotoProfile: {
-		type: 'keycode',
-		value: [85, false, false, false, false], // u
-		description: 'keyboardNavProfileDesc',
-		title: 'keyboardNavProfileTitle',
-		callback() {
-			const user = loggedInUser();
-			if (user) navigateTo(false, `/user/${user}`);
-		},
-		goMode: true,
-	},
-	gotoProfileNewTab: {
-		type: 'keycode',
-		value: [85, false, false, true, false], // shift+u
-		description: 'keyboardNavProfileNewTabDesc',
-		title: 'keyboardNavProfileNewTabTitle',
-		callback() {
-			const user = loggedInUser();
-			if (user) navigateTo(true, `/user/${user}`);
-		},
-		goMode: true,
-	},
-	gotoFrontPage: {
-		type: 'keycode',
-		value: [70, false, false, false, false], // f
-		description: 'keyboardNavFrontPageDesc',
-		title: 'keyboardNavFrontPageTitle',
-		callback() { navigateTo(false, '/'); },
-		goMode: true,
-	},
-	gotoSlashAll: {
-		type: 'keycode',
-		value: [65, true, false, false, false], // alt-a
-		description: 'keyboardNavSlashAllDesc',
-		title: 'keyboardNavSlashAllTitle',
-		callback() { navigateTo(false, '/r/all'); },
-		goMode: true,
-	},
-	gotoSubredditFrontPage: {
-		type: 'keycode',
-		value: [70, false, false, true, false], // shift-f
-		description: 'keyboardNavsSubredditFrontPageDesc',
-		title: 'keyboardNavsSubredditFrontPageTitle',
-		callback() {
-			const sub = currentSubreddit();
-			if (sub) navigateTo(false, `/r/${sub}`);
-		},
-		goMode: true,
-	},
-	gotoRandom: {
-		type: 'keycode',
-		value: [89, true, false, false, false], // alt-y   SO RANDOM
-		description: 'keyboardNavRandomDesc',
-		title: 'keyboardNavRandomTitle',
-		callback() { navigateTo(false, '/r/random'); },
-		goMode: true,
-	},
-	gotoNextPage: {
-		type: 'keycode',
-		include: ['linklist', 'commentsLinklist', 'modqueue', 'profile', 'inbox'],
-		value: [78, false, false, false, false], // n
-		description: 'keyboardNavNextPageDesc',
-		title: 'keyboardNavNextPageTitle',
-		callback: nextPage,
-		goMode: true,
-	},
-	gotoPrevPage: {
-		type: 'keycode',
-		include: ['linklist', 'commentsLinklist', 'modqueue', 'profile', 'inbox'],
-		value: [80, false, false, false, false], // p
-		description: 'keyboardNavPrevPageDesc',
-		title: 'keyboardNavPrevPageTitle',
-		callback: prevPage,
-		goMode: true,
-	},
-	gotoOverviewLegacy: {
-		type: 'keycode',
-		include: ['d2x', 'profile'],
-		value: [79, false, false, true, false], // shift+o
-		description: 'keyboardNavOverviewLegacyDesc',
-		title: 'keyboardNavOverviewLegacyTitle',
-		callback() {
-			const currentUser = currentUserProfile();
-			if (currentUser) navigateTo(false, `/user/${currentUser}/overview`);
-		},
-		goMode: true,
-	},
-	gotoProfileView: {
-		type: 'keycode',
-		include: ['d2x', 'profile'],
-		value: [80, false, false, true, false], // shift+p
-		description: 'keyboardNavProfileViewDesc',
-		title: 'keyboardNavProfileViewTitle',
-		callback() {
-			const currentUser = currentUserProfile();
-			if (currentUser) navigateTo(false, `/user/${currentUser}`);
-		},
-		goMode: true,
-	},
 	toggleCommentNavigator: {
 		type: 'keycode',
 		requiresModule: CommentNavigator,
@@ -824,6 +679,151 @@ module.options = {
 		description: 'keyboardNavFocusOnSearchBoxDesc',
 		title: 'keyboardNavFocusOnSearchBoxTitle',
 		callback() { document.querySelector('#search input[name="q"]').focus(); },
+	},	
+	useGoMode: {
+		type: 'boolean',
+		value: true,
+		description: 'keyboardNavUseGoModeDesc',
+		title: 'keyboardNavUseGoModeTitle',
+	},
+	goMode: {
+		type: 'keycode',
+		value: [71, false, false, false, false], // g
+		description: 'keyboardNavGoModeDesc',
+		title: 'keyboardNavGoModeTitle',
+		dependsOn: options => options.useGoMode.value,
+		callback() { if (module.options.useGoMode.value) toggleGoMode(); },
+	},
+	inbox: {
+		type: 'keycode',
+		value: [73, false, false, false, false], // i
+		description: 'keyboardNavInboxDesc',
+		title: 'keyboardNavInboxTitle',
+		callback() { navigateTo(false, '/message/inbox/'); },
+		goMode: true,
+	},
+	inboxNewTab: {
+		type: 'keycode',
+		value: [73, false, false, true, false], // shift+i
+		description: 'keyboardNavInboxNewTabDesc',
+		title: 'keyboardNavInboxNewTabTitle',
+		callback() { navigateTo(true, '/message/inbox/'); },
+		goMode: true,
+	},
+	modmail: {
+		type: 'keycode',
+		value: [77, false, false, false, false], // m
+		description: 'keyboardNavModmailDesc',
+		title: 'keyboardNavModmailTitle',
+		callback() { navigateTo(false, '/message/moderator/'); },
+		goMode: true,
+	},
+	modmailNewTab: {
+		type: 'keycode',
+		value: [77, false, false, true, false], // shift+m
+		description: 'keyboardNavModmailNewTabDesc',
+		title: 'keyboardNavModmailNewTabTitle',
+		callback() { navigateTo(true, '/message/moderator/'); },
+		goMode: true,
+	},
+	profile: {
+		type: 'keycode',
+		value: [85, false, false, false, false], // u
+		description: 'keyboardNavProfileDesc',
+		title: 'keyboardNavProfileTitle',
+		callback() {
+			const user = loggedInUser();
+			if (user) navigateTo(false, `/user/${user}`);
+		},
+		goMode: true,
+	},
+	profileNewTab: {
+		type: 'keycode',
+		value: [85, false, false, true, false], // shift+u
+		description: 'keyboardNavProfileNewTabDesc',
+		title: 'keyboardNavProfileNewTabTitle',
+		callback() {
+			const user = loggedInUser();
+			if (user) navigateTo(true, `/user/${user}`);
+		},
+		goMode: true,
+	},
+	frontPage: {
+		type: 'keycode',
+		value: [70, false, false, false, false], // f
+		description: 'keyboardNavFrontPageDesc',
+		title: 'keyboardNavFrontPageTitle',
+		callback() { navigateTo(false, '/'); },
+		goMode: true,
+	},
+	slashAll: {
+		type: 'keycode',
+		value: [65, true, false, false, false], // alt-a
+		description: 'keyboardNavSlashAllDesc',
+		title: 'keyboardNavSlashAllTitle',
+		callback() { navigateTo(false, '/r/all'); },
+		goMode: true,
+	},
+	subredditFrontPage: {
+		type: 'keycode',
+		value: [70, false, false, true, false], // shift-f
+		description: 'keyboardNavsSubredditFrontPageDesc',
+		title: 'keyboardNavsSubredditFrontPageTitle',
+		callback() {
+			const sub = currentSubreddit();
+			if (sub) navigateTo(false, `/r/${sub}`);
+		},
+		goMode: true,
+	},
+	random: {
+		type: 'keycode',
+		value: [89, true, false, false, false], // alt-y   SO RANDOM
+		description: 'keyboardNavRandomDesc',
+		title: 'keyboardNavRandomTitle',
+		callback() { navigateTo(false, '/r/random'); },
+		goMode: true,
+	},
+	nextPage: {
+		type: 'keycode',
+		include: ['linklist', 'commentsLinklist', 'modqueue', 'profile', 'inbox'],
+		value: [78, false, false, false, false], // n
+		description: 'keyboardNavNextPageDesc',
+		title: 'keyboardNavNextPageTitle',
+		callback: nextPage,
+		goMode: true,
+	},
+	prevPage: {
+		type: 'keycode',
+		include: ['linklist', 'commentsLinklist', 'modqueue', 'profile', 'inbox'],
+		value: [80, false, false, false, false], // p
+		description: 'keyboardNavPrevPageDesc',
+		title: 'keyboardNavPrevPageTitle',
+		callback: prevPage,
+		goMode: true,
+	},
+	overviewLegacy: {
+		type: 'keycode',
+		include: ['d2x', 'profile'],
+		value: [79, false, false, true, false], // shift+o
+		description: 'keyboardNavOverviewLegacyDesc',
+		title: 'keyboardNavOverviewLegacyTitle',
+		callback() {
+			const currentUser = currentUserProfile();
+			if (currentUser) navigateTo(false, `/user/${currentUser}/overview`);
+		},
+		goMode: true,
+	},
+	profileView: {
+		type: 'keycode',
+		include: ['d2x', 'profile'],
+		value: [80, false, false, true, false], // shift+p
+		description: 'keyboardNavProfileViewDesc',
+		title: 'keyboardNavProfileViewTitle',
+		callback() {
+			const currentUser = currentUserProfile();
+			if (currentUser) navigateTo(false, `/user/${currentUser}`);
+		},
+		goMode: true,
 	},
 	// numbers and numpad numbers are used to access links (see getLinkKeys)
 };

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1184,8 +1184,8 @@ function navigateTo(newWindow, href) {
 
 const goModePanel = _.once(() => {
 	const goModes = getActiveCommandOptions()
-	  .filter(opt => opt.goMode)
-	  .map(opt => ({ key: i18n(opt.title), niceKeyCode: niceKeyCode(opt.value) }));
+		.filter(opt => opt.goMode)
+		.map(opt => ({ key: i18n(opt.title), niceKeyCode: niceKeyCode(opt.value) }));
 
 	return $(string.html`
 		<div id="goModePanel" class="RESDialogSmall">

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1183,16 +1183,9 @@ function navigateTo(newWindow, href) {
 }
 
 const goModePanel = _.once(() => {
-	const goModes = filterMap(Object.entries(module.options), ([, option]) => {
-		if (option.goMode && option.type === 'keycode' &&
-			option.callback &&
-			(!option.dependsOn || option.dependsOn(module.options)) &&
-			(!option.include || matchesPageLocation(option.include)) &&
-			(!option.mustBeLoggedIn || loggedInUser()) &&
-			(!option.requiresModule || Modules.isRunning(option.requiresModule))) {
-			return [{ key: i18n(option.title), niceKeyCode: niceKeyCode(option.value) }];
-		}
-	});
+	const goModes = getActiveCommandOptions()
+	  .filter(opt => opt.goMode)
+	  .map(opt => ({ key: i18n(opt.title), niceKeyCode: niceKeyCode(opt.value) }));
 
 	return $(string.html`
 		<div id="goModePanel" class="RESDialogSmall">

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -679,7 +679,7 @@ module.options = {
 		description: 'keyboardNavFocusOnSearchBoxDesc',
 		title: 'keyboardNavFocusOnSearchBoxTitle',
 		callback() { document.querySelector('#search input[name="q"]').focus(); },
-	},	
+	},
 	useGoMode: {
 		type: 'boolean',
 		value: true,
@@ -1183,7 +1183,7 @@ function navigateTo(newWindow, href) {
 }
 
 const goModePanel = _.once(() => {
-	const goModes = filterMap(Object.entries(module.options), ([key, option]) => {
+	const goModes = filterMap(Object.entries(module.options), ([, option]) => {
 		if (option.goMode && option.type === 'keycode' &&
 			option.callback &&
 			(!option.dependsOn || option.dependsOn(module.options)) &&

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -663,7 +663,7 @@ module.options = {
 		dependsOn: options => options.useGoMode.value,
 		callback() { if (module.options.useGoMode.value) toggleGoMode(); },
 	},
-	inbox: {
+	gotoInbox: {
 		type: 'keycode',
 		value: [73, false, false, false, false], // i
 		description: 'keyboardNavInboxDesc',
@@ -671,7 +671,7 @@ module.options = {
 		callback() { navigateTo(false, '/message/inbox/'); },
 		goMode: true,
 	},
-	inboxNewTab: {
+	gotoInboxNewTab: {
 		type: 'keycode',
 		value: [73, false, false, true, false], // shift+i
 		description: 'keyboardNavInboxNewTabDesc',
@@ -679,7 +679,7 @@ module.options = {
 		callback() { navigateTo(true, '/message/inbox/'); },
 		goMode: true,
 	},
-	modmail: {
+	gotoModmail: {
 		type: 'keycode',
 		value: [77, false, false, false, false], // m
 		description: 'keyboardNavModmailDesc',
@@ -687,7 +687,7 @@ module.options = {
 		callback() { navigateTo(false, '/message/moderator/'); },
 		goMode: true,
 	},
-	modmailNewTab: {
+	gotoModmailNewTab: {
 		type: 'keycode',
 		value: [77, false, false, true, false], // shift+m
 		description: 'keyboardNavModmailNewTabDesc',
@@ -695,7 +695,7 @@ module.options = {
 		callback() { navigateTo(true, '/message/moderator/'); },
 		goMode: true,
 	},
-	profile: {
+	gotoProfile: {
 		type: 'keycode',
 		value: [85, false, false, false, false], // u
 		description: 'keyboardNavProfileDesc',
@@ -706,7 +706,7 @@ module.options = {
 		},
 		goMode: true,
 	},
-	profileNewTab: {
+	gotoProfileNewTab: {
 		type: 'keycode',
 		value: [85, false, false, true, false], // shift+u
 		description: 'keyboardNavProfileNewTabDesc',
@@ -717,7 +717,7 @@ module.options = {
 		},
 		goMode: true,
 	},
-	frontPage: {
+	gotoFrontPage: {
 		type: 'keycode',
 		value: [70, false, false, false, false], // f
 		description: 'keyboardNavFrontPageDesc',
@@ -725,7 +725,7 @@ module.options = {
 		callback() { navigateTo(false, '/'); },
 		goMode: true,
 	},
-	slashAll: {
+	gotoSlashAll: {
 		type: 'keycode',
 		value: [65, true, false, false, false], // alt-a
 		description: 'keyboardNavSlashAllDesc',
@@ -733,7 +733,7 @@ module.options = {
 		callback() { navigateTo(false, '/r/all'); },
 		goMode: true,
 	},
-	subredditFrontPage: {
+	gotoSubredditFrontPage: {
 		type: 'keycode',
 		value: [70, false, false, true, false], // shift-f
 		description: 'keyboardNavsSubredditFrontPageDesc',
@@ -744,7 +744,7 @@ module.options = {
 		},
 		goMode: true,
 	},
-	random: {
+	gotoRandom: {
 		type: 'keycode',
 		value: [89, true, false, false, false], // alt-y   SO RANDOM
 		description: 'keyboardNavRandomDesc',
@@ -752,7 +752,7 @@ module.options = {
 		callback() { navigateTo(false, '/r/random'); },
 		goMode: true,
 	},
-	nextPage: {
+	gotoNextPage: {
 		type: 'keycode',
 		include: ['linklist', 'commentsLinklist', 'modqueue', 'profile', 'inbox'],
 		value: [78, false, false, false, false], // n
@@ -761,7 +761,7 @@ module.options = {
 		callback: nextPage,
 		goMode: true,
 	},
-	prevPage: {
+	gotoPrevPage: {
 		type: 'keycode',
 		include: ['linklist', 'commentsLinklist', 'modqueue', 'profile', 'inbox'],
 		value: [80, false, false, false, false], // p
@@ -770,7 +770,7 @@ module.options = {
 		callback: prevPage,
 		goMode: true,
 	},
-	overviewLegacy: {
+	gotoOverviewLegacy: {
 		type: 'keycode',
 		include: ['d2x', 'profile'],
 		value: [79, false, false, true, false], // shift+o
@@ -782,7 +782,7 @@ module.options = {
 		},
 		goMode: true,
 	},
-	profileView: {
+	gotoProfileView: {
 		type: 'keycode',
 		include: ['d2x', 'profile'],
 		value: [80, false, false, true, false], // shift+p
@@ -1183,14 +1183,14 @@ function navigateTo(newWindow, href) {
 }
 
 const goModePanel = _.once(() => {
-	const goModes = filterMap(Object.entries(module.options), ([key, opt]) => {
+	const goModes = filterMap(Object.entries(module.options), ([key, option]) => {
 		if (option.goMode && option.type === 'keycode' &&
 			option.callback &&
 			(!option.dependsOn || option.dependsOn(module.options)) &&
 			(!option.include || matchesPageLocation(option.include)) &&
 			(!option.mustBeLoggedIn || loggedInUser()) &&
 			(!option.requiresModule || Modules.isRunning(option.requiresModule))) {
-			return [{ key, niceKeyCode: niceKeyCode(option.value) }];
+			return [{ key: i18n(option.title), niceKeyCode: niceKeyCode(option.value) }];
 		}
 	});
 


### PR DESCRIPTION
To match the other filters, will only show hotkeys that are enabled options, specific to the page, etc. Previously was showing every option on every page, despite the options having `include` set for specific pages.

~~Changed the names of all the 'Go to' hotkeys to start with "goto[Inbox|Frontpage|etc]" so it was more obvious which ones were linked with the Go-Mode function, based on it's description.~~
*Reordered the options so that all the 'Go to' hotkeys and options were grouped together at the bottom.*

Also made the popup show the friendly name.

![chrome_2018-03-08_16-20-25](https://user-images.githubusercontent.com/510057/37183790-b50195a6-22ec-11e8-88e4-edcc6bb88463.png)

