### PR TITLE
Restructure builder (customFilters) to accept custom options

### DIFF
--- a/lib/core/migrate/migrate.js
+++ b/lib/core/migrate/migrate.js
@@ -687,6 +687,18 @@ const migrations = [
 
 			// TODO Next stable: Remove `RESmodules.filteReddit` and option filteReddit customFilters
 		},
+	}, {
+		versionNumber: '5.11.1-settingsConsole-builder-tweak',
+		async go() {
+			const { customFiltersP, customFiltersC } = await Options.loadRaw('filteReddit') || {};
+			for (const v of [...(customFiltersP.value || []), ...(customFiltersC.value || [])]) {
+				const { body: { name }, ondemand } = v;
+				v.opts = { ondemand, name };
+				// The trash values will be ignored by the builder, so no need to remove them
+			}
+			if (customFiltersP)	await Options.set('filteReddit', 'customFiltersP', customFiltersP.value);
+			if (customFiltersC)	await Options.set('filteReddit', 'customFiltersC', customFiltersC.value);
+		},
 	},
 
 ]; // ^^ Add new migrations ^^

--- a/lib/core/migrate/migrate.js
+++ b/lib/core/migrate/migrate.js
@@ -691,9 +691,11 @@ const migrations = [
 		versionNumber: '5.11.1-settingsConsole-builder-tweak',
 		async go() {
 			const { customFiltersP, customFiltersC } = await Options.loadRaw('filteReddit') || {};
+			let i = Date.now();
 			for (const v of [...(customFiltersP.value || []), ...(customFiltersC.value || [])]) {
 				const { body: { name }, ondemand } = v;
 				v.opts = { ondemand, name };
+				v.id = `customFilter-${String(i++)}`;
 				// The trash values will be ignored by the builder, so no need to remove them
 			}
 			if (customFiltersP)	await Options.set('filteReddit', 'customFiltersP', customFiltersP.value);

--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -221,6 +221,7 @@ export type BuilderOption<Ctx> = {|
 	defaultTemplate: () => BuilderRootValue,
 	cases: { [string]: BuilderCase<*> },
 	value: BuilderRootValue[],
+	customOptionsFields: Array<Array<BuilderField | string>>,
 	...CommonOptionProps<Ctx>,
 |};
 
@@ -228,7 +229,7 @@ export type BuilderRootValue = {|
 	note: string,
 	ver: number,
 	body: BuilderValue,
-	ondemand?: boolean,
+	opts?: { [string]: mixed },
 |};
 
 export type BuilderValue = {
@@ -241,7 +242,7 @@ type BuilderCase = {
 	fields: Array<BuilderField | string>,
 };
 
-type BuilderField = BuilderSelectField | BuilderMultiField | BuilderTextField | BuilderDurationField | BuilderChecksetField | BuilderNumberField;
+type BuilderField = BuilderSelectField | BuilderMultiField | BuilderDurationField | BuilderChecksetField | BuilderNumberField | BuilderCheckboxField | BuilderGenericInputField;
 
 type PredefinedSelectChoice = 'COMPARISON';
 
@@ -254,11 +255,6 @@ type BuilderSelectField = {|
 type BuilderMultiField = {|
 	type: 'multi',
 	include: 'all',
-	id: string,
-|};
-
-type BuilderTextField = {|
-	type: 'text',
 	id: string,
 |};
 
@@ -275,5 +271,16 @@ type BuilderChecksetField = {|
 
 type BuilderNumberField = {|
 	type: 'number',
+	id: string,
+|};
+
+type BuilderCheckboxField = {|
+	type: 'check',
+	id: string,
+	label: string,
+|};
+
+type BuilderGenericInputField = {|
+	type: string,
 	id: string,
 |};

--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -229,7 +229,11 @@ export type BuilderRootValue = {|
 	note: string,
 	ver: number,
 	body: BuilderValue,
-	opts?: { [string]: mixed },
+	opts?: {
+		[string]: mixed,
+		// Some typed (reserved) values in order to simplify type checking
+		name?: string,
+	},
 |};
 
 export type BuilderValue = {

--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -228,6 +228,7 @@ export type BuilderOption<Ctx> = {|
 export type BuilderRootValue = {|
 	note: string,
 	ver: number,
+	id: string,
 	body: BuilderValue,
 	opts?: {
 		[string]: mixed,

--- a/lib/css/res.scss
+++ b/lib/css/res.scss
@@ -1423,6 +1423,10 @@ body.RESScrollLock {
 		display: flex;
 		margin-bottom: 5px;
 
+		> .builderCustomOptions {
+			margin-left: 10px;
+		}
+
 		> .builderControls {
 			padding: .3em .2em;
 		}
@@ -1432,6 +1436,10 @@ body.RESScrollLock {
 
 			&.handle { font-size: 27px; }
 		}
+	}
+
+	input[type='checkbox'] {
+		vertical-align: text-bottom !important;
 	}
 }
 

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -361,6 +361,7 @@ export type FilterStorageValues = {|
 	type: string,
 	state: boolean | null,
 	criterion?: string,
+	name?: string,
 	conditions?: {},
 	undeletable?: boolean,
 |};

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -15,6 +15,7 @@ import {
 	currentUserProfile,
 	fullLocation,
 	CreateElement,
+	extendDeep,
 	fastAsync,
 	filterMap,
 	loggedInUser,
@@ -276,11 +277,18 @@ module.options = {
 		defaultTemplate() {
 			return {
 				note: '',
-				ver: 2,
+				ver: 3,
 				body: Cases.getConditions('group'),
-				ondemand: false,
+				opts: {
+					ondemand: false,
+					name: '',
+				},
 			};
 		},
+		customOptionsFields: [
+			[{ type: 'check', id: 'ondemand', label: 'Only filter when added to Filterline (on-demand)' }],
+			['Filterline name: ', { type: 'text', id: 'name' }],
+		],
 		get cases() { Cases.populatePrimitives(); return { ...Cases.getByContext('post'), ...Cases.getByContext('browse') }; },
 	},
 	customFiltersC: {
@@ -293,11 +301,18 @@ module.options = {
 		defaultTemplate() {
 			return {
 				note: '',
-				ver: 2,
+				ver: 3,
 				body: Cases.getConditions('group'),
-				ondemand: false,
+				opts: {
+					ondemand: false,
+					name: '',
+				},
 			};
 		},
+		customOptionsFields: [
+			[{ type: 'check', id: 'ondemand', label: 'Only filter when added to Filterline (on-demand)' }],
+			['Filterline name: ', { type: 'text', id: 'name' }],
+		],
 		get cases() { Cases.populatePrimitives(); return { ...Cases.getByContext('comment'), ...Cases.getByContext('browse') }; },
 	},
 };
@@ -451,6 +466,7 @@ function registerThing(thing) {
 }
 
 const externalFilterSourceMap: Map<*, mixed> = new Map();
+const customFilterSourceMap: Map<*, BuilderRootValue> = new Map();
 
 const createFilterline = _.once(({
 	filters: storedFilters = {},
@@ -460,24 +476,29 @@ const createFilterline = _.once(({
 	const filterline = new Filterline(filterlineStorage, thingType);
 
 	const filters = {};
-	const addDefaultFilter = (type, state) => { filters[type] = { type, state, undeletable: true }; };
+	const addDefaultFilter = (type, opts = {}) => { filters[type] = { type, undeletable: true, ...opts }; };
 
-	function addExternalFilter(type: $Keys<typeof module.options>, getConditions) {
+	function addExternalFilter(type: $Keys<typeof module.options>, getConditions: () => *, opts = {}) {
 		Cases.createAdHoc(type, () => Cases.getGroup('any', getConditions()), 'external', thingType);
-		addDefaultFilter(type, false);
+		addDefaultFilter(type, { state: false, ...opts });
 	}
 
 	function addLineDefaults(types) {
 		filterMap(types, v => Cases.isUseful(v) ? [v] : undefined)
-			.forEach(v => addDefaultFilter(v, null));
+			.forEach(v => addDefaultFilter(v));
 	}
 
-	module.options[customFilterVariant].value
-		.filter(({ ondemand }) => ondemand)
-		.forEach(v => addOndemandCase(v));
+	const customFilters = _.groupBy(
+		module.options[customFilterVariant].value,
+		({ opts: { ondemand } = {} }) => ondemand ? 'ondemand' : 'always'
+	);
 
-	addExternalFilter(customFilterVariant, () => module.options[customFilterVariant].value.filter(v => !v.ondemand).map(v => {
-		externalFilterSourceMap.set(v.body, v);
+	if (customFilters.ondemand) {
+		customFilters.ondemand.forEach(v => addOndemandCase(v));
+	}
+
+	addExternalFilter(customFilterVariant, () => (customFilters.always || []).map(v => {
+		customFilterSourceMap.set(v.body, v);
 		return v.body;
 	}));
 
@@ -613,14 +634,15 @@ function updateNsfwThingClass(thing) {
 }
 
 export function addOndemandCase(customFilter: BuilderRootValue, forceUseful: boolean = false) {
-	const conditions = Cases.resolveGroup(customFilter.body);
-	externalFilterSourceMap.set(conditions, customFilter);
+	const conditions = Cases.resolveGroup(customFilter.body, true, true);
+	customFilterSourceMap.set(conditions, customFilter);
 
-	let { name } = (customFilter.body: any);
+	const opts = customFilter.opts || {};
+	let name = typeof opts.name === 'string' && opts.name || '';
 	while (!name || Cases.has(name)) {
 		// Make sure filter has an unique name
 		name += randomHash();
-		updateCustomFilter(customFilter, { name });
+		updateCustomFilter(customFilter, { opts });
 	}
 
 	let cased;
@@ -634,13 +656,13 @@ export function addOndemandCase(customFilter: BuilderRootValue, forceUseful: boo
 	return cased;
 }
 
-export function addCustomFilter(data: {| body: *, ondemand: * |}): BuilderRootValue {
-	const customFilter = ({
+export function addCustomFilter({ body, opts }: {| body: *, opts?: * |}): BuilderRootValue {
+	const customFilter = {
 		note: `From ${fullLocation()}`,
-		ver: 2,
-		ondemand: false,
-		...data,
-	}: any);
+		ver: 3,
+		body,
+		opts,
+	};
 
 	Options.set(module, customFilterVariant, [customFilter, ...module.options[customFilterVariant].value]);
 
@@ -648,14 +670,14 @@ export function addCustomFilter(data: {| body: *, ondemand: * |}): BuilderRootVa
 }
 
 export function getCustomFilter(entry: *): BuilderRootValue {
-	const customFilter: ?BuilderRootValue = (externalFilterSourceMap.get(entry): any);
+	const customFilter = customFilterSourceMap.get(entry);
 	if (!customFilter) throw new Error('Could not find customFilter');
 	return customFilter;
 }
 
-export function updateCustomFilter(customFilter: BuilderRootValue, val: any) {
-	const { body } = customFilter;
-	Object.assign(body, val);
+export function updateCustomFilter(customFilter: BuilderRootValue, val: $Shape<BuilderRootValue>) {
+	// XXX May leave trash in the object
+	extendDeep((customFilter: any), (val: any)); // This mutates the option array
 	Options.set(module, customFilterVariant, module.options[customFilterVariant].value);
 }
 

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -477,16 +477,16 @@ const createFilterline = _.once(({
 	const filterline = new Filterline(filterlineStorage, thingType);
 
 	const filters = {};
-	const addDefaultFilter = (type, opts = {}) => { filters[type] = { type, undeletable: true, ...opts }; };
+	const addDefaultFilter = (id, opts: { type: string }) => { filters[id] = { undeletable: true, ...opts }; };
 
-	function addExternalFilter(name: string, getConditions: () => *, Filter, source) {
-		const cased = Cases.createAdHoc(name, getConditions, 'external', thingType, source);
-		addDefaultFilter(cased.type, { state: false, Filter });
+	function addExternalFilter(key, name, getConditions, Filter, source) {
+		const cased = Cases.createAdHoc(key, name, getConditions, 'external', thingType, source);
+		addDefaultFilter(key, { Filter, type: cased.type, state: false });
 	}
 
 	function addLineDefaults(types) {
 		filterMap(types, v => Cases.isUseful(v) ? [v] : undefined)
-			.forEach(v => addDefaultFilter(v));
+			.forEach(type => addDefaultFilter(type, { type }));
 	}
 
 	const customFilters = _.groupBy(
@@ -499,13 +499,12 @@ const createFilterline = _.once(({
 	}
 
 	// Make customFilter(C|P) so that the settings link is available
-	addExternalFilter(customFilterVariant, () => ({ type: 'false' }), ExternalFilter);
+	addExternalFilter(customFilterVariant, i18n(module.options[customFilterVariant].title), () => ({ type: 'false' }), ExternalFilter);
 
 	for (const customFilter of (customFilters.always || [])) {
 		const conditions = Cases.resolveGroup(customFilter.body);
 		if (!Cases.isUseful(conditions.type)) continue;
-		const { id } = customFilter;
-		addExternalFilter(id, () => conditions, ExternalFilter, customFilter);
+		addExternalFilter(customFilter.id, (customFilter.opts || {}).name, () => conditions, ExternalFilter, customFilter);
 	}
 
 	function addListFilter(externalKey, caseType, additionalCriteria) {
@@ -535,7 +534,7 @@ const createFilterline = _.once(({
 			}
 		};
 
-		addExternalFilter(externalKey, getConditions, Filter);
+		addExternalFilter(externalKey, i18n(module.options[externalKey].title), getConditions, Filter);
 	}
 
 	function addPostFilters() {
@@ -673,8 +672,7 @@ export function addOndemandCase(customFilter: BuilderRootValue, onlyUseful: bool
 	const getConditions = () => Cases.resolveGroup(customFilter.body);
 
 	if (!onlyUseful || Cases.isUseful(getConditions().type)) {
-		const { id } = customFilter;
-		return Cases.createAdHoc(id, getConditions, 'ondemand', thingType, customFilter);
+		return Cases.createAdHoc(customFilter.id, (customFilter.opts || {}).name, getConditions, 'ondemand', thingType, customFilter);
 	} else {
 		return Cases.Inert;
 	}

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -8,6 +8,7 @@ import { Module } from '../core/module';
 import * as Options from '../core/options';
 import {
 	BodyClasses,
+	asyncFind,
 	asyncFlow,
 	batch,
 	currentDomain,
@@ -26,7 +27,6 @@ import {
 	mutex,
 	reifyPromise,
 	watchForThings,
-	randomHash,
 	scrollToElement,
 } from '../utils';
 import { Storage, ajax, i18n } from '../environment';
@@ -38,7 +38,9 @@ import * as Notifications from './notifications';
 import * as RESTips from './RESTips';
 import * as SelectedEntry from './selectedEntry';
 import * as Cases from './filteReddit/cases';
+import { Case } from './filteReddit/Case';
 import { Filterline } from './filteReddit/Filterline';
+import { ExternalFilter } from './filteReddit/ExternalFilter';
 
 export const module: Module<*> = new Module('filteReddit');
 
@@ -465,9 +467,6 @@ function registerThing(thing) {
 	return createFilterline().filterline.addThing(thing);
 }
 
-const externalFilterSourceMap: Map<*, mixed> = new Map();
-const customFilterSourceMap: Map<*, BuilderRootValue> = new Map();
-
 const createFilterline = _.once(({
 	filters: storedFilters = {},
 	visible: initialVisibility = module.options.showFilterline.value,
@@ -478,9 +477,9 @@ const createFilterline = _.once(({
 	const filters = {};
 	const addDefaultFilter = (type, opts = {}) => { filters[type] = { type, undeletable: true, ...opts }; };
 
-	function addExternalFilter(type: $Keys<typeof module.options>, getConditions: () => *, opts = {}) {
-		Cases.createAdHoc(type, () => Cases.getGroup('any', getConditions()), 'external', thingType);
-		addDefaultFilter(type, { state: false, ...opts });
+	function addExternalFilter(name: string, getConditions: () => *, Filter, source) {
+		const cased = Cases.createAdHoc(name, getConditions, 'external', thingType, source);
+		addDefaultFilter(cased.type, { state: false, Filter });
 	}
 
 	function addLineDefaults(types) {
@@ -494,17 +493,52 @@ const createFilterline = _.once(({
 	);
 
 	if (customFilters.ondemand) {
-		customFilters.ondemand.forEach(v => addOndemandCase(v));
+		customFilters.ondemand.forEach(v => addOndemandCase(v, true));
 	}
 
-	addExternalFilter(customFilterVariant, () => (customFilters.always || []).map(v => {
-		customFilterSourceMap.set(v.body, v);
-		return v.body;
-	}));
+	// Make customFilter(C|P) so that the settings link is available
+	addExternalFilter(customFilterVariant, () => ({ type: 'false' }), ExternalFilter);
+
+	for (const customFilter of (customFilters.always || [])) {
+		const conditions = Cases.resolveGroup(customFilter.body);
+		if (!Cases.isUseful(conditions.type)) continue;
+		const { name } = customFilter.opts || {};
+		addExternalFilter(name, () => conditions, ExternalFilter, customFilter);
+	}
+
+	function addListFilter(externalKey, caseType, additionalCriteria) {
+		const list = module.options[externalKey].value;
+		const sources = new Map();
+
+		function getConditions() {
+			sources.clear();
+			return Cases.resolveGroup(Cases.getGroup('any', list.map(v => {
+				const c = getStringMatchConditions(v, caseType, additionalCriteria);
+				sources.set(c, v);
+				return c;
+			})));
+		}
+
+		const Filter = class ExternalFilterList extends ExternalFilter {
+			async getMatchingEntry(thing) {
+				return sources.get(
+					await asyncFind(sources.keys(), v => Case.fromConditions(v).evaluate(thing))
+				);
+			}
+
+			removeEntry(entry) {
+				const newValueArray = _.pull(list, entry);
+				Options.set(module, externalKey, newValueArray);
+				this.update(this.state, null); // `null` in order to regenerate case from `getConditions`
+			}
+		};
+
+		addExternalFilter(externalKey, getConditions, Filter);
+	}
 
 	function addPostFilters() {
-		addExternalFilter('keywords', () => getStringMatchConditions('keywords', 'postTitle'));
-		addExternalFilter('domains', () => getStringMatchConditions('domains', 'domain', { fullMatch: false }));
+		addListFilter('keywords', 'postTitle');
+		addListFilter('domains', 'domain', { fullMatch: false });
 		if (
 			module.options.filterSubredditsFrom.value === 'everywhere' ||
 			module.options.filterSubredditsFrom.value === 'everywhere-except-subreddit' && !currentSubreddit() ||
@@ -512,9 +546,9 @@ const createFilterline = _.once(({
 			currentDomain() ||
 			isCurrentMultireddit('me/f/all')
 		) {
-			addExternalFilter('subreddits', () => getStringMatchConditions('subreddits', 'subreddit'));
+			addListFilter('subreddits', 'subreddit');
 		}
-		addExternalFilter('flair', () => getStringMatchConditions('flair', 'linkFlair', { fullMatch: false }));
+		addListFilter('flair', 'linkFlair', { fullMatch: false });
 
 		addLineDefaults([
 			!module.options.NSFWfilter.value && 'isNSFW',
@@ -633,27 +667,15 @@ function updateNsfwThingClass(thing) {
 	}
 }
 
-export function addOndemandCase(customFilter: BuilderRootValue, forceUseful: boolean = false) {
-	const conditions = Cases.resolveGroup(customFilter.body, true, true);
-	customFilterSourceMap.set(conditions, customFilter);
+export function addOndemandCase(customFilter: BuilderRootValue, onlyUseful: boolean = false) {
+	const getConditions = () => Cases.resolveGroup(customFilter.body);
 
-	const opts = customFilter.opts || {};
-	let name = typeof opts.name === 'string' && opts.name || '';
-	while (!name || Cases.has(name)) {
-		// Make sure filter has an unique name
-		name += randomHash();
-		updateCustomFilter(customFilter, { opts });
-	}
-
-	let cased;
-	if (Cases.isUseful(conditions.type) || forceUseful) {
-		cased = Cases.createAdHoc(name, () => conditions, 'ondemand', thingType);
+	if (!onlyUseful || Cases.isUseful(getConditions().type)) {
+		const { name } = customFilter.opts || {};
+		return Cases.createAdHoc(name, getConditions, 'ondemand', thingType, customFilter);
 	} else {
-		cased = Cases.Inert;
+		return Cases.Inert;
 	}
-
-	Cases.add(name, cased);
-	return cased;
 }
 
 export function addCustomFilter({ body, opts }: {| body: *, opts?: * |}): BuilderRootValue {
@@ -669,21 +691,10 @@ export function addCustomFilter({ body, opts }: {| body: *, opts?: * |}): Builde
 	return customFilter;
 }
 
-export function getCustomFilter(entry: *): BuilderRootValue {
-	const customFilter = customFilterSourceMap.get(entry);
-	if (!customFilter) throw new Error('Could not find customFilter');
-	return customFilter;
-}
-
 export function updateCustomFilter(customFilter: BuilderRootValue, val: $Shape<BuilderRootValue>) {
 	// XXX May leave trash in the object
 	extendDeep((customFilter: any), (val: any)); // This mutates the option array
 	Options.set(module, customFilterVariant, module.options[customFilterVariant].value);
-}
-
-export function removeExternalFilterEntry(externalType: string, entry: *) {
-	const newValueArray = _.pull(module.options[externalType].value, externalFilterSourceMap.get(entry));
-	Options.set(module, externalType, newValueArray);
 }
 
 export async function saveFilterlineStateAsDefault(type: string) {
@@ -697,59 +708,54 @@ export async function saveFilterlineStateAsDefault(type: string) {
 	Notifications.showNotification('Saved.', 1000);
 }
 
-function getStringMatchConditions(externalType, caseType, additionalCriteria) {
-	return module.options[externalType].value.map(source => {
-		const [matchString = '', applyTo = 'everywhere', applyList = '', except = ''] = Array.isArray(source) ? source : [source];
+function getStringMatchConditions(source, caseType, additionalCriteria) {
+	const [matchString = '', applyTo = 'everywhere', applyList = '', except = ''] = Array.isArray(source) ? source : [source];
 
-		let applyToConditions;
-		if (applyTo !== 'everywhere') {
-			const subreddits = applyList.split(',');
+	let applyToConditions;
+	if (applyTo !== 'everywhere') {
+		const subreddits = applyList.split(',');
 
-			if (subreddits.findIndex(v => !v) !== -1) {
-				console.error('Filter must have subreddits specified', source);
-				return { type: 'false' };
-			}
-
-			applyToConditions = Cases.getGroup(applyTo === 'exclude' ? 'none' : 'any', _.compact([
-				// /r/all special case
-				// (nothing is posted to /r/all, but we could be browsing it)
-				subreddits.includes('all') ? {
-					type: 'currentSub',
-					patt: 'all',
-				} : null,
-				// and the same for /r/popular
-				subreddits.includes('popular') ? {
-					type: 'currentSub',
-					patt: 'popular',
-				} : null,
-				// normal subreddit include/exclude
-				...subreddits.map(sr => ({
-					type: 'subreddit',
-					patt: sr,
-				})),
-			]));
+		if (subreddits.findIndex(v => !v) !== -1) {
+			console.error('Filter must have subreddits specified', source);
+			return { type: 'false' };
 		}
 
-		const conditions = Cases.resolveGroup(Cases.getGroup('all', _.compact([
-			// applyTo filtering
-			applyToConditions || null,
-			// main filter
-			{
-				type: caseType,
-				patt: matchString,
-				...additionalCriteria,
-			},
-			// filter exclusions
-			(except && except.length) && Cases.getGroup('none', [{
-				type: caseType,
-				patt: except,
-				...additionalCriteria,
-			}]) || null,
-		])));
+		applyToConditions = Cases.getGroup(applyTo === 'exclude' ? 'none' : 'any', [
+			// /r/all special case
+			// (nothing is posted to /r/all, but we could be browsing it)
+			subreddits.includes('all') ? {
+				type: 'currentSub',
+				patt: 'all',
+			} : null,
+			// and the same for /r/popular
+			subreddits.includes('popular') ? {
+				type: 'currentSub',
+				patt: 'popular',
+			} : null,
+			// normal subreddit include/exclude
+			...subreddits.map(sr => ({
+				type: 'subreddit',
+				patt: sr,
+			})),
+		].filter(Boolean));
+	}
 
-		externalFilterSourceMap.set(conditions, source);
-		return conditions;
-	});
+	return Cases.getGroup('all', [
+		// applyTo filtering
+		applyToConditions || null,
+		// main filter
+		{
+			type: caseType,
+			patt: matchString,
+			...additionalCriteria,
+		},
+		// filter exclusions
+		(except && except.length) && Cases.getGroup('none', [{
+			type: caseType,
+			patt: except,
+			...additionalCriteria,
+		}]) || null,
+	].filter(Boolean));
 }
 
 /**

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -281,6 +281,7 @@ module.options = {
 				note: '',
 				ver: 3,
 				body: Cases.getConditions('group'),
+				id: `customFilter-${Date.now()}`,
 				opts: {
 					ondemand: false,
 					name: '',
@@ -305,6 +306,7 @@ module.options = {
 				note: '',
 				ver: 3,
 				body: Cases.getConditions('group'),
+				id: `customFilter-${Date.now()}`,
 				opts: {
 					ondemand: false,
 					name: '',
@@ -502,8 +504,8 @@ const createFilterline = _.once(({
 	for (const customFilter of (customFilters.always || [])) {
 		const conditions = Cases.resolveGroup(customFilter.body);
 		if (!Cases.isUseful(conditions.type)) continue;
-		const { name } = customFilter.opts || {};
-		addExternalFilter(name, () => conditions, ExternalFilter, customFilter);
+		const { id } = customFilter;
+		addExternalFilter(id, () => conditions, ExternalFilter, customFilter);
 	}
 
 	function addListFilter(externalKey, caseType, additionalCriteria) {
@@ -671,8 +673,8 @@ export function addOndemandCase(customFilter: BuilderRootValue, onlyUseful: bool
 	const getConditions = () => Cases.resolveGroup(customFilter.body);
 
 	if (!onlyUseful || Cases.isUseful(getConditions().type)) {
-		const { name } = customFilter.opts || {};
-		return Cases.createAdHoc(name, getConditions, 'ondemand', thingType, customFilter);
+		const { id } = customFilter;
+		return Cases.createAdHoc(id, getConditions, 'ondemand', thingType, customFilter);
 	} else {
 		return Cases.Inert;
 	}
@@ -682,6 +684,7 @@ export function addCustomFilter({ body, opts }: {| body: *, opts?: * |}): Builde
 	const customFilter = {
 		note: `From ${fullLocation()}`,
 		ver: 3,
+		id: `customFilter-${Date.now()}`,
 		body,
 		opts,
 	};

--- a/lib/modules/filteReddit/Case.js
+++ b/lib/modules/filteReddit/Case.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 import { Thing } from '../../utils';
-import type { BuilderValue } from '../../core/module';
+import type { BuilderValue, BuilderRootValue } from '../../core/module';
 import * as SelectedEntry from '../selectedEntry';
 import * as Cases from './cases';
 
@@ -105,6 +105,9 @@ export class Case {
 	static variant: 'basic' | 'ondemand' | 'external' = 'basic';
 	static pattern: string = '';
 	static criterionOperators = false; // Create groups on encountering operators: ' & ' → 'and'
+
+	static _customFilter: ?BuilderRootValue;
+	static getCustomFilter() { if (this._customFilter) return this._customFilter; throw new Error('Source not found'); }
 
 	+trueText: ?string;
 	falseText: ?string;

--- a/lib/modules/filteReddit/Case.js
+++ b/lib/modules/filteReddit/Case.js
@@ -62,7 +62,6 @@ export class Case {
 			const CaseClass = Cases.get(type);
 			if (CaseClass.disabled) throw new Error(`${CaseClass.type} is disabled`);
 			cased = new CaseClass(conditions);
-			cased.value = cased.getValue ? cased.getValue(conditions) : conditions;
 		} catch (e) {
 			if (propagateError) throw e;
 			console.error(`Could not build case: ${e.message}. Ignoring.`, e);
@@ -113,10 +112,8 @@ export class Case {
 	falseText: ?string;
 
 	constructor(conditions: *) {
-		this.conditions = conditions;
+		this.conditions = this.value = conditions;
 	}
-
-	+getValue: ?(conditions: BuilderValue) => *;
 
 	isValid(): boolean { return true; }
 

--- a/lib/modules/filteReddit/Case.js
+++ b/lib/modules/filteReddit/Case.js
@@ -46,8 +46,7 @@ export class Case {
 		const parts = criterion.split(' & ');
 
 		if (this.criterionOperators && criterion && parts.length > 1) {
-			const name = `${this.text.toLowerCase()} ${criterion}`;
-			return Cases.getGroup('all', parts.map(v => Cases.getConditions(this.type, parse(v))), name);
+			return Cases.getGroup('all', parts.map(v => Cases.getConditions(this.type, parse(v))));
 		} else {
 			return parse(criterion);
 		}

--- a/lib/modules/filteReddit/ExternalFilter.js
+++ b/lib/modules/filteReddit/ExternalFilter.js
@@ -10,7 +10,7 @@ export class ExternalFilter extends Filter {
 	createElement() {
 		this.element = string.html`
 			<div class="res-filterline-external-filter" type="${this.BaseCase.type}">
-				<div>${this.BaseCase.type}</div>
+				<div>${this.name || this.BaseCase.type}</div>
 			</div>
 		`;
 

--- a/lib/modules/filteReddit/ExternalFilter.js
+++ b/lib/modules/filteReddit/ExternalFilter.js
@@ -1,37 +1,28 @@
 /* @flow */
 
-import { $ } from '../../vendor';
-import { string, CreateElement, asyncFind } from '../../utils';
+import { string, CreateElement } from '../../utils';
 import * as FilteReddit from '../filteReddit';
 import * as SettingsNavigation from '../settingsNavigation';
+import * as Cases from './cases';
 import { Filter } from './Filter';
 
 export class ExternalFilter extends Filter {
 	createElement() {
 		this.element = string.html`
 			<div class="res-filterline-external-filter" type="${this.BaseCase.type}">
-				${string.safe(SettingsNavigation.makeUrlHashLink(FilteReddit.module.moduleID, this.BaseCase.type, ' ', 'gearIcon'))}
 				<div>${this.BaseCase.type}</div>
 			</div>
 		`;
-		this.element.appendChild(
-			CreateElement.toggleButton(state => { this.update(state ? false : null); }, null, this.state === false, '', '')
-		);
-	}
 
-	async showThingFilterReason(thing: *) {
-		thing.element.setAttribute('filter-reason', `specified by filter ${this.BaseCase.type}`);
+		if (FilteReddit.module.options.hasOwnProperty(this.BaseCase.type)) {
+			this.element.prepend(string.html`${string.safe(
+				SettingsNavigation.makeUrlHashLink(FilteReddit.module.moduleID, this.BaseCase.type, ' ', 'gearIcon')
+			)}`);
+		}
 
-		if (!Array.isArray((this.case.conditions: any).of)) throw new Error('Must be a group case');
-		const entry = await asyncFind((this.case.conditions: any).of, v => this.BaseCase.fromConditions(v).evaluate(thing));
-
-		$('<span>', {
-			class: 'res-filter-remove-entry',
-			title: JSON.stringify(entry, null, '  '),
-			click: () => {
-				FilteReddit.removeExternalFilterEntry(this.BaseCase.type, entry);
-				this.update(this.state, null, false);
-			},
-		}).prependTo(thing.element);
+		if (Cases.isUseful(this.case.constructor.type)) {
+			const t = CreateElement.toggleButton(state => { this.update(state ? false : null); }, null, this.state === false, '', '');
+			this.element.appendChild(t);
+		}
 	}
 }

--- a/lib/modules/filteReddit/Filter.js
+++ b/lib/modules/filteReddit/Filter.js
@@ -49,10 +49,10 @@ export class Filter {
 
 		if (this.BaseCase.variant === 'basic') {
 			values.conditions = this.case.conditions;
-		}
 
-		if (this.name && this.name !== this.case.trueText) {
-			values.name = this.name;
+			if (this.name && this.name !== this.case.trueText) {
+				values.name = this.name;
+			}
 		}
 
 		return values;
@@ -69,7 +69,7 @@ export class Filter {
 
 	setCase(newCase: Case) {
 		this.case = newCase;
-		if (this.state !== null) this.case.observe(this);
+		this.case.observe(this);
 	}
 
 	update(state: *, conditions?: *, describeOnly: boolean = false) {
@@ -135,13 +135,23 @@ export class Filter {
 		}
 	});
 
-	showThingFilterReason(thing: Thing) {
+	getMatchingEntry(thing: Thing) { // eslint-disable-line no-unused-vars
+		return this.case.conditions;
+	}
+
+	removeEntry(entry: *) { // eslint-disable-line no-unused-vars
+		this.update(null);
+	}
+
+	async showThingFilterReason(thing: Thing) {
 		thing.element.setAttribute('filter-reason', this.getStateText(!this.state));
+
+		const entry = await this.getMatchingEntry(thing);
 
 		$('<span>', {
 			class: 'res-filter-remove-entry',
-			title: JSON.stringify(this.case.conditions, null, '  '),
-			click: () => { this.update(null); },
+			title: JSON.stringify(entry, null, '  '),
+			click: () => { this.removeEntry(entry); },
 		}).prependTo(thing.element);
 	}
 

--- a/lib/modules/filteReddit/Filter.js
+++ b/lib/modules/filteReddit/Filter.js
@@ -11,6 +11,7 @@ import type { Filterline } from './Filterline';
 
 export class Filter {
 	id: string;
+	name: string;
 	parent: ?Filterline;
 	undeletable: boolean;
 
@@ -22,9 +23,10 @@ export class Filter {
 
 	element: HTMLElement;
 
-	constructor(id: *, BaseCase: *, conditions: * = null, state: * = null, undeletable: * = false) {
+	constructor(id: *, BaseCase: *, name: *, conditions: * = null, state: * = null, undeletable: * = false) {
 		this.id = id;
 		this.BaseCase = BaseCase;
+		this.name = name;
 		this.state = state;
 		this.setCase(BaseCase.fromConditions(conditions));
 		this.undeletable = undeletable;
@@ -38,8 +40,8 @@ export class Filter {
 
 	getStateText(state: ?boolean, cased: Case = this.case): string {
 		return state !== false ?
-			cased.trueText || (this.BaseCase.text || this.BaseCase.type).toLowerCase() :
-			cased.falseText || `¬ ${this.getStateText()}`;
+			this.name || cased.trueText || (this.BaseCase.text || this.BaseCase.type).toLowerCase() :
+			this.name && `¬ ${this.name}` || cased.falseText || `¬ ${this.getStateText()}`;
 	}
 
 	getSaveValues() {
@@ -47,6 +49,10 @@ export class Filter {
 
 		if (this.BaseCase.variant === 'basic') {
 			values.conditions = this.case.conditions;
+		}
+
+		if (this.name && this.name !== this.case.trueText) {
+			values.name = this.name;
 		}
 
 		return values;
@@ -74,11 +80,9 @@ export class Filter {
 			return `Show only posts which matches "${this.getStateText(state)}"`;
 		}
 
-		if (state !== this.state || this.case !== cased) {
-			this.state = state;
-			this.setCase(cased);
-			this.refresh();
-		}
+		this.state = state;
+		this.setCase(cased);
+		this.refresh();
 	}
 
 	refresh = (save: boolean = true, thing?: Thing) => {

--- a/lib/modules/filteReddit/Filterline.js
+++ b/lib/modules/filteReddit/Filterline.js
@@ -377,6 +377,7 @@ export class Filterline {
 		save = true,
 		type,
 		criterion,
+		name,
 		conditions,
 		state,
 		undeletable,
@@ -388,7 +389,7 @@ export class Filterline {
 			conditions = CaseClass.criterionToConditions(criterion);
 		}
 
-		const filter = new (CaseClass.variant === 'external' ? ExternalFilter : LineFilter)(id, CaseClass, conditions, state, undeletable);
+		const filter = new (CaseClass.variant === 'external' ? ExternalFilter : LineFilter)(id, CaseClass, name, conditions, state, undeletable);
 
 		if (add) {
 			this.addFilter(filter);

--- a/lib/modules/filteReddit/Filterline.js
+++ b/lib/modules/filteReddit/Filterline.js
@@ -310,24 +310,30 @@ export class Filterline {
 
 		const findMatchingCases = val =>
 			this.getPickable()
-				.filter(({ type }) => type.toLowerCase().match(val.toLowerCase()))
-				.sort((a, b) => a.variant.localeCompare(b.variant) || a.type.localeCompare(b.type));
+				.sort((a, b) => a.variant.localeCompare(b.variant) || a.type.localeCompare(b.type))
+				.map(CaseClass => ({
+					// on-demand cases' type name are hard to discern
+					name: CaseClass.variant === 'ondemand' ? CaseClass.text : CaseClass.type,
+					cls: CaseClass,
+				}))
+				.filter(({ name }) => name.toLowerCase().match(val.toLowerCase()));
 
 		let filter;
 
 		async function getTip(val) {
 			const deconstructed = deconstruct(val);
 			const { key, asNewFilter } = deconstructed;
-			const bestMatch = key && _.sortBy(findMatchingCases(key), ({ type }) => type.toLowerCase().indexOf(key.toLowerCase()))[0];
+			const bestMatch = key && _.sortBy(findMatchingCases(key), ({ name }) => name.toLowerCase().indexOf(key.toLowerCase()))[0];
+			const { cls: MatchedCase } = bestMatch || {};
 
 			let message;
 
 			if (bestMatch) {
 				try {
-					const lastFilter = _.last(this.getFiltersOfCase(bestMatch));
+					const lastFilter = _.last(this.getFiltersOfCase(MatchedCase));
 					filter = lastFilter && !asNewFilter ?
 						lastFilter :
-						this.createFilter({ type: bestMatch.type });
+						this.createFilter({ type: MatchedCase.type });
 
 					const actionDescription = await filter.updateByInputConstruction(deconstructed, true);
 					/*:: if (!actionDescription ) throw new Error(); */
@@ -347,7 +353,9 @@ export class Filterline {
 				message,
 				'',
 				'Filters:',
-				...findMatchingCases('').map(v => ` ${(bestMatch === v) ? `<b>${v.type}</b>` : v.type} ${v.pattern}`),
+				...findMatchingCases('').map(v =>
+					` ${(MatchedCase === v.cls) ? `<b>${v.name}</b>` : v.name} ${v.cls.pattern}`
+				),
 				'',
 				'Modifiers:',
 				' / — clear the filter',

--- a/lib/modules/filteReddit/Filterline.js
+++ b/lib/modules/filteReddit/Filterline.js
@@ -404,6 +404,11 @@ export class Filterline {
 			if (!name) ({ name } = externOpts);
 		}
 
+		if (CaseClass.variant === 'ondemand') {
+			// customFilters hides posts that don't match; keep on-demand consistent
+			if (state === undefined) state = false;
+		}
+
 		const filter = new Filter(id, CaseClass, name, conditions, state, undeletable);
 
 		if (add) {

--- a/lib/modules/filteReddit/Filterline.js
+++ b/lib/modules/filteReddit/Filterline.js
@@ -30,6 +30,7 @@ import type { Filter } from './Filter';
 import type { Case } from './Case';
 
 type NewFilterOpts = {|
+	Filter?: Class<Filter>,
 	id?: string,
 	add?: boolean,
 	save?: boolean,
@@ -372,6 +373,7 @@ export class Filterline {
 	}
 
 	createFilter({
+		Filter = LineFilter,
 		id = `~${performance.timing.navigationStart + performance.now()}`, // timestamp, so that filters will restored in the same order as they initially were created
 		add = false,
 		save = true,
@@ -389,7 +391,12 @@ export class Filterline {
 			conditions = CaseClass.criterionToConditions(criterion);
 		}
 
-		const filter = new (CaseClass.variant === 'external' ? ExternalFilter : LineFilter)(id, CaseClass, name, conditions, state, undeletable);
+		const externOpts = CaseClass._customFilter && CaseClass._customFilter.opts;
+		if (externOpts) {
+			if (!name) ({ name } = externOpts);
+		}
+
+		const filter = new Filter(id, CaseClass, name, conditions, state, undeletable);
 
 		if (add) {
 			this.addFilter(filter);

--- a/lib/modules/filteReddit/LineFilter.js
+++ b/lib/modules/filteReddit/LineFilter.js
@@ -21,11 +21,8 @@ export class LineFilter extends Filter {
 	inner: HTMLElement;
 
 	update(state: * = this.state, conditions?: *, describeOnly: *) {
-		if (this.BaseCase.variant === 'ondemand' && !describeOnly) {
-			Cases.remove(this.BaseCase.type);
-			const customFilter = FilteReddit.getCustomFilter(this.BaseCase.defaultConditions);
-			if (conditions) FilteReddit.updateCustomFilter(customFilter, { body: conditions });
-			this.BaseCase = FilteReddit.addOndemandCase(customFilter, true);
+		if (this.BaseCase.variant === 'ondemand' && conditions && !describeOnly) {
+			FilteReddit.updateCustomFilter(this.BaseCase.getCustomFilter(), { body: conditions });
 			conditions = null; // Force create new case
 		}
 
@@ -36,7 +33,6 @@ export class LineFilter extends Filter {
 
 	setParent(parent: *) {
 		super.setParent(parent);
-		this.initialConditions = this.case.conditions;
 		this.getBuilder.cache.clear();
 	}
 
@@ -93,8 +89,10 @@ export class LineFilter extends Filter {
 			Object.assign(builderCases, Cases.getByContext('browse'));
 
 			// Use customFilter conditions
-			lastConditions = FilteReddit.getCustomFilter(this.BaseCase.defaultConditions).body;
+			lastConditions = this.BaseCase.getCustomFilter().body;
 		}
+
+		if (!this.initialConditions) this.initialConditions = lastConditions;
 
 		const $builder = SettingsConsole.drawBuilderBlock(lastConditions, builderCases);
 
@@ -190,18 +188,19 @@ export class LineFilter extends Filter {
 					Cases.getGroup(this.state === false ? 'all' : 'none', [this.case.conditions]),
 				]);
 
+				if (!this.name) this.name = window.prompt('Filter name:');
+
 				this.BaseCase = FilteReddit.addOndemandCase(
 					FilteReddit.addCustomFilter({
 						body: Cases.resolveGroup(conditions, false, true),
 						opts: {
 							ondemand: true,
-							name: this.name || window.prompt('Filter name:'),
+							name: this.name,
 						},
 					})
 				);
 
-				this.state = this.state === null ? null : false;
-				this.update();
+				this.update(this.state === null ? null : false, null);
 			}).then(redraw);
 		}
 
@@ -213,11 +212,11 @@ export class LineFilter extends Filter {
 
 		if (this.BaseCase.variant === 'ondemand' || this.BaseCase === Cases.Group) {
 			addButton(head, 'Rename', 'case-actions', 'rename').then(() => {
-				const name = window.prompt('New filter name:', this.name || this.case.trueText);
+				const name = window.prompt('New filter name:', this.case.trueText);
 				if (!name) return;
 
 				if (this.BaseCase.variant === 'ondemand') {
-					const customFilter = FilteReddit.getCustomFilter(this.BaseCase.defaultConditions);
+					const customFilter = this.BaseCase.getCustomFilter();
 					FilteReddit.updateCustomFilter(customFilter, { opts: { name } });
 				}
 

--- a/lib/modules/filteReddit/LineFilter.js
+++ b/lib/modules/filteReddit/LineFilter.js
@@ -202,11 +202,10 @@ export class LineFilter extends Filter {
 
 		if (this.BaseCase.variant === 'basic' && this.BaseCase === Cases.Group) {
 			addButton(head, 'To on-demand', 'case-actions', 'to-ondemand').then(() => {
-				const { name } = (getConditions(): any);
 				const conditions = Cases.getGroup('all', [
 					Cases.getConditions('currentLocation'),
 					Cases.getGroup(this.state === false ? 'all' : 'none', [this.case.conditions]),
-				], name);
+				]);
 				const customFilter = FilteReddit.addCustomFilter({
 					body: Cases.resolveGroup(conditions, false, true),
 					ondemand: true,
@@ -225,9 +224,10 @@ export class LineFilter extends Filter {
 
 		if (this.BaseCase.variant === 'ondemand' || this.BaseCase === Cases.Group) {
 			addButton(head, 'Rename', 'case-actions', 'rename').then(() => {
-				const name = window.prompt('New filter name:', this.case.trueText);
-				if (name) update({ ...getConditions(), name });
-				this.setInitialConditions(); // Cannot undo this conversion
+				const name = window.prompt('New filter name:', this.name || this.case.trueText);
+				if (!name) return;
+				this.name = name;
+				this.update();
 			}).then(redraw);
 		}
 

--- a/lib/modules/filteReddit/LineFilter.js
+++ b/lib/modules/filteReddit/LineFilter.js
@@ -20,11 +20,11 @@ export class LineFilter extends Filter {
 	initialConditions: *;
 	inner: HTMLElement;
 
-	update(state: *, conditions?: *, describeOnly: *) {
-		if (this.BaseCase.variant === 'ondemand') {
+	update(state: * = this.state, conditions?: *, describeOnly: *) {
+		if (this.BaseCase.variant === 'ondemand' && !describeOnly) {
 			Cases.remove(this.BaseCase.type);
 			const customFilter = FilteReddit.getCustomFilter(this.BaseCase.defaultConditions);
-			FilteReddit.updateCustomFilter(customFilter, conditions);
+			if (conditions) FilteReddit.updateCustomFilter(customFilter, { body: conditions });
 			this.BaseCase = FilteReddit.addOndemandCase(customFilter, true);
 			conditions = null; // Force create new case
 		}
@@ -34,17 +34,9 @@ export class LineFilter extends Filter {
 		return message;
 	}
 
-	setInitialConditions() {
-		this.initialConditions = _.cloneDeep(
-			this.BaseCase.variant === 'ondemand' ?
-				FilteReddit.getCustomFilter(this.BaseCase.defaultConditions).body :
-				this.case.conditions
-		);
-	}
-
 	setParent(parent: *) {
 		super.setParent(parent);
-		this.setInitialConditions();
+		this.initialConditions = this.case.conditions;
 		this.getBuilder.cache.clear();
 	}
 
@@ -141,7 +133,10 @@ export class LineFilter extends Filter {
 		const { parent: filterline } = this;
 		if (!filterline) throw new Error('Filter not attached');
 
-		const redraw = () => this.populateHover(card);
+		const redraw = () => {
+			this.getBuilder.cache.clear();
+			this.populateHover(card);
+		};
 
 		const head = string.html`
 			<div class="res-filterline-filter-hover-preamble">
@@ -188,37 +183,31 @@ export class LineFilter extends Filter {
 			return waitForEvent(button, 'click');
 		}
 
-		const update = conditions => {
-			if (this.BaseCase.variant === 'basic') {
-				this.update(this.state, conditions);
-			} else if (this.BaseCase.variant === 'ondemand') {
-				const { name } = (conditions: any);
-				if (!name) throw new Error('ondemand requires name');
-				this.update(this.state, conditions);
-			}
-
-			this.getBuilder.cache.clear();
-		};
-
 		if (this.BaseCase.variant === 'basic' && this.BaseCase === Cases.Group) {
 			addButton(head, 'To on-demand', 'case-actions', 'to-ondemand').then(() => {
 				const conditions = Cases.getGroup('all', [
 					Cases.getConditions('currentLocation'),
 					Cases.getGroup(this.state === false ? 'all' : 'none', [this.case.conditions]),
 				]);
-				const customFilter = FilteReddit.addCustomFilter({
-					body: Cases.resolveGroup(conditions, false, true),
-					ondemand: true,
-				});
-				this.BaseCase = FilteReddit.addOndemandCase(customFilter, true);
+
+				this.BaseCase = FilteReddit.addOndemandCase(
+					FilteReddit.addCustomFilter({
+						body: Cases.resolveGroup(conditions, false, true),
+						opts: {
+							ondemand: true,
+							name: this.name || window.prompt('Filter name:'),
+						},
+					})
+				);
+
 				this.state = this.state === null ? null : false;
-				update(customFilter.body);
+				this.update();
 			}).then(redraw);
 		}
 
 		if (isCaseChanged()) {
 			addButton(head, 'Reset change', 'case-actions', 'reset').then(() => {
-				update(this.initialConditions);
+				this.update(undefined, this.initialConditions);
 			}).then(redraw);
 		}
 
@@ -226,6 +215,12 @@ export class LineFilter extends Filter {
 			addButton(head, 'Rename', 'case-actions', 'rename').then(() => {
 				const name = window.prompt('New filter name:', this.name || this.case.trueText);
 				if (!name) return;
+
+				if (this.BaseCase.variant === 'ondemand') {
+					const customFilter = FilteReddit.getCustomFilter(this.BaseCase.defaultConditions);
+					FilteReddit.updateCustomFilter(customFilter, { opts: { name } });
+				}
+
 				this.name = name;
 				this.update();
 			}).then(redraw);

--- a/lib/modules/filteReddit/browseCases/CurrentMulti.js
+++ b/lib/modules/filteReddit/browseCases/CurrentMulti.js
@@ -9,12 +9,10 @@ export class CurrentMulti extends Case {
 	static defaultConditions = { user: '', name: '' };
 	static fields = ['when browsing /u/', { type: 'text', id: 'user' }, '/m/', { type: 'text', id: 'name' }];
 
-	getValue(conditions: *) {
-		return {
-			name: Case.buildRegex(conditions.name),
-			user: Case.buildRegex(conditions.user),
-		};
-	}
+	value = {
+		name: Case.buildRegex(this.conditions.name),
+		user: Case.buildRegex(this.conditions.user),
+	};
 
 	evaluate() {
 		const rawMulti = currentMultireddit();

--- a/lib/modules/filteReddit/browseCases/CurrentSub.js
+++ b/lib/modules/filteReddit/browseCases/CurrentSub.js
@@ -9,9 +9,7 @@ export class CurrentSub extends Case {
 	static defaultConditions = { patt: '' };
 	static fields = ['when browsing /r/', { type: 'text', id: 'patt' }];
 
-	getValue(conditions: *) {
-		return Case.buildRegex(conditions.patt);
-	}
+	value = Case.buildRegex(this.conditions.patt);
 
 	evaluate() {
 		const sub = currentSubreddit();

--- a/lib/modules/filteReddit/browseCases/CurrentUserProfile.js
+++ b/lib/modules/filteReddit/browseCases/CurrentUserProfile.js
@@ -9,9 +9,7 @@ export class CurrentUserProfile extends Case {
 	static defaultConditions = { patt: '' };
 	static fields = ['when browsing /u/', { type: 'text', id: 'patt' }, '\'s posts'];
 
-	getValue(conditions: *) {
-		return Case.buildRegex(conditions.patt);
-	}
+	value = Case.buildRegex(this.conditions.patt);
 
 	evaluate() {
 		const user = currentUserProfile();

--- a/lib/modules/filteReddit/browseCases/Date.js
+++ b/lib/modules/filteReddit/browseCases/Date.js
@@ -14,9 +14,7 @@ export class Date extends Case {
 	static defaultConditions = { op: '<', date: moment().add(1, 'M').format('Y-M-D') };
 	static fields = ['today is ', { type: 'select', options, id: 'op' }, ' ', { type: 'text', id: 'date' }];
 
-	getValue({ date, op }: *) {
-		return { op, date: moment(date) };
-	}
+	value = { op: this.conditions.op, date: moment(this.conditions.date) };
 
 	isValid() { return this.value.date.isValid(); }
 

--- a/lib/modules/filteReddit/browseCases/LoggedInAs.js
+++ b/lib/modules/filteReddit/browseCases/LoggedInAs.js
@@ -9,9 +9,7 @@ export class LoggedInAs extends Case {
 	static get defaultConditions(): * { return { loggedInAs: loggedInUser() }; } // loggedInUser requires documentReady
 	static fields = ['logged in as /u/', { type: 'text', id: 'loggedInAs' }];
 
-	getValue(conditions: *) {
-		return Case.buildRegex(conditions.loggedInAs);
-	}
+	value = Case.buildRegex(this.conditions.loggedInAs);
 
 	evaluate() {
 		const myName = loggedInUser();

--- a/lib/modules/filteReddit/cases.js
+++ b/lib/modules/filteReddit/cases.js
@@ -42,10 +42,13 @@ export class Group extends Case {
 	static +defaultConditions = { op: 'all', of: [] };
 	static slow = 1;
 
-	get trueText() {
-		return this._cases.length && this.toCriterion(this.conditions.op, this._cases) ||
-			'empty group';
-	}
+	_cases = _.sortBy(
+		this.conditions.of.map(v => Case.fromConditions(v)),
+		v => v.constructor.slow,
+		v => v.constructor.type
+	);
+
+	trueText = this._cases.length && this.toCriterion(this.conditions.op, this._cases) || 'empty group';
 
 	toCriterion(op: *, cases: *) {
 		const symbol = (op === 'any' || op === 'none') && '∨' || op === 'one' && '⊕' || '∧';
@@ -54,8 +57,6 @@ export class Group extends Case {
 		return op === 'none' ? `¬ ${str}` : str;
 	}
 
-	_cases = [];
-
 	isValid() { return this._cases.every(v => v.isValid()); }
 
 	value = (() => {
@@ -63,17 +64,12 @@ export class Group extends Case {
 		const [NONE, ANY, ONE, ALL] = [op === 'none', op === 'any', op === 'one', op === 'all'];
 
 		const evaluators = [];
-		let seenTrue = false;
 
-		const cases = of
-			.map(v => Case.fromConditions(v))
-			.sort(({ constructor: a }, { constructor: b }) => Number(a !== b));
-
+		const cases = this._cases;
 		const l = cases.length;
 		for (let i = 0; i < l; i++) { // eslint-disable-line no-restricted-syntax
 			const caseA = cases[i];
-			if (caseA instanceof Inert) return caseA;
-			this._cases.push(caseA);
+			if (caseA instanceof Inert) throw new Error('Group can not contain inert case');
 
 			if ((ANY || NONE) && caseA.constructor.reconcilable) {
 				const values = [caseA.value];
@@ -91,7 +87,7 @@ export class Group extends Case {
 		}
 
 		return fastAsync(function*(thing) {
-			seenTrue = false;
+			let seenTrue = false;
 
 			for (const evaluator of evaluators) {
 				if (yield evaluator(thing)) {
@@ -107,11 +103,12 @@ export class Group extends Case {
 			if (NONE) return true;
 			else if (ANY) return false;
 			else if (ONE) return seenTrue;
-			else if (ALL) return true;
+			else /* if (ALL) */ return true;
 		});
 	})();
 
 	hasType(type: *) { return super.hasType(type) || this._cases.some(v => v.hasType(type)); }
+
 	evaluate(thing: *) { return this.value(thing); }
 
 	onObserve() {
@@ -129,12 +126,14 @@ type GroupConditions = { type: string, op: 'none' | 'any' | 'one' | 'all', of: A
 declare function resolveGroup(GroupConditions, boolean, true): GroupConditions;
 declare function resolveGroup(GroupConditions, ?boolean, ?boolean): BuilderValue;
 
-export function resolveGroup({ op, of }: GroupConditions, precompute: boolean = true, keepGroup: boolean = false) {
-	const parts = [];
+export function resolveGroup(initial: GroupConditions, precompute: boolean = true, keepGroup: boolean = false) {
 	const groupOpMap = {};
 	let seenTrue = false;
 
-	for (let v of of) {
+	const of = [];
+	let op = initial.op;
+
+	for (let v of initial.of) {
 		if (!has(v.type)) return inertConditions;
 
 		if (v.type === 'group') v = resolveGroup(v, precompute);
@@ -142,7 +141,7 @@ export function resolveGroup({ op, of }: GroupConditions, precompute: boolean = 
 		// Some groups can be merged
 		if (v.type === 'group' && ['any', 'all', 'none'].includes(v.op)) {
 			if (['any', 'all'].includes(v.op) && (v.op === op || v.of.length <= 1)) {
-				parts.push(...v.of);
+				of.push(...v.of);
 				continue;
 			}
 
@@ -165,18 +164,22 @@ export function resolveGroup({ op, of }: GroupConditions, precompute: boolean = 
 			} else {
 				if (op === 'all') return falseConditions;
 			}
+
+			continue;
 		}
 
-		parts.push(v);
+		of.push(v);
 	}
 
-	// Set `op` to `none` since a case has matched already
-	if (op === 'one' && seenTrue) op = 'none';
+	if (op === 'one' && seenTrue) {
+		// Set `op` to `none` since a case has matched already
+		op = 'none';
+	}
 
 	if (!keepGroup) {
 		// Single cases can be released
-		if (parts.length === 1) {
-			const p = parts[0];
+		if (of.length === 1) {
+			const p = of[0];
 
 			if (op === 'none' && p.type === 'group') {
 				if (p.op === 'none') {
@@ -194,7 +197,7 @@ export function resolveGroup({ op, of }: GroupConditions, precompute: boolean = 
 		}
 
 		// Empty groups can be resolved
-		if (!parts.length) {
+		if (!of.length) {
 			if (op === 'none') return trueConditions;
 			if (op === 'any') return falseConditions;
 			if (op === 'one') return falseConditions;
@@ -202,9 +205,7 @@ export function resolveGroup({ op, of }: GroupConditions, precompute: boolean = 
 		}
 	}
 
-	const sortedParts = _.sortBy(parts, ({ type }) => available[type].slow);
-
-	return { type: 'group', op, of: sortedParts };
+	return { type: 'group', op, of };
 }
 /* eslint-enable no-redeclare, no-unused-vars */
 

--- a/lib/modules/filteReddit/cases.js
+++ b/lib/modules/filteReddit/cases.js
@@ -215,9 +215,9 @@ export function getGroup(op: *, of: *): GroupConditions {
 	return getConditions('group', { op, of });
 }
 
-export function createAdHoc(name: ?string, getConditions: *, variant: *, context: *, customFilter: *) {
+export function createAdHoc(name: string, getConditions: *, variant: *, context: *, customFilter: *) {
 	class AdHoc extends Case {
-		static text = name || 'Unnamed';
+		static text = name;
 
 		// Generate new conditions each time in order to avoid caching, as
 		// `getConditions` can return updated values, e.g. if a external filter has been removed

--- a/lib/modules/filteReddit/cases.js
+++ b/lib/modules/filteReddit/cases.js
@@ -128,7 +128,7 @@ type GroupConditions = { type: string, op: 'none' | 'any' | 'one' | 'all', of: A
 declare function resolveGroup(GroupConditions, boolean, true): GroupConditions;
 declare function resolveGroup(GroupConditions, ?boolean, ?boolean): BuilderValue;
 
-export function resolveGroup({ op, of }: any, precompute: boolean = true, keepGroup: boolean = false) {
+export function resolveGroup({ op, of }: GroupConditions, precompute: boolean = true, keepGroup: boolean = false) {
 	const parts = [];
 	const groupOpMap = {};
 	let seenTrue = false;

--- a/lib/modules/filteReddit/cases.js
+++ b/lib/modules/filteReddit/cases.js
@@ -37,10 +37,9 @@ export class Group extends Case {
 		{ type: 'select', options: ['none', 'any', 'one', 'all'], id: 'op' },
 		' of these are true:',
 		{ type: 'multi', include: 'all', id: 'of' },
-		{ type: 'hidden', id: 'name' },
 	];
 
-	static +defaultConditions = { op: 'all', of: [], name: '' };
+	static +defaultConditions = { op: 'all', of: [] };
 	static slow = 1;
 
 	get trueText() {
@@ -123,15 +122,13 @@ const falseConditions = { type: 'false' };
 const trueConditions = { type: 'true' };
 const inertConditions = { type: 'inert' };
 
-type GroupConditions = { type: string, op: 'none' | 'any' | 'one' | 'all', of: Array<BuilderValue>, name?: string };
+type GroupConditions = { type: string, op: 'none' | 'any' | 'one' | 'all', of: Array<BuilderValue> };
 
 /* eslint-disable no-redeclare, no-unused-vars */
 declare function resolveGroup(GroupConditions, boolean, true): GroupConditions;
 declare function resolveGroup(GroupConditions, ?boolean, ?boolean): BuilderValue;
 
-export function resolveGroup({ op, of, name = '' }: any, precompute: boolean = true, keepGroup: boolean = false) {
-	if (name) keepGroup = true;
-
+export function resolveGroup({ op, of }: any, precompute: boolean = true, keepGroup: boolean = false) {
 	const parts = [];
 	const groupOpMap = {};
 	let seenTrue = false;
@@ -206,7 +203,7 @@ export function resolveGroup({ op, of, name = '' }: any, precompute: boolean = t
 
 	const sortedParts = _.sortBy(parts, ({ type }) => available[type].slow);
 
-	return { type: 'group', op, of: sortedParts, name };
+	return { type: 'group', op, of: sortedParts };
 }
 /* eslint-enable no-redeclare, no-unused-vars */
 
@@ -214,8 +211,8 @@ export function getConditions(type: string, conditions?: ?{}): BuilderValue {
 	return { type, ...available[type].defaultConditions, ...conditions };
 }
 
-export function getGroup(op: *, of: *, name: * = ''): GroupConditions {
-	return getConditions('group', { op, of, name });
+export function getGroup(op: *, of: *): GroupConditions {
+	return getConditions('group', { op, of });
 }
 
 export function createAdHoc(type: string, getConditions: () => *, variant: *, context: *) {

--- a/lib/modules/filteReddit/cases.js
+++ b/lib/modules/filteReddit/cases.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import _ from 'lodash';
-import { asyncFilter, fastAsync } from '../../utils';
+import { asyncFilter, fastAsync, randomHash } from '../../utils';
 import type { BuilderValue } from '../../core/module';
 import { Case } from './Case';
 import * as postCases from './postCases';
@@ -215,9 +215,9 @@ export function getGroup(op: *, of: *): GroupConditions {
 	return getConditions('group', { op, of });
 }
 
-export function createAdHoc(type: string, getConditions: () => *, variant: *, context: *) {
+export function createAdHoc(name: ?string, getConditions: *, variant: *, context: *, customFilter: *) {
 	class AdHoc extends Case {
-		static text = type;
+		static text = name || 'Unnamed';
 
 		// Generate new conditions each time in order to avoid caching, as
 		// `getConditions` can return updated values, e.g. if a external filter has been removed
@@ -226,19 +226,30 @@ export function createAdHoc(type: string, getConditions: () => *, variant: *, co
 		static unique = true;
 
 		static variant = variant;
+
+		static _customFilter = customFilter;
 	}
 
-	add(type, AdHoc, context);
+	add(name, AdHoc, context);
 
 	return AdHoc;
 }
 
 const available: { [type: string]: Class<Case> } = {};
 
-export function add(type: string, c: Class<Case>, ...contexts: Array<'post' | 'comment' | 'browse'>) {
-	if (available.hasOwnProperty(type) && c !== available[type]) {
-		console.error(`A case named ${type} already exists. Existing:`, available[type].defaultConditions, 'Ignoring:', c.defaultConditions);
-		return;
+function getUniqueTypeName(name: any): string {
+	if (typeof name !== 'string') name = '';
+	while (!name || has(name)) {
+		// Make sure filter has an unique name
+		name += randomHash();
+	}
+
+	return name;
+}
+
+export function add(type: ?string, c: Class<Case>, ...contexts: Array<'post' | 'comment' | 'browse'>) {
+	if (!type || (available.hasOwnProperty(type) && c !== available[type])) {
+		type = getUniqueTypeName(type);
 	}
 
 	c.type = type;

--- a/lib/modules/filteReddit/cases.js
+++ b/lib/modules/filteReddit/cases.js
@@ -58,7 +58,8 @@ export class Group extends Case {
 
 	isValid() { return this._cases.every(v => v.isValid()); }
 
-	getValue({ op, of }: GroupConditions) {
+	value = (() => {
+		const op = this.conditions.op;
 		const [NONE, ANY, ONE, ALL] = [op === 'none', op === 'any', op === 'one', op === 'all'];
 
 		const evaluators = [];
@@ -108,7 +109,7 @@ export class Group extends Case {
 			else if (ONE) return seenTrue;
 			else if (ALL) return true;
 		});
-	}
+	})();
 
 	hasType(type: *) { return super.hasType(type) || this._cases.some(v => v.hasType(type)); }
 	evaluate(thing: *) { return this.value(thing); }

--- a/lib/modules/filteReddit/cases.js
+++ b/lib/modules/filteReddit/cases.js
@@ -217,9 +217,9 @@ export function getGroup(op: *, of: *): GroupConditions {
 	return getConditions('group', { op, of });
 }
 
-export function createAdHoc(name: string, getConditions: *, variant: *, context: *, customFilter: *) {
+export function createAdHoc(type: string, name: ?string, getConditions: *, variant: *, context: *, customFilter: *) {
 	class AdHoc extends Case {
-		static text = name;
+		static text = name || 'Unnamed';
 
 		// Generate new conditions each time in order to avoid caching, as
 		// `getConditions` can return updated values, e.g. if a external filter has been removed
@@ -232,7 +232,7 @@ export function createAdHoc(name: string, getConditions: *, variant: *, context:
 		static _customFilter = customFilter;
 	}
 
-	add(name, AdHoc, context);
+	add(type, AdHoc, context);
 
 	return AdHoc;
 }

--- a/lib/modules/filteReddit/commentCases/CommentContent.js
+++ b/lib/modules/filteReddit/commentCases/CommentContent.js
@@ -15,9 +15,7 @@ export class CommentContent extends Case {
 
 	trueText = `comment contains ${this.conditions.patt}`;
 
-	getValue(conditions: *) {
-		return Case.buildRegex(conditions.patt, { fullMatch: false });
-	}
+	value = Case.buildRegex(this.conditions.patt, { fullMatch: false });
 
 	evaluate(thing: *, values: * = [this.value]) {
 		const md = thing.entry.querySelector('.md');

--- a/lib/modules/filteReddit/postCases/Domain.js
+++ b/lib/modules/filteReddit/postCases/Domain.js
@@ -16,9 +16,7 @@ export class Domain extends Case {
 
 	trueText = `domain ${this.conditions.patt}`;
 
-	getValue({ patt, fullMatch = true }: *) {
-		return Case.buildRegex(patt, { fullMatch });
-	}
+	value = (({ patt, fullMatch = true }) => Case.buildRegex(patt, { fullMatch }))(this.conditions);
 
 	evaluate(thing: *, values: * = [this.value]) {
 		const domain = thing.getPostDomain();

--- a/lib/modules/filteReddit/postCases/LinkFlair.js
+++ b/lib/modules/filteReddit/postCases/LinkFlair.js
@@ -16,9 +16,7 @@ export class LinkFlair extends Case {
 
 	trueText = `link flair ${this.conditions.patt}`.trim();
 
-	getValue({ patt, fullMatch = true }: *) {
-		return Case.buildRegex(patt || '/./', { fullMatch, allowEmptyString: true });
-	}
+	value = (({ patt, fullMatch = true }) => Case.buildRegex(patt || '/./', { fullMatch, allowEmptyString: true }))(this.conditions);
 
 	evaluate(thing: *, values: * = [this.value]) {
 		const text = thing.getPostFlairText();

--- a/lib/modules/filteReddit/postCases/PostAfter.js
+++ b/lib/modules/filteReddit/postCases/PostAfter.js
@@ -15,9 +15,7 @@ export class PostAfter extends Case {
 
 	trueText = `after ${this.conditions.patt}`;
 
-	getValue(conditions: *) {
-		return new Date(conditions.patt);
-	}
+	value = new Date(this.conditions.patt);
 
 	isValid() { return !isNaN(this.value); }
 

--- a/lib/modules/filteReddit/postCases/PostTitle.js
+++ b/lib/modules/filteReddit/postCases/PostTitle.js
@@ -15,9 +15,7 @@ export class PostTitle extends Case {
 
 	trueText = `title contains ${this.conditions.patt}`;
 
-	getValue(conditions: *) {
-		return Case.buildRegex(conditions.patt, { fullMatch: false });
-	}
+	value = Case.buildRegex(this.conditions.patt, { fullMatch: false });
 
 	evaluate(thing: *, values: * = [this.value]) {
 		const title = thing.getTitle();

--- a/lib/modules/filteReddit/postCases/Subreddit.js
+++ b/lib/modules/filteReddit/postCases/Subreddit.js
@@ -16,9 +16,7 @@ export class Subreddit extends Case {
 
 	trueText = `in ${this.conditions.patt}`;
 
-	getValue(conditions: *) {
-		return Case.buildRegex(conditions.patt);
-	}
+	value = Case.buildRegex(this.conditions.patt);
 
 	evaluate(thing: *, values: * = [this.value]) {
 		const subreddit = thing.getSubreddit();

--- a/lib/modules/filteReddit/postCases/UserFlair.js
+++ b/lib/modules/filteReddit/postCases/UserFlair.js
@@ -16,9 +16,7 @@ export class UserFlair extends Case {
 
 	trueText = `user flair ${this.conditions.patt}`.trim();
 
-	getValue(conditions: *) {
-		return Case.buildRegex(conditions.patt || '/./');
-	}
+	value = Case.buildRegex(this.conditions.patt || '/./');
 
 	evaluate(thing: *, values: * = [this.value]) {
 		const text = thing.getUserFlairText();

--- a/lib/modules/filteReddit/postCases/Username.js
+++ b/lib/modules/filteReddit/postCases/Username.js
@@ -16,9 +16,7 @@ export class Username extends Case {
 
 	trueText = `by ${this.conditions.patt}`;
 
-	getValue(conditions: *) {
-		return Case.buildRegex(conditions.patt);
-	}
+	value = Case.buildRegex(this.conditions.patt);
 
 	evaluate(thing: *, values: * = [this.value]) {
 		const user = thing.getAuthor();

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -1200,6 +1200,12 @@ function drawDeleteButton() {
 }
 
 export function drawBuilderBlock(data: *, cases: *) {
+	if (!cases.hasOwnProperty(data.type)) {
+		console.error(`Case type ${data.type} is not available. Ignoring block.`, data);
+		// This also prevents the data from being read, i.e. it will be trashed
+		return $();
+	}
+
 	const $block = $('<div class="builderBlock">')
 		.attr('data-type', data.type)
 		.append(drawFields(cases[data.type].fields, data, cases));

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -12,6 +12,7 @@ import {
 	Alert,
 	CreateElement,
 	NAMED_KEYS,
+	downcast,
 	escapeHTML,
 	niceKeyCode,
 	string,
@@ -867,13 +868,12 @@ function stageCurrentModuleOptions() {
 		const moduleId = this.dataset.moduleId;
 		const optionName = this.dataset.optionName;
 
-		const option = Modules.get(moduleId).options[optionName];
-		const config = option.cases;
+		const { customOptionsFields, cases } = Modules.get(moduleId).options[optionName];
 
 		const items = [];
 		$(builder).find('.builderItem').each(function() {
 			try {
-				items.push(readBuilderItem(this, config));
+				items.push(readBuilderItem(this, customOptionsFields, cases));
 			} catch (e) {
 				console.error('Ignoring invalid item.', e);
 			}
@@ -1122,34 +1122,34 @@ function drawOptionBuilder(options, mod, optionName) {
 	$addRowButton
 		.text(i18n(option.addItemText) || '+add item')
 		.on('click', function() {
-			const $newBody = drawBuilderItem(option.defaultTemplate(), option.cases);
+			const $newBody = drawBuilderItem(option.defaultTemplate(), option.customOptionsFields, option.cases);
 			$(this).siblings('.optionBuilder:first').trigger('change').append($newBody);
 			const firstText = $newBody.find('input[type=text], textarea')[0];
 			if (firstText) {
 				setTimeout(() => firstText.focus(), 200);
 			}
 		});
-	option.value.forEach(item => drawBuilderItem(item, option.cases).appendTo($itemContainer));
+	option.value.forEach(item => drawBuilderItem(item, option.customOptionsFields, option.cases).appendTo($itemContainer));
 	makeBuilderItemsSortable($itemContainer);
 
 	return $('<div>').append($itemContainer, $addRowButton)[0];
 }
 
-function drawBuilderItem(data, config) {
+function drawBuilderItem(data, customOptionsFields = [], cases) {
 	const $editButton = $('<div>')
 		.addClass('res-icon-button res-icon builderControls builderTrailingControls')
 		.html('&#xF061;')
 		.attr('title', 'copy and share, or update your settings with a new version')
 		.on('click', function() {
 			const $item = $(this).closest('.builderItem');
-			const data = readBuilderItem($item, config);
+			const data = readBuilderItem($item, customOptionsFields, cases);
 			const json = prompt(
 				'Copy this and share it, or paste a new version and update your settings',
 				JSON.stringify(data)
 			);
 			if (json !== null) {
 				const newData = JSON.parse(json);
-				$item.trigger('change').replaceWith(drawBuilderItem(newData, config));
+				$item.trigger('change').replaceWith(drawBuilderItem(newData, customOptionsFields, cases));
 			}
 		});
 
@@ -1162,27 +1162,24 @@ function drawBuilderItem(data, config) {
 			}
 		});
 
-	const $ondemand = $('<label class="builderControls builderTrailingControls">On-demand via Filterline</label>')
-		.prepend(`<input type="checkbox" ${data.ondemand ? 'checked' : ''} name="ondemand">`)
-		.change(({ target: { checked } }: { target: any }) => {
-			const nameElement = $body.find('> .builderBlock > [name=name]');
-			if (!checked || nameElement.val()) return;
-			const name = window.prompt('Set filter name.\n\nThis filter will be available in the Filterline dropdown menu by the given name.');
-			nameElement.val(name);
-		});
-
+	const customOptions = string.html`<ul class="builderCustomOptions"></ul>`;
+	for (const fields of customOptionsFields) {
+		const li = document.createElement('li');
+		$(li).append(drawFields(fields, data.opts || {}));
+		customOptions.append(li);
+	}
 
 	const $header = $('<div class="builderItemControls">')
 		.append(
 			drawHandle(),
 			$('<textarea name="builderNote" rows="2" cols="40" placeholder="Write a description/note for this">').val(data.note),
 			$('<input type="hidden" name="version">').val(data.ver),
-			$ondemand,
+			customOptions,
 			$editButton,
 			$deleteButton
 		);
 
-	const $body = drawBuilderBlock(data.body, config);
+	const $body = drawBuilderBlock(data.body, cases);
 	makeBuilderBlockSortable($body);
 
 	return $('<div class="builderItem">').append($header, $body);
@@ -1202,19 +1199,10 @@ function drawDeleteButton() {
 		.attr('title', 'remove this condition');
 }
 
-export function drawBuilderBlock(data: *, config: *) {
+export function drawBuilderBlock(data: *, cases: *) {
 	const $block = $('<div class="builderBlock">')
-		.attr('data-type', data.type);
-
-	const BlockClass = config[data.type];
-
-	BlockClass.fields.forEach(field => {
-		if (typeof field === 'string') return $block.append(field);
-
-		const fieldModule = builderFields[field.type];
-		if (fieldModule === undefined) throw new Error(`Unimplemented field type: ${field.type}`);
-		$block.append(fieldModule.draw(data, field, config));
-	});
+		.attr('data-type', data.type)
+		.append(drawFields(cases[data.type].fields, data, cases));
 
 	const $deleteButton = drawDeleteButton()
 		.addClass('builderTrailingControls')
@@ -1233,35 +1221,26 @@ export function drawBuilderBlock(data: *, config: *) {
 		);
 }
 
-function readBuilderItem(item, config) {
+function readBuilderItem(item, customOptionsFields = [], cases) {
 	const $firstBlock = $(item).find('> .builderWrap > .builderBlock');
 	const $header = $(item).find('.builderItemControls');
+
 	return {
 		note: $header.find('textarea[name=builderNote]').val(),
 		ver: parseInt($header.find('input[name=version]').val(), 10),
-		body: readBuilderBlock($firstBlock, config),
-		ondemand: $header.find('input[name=ondemand]').is(':checked'),
+		body: readBuilderBlock($firstBlock, cases),
+		opts: readFields($header.find('.builderCustomOptions li'), _.flatten(customOptionsFields), cases),
 	};
 }
 
-export function readBuilderBlock($element: *, config: *) {
+export function readBuilderBlock($element: *, cases: *) {
 	const type = $element.attr('data-type');
-	const BlockClass = config[type];
-	const data = { type };
-	let validate = true;
-	BlockClass.fields.forEach(field => {
-		if (typeof field === 'string') return;
-		const fieldType = field.type;
-		if (fieldType === 'multi') validate = false;
-		const $fieldElem = $element.find(`> [name=${field.id}]`);
-		if (typeof builderFields[fieldType].read === 'function') {
-			data[field.id] = builderFields[fieldType].read($fieldElem, field, config);
-		} else {
-			data[field.id] = $fieldElem.val();
-		}
-	});
+	const BlockClass = cases[type];
 
-	if (validate) {
+	const data = { type, ...readFields($element, BlockClass.fields, cases) };
+
+	const multiType = BlockClass.fields.find(({ type }) => type === 'multi');
+	if (!multiType) { // `multi`-types cannot have errors, so avoid duplicating error messages by not validating them
 		try {
 			BlockClass.validate(data);
 			$element.removeClass('builderBlock-error');
@@ -1274,6 +1253,35 @@ export function readBuilderBlock($element: *, config: *) {
 	}
 
 	return data;
+}
+
+function readFields($element, fields, cases) {
+	return fields.reduce((acc, field) => {
+		if (typeof field === 'string') return acc;
+		const $fieldElem = $element.find(`> [name=${field.id}]`);
+		const fieldModule = builderFields[field.type];
+		if (fieldModule && typeof fieldModule.read === 'function') {
+			acc[field.id] = fieldModule.read($fieldElem, field, cases);
+		} else {
+			acc[field.id] = $fieldElem.val();
+		}
+		return acc;
+	}, {});
+}
+
+function drawFields(fields, data, cases) {
+	return fields.map(field => {
+		if (typeof field === 'string') return field;
+
+		const fieldModule = builderFields[field.type];
+		if (fieldModule) {
+			return fieldModule.draw(data, field, cases);
+		} else {
+			return $(`<input type="${field.type}">`)
+				.attr('name', field.id)
+				.val(data[field.id]);
+		}
+	});
 }
 
 function makeBuilderItemsSortable($builder) {
@@ -1383,48 +1391,48 @@ export function makeBuilderBlockSortable($builderBlock: *) {
 
 const builderFields = {
 	multi: {
-		draw(data, BlockClass, config) {
-			const $rowWrapper = $('<ul class="builderMulti">').attr('name', BlockClass.id);
-			const addItem = itemData => drawBuilderBlock(itemData, config).appendTo($rowWrapper).wrap('<li>');
+		draw(data, field, cases = {}) {
+			const $rowWrapper = $('<ul class="builderMulti">').attr('name', field.id);
+			const addItem = itemData => drawBuilderBlock(itemData, cases).appendTo($rowWrapper).wrap('<li>');
 
-			const items = data[BlockClass.id];
+			const items = data[field.id];
 			items.forEach(addItem);
 
-			const addButton: HTMLSelectElement = (string.html`
+			const addCaseSelect = downcast(string.html`
 				<select class="addBuilderBlock">
 					<option>+ add a condition</option>
-					${Object.entries(config).map(([key, { text, disabled }]) => string._html`
-						<option value="${key}" ${disabled && 'disabled'}>${text}</option>
+					${Object.entries(cases).map(([key, { text }]) => string._html`
+						<option value="${key}">${text}</option>
 					`)}
 				</select>
-			`: any);
-			addButton.addEventListener('change', () => {
-				const type = addButton.value;
-				if (type !== '' && config.hasOwnProperty(type)) {
-					addItem({ type, ...config[type].defaultConditions })
+			`, HTMLSelectElement);
+			addCaseSelect.addEventListener('change', () => {
+				const type = addCaseSelect.value;
+				if (type !== '' && cases.hasOwnProperty(type)) {
+					addItem({ type, ...cases[type].defaultConditions })
 						.find('input[type=text], input[type=number], textarea').focus();
 				}
 
-				addButton.selectedIndex = 0;
+				addCaseSelect.selectedIndex = 0;
 			});
 
-			return $rowWrapper.add(addButton);
+			return $rowWrapper.add(addCaseSelect);
 		},
-		read($elem, fieldConfig, config) {
+		read($elem, fields, cases) {
 			return $elem.find('> li > .builderWrap > .builderBlock').map(function() {
-				return readBuilderBlock($(this), config);
+				return readBuilderBlock($(this), cases);
 			}).get();
 		},
 	},
 	hidden: {
-		draw(data, BlockClass) {
-			const id = BlockClass.id;
+		draw(data, field) {
+			const id = field.id;
 			return $('<input type="hidden">').attr('name', id).val(data[id]);
 		},
 	},
 	number: {
-		draw(data, BlockClass) {
-			const id = BlockClass.id;
+		draw(data, field) {
+			const id = field.id;
 			return $('<input type="number">').attr('name', id).val(data[id]);
 		},
 		read($elem) {
@@ -1432,18 +1440,22 @@ const builderFields = {
 		},
 	},
 	check: {
-		draw(data, BlockClass) {
-			const id = BlockClass.id;
-			return $('<input type="checkbox">').attr('name', id).val(data[id]);
+		draw(data, field) {
+			const id = field.id;
+			const $input = $('<input type="checkbox">').prop('checked', data[id]);
+			return $('<label>').attr('name', id).text(field.label).prepend($input);
+		},
+		read($elem) {
+			return $elem.find('input').get(0).checked;
 		},
 	},
 	checkset: {
 		uid: 0,
-		draw(data, BlockClass) {
-			const id = BlockClass.id;
+		draw(data, field) {
+			const id = field.id;
 			const prefixId = this.uid++;
-			const $wrap = $('<span class="checkset">').attr('name', BlockClass.id);
-			BlockClass.items.forEach((e, idx) => {
+			const $wrap = $('<span class="checkset">').attr('name', field.id);
+			field.items.forEach((e, idx) => {
 				const itemId = `checkset-${prefixId}-${idx}X`;
 				const $box = $('<input type="checkbox" />')
 					.attr('id', itemId)
@@ -1458,29 +1470,14 @@ const builderFields = {
 			});
 			return $wrap;
 		},
-		read($elem, fieldConfig) {
-			return fieldConfig.items.filter(e => $elem.children(`[name="${e}"]`).prop('checked'));
-		},
-	},
-	text: {
-		draw(data, BlockClass) {
-			const id = BlockClass.id;
-			const $field = $('<input type="text">')
-				.attr('name', id)
-				.val(data[id]);
-			if (BlockClass.hasOwnProperty('pattern')) {
-				$field.attr('pattern', BlockClass.pattern);
-			}
-			if (BlockClass.hasOwnProperty('placeholder')) {
-				$field.attr('placeholder', BlockClass.placeholder);
-			}
-			return $field;
+		read($elem, fields) {
+			return fields.items.filter(e => $elem.children(`[name="${e}"]`).prop('checked'));
 		},
 	},
 	duration: {
-		draw(data, BlockClass) {
+		draw(data, field) {
 			// Store as milliseconds like JavaScript Date
-			let durr = data[BlockClass.id];
+			let durr = data[field.id];
 			durr /= 60 * 1000;
 			const minutes = durr % 60;
 			durr = (durr - minutes) / 60;
@@ -1489,7 +1486,7 @@ const builderFields = {
 			const days = durr;
 
 			return $('<span class="durationField">')
-				.attr('name', BlockClass.id)
+				.attr('name', field.id)
 				.append([
 					$('<input type="number" name="days" />').val(days), ' days ',
 					$('<input type="number" name="hours" />').val(hours), ' hours ',
@@ -1512,15 +1509,15 @@ const builderFields = {
 		},
 	},
 	select: {
-		draw(data, BlockClass) {
-			const value = data[BlockClass.id];
-			let entries = BlockClass.options;
+		draw(data, field) {
+			const value = data[field.id];
+			let entries = field.options;
 
 			if (typeof entries === 'string') {
 				entries = this.getPredefinedChoices(entries);
 			}
 
-			const $dropdown = $('<select>').attr('name', BlockClass.id);
+			const $dropdown = $('<select>').attr('name', field.id);
 			entries.forEach(row => {
 				let label, value;
 				if (typeof row === 'string') {

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -1174,6 +1174,7 @@ function drawBuilderItem(data, customOptionsFields = [], cases) {
 			drawHandle(),
 			$('<textarea name="builderNote" rows="2" cols="40" placeholder="Write a description/note for this">').val(data.note),
 			$('<input type="hidden" name="version">').val(data.ver),
+			$('<input type="hidden" name="id">').val(data.id),
 			customOptions,
 			$editButton,
 			$deleteButton
@@ -1234,6 +1235,7 @@ function readBuilderItem(item, customOptionsFields = [], cases) {
 	return {
 		note: $header.find('textarea[name=builderNote]').val(),
 		ver: parseInt($header.find('input[name=version]').val(), 10),
+		id: $header.find('input[name=id]').val(),
 		body: readBuilderBlock($firstBlock, cases),
 		opts: readFields($header.find('.builderCustomOptions li'), _.flatten(customOptionsFields), cases),
 	};

--- a/tests/Filterline.js
+++ b/tests/Filterline.js
@@ -125,7 +125,7 @@ module.exports = {
 
 		const thing = '#thing_t3_5nacp4';
 
-		tempAdditionalFilterSelector = '[type="group"]';
+		tempAdditionalFilterSelector = ':last-child';
 		hideInfocard = false;
 
 		browser
@@ -142,7 +142,7 @@ module.exports = {
 			.click('.res-filterline-preamble')
 			.click('.res-filterline-new-group')
 			.click('.res-filterline-new-group .res-filterline-filter-new')
-			.waitForElementVisible(`${filter}${tempAdditionalFilterSelector}`)
+			.waitForElementVisible(`${filter}[type="group"]`)
 			.perform(switchActiveState)
 			.waitForElementNotVisible(thing)
 			.perform(switchActiveState)
@@ -150,6 +150,8 @@ module.exports = {
 			.moveToElement(`${filter}[type="group"]`, 0, 0)
 			.waitForElementVisible(`${cardButton}[action="to-ondemand"]`)
 			.click(`${cardButton}[action="to-ondemand"]`)
+			.setAlertText('new-ondemand-filter')
+			.acceptAlert()
 			.perform(switchActiveState)
 			.waitForElementNotVisible(thing)
 


### PR DESCRIPTION
- The builder is less coupled with customFilter options (`ondemand`)
- Custom options is necessary for future comment filter options which diverges from post options
- ondemand name field is now visible

Tested in browser: Chrome 68
