### PR TITLE
Add streamja host

### DIFF
--- a/lib/modules/hosts/streamja.js
+++ b/lib/modules/hosts/streamja.js
@@ -1,0 +1,22 @@
+/* @flow */
+
+import { Host } from '../../core/host';
+
+export default new Host('streamja', {
+	name: 'streamja',
+	domains: ['streamja.com'],
+	logo: 'https://streamja.com/favicon.ico',
+	detect: ({ pathname }) => (/^\/([^\/]+)$/i).exec(pathname),
+	handleLink(href, [, code]) {
+		const short = code.substring(0, 2).toLowerCase();
+		return {
+			type: 'VIDEO',
+			loop: true,
+			sources: [{
+				source: `https://upload.streamja.com/mp4/${short}/${code}.mp4`,
+				type: 'video/mp4',
+			}],
+			poster: `https://upload.streamja.com/i/${short}/${code}.jpg`,
+		};
+	},
+});


### PR DESCRIPTION
This adds host integration for video hosting service streamja.com, commonly used on /r/soccer. Since streamja uses a consistent pattern for their mp4 urls, the browser's video player can be used without any API request.
Tested in Chrome 65.
