### PR TITLE
Restrict "new profile" darkmode to correct layout

### DIFF
--- a/lib/css/modules/_nightMode.scss
+++ b/lib/css/modules/_nightMode.scss
@@ -1611,7 +1611,7 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 	}
 }
 
-.res-d2x-nightmode {
+.res-d2x-nightmode #container > .App {
 	.ProfileTemplate.m-updated,
 	.ProfileBarDropdown__list,
 	.ProfileSidebar__counterInfo,


### PR DESCRIPTION
i.e. don't leak into redesign

It may be worth adding tooling later to distinguish between app types for "new profiles" and "redesign", depending on the expected lifetime of "new profiles" and how much redesign tooling gets backported to it.

<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: 
* https://www.reddit.com/r/redesign/comments/8d0185/every_single_thread_i_open_across_all_of_reddit/
* https://new.reddit.com/r/beta/comments/8ctbjn/just_got_into_the_new_reddit_alpha_why_cant_i/
Tested in browser: Chrome
