### PR TITLE
Implement NightMode for New ModMail

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -31,7 +31,6 @@
 			"https://*.reddit.com/*"
 		],
 		"exclude_matches": [
-			"https://mod.reddit.com/*",
 			"https://ads.reddit.com/*",
 			"https://i.reddit.com/*",
 			"https://m.reddit.com/*",

--- a/lib/css/modules/_nightMode.scss
+++ b/lib/css/modules/_nightMode.scss
@@ -4,8 +4,14 @@ $header-background-color: rgb(105, 105, 105);
 $border-color: #777;
 $color:  #aaa;
 $link-color: hsl(210, 50%, 70%);
+$src-link-color: hsl(0, 0%, 80%);
+$src-link-visited-color: hsl(0, 0%, 60%);
 $title-link-color: hsl(0, 0%, 87%);
 $title-link-visited-color: hsl(0, 0%, 65%);
+$nm-src-link-color: hsl(210, 60%, 50%);
+$nm-src-link-visited-color: hsl(270, 50%, 58%);
+$nm-title-link-color: hsl(210, 60%, 60%);
+$nm-title-link-visited-color: hsl(270, 50%, 65%);
 
 .res-nightmode {
 	body,
@@ -605,15 +611,15 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 		color: $title-link-color;
 
 		.res-nightMode-coloredLinks & {
-			color: hsl(210, 60%, 60%);
+			color: $nm-title-link-color;
 		}
 	}
 
 	.thing .source-url {
-		color: hsl(0, 0%, 80%);
+		color: $src-link-color;
 
 		.res-nightMode-coloredLinks & {
-			color: hsl(210, 60%, 50%);
+			color: $nm-src-link-color;
 		}
 	}
 
@@ -635,15 +641,15 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 		color: $title-link-visited-color;
 
 		.res-nightMode-coloredLinks & {
-			color: hsl(270, 50%, 65%);
+			color: $nm-title-link-visited-color;
 		}
 	}
 
 	.thing .source-url:visited {
-		color: hsl(0, 0%, 60%);
+		color: $src-link-visited-color;
 
 		.res-nightMode-coloredLinks & {
-			color: hsl(270, 50%, 58%);
+			color: $nm-src-link-visited-color;
 		}
 	}
 
@@ -1660,7 +1666,7 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 	}
 
 
-	.ProfileBarDropdown__list:hover
+	.ProfileBarDropdown__list:hover,
 	.ProfileBarDropdown__listItem:hover {
 		background-color: $header-background-color;
 	}
