### PR TITLE
Reordered test actions to avoid issues with built-in userinfo

### DIFF
--- a/tests/selectedEntry.js
+++ b/tests/selectedEntry.js
@@ -31,20 +31,20 @@ module.exports = {
 			.assert.cssClassPresent(stickiedComment, selectedClass)
 
 			.pause(1000)
-			.click(loadMoreComments)
-			.waitForElementVisible(childComment1)
-			.assert.cssClassPresent(childComment1, selectedClass)
-
-			.click(childComment2)
-			.assert.cssClassPresent(childComment2, selectedClass)
-
-			.pause(1000)
 			.click(loadMoreChildrenOfSticky)
 			.waitForElementVisible(childOfStickiedComment2)
 			.assert.cssClassPresent(childOfStickiedComment1, selectedClass)
 
 			.click(childOfStickiedComment2)
 			.assert.cssClassPresent(childOfStickiedComment2, selectedClass)
+
+			.pause(1000)
+			.click(loadMoreComments)
+			.waitForElementVisible(childComment1)
+			.assert.cssClassPresent(childComment1, selectedClass)
+
+			.click(childComment2)
+			.assert.cssClassPresent(childComment2, selectedClass)
 
 			.end();
 	},


### PR DESCRIPTION
I can't reproduce the issue myself, but I think, like the [comment describes](https://github.com/honestbleeps/Reddit-Enhancement-Suite/blob/master/tests/selectedEntry.js#L14), the reddit built-in usertip might be overlaying the `loadMoreChildrenOfSticky`. So I reordered so they'd work top to bottom to hopefully avoid that issue.