### PR TITLE
messaging tests: Simplify nested promises

### DIFF
--- a/lib/environment/utils/__tests__/messaging.js
+++ b/lib/environment/utils/__tests__/messaging.js
@@ -6,11 +6,11 @@ import { createMessageHandler } from '../messaging';
 
 function createPair() {
 	const { _handleMessage: _handleMessageA, ...a } = createMessageHandler((info, context) =>
-		Promise.resolve().then(() => new Promise(resolve => _handleMessageB(info, resolve, context)))
+		new Promise(resolve => _handleMessageB(info, resolve, context))
 	);
 
 	const { _handleMessage: _handleMessageB, ...b } = createMessageHandler((info, context) =>
-		Promise.resolve().then(() => new Promise(resolve => _handleMessageA(info, resolve, context)))
+		new Promise(resolve => _handleMessageA(info, resolve, context))
 	);
 
 	return { a, b };


### PR DESCRIPTION
I think this can be safely done, as `Promise.resolve().then()` should just return the internal `Promise` and resolve to whatever that `Promise` resolves to.