### PR TITLE
Enable commentPreview module on New ModMail

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -31,7 +31,6 @@
 			"https://*.reddit.com/*"
 		],
 		"exclude_matches": [
-			"https://mod.reddit.com/*",
 			"https://ads.reddit.com/*",
 			"https://i.reddit.com/*",
 			"https://m.reddit.com/*",

--- a/lib/modules/announcements.js
+++ b/lib/modules/announcements.js
@@ -17,8 +17,8 @@ module.description = 'announcementsDesc';
 module.hidden = true;
 
 const subreddit = Metadata.announcementsSubreddit;
-const sourceUrl = `/r/${subreddit}/new.json?limit=1`;
-const viewUrl = `/r/${subreddit}/new`;
+const sourceUrl = `//www.reddit.com/r/${subreddit}/new.json?limit=1`;
+const viewUrl = `//www.reddit.com/r/${subreddit}/new`;
 
 const markedReadDate = Storage.wrap('RESmodules.announcement.markedReadDate', 0);
 const lastUnreadDate = Storage.wrap('RESmodules.announcement.lastUnreadDate', 0);

--- a/lib/modules/commentPreview.js
+++ b/lib/modules/commentPreview.js
@@ -112,8 +112,8 @@ module.include = [
 	'modqueue',
 	'subredditAbout',
 	'wiki',
-	'newModMail',
-	'composeNewModMail',
+	'modmail2x',
+	'modmail2xCompose',
 ];
 module.exclude = [
 	'd2x',

--- a/lib/modules/commentPreview.js
+++ b/lib/modules/commentPreview.js
@@ -13,6 +13,7 @@ import {
 	currentSubreddit,
 	downcast,
 	isPageType,
+	isAppType,
 	string,
 	empty,
 } from '../utils';
@@ -88,6 +89,13 @@ module.options = {
 		title: 'commentPreviewEnableForBanMessagesTitle',
 		advanced: true,
 	},
+	enableForNewModMail: {
+		type: 'boolean',
+		value: true,
+		description: 'commentPreviewEnableForNewModMailDesc',
+		title: 'commentPreviewEnableForNewModMailTitle',
+		advanced: true,
+	},
 	sidebarPreview: {
 		type: 'boolean',
 		value: true,
@@ -104,6 +112,8 @@ module.include = [
 	'modqueue',
 	'subredditAbout',
 	'wiki',
+	'newModMail',
+	'composeNewModMail',
 ];
 module.exclude = [
 	'd2x',
@@ -281,7 +291,8 @@ function attachPreview(ele) {
 				!module.options.enableForComments.value && ele.closest('.commentarea, .message') ||
 				!module.options.enableForPosts.value && (isPageType('submit') || ele.closest('.link')) ||
 				!module.options.enableForSubredditConfig.value && (/^\/r\/[\-\w.]+\/about\/edit/i).test(location.pathname) ||
-				!module.options.enableForBanMessages.value && isBan
+				!module.options.enableForBanMessages.value && isBan ||
+				!module.options.enableForNewModMail.value && isAppType('nmm')
 			) {
 				// avoid repeating this (potentially expensive) check
 				ele.setAttribute('res-commentPreview-state', 'disabled');
@@ -292,7 +303,7 @@ function attachPreview(ele) {
 			break;
 	}
 
-	const container = ele.closest('.usertext-edit, #banned');
+	const container = ele.closest('.usertext-edit, #banned, .NewThread__fields, .ThreadViewer__replyContainer');
 	if (!container) return;
 
 	const preview = container.querySelector('.livePreview') || container.appendChild(makePreviewBox());
@@ -335,6 +346,23 @@ const onTextareaInput = _.debounce((e, preview, elements) => {
 }, 250);
 
 function makePreviewBox() {
+	if (isAppType('nmm')) {
+		return string.html`
+		<div style="display: none" class="RESDialogSmall livePreview">
+			<h3>Live Preview</h3>
+			${string.safe(SettingsNavigation.makeUrlHashLink(module.moduleID, undefined, ' ', 'gearIcon'))}
+			<div class="Thread__message">
+				<article class="Message">
+					<div class="Message__body">
+						<div class="StyledHtml">
+							<div class="md RESDialogContents"></div>
+						</div>
+					</div>
+				</article>
+			</div>
+		`;
+	}
+
 	return string.html`
 		<div style="display: none" class="RESDialogSmall livePreview">
 			<h3>Live Preview</h3>
@@ -433,32 +461,34 @@ function showBigEditor(e: Event) {
 	$('.side').addClass('BESideHide');
 	$('body').addClass('RESScrollLock');
 	let $baseText;
+	const $bigText = $('#BigText');
+	const $bigPreview = $('BigPreview');
 	if (!isWiki && !isBan) {
 		$baseText = $(e.target).parents('.usertext-edit:first').find('textarea');
 
 		const limit = $baseText.attr('data-limit');
-		$('#BigText').attr('data-limit', limit);
-		$('#BigPreview').removeClass('wiki');
+		$bigText.attr('data-limit', limit);
+		$bigPreview.removeClass('wiki');
 		$('.BERight .RESDialogContents').removeClass('wiki-page-content');
 	} else if (isBan) {
 		$baseText = $('#ban_message');
 
 		const limit = $baseText.attr('data-limit');
-		$('#BigText').attr('data-limit', limit);
-		$('#BigPreview').removeClass('wiki');
+		$bigText.attr('data-limit', limit);
+		$bigPreview.removeClass('wiki');
 		$('.BERight .RESDialogContents').removeClass('wiki-page-content');
 	} else {
 		$baseText = $('#wiki_page_content');
-		$('#BigPreview').addClass('wiki');
+		$bigPreview.addClass('wiki');
 		$('.BERight .RESDialogContents').addClass('wiki-page-content');
 	}
 
 	const markdown = $baseText.val();
 	const maxLength = $baseText.data('max-length');
-	$('#BigText').data('max-length', maxLength).val(markdown).focus();
-	CommentTools.updateCounter($('#BigText')[0]);
+	$bigText.data('max-length', maxLength).val(markdown).focus();
+	CommentTools.updateCounter($bigText[0]);
 	// SnuOwnd created this HTML from markdown so it is safe.
-	$('#BigPreview').html(markdownToHTML(markdown));
+	$bigPreview.html(markdownToHTML(markdown));
 	bigTextTarget = $baseText;
 
 	// dynamically set paddingBottom on .RESDialogContents to make textarea scale correctly.

--- a/lib/modules/commentPreview.js
+++ b/lib/modules/commentPreview.js
@@ -292,7 +292,7 @@ function attachPreview(ele) {
 				!module.options.enableForPosts.value && (isPageType('submit') || ele.closest('.link')) ||
 				!module.options.enableForSubredditConfig.value && (/^\/r\/[\-\w.]+\/about\/edit/i).test(location.pathname) ||
 				!module.options.enableForBanMessages.value && isBan ||
-				!module.options.enableForNewModMail.value && isAppType('nmm')
+				!module.options.enableForNewModMail.value && isAppType('mm2x')
 			) {
 				// avoid repeating this (potentially expensive) check
 				ele.setAttribute('res-commentPreview-state', 'disabled');
@@ -346,7 +346,7 @@ const onTextareaInput = _.debounce((e, preview, elements) => {
 }, 250);
 
 function makePreviewBox() {
-	if (isAppType('nmm')) {
+	if (isAppType('mm2x')) {
 		return string.html`
 		<div style="display: none" class="RESDialogSmall livePreview">
 			<h3>Live Preview</h3>

--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -350,6 +350,8 @@ const className = () => {
 			return 'res-nightmode';
 		case 'd2x':
 			return 'res-d2x-nightmode';
+		case 'nmm':
+			return 'res-nmm-nightmode';
 		default:
 			throw new Error(`Impossible appType: ${appType()}`);
 	}

--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -350,8 +350,8 @@ const className = () => {
 			return 'res-nightmode';
 		case 'd2x':
 			return 'res-d2x-nightmode';
-		case 'nmm':
-			return 'res-nmm-nightmode';
+		case 'mm2x':
+			return 'res-mm2x-nightmode';
 		default:
 			throw new Error(`Impossible appType: ${appType()}`);
 	}

--- a/lib/utils/location.js
+++ b/lib/utils/location.js
@@ -39,6 +39,8 @@ export const regexes: { [string]: RegExp } = {
 	domain:           /^\/domain\/([\w\.]+)(?:\/|$)/i,
 	composeMessage:   /^\/(?:r\/([\w\.\+]+)\/)?message\/compose(?:\/|$)/i,
 	liveThread:       /^\/live\/(?!create(?:\/|$))([a-z0-9]+)(?:\/|$)/i,
+	newModMail:       /^\/mail\/(?:all|new|inprogress|archived|highlighted|mod|notifications)(?:\/([0-9a-z]+))?\/?$/i,
+	composeNewModMail:/^\/mail\/create(?:\/|$)/i,
 };
 /* eslint-enable key-spacing */
 
@@ -51,12 +53,14 @@ export const execRegexes: { [string]: (path: string) => ?string[] } = {
 	},
 };
 
-export type PageType = 'wiki' | 'search' | 'profile' | 'profile2x' | 'profileCommentsPage' | 'stylesheet' | 'modqueue' | 'subredditAbout' | 'comments' | 'commentsLinklist' | 'liveThread' | 'inbox' | 'submit' | 'account' | 'prefs' | 'linklist';
-export type AppType = 'r2' | 'd2x';
+export type PageType = 'wiki' | 'search' | 'profile' | 'profile2x' | 'profileCommentsPage' | 'stylesheet' | 'modqueue' | 'subredditAbout' | 'comments' | 'commentsLinklist' | 'liveThread' | 'inbox' | 'submit' | 'account' | 'prefs' | 'linklist' | 'newModMail' | 'composeNewModMail';
+export type AppType = 'r2' | 'd2x' | 'nmm';
 
 export const appType = _.once((): AppType => {
 	if (document.documentElement.getAttribute('xmlns')) {
 		return 'r2';
+	} else if (window.location.hostname === 'mod.reddit.com') {
+		return 'nmm';
 	}
 	return 'd2x';
 });
@@ -73,6 +77,9 @@ const appPageTypes: { [AppType]: {| default?: PageType, pageTypes: PageType[] |}
 	},
 	d2x: {
 		pageTypes: ['profile2x', 'profileCommentsPage'],
+	},
+	nmm: {
+		pageTypes: ['newModMail', 'composeNewModMail'],
 	},
 };
 

--- a/lib/utils/location.js
+++ b/lib/utils/location.js
@@ -39,8 +39,8 @@ export const regexes: { [string]: RegExp } = {
 	domain:           /^\/domain\/([\w\.]+)(?:\/|$)/i,
 	composeMessage:   /^\/(?:r\/([\w\.\+]+)\/)?message\/compose(?:\/|$)/i,
 	liveThread:       /^\/live\/(?!create(?:\/|$))([a-z0-9]+)(?:\/|$)/i,
-	newModMail:       /^\/mail\/(?:all|new|inprogress|archived|highlighted|mod|notifications)(?:\/([0-9a-z]+))?\/?$/i,
-	composeNewModMail:/^\/mail\/create(?:\/|$)/i,
+	modmail2x:        /^\/mail\/(?:all|new|inprogress|archived|highlighted|mod|notifications)(?:\/([0-9a-z]+))?\/?$/i,
+	modmail2xCompose: /^\/mail\/create(?:\/|$)/i,
 };
 /* eslint-enable key-spacing */
 
@@ -53,14 +53,14 @@ export const execRegexes: { [string]: (path: string) => ?string[] } = {
 	},
 };
 
-export type PageType = 'wiki' | 'search' | 'profile' | 'profile2x' | 'profileCommentsPage' | 'stylesheet' | 'modqueue' | 'subredditAbout' | 'comments' | 'commentsLinklist' | 'liveThread' | 'inbox' | 'submit' | 'account' | 'prefs' | 'linklist' | 'newModMail' | 'composeNewModMail';
-export type AppType = 'r2' | 'd2x' | 'nmm';
+export type PageType = 'wiki' | 'search' | 'profile' | 'profile2x' | 'profileCommentsPage' | 'stylesheet' | 'modqueue' | 'subredditAbout' | 'comments' | 'commentsLinklist' | 'liveThread' | 'inbox' | 'submit' | 'account' | 'prefs' | 'linklist' | 'modmail2x' | 'modmail2xCompose';
+export type AppType = 'r2' | 'd2x' | 'mm2x';
 
 export const appType = _.once((): AppType => {
 	if (document.documentElement.getAttribute('xmlns')) {
 		return 'r2';
 	} else if (window.location.hostname === 'mod.reddit.com') {
-		return 'nmm';
+		return 'mm2x';
 	}
 	return 'd2x';
 });
@@ -78,8 +78,8 @@ const appPageTypes: { [AppType]: {| default?: PageType, pageTypes: PageType[] |}
 	d2x: {
 		pageTypes: ['profile2x', 'profileCommentsPage'],
 	},
-	nmm: {
-		pageTypes: ['newModMail', 'composeNewModMail'],
+	mm2x: {
+		pageTypes: ['modmail2x', 'modmail2x'],
 	},
 };
 

--- a/lib/utils/location.js
+++ b/lib/utils/location.js
@@ -79,7 +79,7 @@ const appPageTypes: { [AppType]: {| default?: PageType, pageTypes: PageType[] |}
 		pageTypes: ['profile2x', 'profileCommentsPage'],
 	},
 	mm2x: {
-		pageTypes: ['modmail2x', 'modmail2x'],
+		pageTypes: ['modmail2x', 'modmail2xCompose'],
 	},
 };
 

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -2070,6 +2070,12 @@
 	"commentPreviewEnableForBanMessagesDesc": {
 		"message": "Show preview for ban notes."
 	},
+	"commentPreviewEnableForNewModMailTitle": {
+		"message": "Enable For New Mod Mail"
+	},
+	"commentPreviewEnableForNewModMailDesc": {
+		"message": "Show preview when composing New ModMail messages."
+	},
 	"commentPreviewSidebarPreviewTitle": {
 		"message": "Sidebar Preview"
 	},


### PR DESCRIPTION
Enabled commentPreview on both of the newly-created PageType's in #4790 and wrapped the live preview `<div>` in the appropriate hierarchy of elements for proper rendering within the New ModMail CSS.

Blocked by #4790
Tested in browser: Chrome v67