### PR TITLE
keyboardNav linkNumbers: Add option to change/reject altMode modifier

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -128,6 +128,24 @@ module.options = {
 		description: 'keyboardNavLinkToggleExpandoDesc',
 		title: 'keyboardNavLinkToggleExpandoTitle',
 	},
+	linkNumberAltModeModifier: {
+		dependsOn: options => options.linkNumbers.value,
+		type: 'enum',
+		values: [{
+			name: 'none',
+			value: 'none',
+		}, {
+			name: 'Shift',
+			value: 'shift',
+		}, {
+			name: 'Alt',
+			value: 'alt',
+		}],
+		value: 'alt',
+		description: 'keyboardNavLinkNumberAltModeModifierDesc',
+		title: 'keyboardNavLinkNumberAltModeModifierTitle',
+		advanced: true,
+	},
 	linkNewTab: {
 		dependsOn: options => options.linkNumbers.value,
 		type: 'boolean',
@@ -932,16 +950,21 @@ const drawHelp = _.once(() => {
 });
 
 function getLinkKeys() {
+	const altModeModifier = module.options.linkNumberAltModeModifier.value;
 	const keys = [];
 
 	function addKey(key, index) {
 		keys.push({
 			value: [key, false, false, false, false], // number
 			callback() { openLink(index); },
-		}, {
-			value: [key, true, false, false, false], // alt-number
-			callback() { openLink(index, true); },
 		});
+
+		if (altModeModifier !== 'none') {
+			keys.push({
+				value: [key, altModeModifier === 'alt', false, altModeModifier === 'shift', false], // alt-number | shift-number
+				callback() { openLink(index, true); },
+			});
+		}
 	}
 
 	if (module.options.linkNumbers.value) {

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -433,7 +433,13 @@
 		"message": "Link Toggle Expando"
 	},
 	"keyboardNavLinkToggleExpandoDesc": {
-		"message": "When a link has an expando, toggle it instead of opening the link. Holding alt inverts this action."
+		"message": "When a link has an expando, toggle it instead of opening the link. Alt mode inverts this action."
+	},
+	"keyboardNavLinkNumberAltModeModifierTitle": {
+		"message": "Alt mode modifier"
+	},
+	"keyboardNavLinkNumberAltModeModifierDesc": {
+		"message": "Modifier used to invert toggling expando / opening link action."
 	},
 	"keyboardNavLinkNewTabTitle": {
 		"message": "Comments Link New Tab"


### PR DESCRIPTION
Option available under http://reddit.com/#res:settings/keyboardNav/linkNumberAltModeModifier

Relevant issue: Closes #4251
Tested in browser:  Chrome 65
