### PR TITLE
nightmode: Don't change global state on load

### DIFF
--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -106,6 +106,7 @@ module.exclude = [
 
 const localStorageKey = 'RES_nightMode';
 const nightmodeOverrideStorage = Storage.wrap('RESmodules.nightMode.nightModeOverrideStart', (null: null | number));
+let enableNightMode, disableNightMode;
 
 module.onToggle = toggle => {
 	// If the module is turned off, disable night mode completely
@@ -118,25 +119,34 @@ module.loadDynamicOptions = () => {
 	// To avoid the flash of unstyled content, the very first thing we should do is get a hold
 	// of the document object and add necessary classes...
 	if (typeof localStorage === 'object' && localStorage.getItem(localStorageKey)) {
-		// No need to check the background - we're in night mode for sure.
-		enableNightMode();
+		addNightMode();
 	}
 };
 
 module.beforeLoad = () => {
-	// If night mode is enabled, set a localStorage token so that in the future,
-	// we can add the res-nightmode class to the page prior to page load.
 	if (isNightModeOn()) {
-		enableNightMode();
+		addNightMode();
 	} else {
-		disableNightMode();
+		removeNightMode();
 	}
+
+	enableNightMode = multicast(() => {
+		Options.set(module, 'nightModeOn', true);
+		addNightMode();
+		updateNightSwitch(true);
+	}, { name: 'enableNightMode' });
+
+	disableNightMode = multicast(() => {
+		Options.set(module, 'nightModeOn', false);
+		removeNightMode();
+		updateNightSwitch(false);
+	}, { name: 'disableNightMode' });
 };
 
 module.always = () => {
-	if (!Modules.isEnabled(module)) {
-		// Failsafe to disable night mode if the module is disabled
-		disableNightMode();
+	if (!Modules.isRunning(module)) {
+		// Nightmode might have been erronously applied in `loadDynamicOptions`
+		removeNightMode();
 	}
 };
 
@@ -389,9 +399,9 @@ function userToggledNightMode(e) {
 
 function toggleNightMode() {
 	if (isNightModeOn()) {
-		disableNightMode();
+		if (disableNightMode) disableNightMode();
 	} else {
-		enableNightMode();
+		if (enableNightMode) enableNightMode();
 	}
 	StyleTweaks.toggleSubredditStyleIfNecessary();
 }
@@ -407,16 +417,13 @@ const className = () => {
 	}
 };
 
-const enableNightMode = multicast(() => {
-	Options.set(module, 'nightModeOn', true);
-	localStorage.setItem(localStorageKey, 'true');
+const addNightMode = () => {
 	BodyClasses.add(className());
-	updateNightSwitch(true);
-}, { name: 'enableNightMode' });
+	// Set a localStorage token so that in the future we can add nightmode to the page prior to page load.
+	localStorage.setItem(localStorageKey, 'true');
+};
 
-const disableNightMode = multicast(() => {
-	Options.set(module, 'nightModeOn', false);
-	localStorage.removeItem(localStorageKey);
+const removeNightMode = () => {
 	BodyClasses.remove(className());
-	updateNightSwitch(false);
-}, { name: 'disableNightMode' });
+	localStorage.removeItem(localStorageKey);
+};


### PR DESCRIPTION
The multicasted functions were invoked on all tabs, also those where the nightmode module was not running (d2x pages).

Relevant issue: 
Tested in browser: Chrome 65