### PR TITLE
Use toggle interface for nightMode and NSFW mode

### DIFF
--- a/lib/modules/customToggles.js
+++ b/lib/modules/customToggles.js
@@ -38,6 +38,7 @@ module.options = {
 };
 
 const toggles: Map<string, Toggle> = new Map();
+const customToggles: Array<Toggle> = [];
 
 module.beforeLoad = () => {
 	for (const instance of module.options.toggle.value) {
@@ -45,9 +46,11 @@ module.beforeLoad = () => {
 
 		if (toggles.has(key)) {
 			console.error(`A toggle with key ${key} already exists`, instance);
+			continue;
 		}
 
 		const toggle = new Toggle(key, text, initialEnabled);
+		customToggles.push(toggle);
 
 		toggle.onStateChange(() => {
 			// Keep the settings data current to avoid overwriting modifications from other tabs
@@ -63,7 +66,7 @@ module.beforeLoad = () => {
 module.go = () => {
 	registerCommandLine();
 
-	for (const toggle of toggles.values()) {
+	for (const toggle of customToggles) {
 		toggle.addMenuItem();
 	}
 };
@@ -73,7 +76,7 @@ export class Toggle {
 	enabled: boolean;
 
 	stateChangeCallbacks: Array<() => void> = []; // Invoked on all tabs
-	toggleCallbacks: Array<() => void> = []; // Invoked on the tab which caused the change
+	toggleCallbacks: Array<(type: 'auto' | 'manual') => void> = []; // Invoked on the tab which caused the change
 
 	constructor(key: string, text: *, enabled: *) {
 		this.text = text;
@@ -88,10 +91,10 @@ export class Toggle {
 		toggles.set(key, this);
 	}
 
-	toggle() {
+	toggle(type: * = 'manual') {
 		this.setLocalState(!this.enabled);
 
-		for (const callback of this.toggleCallbacks) callback();
+		for (const callback of this.toggleCallbacks) callback(type);
 	}
 
 	setLocalState(enabled: boolean) {
@@ -111,11 +114,18 @@ export class Toggle {
 		this.toggleCallbacks.push(callback);
 	}
 
-	addMenuItem(text: string = this.text, title: string = `Toggle ${this.text}`, on?: string, off?: string) {
-		const $toggle = $('<div>', { text: text || '\u00A0' /* nbsp */, title })
+	addMenuItem(title: string = `Toggle ${this.text}`, on?: string, off?: string) {
+		const $toggle = $('<div>', { text: this.text || '\u00A0' /* nbsp */, title })
 			.append(CreateElement.toggleButton(undefined, this.text, this.enabled, on, off));
 		this.onStateChange(() => { $toggle.find('.toggleButton').toggleClass('enabled', this.enabled); });
 		Menu.addMenuItem($toggle, () => { this.toggle(); });
+	}
+
+	addCLI(commandPredicate: string) {
+		CommandLine.registerCommand(commandPredicate, `${commandPredicate} - toggle ${this.text}`,
+			() => ` ${this.enabled ? 'Disable' : 'Enable'} ${this.text}`,
+			() => { this.toggle(); }
+		);
 	}
 }
 

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -32,7 +32,7 @@ import { Storage, ajax, i18n } from '../environment';
 import type { BuilderRootValue } from '../core/module';
 import type { RedditListing, RedditLink } from '../types/reddit';
 import * as CommandLine from './commandLine';
-import * as Menu from './menu';
+import * as CustomToggles from './customToggles';
 import * as Notifications from './notifications';
 import * as RESTips from './RESTips';
 import * as SelectedEntry from './selectedEntry';
@@ -402,8 +402,15 @@ const initialFilterlineState = reifyPromise((async () =>
 	Object.assign({}, ...(await Promise.resolve().then(() => Promise.all([getDefaultFilters(), filterlineStorage.get()]))))
 )());
 
+let nsfwToggle;
+
 module.beforeLoad = fastAsync(function*() {
 	updateNsfwBodyClass(module.options.NSFWfilter.value);
+
+	nsfwToggle = new CustomToggles.Toggle('nsfwMode', i18n('nsfwSwitchToggleText'), module.options.NSFWfilter.value);
+	nsfwToggle.onToggle(() => { Options.set(module, 'NSFWfilter', nsfwToggle.enabled); });
+	nsfwToggle.onStateChange(() => { updateNsfwBodyClass(nsfwToggle.enabled); });
+	nsfwToggle.addCLI('nsfw');
 
 	// start initializing filterline early
 	createFilterline(yield initialFilterlineState.get());
@@ -412,16 +419,10 @@ module.beforeLoad = fastAsync(function*() {
 	watchForThings([thingType], registerThing, { immediate: true });
 });
 
-const $nsfwSwitch = _.once(() => $(CreateElement.toggleButton(undefined, 'nsfwSwitchToggle', module.options.NSFWfilter.value)));
 
 module.go = () => {
-	registerNsfwToggleCommand();
 	if (module.options.NSFWQuickToggle.value) {
-		Menu.addMenuItem($('<div>', {
-			text: i18n('nsfwSwitchToggleText'),
-			title: i18n('nsfwSwitchToggleTitle'),
-			append: $nsfwSwitch(),
-		}), toggleNsfwFilter);
+		nsfwToggle.addMenuItem(i18n('nsfwSwitchToggleTitle'));
 	}
 
 	createFilterline().go();
@@ -918,51 +919,8 @@ function allowNSFW(postSubreddit, currSubreddit = currentSubreddit()) {
 	return false;
 }
 
-function toggleNsfwFilter(toggle, notify) {
-	if (toggle === false || module.options.NSFWfilter.value) {
-		updateNsfwBodyClass(false);
-		Options.set(module, 'NSFWfilter', false);
-		$nsfwSwitch().removeClass('enabled');
-	} else {
-		updateNsfwBodyClass(true);
-		Options.set(module, 'NSFWfilter', true);
-		$nsfwSwitch().addClass('enabled');
-	}
-
-	if (notify) {
-		const onOff = module.options.NSFWfilter.value ? 'on' : ' off';
-
-		Notifications.showNotification({
-			header: 'NSFW Filter',
-			moduleID: 'filteReddit',
-			optionKey: 'NSFWfilter',
-			message: `NSFW Filter has been turned ${onOff}.`,
-		}, 4000);
-	}
-}
-
 function updateNsfwBodyClass(filterOn) {
 	BodyClasses.toggle(filterOn, 'hideOver18');
-}
-
-function registerNsfwToggleCommand() {
-	CommandLine.registerCommand('nsfw', 'nsfw [on|off] - toggle nsfw filter on/off',
-		() => 'Toggle nsfw filter on or off',
-		(command, val) => {
-			let toggle;
-			switch (val && val.toLowerCase()) {
-				case 'on':
-					toggle = true;
-					break;
-				case 'off':
-					toggle = false;
-					break;
-				default:
-					return 'nsfw on &nbsp; or &nbsp; nsfw off ?';
-			}
-			toggleNsfwFilter(toggle, true);
-		}
-	);
 }
 
 function registerSubredditFilterCommand() {

--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -2,7 +2,6 @@
 
 import _ from 'lodash';
 import { getTimes as getSunriseSunset } from 'suncalc';
-import { $ } from '../vendor';
 import { Module } from '../core/module';
 import * as Init from '../core/init';
 import * as Modules from '../core/modules';
@@ -11,14 +10,12 @@ import {
 	appType,
 	Alert,
 	BodyClasses,
-	CreateElement,
 	currentSubreddit,
 	HOUR,
 	MINUTE,
 } from '../utils';
-import { Session, Storage, i18n, multicast } from '../environment';
-import * as CommandLine from './commandLine';
-import * as Menu from './menu';
+import { Session, Storage, i18n } from '../environment';
+import * as CustomToggles from './customToggles';
 import * as StyleTweaks from './styleTweaks';
 
 export const module: Module<*> = new Module('nightMode');
@@ -106,13 +103,11 @@ module.exclude = [
 
 const localStorageKey = 'RES_nightMode';
 const nightmodeOverrideStorage = Storage.wrap('RESmodules.nightMode.nightModeOverrideStart', (null: null | number));
-let enableNightMode, disableNightMode;
+let toggle;
 
-module.onToggle = toggle => {
+module.onToggle = enabled => {
 	// If the module is turned off, disable night mode completely
-	if (!toggle) {
-		disableNightMode();
-	}
+	if (toggle.enabled && !enabled) toggle.toggle();
 };
 
 module.loadDynamicOptions = () => {
@@ -130,17 +125,17 @@ module.beforeLoad = () => {
 		removeNightMode();
 	}
 
-	enableNightMode = multicast(() => {
-		Options.set(module, 'nightModeOn', true);
-		addNightMode();
-		updateNightSwitch(true);
-	}, { name: 'enableNightMode' });
-
-	disableNightMode = multicast(() => {
-		Options.set(module, 'nightModeOn', false);
-		removeNightMode();
-		updateNightSwitch(false);
-	}, { name: 'disableNightMode' });
+	toggle = new CustomToggles.Toggle('nightMode', i18n('nightModeToggleText'), module.options.nightModeOn.value);
+	toggle.onToggle(type => {
+		if (type === 'manual') overrideNightMode();
+		Options.set(module, 'nightModeOn', toggle.enabled);
+	});
+	toggle.onStateChange(() => {
+		if (toggle.enabled) addNightMode();
+		else removeNightMode();
+		StyleTweaks.toggleSubredditStyleIfNecessary();
+	});
+	toggle.addCLI('ns');
 };
 
 module.always = () => {
@@ -154,20 +149,8 @@ module.go = () => {
 	handleAutomaticNightMode();
 
 	if (module.options.nightSwitch.value) {
-		createNightSwitch();
+		toggle.addMenuItem(i18n('nightModeToggleTitle'), '☽', '☀');
 	}
-
-	CommandLine.registerCommand(/^(ls|ns)$/, 'ns - toggle nightSwitch',
-		(command, val, match) => {
-			if (match[1] === 'ls') {
-				return 'Toggle nightSwitch (deprecated, use "ns" instead).';
-			} else {
-				return 'Toggle nightSwitch';
-			}
-		}, () => {
-			userToggledNightMode();
-		}
-	);
 };
 
 export function isNightModeOn(): boolean {
@@ -265,7 +248,7 @@ const handleAutomaticNightMode = _.once(async function check() {
 		(isNightModeOn() !== await isTimeForNightMode());
 
 	if (needsNightModeToggle) {
-		toggleNightMode();
+		toggle.toggle('auto');
 	}
 
 	// wait 5 minutes, then wait for the next frame (i.e. wait for the tab to be focused)
@@ -361,49 +344,6 @@ function timeStringToDate(timeString) {
 	const date = new Date();
 	date.setHours(hour, minute, 0 /* s */, 0 /* ms */);
 	return date;
-}
-
-let $nightSwitch;
-
-function createNightSwitch() {
-	$nightSwitch = $('<div>', {
-		text: i18n('nightModeToggleText'),
-		title: i18n('nightModeToggleTitle'),
-	});
-
-	const toggle = CreateElement.toggleButton(
-		undefined,
-		'nightSwitchToggle',
-		isNightModeOn(),
-		'☽',
-		'☀'
-	);
-	$(toggle).appendTo($nightSwitch);
-
-	Menu.addMenuItem($nightSwitch, userToggledNightMode);
-}
-
-function updateNightSwitch(toggle) {
-	if (!$nightSwitch) return;
-	$nightSwitch.find('.toggleButton').toggleClass('enabled', toggle);
-}
-
-function userToggledNightMode(e) {
-	if (e) {
-		e.preventDefault();
-	}
-
-	toggleNightMode();
-	overrideNightMode();
-}
-
-function toggleNightMode() {
-	if (isNightModeOn()) {
-		if (disableNightMode) disableNightMode();
-	} else {
-		if (enableNightMode) enableNightMode();
-	}
-	StyleTweaks.toggleSubredditStyleIfNecessary();
 }
 
 const className = () => {


### PR DESCRIPTION
- NSFW mode applies to all active tabs when toggled
- `nsfw` command no longer needs to have `on` or `off` specified
- `ls` command for toggling nightMode is removed

Tested in browser: Chrome 65
