### PR TITLE
Remove Edge isIntersecting polyfill

### DIFF
--- a/edge/edge.entry.js
+++ b/edge/edge.entry.js
@@ -79,6 +79,8 @@ Element.prototype.replaceWith = function replaceWith(...nodes) {
 	}
 };
 
+
+// https://developer.microsoft.com/en-us/microsoft-edge/platform/status/requestidlecallback/
 if (typeof requestIdleCallback === 'undefined') {
 	window.requestIdleCallback = fn => requestAnimationFrame(() => { requestAnimationFrame(fn); });
 }

--- a/edge/edge.entry.js
+++ b/edge/edge.entry.js
@@ -79,20 +79,6 @@ Element.prototype.replaceWith = function replaceWith(...nodes) {
 	}
 };
 
-// polyfill IntersectionObserverEntry.prototype.isIntersecting
-// Snippet from https://github.com/WICG/IntersectionObserver/pull/224
-if (!IntersectionObserverEntry.prototype.hasOwnProperty('isIntersecting')) {
-	Object.defineProperty(IntersectionObserverEntry.prototype,
-		'isIntersecting', {
-			get() {
-				return this.intersectionRatio > 0;
-			},
-		});
-}
-
-if (typeof requestIdleCallback === 'undefined') {
-	window.requestIdleCallback = fn => requestAnimationFrame(() => { requestAnimationFrame(fn); });
-}
 
 // polyfill KeyboardEvent.key
 // Edge names from https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values

--- a/edge/edge.entry.js
+++ b/edge/edge.entry.js
@@ -79,6 +79,9 @@ Element.prototype.replaceWith = function replaceWith(...nodes) {
 	}
 };
 
+if (typeof requestIdleCallback === 'undefined') {
+	window.requestIdleCallback = fn => requestAnimationFrame(() => { requestAnimationFrame(fn); });
+}
 
 // polyfill KeyboardEvent.key
 // Edge names from https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values


### PR DESCRIPTION
References: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12156111/

Appears to correctly function in Edge 17 per the following test, implemented in Edge 16 (polyfilled in 15): http://bl.ocks.org/nolanlawson/raw/bf31e883ca28579bc063c97fa5d1882b/