@@ -1739,5 +1745,179 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 
 	.ProfileVoiceAd {
 		background-color: #202020;
+	}
+}
+
+.res-mm2x-nightmode #container > .App {
+	.App__sidebarFooterIcon,
+	.App__sidebarFooterText,
+	.Header__user,
+	.Login__tfa-header,
+	.FancySelect:not([class*=' m-']) .FancySelect__value.m-nocolor,
+	.FancySelect.m-error .FancySelect__value.m-nocolor,
+	.FancySelect__option,
+	.FormattingHelp,
+	.FormattingHelp__tableCol,
+	.Header__tooltipItem,
+	.InfoBar__controlText,
+	.InfoBar__recentsNone,
+	.InfoBar__username:not(:hover),
+	.Input,
+	.Message__author:not(.m-mod):not(.m-admin):not(:hover),
+	.Message__internalNote,
+	.ModAction__text,
+	div[class^='NewThread__']:not(.icon):not(.NewThread__errors),
+	.Sidebar__newMessage,
+	.Sidebar__title,
+	.StyledHtml,
+	.Textarea,
+	div[class^='Thread__groupedText'],
+	*[class^='ThreadPreview__']:not(.m-mod):not(.m-admin):not(:hover),
+	div[class^='ThreadPreview__']:not(.icon):hover,
+	.ThreadPreviewViewerHeader__iconLabel,
+	.ThreadPreviewViewerHeader__select,
+	*[class^='ThreadTitle__']:not(:hover),
+	div[class^='ThreadTitle__']:hover,
+	.ThreadViewerHeader__controlText,
+	.ThreadViewerHeader__backText,
+	.ThreadViewerReplyForm__replyOptions:not(.m-hiddenAuthor):not(.m-internal),
+	input:checked + label + label {
+		color: $color;
+	}
+
+	.App__body,
+	.App__header,
+	.App__page,
+	.App__sidebar,
+	.FormattingHelp,
+	.FormattingHelp__code,
+	.NewThread__form,
+	.Sidebar__communities,
+	.Sidebar__title,
+	.SidebarNav__top,
+	div[class^='Thread__groupedText'],
+	div[class^='ThreadPreviewViewer__'],
+	.ThreadPreviewViewer__header,
+	.ThreadPreviewViewer__thread.m-read,
+	.ThreadViewer,
+	.ThreadViewer__header {
+		background-color: $background-color;
+		border-color: $border-color;
+	}
+
+	.App__sidebarFooter,
+	.FancySelect__option,
+	.FancySelect__tooltip,
+	.FormattingHelp__codeLine,
+	.FormattingHelp__tableCol pre,
+	.Header__tooltip,
+	.Header__tooltipItem,
+	.Input:not(.m-error),
+	.Input.m-error:focus,
+	.Textarea:not(.m-error),
+	.Textarea.m-error:focus,
+	.Thread__modAction,
+	.ThreadPreviewViewer__thread:not(.m-read),
+	.ThreadViewer__thread {
+		background-color: $highlight-background-color !important;
+		border-color: $border-color;
+	}
+
+	.FancySelect.m-error:not(:focus),
+	.Input.m-error:not(:focus),
+	.Textarea.m-error:not(:focus) {
+		background-color: rgb(71, 51, 51);
+	}
+
+	.m-error {
+		border-color: #EA0027 !important;
+	}
+
+	.App__sidebarFooterLink,
+	.FormattingHelp__tableRow,
+	.Thread__title,
+	.ThreadViewer__infobarContainer,
+	.ThreadViewer__replyContainer {
+		border-color: $border-color;
+	}
+
+	.FancySelect__option:hover,
+	.FormattingHelp__tableCol.m-highlight,
+	.Header__tooltipItem:hover,
+	.Thread__grouped {
+		background-color: $header-background-color !important;
+		color: $title-link-color;
+	}
+
+	div[class$='__tooltip__arrow'] {
+		border-bottom-color: $border-color !important;
+	}
+
+	.FormattingHelp {
+		overflow: auto;
+	}
+
+	.Header__icon {
+		filter: invert(79%) hue-rotate(180deg);
+	}
+
+	.InfoBar__age,
+	.InfoBar__recentsTitle,
+	.Login__tfa-desc,
+	input:not(:checked) + label,
+	input:not(:checked) + label + label,
+	div[class$='__formattingHelp']:not(:hover) {
+		color: hsl(0, 0%, 45%) !important;
+	}
+
+	.RESDialogSmall {
+		color: #ccc;
+		border-color: hsl(0, 0%, 30%);
+		background-color: $highlight-background-color;
+	}
+
+	.RESDialogSmall > h3,
+	.NERPageMarker {
+		color: inherit;
+		border-color: hsl(0, 0%, 30%);
+		background-color: transparent;
+	}
+
+	.Sidebar__newMessage.icon-edit:hover::before  {
+		color: rgb(13, 211, 187);
+	}
+
+	.SidebarCommunity__blankIcon,
+	.SidebarCommunity__name {
+		color: $color;
+		opacity: .3;
+	}
+
+	.SidebarCommunity:hover .SidebarCommunity__blankIcon,
+	.SidebarCommunity__name.m-selected {
+		opacity: unset;
+	}
+
+	.StyledHtml a:not(:active) {
+		color: $link-color;
+	}
+
+	.StyledHtml a:visited:not(:active) {
+		color: $nm-title-link-visited-color;
+	}
+
+	.FormattingHelp__tableCol blockquote,
+	.StyledHtml blockquote {
+		background-color: hsl(0, 0%, 25%);
+		color: hsl(0, 0%, 80%);
+		border-color: $border-color;
+	}
+
+	.ThreadPreviewViewer__thread {
+		box-shadow: 0 2px 4px rgba(255, 255, 255, .14);
+	}
+
+	.ThreadPreviewViewer__thread:hover {
+		outline: 1px solid $border-color;
 	}
 }

--- a/lib/modules/announcements.js
+++ b/lib/modules/announcements.js
@@ -17,8 +17,8 @@ module.description = 'announcementsDesc';
 module.hidden = true;
 
 const subreddit = Metadata.announcementsSubreddit;
-const sourceUrl = `/r/${subreddit}/new.json?limit=1`;
-const viewUrl = `/r/${subreddit}/new`;
+const sourceUrl = `//www.reddit.com/r/${subreddit}/new.json?limit=1`;
+const viewUrl = `//www.reddit.com/r/${subreddit}/new`;
 
 const markedReadDate = Storage.wrap('RESmodules.announcement.markedReadDate', 0);
 const lastUnreadDate = Storage.wrap('RESmodules.announcement.lastUnreadDate', 0);

