### PR TITLE
commentNav: Fix initializion when moving without opening widget

### DIFF
--- a/lib/modules/commentNavigator.js
+++ b/lib/modules/commentNavigator.js
@@ -339,6 +339,8 @@ export function toggle(focus: boolean = false, open: boolean = !isOpen) {
 }
 
 export async function move(change: 'up' | 'down' | 'top') {
+	initialize();
+
 	if (!sortTypes[currentCategory].nonlinear) {
 		const all = Thing.things();
 		const lastNavigatedToIndex = all.indexOf(lastNavigatedTo);


### PR DESCRIPTION
Using the keyboard shortcuts for move up and down did not call `initialize`, which is required for having an accurate array of matching posts.

Tested in browser: Chrome 65
