### PR TITLE
nightmode: Fix automatic night mode handling from outdated tabs

### DIFF
--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -154,7 +154,9 @@ module.go = () => {
 };
 
 export function isNightModeOn(): boolean {
-	return Modules.isRunning(module) && module.options.nightModeOn.value;
+	if (!Modules.isRunning(module)) return false;
+	// `toggle` contains the current nightMode state
+	return toggle ? toggle.enabled : module.options.nightModeOn.value;
 }
 
 export async function isNightmodeCompatible(): Promise<boolean> {


### PR DESCRIPTION
Fixes regression from #4730

Tested in browser: Chrome 66
