### PR TITLE
Use ctrl-enter not shift-enter to open a link in a new tab

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -327,7 +327,7 @@ module.options = {
 	followLinkNewTab: {
 		type: 'keycode',
 		include: ['linklist', 'modqueue', 'profile', 'comments', 'search'],
-		value: [13, false, false, true, false], // shift-enter
+		value: [13, false, true, false, false], // ctrl-enter
 		description: 'keyboardNavFollowLinkNewTabDesc',
 		title: 'keyboardNavFollowLinkNewTabTitle',
 		callback() { followLink(true); },


### PR DESCRIPTION
Nearly all applications use ctrl-enter to open a link in a new tab, not shift-enter, so making RES do the same seems intuitive. 