### PR TITLE
profileRedirect: use location.replace to avoid continuous redirect

### DIFF
--- a/lib/modules/profileRedirect.js
+++ b/lib/modules/profileRedirect.js
@@ -61,7 +61,7 @@ module.beforeLoad = function() {
 			const preferredSection = module.options.fromLandingPage.value === 'custom' ?
 				module.options.customFromLandingPage.value :
 				module.options.fromLandingPage.value;
-			window.location = `/user/${username}/${preferredSection}`;
+			window.location.replace(`/user/${username}/${preferredSection}`);
 		} else if (isPageType('profile2x')) {
 			const notificationPromise = Notifications.showNotification({
 				moduleID: module.moduleID,


### PR DESCRIPTION
Currently pressing the "Back" button after being redirected by profileRedirect will result in going back to the same page. Using location.replace prevents this behavior.