### PR TITLE
Fixed issue #2731; go mode will now escape NP mode

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1021,6 +1021,7 @@ async function handleCallbacks(options) {
 			console.error('Could not execute callback', i18n(option.title), e);
 		}
 	}
+	npEscapeActive = goModeActive;
 }
 
 const promptUniqueShortcut = _.memoize(async (shortcut, options: any) => {
@@ -1194,7 +1195,17 @@ function reply(selected = getSelected()) {
 	));
 }
 
+let npEscapeActive = false;
+
+function checkNpEscape(href) {
+	if (npEscapeActive) {
+		href = NoParticipation.nonNpLocation(href);
+	}
+	return href;
+}
+
 function navigateTo(newWindow, href) {
+	href = checkNpEscape(href);
 	if (newWindow) {
 		openNewTab(href, module.options.followLinkNewTabFocus.value);
 	} else {
@@ -1263,7 +1274,8 @@ function nextPage() {
 	} else {
 		// get the first link to the next page of reddit...
 		const nextPrevLinks = NeverEndingReddit.getNextPrevLinks();
-		location.href = assertElement(nextPrevLinks.next).getAttribute('href');
+		const href = assertElement(nextPrevLinks.next).getAttribute('href');
+		location.href = checkNpEscape(href);
 	}
 }
 
@@ -1271,7 +1283,8 @@ function prevPage() {
 	// if Never Ending Reddit is enabled, do nothing.  Otherwise, click the 'prev' link.
 	if (!Modules.isRunning(NeverEndingReddit)) {
 		const nextPrevLinks = NeverEndingReddit.getNextPrevLinks();
-		location.href = assertElement(nextPrevLinks.prev).getAttribute('href');
+		const href = assertElement(nextPrevLinks.prev).getAttribute('href');
+		location.href = checkNpEscape(href);
 	}
 }
 

--- a/lib/modules/noParticipation.js
+++ b/lib/modules/noParticipation.js
@@ -108,8 +108,8 @@ function isSubscriber() {
 	return document.body.classList.contains('subscriber');
 }
 
-function nonNpLocation() {
-	const nonNpUrl = new URL(location.href);
+export function nonNpLocation(path: ?string) {
+	const nonNpUrl = path ? new URL(path, location.href) : new URL(location.href);
 	nonNpUrl.hostname = 'www.reddit.com';
 	return nonNpUrl.href;
 }


### PR DESCRIPTION
Relevant issue: Resolves #2731 (gomode should leave noparticipation)
Tested in browsers: Chrome, Firefox

- Passed linter, flow, unit, integration tests. 
- Since Next and Previous page commands are also a part of go mode, I made changes to them as well. But in case that's not desired, the checkNpEscape function is easy to remove.