### PR TITLE
Enable the commentStyle module for the comment link list page

### DIFF
--- a/lib/modules/commentStyle.js
+++ b/lib/modules/commentStyle.js
@@ -55,6 +55,7 @@ module.options = {
 
 module.include = [
 	'comments',
+	'commentsLinklist'
 ];
 
 module.exclude = [

--- a/lib/modules/commentStyle.js
+++ b/lib/modules/commentStyle.js
@@ -55,7 +55,7 @@ module.options = {
 
 module.include = [
 	'comments',
-	'commentsLinklist'
+	'commentsLinklist',
 ];
 
 module.exclude = [


### PR DESCRIPTION
Relevant issue: resolves #4787
Tested in browser: Chrome v67