--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -350,6 +350,8 @@ const className = () => {
 			return 'res-nightmode';
 		case 'd2x':
 			return 'res-d2x-nightmode';
+		case 'nmm':
+			return 'res-nmm-nightmode';
 		default:
 			throw new Error(`Impossible appType: ${appType()}`);
 	}

--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -350,8 +350,8 @@ const className = () => {
 			return 'res-nightmode';
 		case 'd2x':
 			return 'res-d2x-nightmode';
-		case 'nmm':
-			return 'res-nmm-nightmode';
+		case 'mm2x':
+			return 'res-mm2x-nightmode';
 		default:
 			throw new Error(`Impossible appType: ${appType()}`);
 	}

--- a/lib/utils/__tests__/location.js
+++ b/lib/utils/__tests__/location.js
@@ -256,3 +256,31 @@ test('liveThread regex doesn\'t match', regexDoesntMatch, regexes.liveThread, [
 	'/live/create',
 	'/live/create/',
 ]);
+
+test('modmail2x regex', regexMatches, regexes.modmail2x, [
+	['/mail/all', undefined],
+	['/mail/all/', undefined],
+	['/mail/new/12xyz', '12xyz'],
+	['/mail/archived/zyx21/', 'zyx21'],
+]);
+
+test('modmail2x regex doesn\'t match', regexDoesntMatch, regexes.modmail2x, [
+	'/',
+	'/mail',
+	'/mail/',
+	'/mail/create',
+	'/r/example',
+]);
+
+test('modmail2xCompose regex', regexMatches, regexes.modmail2xCompose, [
+	'/mail/create',
+	'/mail/create/',
+]);
+
+test('modmail2xCompose regex doesn\'t match', regexDoesntMatch, regexes.modmail2xCompose, [
+	'/',
+	'/mail',
+	'/mail/',
+	'/mail/all',
+	'/r/example',
+]);

--- a/lib/utils/location.js
+++ b/lib/utils/location.js
@@ -39,6 +39,8 @@ export const regexes: { [string]: RegExp } = {
 	domain:           /^\/domain\/([\w\.]+)(?:\/|$)/i,
 	composeMessage:   /^\/(?:r\/([\w\.\+]+)\/)?message\/compose(?:\/|$)/i,
 	liveThread:       /^\/live\/(?!create(?:\/|$))([a-z0-9]+)(?:\/|$)/i,
+	newModMail:       /^\/mail\/(?:all|new|inprogress|archived|highlighted|mod|notifications)(?:\/([0-9a-z]+))?\/?$/i,
+	composeNewModMail:/^\/mail\/create(?:\/|$)/i,
 };
 /* eslint-enable key-spacing */
 
@@ -51,12 +53,14 @@ export const execRegexes: { [string]: (path: string) => ?string[] } = {
 	},
 };
 
-export type PageType = 'wiki' | 'search' | 'profile' | 'profile2x' | 'profileCommentsPage' | 'stylesheet' | 'modqueue' | 'subredditAbout' | 'comments' | 'commentsLinklist' | 'liveThread' | 'inbox' | 'submit' | 'account' | 'prefs' | 'linklist';
-export type AppType = 'r2' | 'd2x';
+export type PageType = 'wiki' | 'search' | 'profile' | 'profile2x' | 'profileCommentsPage' | 'stylesheet' | 'modqueue' | 'subredditAbout' | 'comments' | 'commentsLinklist' | 'liveThread' | 'inbox' | 'submit' | 'account' | 'prefs' | 'linklist' | 'newModMail' | 'composeNewModMail';
+export type AppType = 'r2' | 'd2x' | 'nmm';
 
 export const appType = _.once((): AppType => {
 	if (document.documentElement.getAttribute('xmlns')) {
 		return 'r2';
+	} else if (window.location.hostname === 'mod.reddit.com') {
+		return 'nmm';
 	}
 	return 'd2x';
 });
@@ -73,6 +77,9 @@ const appPageTypes: { [AppType]: {| default?: PageType, pageTypes: PageType[] |}
 	},
 	d2x: {
 		pageTypes: ['profile2x', 'profileCommentsPage'],
+	},
+	nmm: {
+		pageTypes: ['newModMail', 'composeNewModMail'],
 	},
 };
 

