### PR TITLE
hover: Support fixed positioning

### DIFF
--- a/lib/modules/hover.js
+++ b/lib/modules/hover.js
@@ -63,10 +63,13 @@ module.options = {
 };
 
 module.beforeLoad = () => {
-	for (const [optionKey, { value }] of Object.entries(module.options)) {
-		const parsedValue = typeof value === 'number' ? parseFloat(value) : value;
-		Hover._defaultOptions[optionKey] = parsedValue;
-	}
+	Hover._defaultOptions = {
+		openDelay: parseFloat(module.options.openDelay.value),
+		fadeDelay: parseFloat(module.options.fadeDelay.value),
+		fadeSpeed: parseFloat(module.options.fadeSpeed.value),
+		width: parseFloat(module.options.width.value),
+		closeOnMouseOut: module.options.closeOnMouseOut.value,
+	};
 };
 
 const instances = {};
@@ -158,7 +161,7 @@ class Hover {
 		return this;
 	}
 
-	options(options: { [string]: mixed } = {}) {
+	options(options: { [string]: mixed }) {
 		this._options = {
 			...this._options,
 			...options,

--- a/lib/modules/hover.js
+++ b/lib/modules/hover.js
@@ -110,6 +110,11 @@ function findOrMakeRow(type, id) {
 	return row;
 }
 
+function getFixedParent(e: Element): ?Element {
+	const p = e.parentElement;
+	return p && (window.getComputedStyle(p).position === 'fixed' && e || getFixedParent(p));
+}
+
 export const pin = {
 	bottom: 'bottom',
 	right: 'right',
@@ -140,6 +145,8 @@ class Hover {
 	_target: HTMLElement | void;
 	_callback: HoverCallback | void;
 	_container: HTMLElement | void;
+
+	_fixedPosition: boolean = false;
 
 	constructor(id: string) {
 		this.instanceID = id;
@@ -253,16 +260,38 @@ class Hover {
 			$element.empty().append(item);
 		});
 
+		const fixedParent = getFixedParent(this.getCheckedTarget());
+		if (fixedParent) {
+			this._fixedPosition = true;
+
+			// If the fixed parent scrolls (e.g. if it has a scrollbar, like in lightboxes), then the container loses
+			// position sync with the target.
+			// I am not able to figure out a way to keep them together without requiring CSS recalc on each `scroll`
+			const onScroll = () => {
+				this.close(false);
+				fixedParent.removeEventListener('scroll', onScroll, true);
+			};
+			fixedParent.addEventListener('scroll', onScroll, true);
+		}
+
 		this._updatePosition();
 	}
 
-	_updatePosition() {
-		const { top, left } = this.getCheckedTarget().getBoundingClientRect();
+	_positionContainer({ top = 'auto', right = 'auto', bottom = 'auto', left = 'auto' }: { top?: *, right?: *, bottom?: *, left?: * }) {
 		$(this.getContainer()).css({
-			top,
-			left,
-			zIndex: 2147483646,
+			zIndex: '2147483646',
+			position: this._fixedPosition ? 'fixed' : 'absolute',
+			top: top !== 'auto' ? top + (this._fixedPosition ? 0 : window.scrollY) : 'auto',
+			right: right !== 'auto' ? right + (this._fixedPosition ? 0 : window.scrollX) : 'auto',
+			bottom: bottom !== 'auto' ? bottom + (this._fixedPosition ? 0 : window.scrollY) : 'auto',
+			left: left !== 'auto' ? left + (this._fixedPosition ? 0 : window.scrollX) : 'auto',
 		});
+	}
+
+	_updatePosition() {
+		const target = this.getCheckedTarget();
+		const { top, left } = target.getBoundingClientRect();
+		this._positionContainer({ top, left });
 	}
 
 	_cancelShow(fade: boolean = false) {
@@ -347,7 +376,8 @@ class HoverInfoCard extends Hover {
 	}
 
 	_updatePosition() {
-		const { top, left, bottom, right } = this.getCheckedTarget().getBoundingClientRect();
+		const target = this.getCheckedTarget();
+		const { top, left, bottom, right } = target.getBoundingClientRect();
 		const $container = $(this.getContainer()).removeClass('right below');
 
 		const tooltipWidth = this._options.width;
@@ -366,11 +396,8 @@ class HoverInfoCard extends Hover {
 			tooltipLeft = left - tooltipWidth - 30;
 		}
 
-		$container.css({
-			top: tooltipTop + window.scrollY,
-			left: tooltipLeft + window.scrollX,
-			width: tooltipWidth,
-		});
+		$container.get(0).style.width = `${tooltipWidth}px`;
+		this._positionContainer({ left: tooltipLeft, top: tooltipTop });
 	}
 }
 
@@ -390,37 +417,28 @@ class HoverDropdownList extends Hover {
 	};
 
 	_updatePosition() {
-		const trigger = this.getCheckedTarget();
-		const menu = this.getContainer();
-		const { top: y, left: x } = $(trigger).offset();
-
-		menu.style.zIndex = '2147483646';
+		const target = this.getCheckedTarget();
+		const { top, left, height, width } = target.getBoundingClientRect();
+		const $container = $(this.getContainer());
 
 		switch (this._options.pin) {
 			case pin.right:
-				const viewportBottom = getViewportSize().height;
-				const top = y + this._options.offsetHeight;
-				const height = $(menu).height();
-				const bottomAlign = top + height + this._options.bottomPadding > viewportBottom;
-				menu.style.left = `${x + trigger.offsetWidth + this._options.offsetWidth}px`;
-				menu.style.right = 'auto';
+				const bottomAlign = top + $container.height() + this._options.bottomPadding > getViewportSize().height;
 				if (bottomAlign) {
-					menu.style.position = 'fixed';
-					menu.style.top = 'auto';
-					menu.style.bottom = `${this._options.bottomPadding}px`;
+					this._positionContainer({ left: left + width, bottom: this._options.bottomPadding });
 				} else {
-					menu.style.position = 'absolute';
-					menu.style.top = `${top}px`;
-					menu.style.bottom = 'auto';
+					this._positionContainer({ left: left + width, top: top + this._options.offsetHeight });
 				}
 				break;
 			case pin.bottom:
 				// falls through
 			default:
-				const leftAlign = x + $(menu).outerWidth() < document.body.scrollWidth;
-				menu.style.right = leftAlign ? 'auto' : `${document.body.scrollWidth - x - trigger.offsetWidth + this._options.offsetWidth}px`;
-				menu.style.left = leftAlign ? `${x}px` : 'auto';
-				menu.style.top = `${y + trigger.offsetHeight + this._options.offsetHeight}px`;
+				const leftAlign = left + $container.outerWidth() < getViewportSize().width;
+				if (leftAlign) {
+					this._positionContainer({ left, top: top + height + this._options.offsetHeight });
+				} else {
+					this._positionContainer({ right: getViewportSize().width - left - width + this._options.offsetWidth, top: top + height + this._options.offsetHeight });
+				}
 				break;
 		}
 	}

--- a/lib/modules/messageMenu.js
+++ b/lib/modules/messageMenu.js
@@ -76,9 +76,9 @@ function onMouseOver(e: Event) {
 	Hover.dropdownList(module.moduleID)
 		.target(e.target)
 		.options({
-			openDelay: module.options.hoverDelay.value,
-			fadeDelay: module.options.fadeDelay.value,
-			fadeSpeed: module.options.fadeSpeed.value,
+			openDelay: parseFloat(module.options.hoverDelay.value),
+			fadeDelay: parseFloat(module.options.fadeDelay.value),
+			fadeSpeed: parseFloat(module.options.fadeSpeed.value),
 		})
 		.populateWith(populate)
 		.begin();

--- a/lib/modules/multiredditNavbar.js
+++ b/lib/modules/multiredditNavbar.js
@@ -93,8 +93,8 @@ function onMouseoverMultiLink(e: Event) {
 		.target(e.currentTarget)
 		.options({
 			openDelay: PenaltyBox.penalizedDelay(module.moduleID, 'sectionMenu', module.options.hoverDelay),
-			fadeDelay: module.options.fadeDelay.value,
-			fadeSpeed: module.options.fadeSpeed.value,
+			fadeDelay: parseFloat(module.options.fadeDelay.value),
+			fadeSpeed: parseFloat(module.options.fadeSpeed.value),
 			pin: Hover.pin.right,
 			offsetWidth: -10,
 			offsetHeight: 1,

--- a/lib/modules/profileNavigator.js
+++ b/lib/modules/profileNavigator.js
@@ -83,8 +83,8 @@ function onMouseoverProfileLink(user, e) {
 		.target(e.target)
 		.options({
 			openDelay: PenaltyBox.penalizedDelay(module.moduleID, 'sectionMenu', module.options.hoverDelay),
-			fadeDelay: module.options.fadeDelay.value,
-			fadeSpeed: module.options.fadeSpeed.value,
+			fadeDelay: parseFloat(module.options.fadeDelay.value),
+			fadeSpeed: parseFloat(module.options.fadeSpeed.value),
 			pin: Hover.pin.bottom,
 		})
 		.populateWith(() => populateSectionMenu(user))

--- a/lib/modules/showParent.js
+++ b/lib/modules/showParent.js
@@ -55,9 +55,9 @@ module.include = [
 module.go = () => {
 	$('body').on('mouseenter', '.comment .buttons :not(:first-child) .bylink', function() {
 		startHover(this, {
-			openDelay: module.options.hoverDelay.value,
-			fadeDelay: module.options.fadeDelay.value,
-			fadeSpeed: module.options.fadeSpeed.value,
+			openDelay: parseFloat(module.options.hoverDelay.value),
+			fadeDelay: parseFloat(module.options.fadeDelay.value),
+			fadeSpeed: parseFloat(module.options.fadeSpeed.value),
 		});
 	});
 

--- a/lib/modules/subredditInfo.js
+++ b/lib/modules/subredditInfo.js
@@ -78,9 +78,9 @@ function handleMouseOver(e: Event) {
 		.target(target)
 		.options({
 			width: 450,
-			openDelay: module.options.hoverDelay.value,
-			fadeDelay: module.options.fadeDelay.value,
-			fadeSpeed: module.options.fadeSpeed.value,
+			openDelay: parseFloat(module.options.hoverDelay.value),
+			fadeDelay: parseFloat(module.options.fadeDelay.value),
+			fadeSpeed: parseFloat(module.options.fadeSpeed.value),
 		})
 		.populateWith(card => showSubredditInfo(card, subreddit))
 		.begin();

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -117,9 +117,9 @@ function handleMouseOver(e: Event) {
 		.target(e.target)
 		.options({
 			width: 475,
-			openDelay: module.options.hoverDelay.value,
-			fadeDelay: module.options.fadeDelay.value,
-			fadeSpeed: module.options.fadeSpeed.value,
+			openDelay: parseFloat(module.options.hoverDelay.value),
+			fadeDelay: parseFloat(module.options.fadeDelay.value),
+			fadeSpeed: parseFloat(module.options.fadeSpeed.value),
 		})
 		.populateWith(card => showUserInfo(card, username, thing))
 		.begin();


### PR DESCRIPTION
Mainly fixes a issue in the redesign's lightboxes where `position: absolute` cannot be used to keep the hover container relative to a given target. 

- If a target parent has `position: fixed`, also set `position: fixed` on the hover container
- Closes at once if target is in a lightbox which is scrolled, as to prevent position mismatch with the target

Relevant issue: 
Tested in browser: Chrome 60
