### PR TITLE
Use resize-observer-lite fork which uses different strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "lodash": "4.17.5",
     "moment": "2.22.1",
     "numeral": "2.0.6",
-    "resize-observer-lite": "0.2.3",
+    "resize-observer-lite": "Reddit-Enhancement-Suite/resize-observer-lite#59af4a859cb7da7859fec1f6bceecf26dd278916",
     "snudown-js": "3.1.0",
     "suncalc": "1.8.0",
     "tinycolor2": "1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8886,9 +8886,9 @@ require-uncached@^1.0.2, require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
-resize-observer-lite@0.2.3:
+resize-observer-lite@Reddit-Enhancement-Suite/resize-observer-lite#59af4a859cb7da7859fec1f6bceecf26dd278916:
   version "0.2.3"
-  resolved "https://registry.yarnpkg.com/resize-observer-lite/-/resize-observer-lite-0.2.3.tgz#b557f378e2ce9b9aab1dc71a91047bd7ed1d8915"
+  resolved "https://codeload.github.com/Reddit-Enhancement-Suite/resize-observer-lite/tar.gz/59af4a859cb7da7859fec1f6bceecf26dd278916"
   dependencies:
     element-resize-detector "1.1.13"
 


### PR DESCRIPTION
The `scroll` strategy which was used does not work when animations are globally disabled, causing media to not flow properly. The other available strategy, `object`, does not have this issue. 

Replaces #4759 

@erikdesjardins Can you fork the repo [larsjohnsen/resize-observer-lite](https://github.com/larsjohnsen/resize-observer-lite) to the organization, like is done with jquery.tokeninput?