--- a/lib/utils/location.js
+++ b/lib/utils/location.js
@@ -39,8 +39,8 @@ export const regexes: { [string]: RegExp } = {
 	domain:           /^\/domain\/([\w\.]+)(?:\/|$)/i,
 	composeMessage:   /^\/(?:r\/([\w\.\+]+)\/)?message\/compose(?:\/|$)/i,
 	liveThread:       /^\/live\/(?!create(?:\/|$))([a-z0-9]+)(?:\/|$)/i,
-	newModMail:       /^\/mail\/(?:all|new|inprogress|archived|highlighted|mod|notifications)(?:\/([0-9a-z]+))?\/?$/i,
-	composeNewModMail:/^\/mail\/create(?:\/|$)/i,
+	modmail2x:        /^\/mail\/(?:all|new|inprogress|archived|highlighted|mod|notifications)(?:\/([0-9a-z]+))?\/?$/i,
+	modmail2xCompose: /^\/mail\/create(?:\/|$)/i,
 };
 /* eslint-enable key-spacing */
 
@@ -53,14 +53,14 @@ export const execRegexes: { [string]: (path: string) => ?string[] } = {
 	},
 };
 
-export type PageType = 'wiki' | 'search' | 'profile' | 'profile2x' | 'profileCommentsPage' | 'stylesheet' | 'modqueue' | 'subredditAbout' | 'comments' | 'commentsLinklist' | 'liveThread' | 'inbox' | 'submit' | 'account' | 'prefs' | 'linklist' | 'newModMail' | 'composeNewModMail';
-export type AppType = 'r2' | 'd2x' | 'nmm';
+export type PageType = 'wiki' | 'search' | 'profile' | 'profile2x' | 'profileCommentsPage' | 'stylesheet' | 'modqueue' | 'subredditAbout' | 'comments' | 'commentsLinklist' | 'liveThread' | 'inbox' | 'submit' | 'account' | 'prefs' | 'linklist' | 'modmail2x' | 'modmail2xCompose';
+export type AppType = 'r2' | 'd2x' | 'mm2x';
 
 export const appType = _.once((): AppType => {
 	if (document.documentElement.getAttribute('xmlns')) {
 		return 'r2';
 	} else if (window.location.hostname === 'mod.reddit.com') {
-		return 'nmm';
+		return 'mm2x';
 	}
 	return 'd2x';
 });
@@ -78,8 +78,8 @@ const appPageTypes: { [AppType]: {| default?: PageType, pageTypes: PageType[] |}
 	d2x: {
 		pageTypes: ['profile2x', 'profileCommentsPage'],
 	},
-	nmm: {
-		pageTypes: ['newModMail', 'composeNewModMail'],
+	mm2x: {
+		pageTypes: ['modmail2x', 'modmail2x'],
 	},
 };
 

--- a/lib/utils/location.js
+++ b/lib/utils/location.js
@@ -79,7 +79,7 @@ const appPageTypes: { [AppType]: {| default?: PageType, pageTypes: PageType[] |}
 		pageTypes: ['profile2x', 'profileCommentsPage'],
 	},
 	mm2x: {
-		pageTypes: ['modmail2x', 'modmail2x'],
+		pageTypes: ['modmail2x', 'modmail2xCompose'],
 	},
 };
 

--- a/lib/utils/user.js
+++ b/lib/utils/user.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import { ajax } from '../environment';
 import type { CurrentRedditUser, RedditAccount } from '../types/reddit';
 import { MINUTE } from './time';
-import { regexes } from './location';
+import { isAppType, regexes } from './location';
 import * as string from './string';
 
 export const isLoggedIn = _.once(() => {
@@ -48,8 +48,9 @@ export function getUserInfo(username: ?string = loggedInUser()): Promise<RedditA
 		return Promise.reject(new Error('getUserInfo: null/undefined username'));
 	}
 
+	const urlPrefix = isAppType('mm2x') ? '//www.reddit.com' : '';
 	return ajax({
-		url: string.encode`/user/${username}/about.json`,
+		url: urlPrefix + string.encode`/user/${username}/about.json`,
 		type: 'json',
 		cacheFor: 10 * MINUTE,
 	});


### PR DESCRIPTION
Implement NightMode support for New ModMail pages (AppType "mm2x"). Did my best to keep Reddit-defined colors that still have good contrast on dark backgrounds while re-using existing NightMode color values for others. Used side-by-side comparison of vanilla Chrome instance vs. vanilla+dev build of this extension to ensure the UX is essentially identical (just a bit less eye-straining on one side 😎 ).

Apologies if the way I'm doing these PRs is confusing; I've cherry-picked the commits from #4790 into this branch to make it easier to build & test.

Blocked by #4790
Resolves #4069
Tested in browser: Chrome v67