### PR TITLE
Reddit Link Bar for "Original Content" w.r.t. current interface redesign

### DIFF
--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -190,6 +190,11 @@ module.beforeLoad = () => {
 				background: ${highlightTopLevelColor} !important;
 			}
 		`);
+		addCSS(`
+			.Comment.top-level {
+				border-top: 2px solid ${highlightTopLevelColor};
+			}
+		`);
 	}
 };
 


### PR DESCRIPTION
Relevant issue: 
Tested in browser: 

Looks like this:

![image](https://user-images.githubusercontent.com/9812458/40131285-774e0318-5931-11e8-96c3-a88c8315fe66.png)

We need to create a translation of "Original Content" for other languages apart from English. This is under the new menu option `subredditManagerLinkOriginalTitle` and `subredditManagerLinkOriginalDesc`