### PR TITLE
Tweak usage of Thing#isContentVisible

### DIFF
--- a/lib/modules/commentNavigator.js
+++ b/lib/modules/commentNavigator.js
@@ -211,7 +211,7 @@ const _memoized = _.memoize(async (category: Category): Promise<Thing[]> => {
 	return Cases.filterThings(things, conditions);
 });
 const getPosts = (category: Category) => _memoized(category).then(v =>
-	v.filter(thing => !thing.isFiltered() && !thing.isCollapsed() && thing.isVisible())
+	v.filter(thing => thing.isContentVisible())
 );
 const currentPosts = () => getPosts(currentCategory);
 let lastNavigatedTo: ?Thing = null;

--- a/lib/modules/readComments.js
+++ b/lib/modules/readComments.js
@@ -53,7 +53,7 @@ module.beforeLoad = async () => {
 	const ids = await initialStorage.get();
 
 	SelectedEntry.addListener(selected => {
-		if (selected.isComment() && selected.isVisible()) {
+		if (selected.isComment() && selected.isContentVisible()) {
 			const id = selected.getFullname();
 			ids.add(id);
 			entryStorage.patch(currentId, { ids: { [id]: true }, updateTime: Date.now() });

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -543,11 +543,11 @@ export class Thing {
 		return this.element.classList.contains('deleted');
 	}
 
-	isFiltered(): boolean {
+	isFiltered(alsoPartially: boolean = true): boolean {
 		return !document.body.classList.contains('res-filters-disabled') &&
 			(
 				this.element.classList.contains('RESFiltered') &&
-				!this.element.classList.contains('res-thing-has-visible-child')
+				!(alsoPartially && this.element.classList.contains('res-thing-has-visible-child'))
 			);
 	}
 
@@ -563,14 +563,18 @@ export class Thing {
 	}
 
 	isVisible(): boolean {
-		return (
-			!this.isFiltered() &&
-			!this.isInCollapsed()
+		return !(
+			this.isFiltered() ||
+			this.isInCollapsed()
 		);
 	}
 
 	isContentVisible(): boolean {
-		return this.isVisible() && !this.isCollapsed();
+		return !(
+			this.isFiltered(false) ||
+			this.isCollapsed() ||
+			this.isInCollapsed()
+		);
 	}
 
 	isSelected() {


### PR DESCRIPTION
Necessary in order for CommentNav not to navigate to partially filtered comments.

<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: 
Tested in browser: 
