### PR TITLE
[RFC] Change selected entry from background colour to right border.

### DIFF
--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -59,7 +59,7 @@ module.options = {
 		value: true,
 		description: 'selectedEntrySetColorsDesc',
 	},
-	backgroundColor: {
+	borderColor: {
 		title: 'selectedEntryBackgroundColorTitle',
 		type: 'color',
 		value: '#F0F3FC',
@@ -67,7 +67,7 @@ module.options = {
 		advanced: true,
 		dependsOn: options => options.setColors.value,
 	},
-	backgroundColorNight: {
+	borderColorNight: {
 		title: 'selectedEntryBackgroundColorNightTitle',
 		type: 'color',
 		value: '#373737',
@@ -353,16 +353,16 @@ function styleColor() {
 		}
 	}, 'beforePaint');
 
-	const backgroundColor = module.options.backgroundColor.value ? `
+	const borderColor = module.options.borderColor.value ? `
 		.entry.res-selected,
 		.entry.res-selected .md-container {
-			background-color: ${module.options.backgroundColor.value} !important;
+			border-right: 5px solid ${module.options.borderColor.value} !important;
 		}` : '';
 
-	const backgroundColorNight = module.options.backgroundColorNight.value ? `
+	const borderColorNight = module.options.borderColorNight.value ? `
 		.res-nightmode .entry.res-selected,
 		.res-nightmode .entry.res-selected .md-container {
-			background-color: ${module.options.backgroundColorNight.value} !important;
+			border-right: 5px solid ${module.options.borderColorNight.value} !important;
 		}` : '';
 
 	const textColorNight = module.options.textColorNight.value ? `
@@ -372,7 +372,7 @@ function styleColor() {
 			color: ${module.options.textColorNight.value} !important;
 		}` : '';
 
-	addCSS(backgroundColor + backgroundColorNight + textColorNight);
+	addCSS(borderColor + borderColorNight + textColorNight);
 	installUpdateSelectedElementClassListener();
 }
 


### PR DESCRIPTION
As discussed between @honestbleeps and myself on IRC. It might be worth swapping selected entry from background colour to a right border for the following reasons:

1) It looks cleaner.
2) Would resolve keynav issues on subreddits where they are intentionally styling it out.

The proposal in commit looks like this: 

![](https://i.imgur.com/wlM2DFY.png)

Thoughts?