### PR TITLE
showImages conserveMemory: Don't unload when scrolling horizontally

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -592,7 +592,8 @@ function enableConserveMemory() {
 	// $FlowIssue `mozFullScreenElement` is not recognized
 	const fullscreenActive = () => !!(document.fullscreenElement || document.webkitFullscreenElement || document.mozFullScreenElement: any);
 
-	const rootMargin = `${100 * (parseInt(module.options.bufferScreens.value, 10) || 2)}%`;
+	// x-axis is set to 100000% in order to not unload images when scrolling too far horizontally
+	const rootMargin = `${100 * (parseInt(module.options.bufferScreens.value, 10) || 2)}% 100000%`;
 
 	const mediaMap = new WeakMap();
 	const ioMedia = new IntersectionObserver(entries => {


### PR DESCRIPTION
Necessary since the wrapper stretches vertically only, causing the viewport (+ `bufferScreens` margin) to not intersect with it any longer when zooming and scrolling too far horizontally.

Tested in browser: Chrome 66
