### PR TITLE
Fix account switcher on redesign

### DIFF
--- a/lib/environment/foreground/ajax.js
+++ b/lib/environment/foreground/ajax.js
@@ -58,6 +58,14 @@ export async function ajax(options: AjaxOptions<*>) {
 		}
 	}
 
+	if (sameOrigin) {
+		if (method !== 'GET' && method !== 'HEAD') {
+			// Send modhash for same-origin non-GET requests
+			const hash = await loggedInUserHash();
+			if (hash) headers['X-Modhash'] = hash;
+		}
+	}
+
 	const response = await (sameOrigin ?
 		fetch(url, {
 			method,
@@ -108,12 +116,6 @@ function buildRequestParams({ method = 'GET', url, query = {}, headers = {}, dat
 	if (sameOrigin) {
 		// Add `app=res` to same-origin request URLs
 		urlObj.searchParams.set('app', 'res');
-
-		if (method !== 'GET' && method !== 'HEAD') {
-			// Send modhash for same-origin non-GET requests
-			const hash = loggedInUserHash();
-			if (hash) headers['X-Modhash'] = hash;
-		}
 	}
 
 	// Convert plain data objects to application/x-www-form-urlencoded

--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -3,7 +3,7 @@
 import _ from 'lodash';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
-import { Alert, formatDate, formatDateDiff, getUserInfo, loggedInUser } from '../utils';
+import { Alert, formatDate, formatDateDiff, getUserInfo, isLoggedIn, loggedInUser } from '../utils';
 import { ajax, multicast, i18n } from '../environment';
 import * as BetteReddit from './betteReddit';
 import * as CommandLine from './commandLine';
@@ -328,7 +328,7 @@ async function switchTo(user) {
 	const [username, storedPassword, requiresOtp] = account;
 
 	// Don't await promise yet so that the password and OTP can be entered while logging out
-	const logoutPromise = loggedInUser() && ajax({ method: 'POST', url: '/logout' });
+	const logoutPromise = isLoggedIn() && ajax({ method: 'POST', url: '/logout' });
 
 	const password = storedPassword ? storedPassword : window.prompt(i18n('accountSwitcherPasswordPrompt', username));
 

--- a/lib/types/reddit.js
+++ b/lib/types/reddit.js
@@ -35,6 +35,31 @@ export type RedditAccount = {
 	},
 };
 
+export type CurrentRedditUser = {
+	kind: 't2',
+	loid: string,
+	data: {
+		modhash: string,
+		comment_karma: number,
+		created: number,
+		created_utc: number,
+		gold_expiration: number,
+		has_mod_mail: ?boolean,
+		id: string,
+		in_beta: boolean,
+		inbox_count: number,
+		is_friend: boolean,
+		is_gold: boolean,
+		is_mod: boolean,
+		is_suspended: boolean,
+		link_karma: number,
+		name: string,
+		new_modmail_exists: boolean,
+		over_18: boolean,
+		// etc
+	},
+};
+
 type PreviewSource = {
 	url: string,
 	height: number,

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -153,6 +153,7 @@ export {
 } from './time';
 
 export {
+	isLoggedIn,
 	getUserInfo,
 	isModeratorAnywhere,
 	loggedInUser,

--- a/lib/utils/user.js
+++ b/lib/utils/user.js
@@ -2,10 +2,18 @@
 
 import _ from 'lodash';
 import { ajax } from '../environment';
-import type { RedditAccount } from '../types/reddit';
+import type { CurrentRedditUser, RedditAccount } from '../types/reddit';
 import { MINUTE } from './time';
 import { regexes } from './location';
 import * as string from './string';
+
+export const isLoggedIn = _.once(() => {
+	if (loggedInUser()) {
+		return true;
+	} else if (!document.querySelector('#header a[href*="/login"]')) {
+		return true;
+	}
+});
 
 export const loggedInUser = _.once((): string | void => documentLoggedInUser(document));
 
@@ -13,15 +21,27 @@ export const documentLoggedInUser = (document: Document | Element): string | voi
 	const link: ?HTMLAnchorElement = (document.querySelector('#header-bottom-right > span.user > a'): any);
 	if (!link || link.classList.contains('login-required')) return;
 	const profile = regexes.profile.exec(link.pathname);
-	return profile ? profile[1] : undefined;
+	if (profile) {
+		return profile[1];
+	}
 };
 
 export const isModeratorAnywhere = _.once((): boolean => !!document.getElementById('modmail'));
 
-export const loggedInUserHash = _.once((): ?string => {
-	const hashEle: any = document.querySelector('[name=uh]');
-	return hashEle && hashEle.value;
+export const loggedInUserHash = _.once(async (): Promise<?string> => {
+	const hashEle = document.querySelector('[name=uh]');
+	if (hashEle instanceof HTMLInputElement) {
+		return hashEle.value;
+	}
+
+	const userInfo = await loggedInUserInfo();
+	return userInfo && userInfo.data && userInfo.data.modhash;
 });
+
+export const loggedInUserInfo = _.once((): Promise<CurrentRedditUser | void> =>
+	!isLoggedIn() ? Promise.resolve() : fetch('/api/me.json', { credentials: 'include' })
+		.then(r => r.json())
+		.then(data => data.data && data.data.modhash ? data : undefined));
 
 export function getUserInfo(username: ?string = loggedInUser()): Promise<RedditAccount> {
 	if (!username) {


### PR DESCRIPTION
1. fixed logged-in check prerequisite for logout
1. fetch modhash as prerequisite for logout

tested in chrome

![accountswitcher-d2x](https://user-images.githubusercontent.com/455632/39974392-27354810-56dd-11e8-9763-0a2af3fff88c.gif)
![accountswitcher-r2](https://user-images.githubusercontent.com/455632/39974402-4a2328a6-56dd-11e8-8e77-bccc7003359b.gif)
