### PR TITLE
Restore manual resize events for Firefox

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1401,6 +1401,8 @@ class Image extends Media {
 			});
 		}
 
+		waitForEvent(this.image, 'load').then(() => triggerResizeEvent(this.image));
+
 		setMediaMaxSize(this.image);
 		makeMediaZoomable(this.element, this.image);
 		const wrapper = setMediaControls(anchor, src, src);
@@ -1849,6 +1851,14 @@ function makeMediaMovable(media: HTMLElement, element: HTMLElement, dragInitiate
 	});
 }
 
+function triggerResizeEvent(element: HTMLElement) {
+	// The ResizeObserver polyfill sometimes doesn't work properly in Firefox
+	if (process.env.BUILD_TARGET === 'firefox') {
+		const { width, height } = element.getBoundingClientRect();
+		element.dispatchEvent(new CustomEvent('mediaResize', { detail: { height, width }, bubbles: true }));
+	}
+}
+
 function makeMediaIndependent(element: HTMLElement) {
 	const wrapper = document.createElement('div');
 	const independent = document.createElement('div');
@@ -2039,6 +2049,8 @@ class Video extends Media {
 			waitForEvent(this.video, 'ended').then(() => this.stopAutoplay());
 		}
 
+		waitForEvent(this.video, 'loadedmetadata').then(() => triggerResizeEvent(this.video));
+
 		setMediaMaxSize(this.video);
 		makeMediaZoomable(this.element, this.video);
 		setMediaControls(this.video, undefined, sources[0].source);
@@ -2170,4 +2182,6 @@ export function resizeMedia(ele: HTMLElement, newWidth: number, newHeight?: numb
 
 	ele.style.width = `${newWidth}px`;
 	ele.style.maxWidth = ele.style.maxHeight = 'none';
+
+	triggerResizeEvent(ele);
 }


### PR DESCRIPTION
This causes some performance loss, but is evidently necessary.

Relevant issue: https://www.reddit.com/r/RESissues/comments/8gtfpz/images_overlaps_in_latest_res_update/  https://www.reddit.com/r/Enhancement/comments/8gljh7/firefox_5903_images_overlap_in_inline_viewer/
Tested in browser: Firefox 59, 61
