### PR TITLE
showImages video: Add volume control

### DIFF
--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -483,6 +483,36 @@ img {
 						}
 					}
 				}
+
+				.video-advanced-volume {
+					position: relative;
+
+					&:not(:hover) .video-advanced-volume-level {
+						display: none;
+					}
+
+					.video-advanced-volume-level {
+						position: absolute;
+						background-color: rgba(0, 0, 0, 0.67);
+						cursor: pointer;
+						height: 50px;
+						width: 16px;
+						bottom: 100%;
+						left: 0;
+						border-radius: 4px;
+						padding: 2px;
+						display: flex;
+						margin-left: -2px;
+
+						.video-advanced-volume-percentage {
+							width: 100%;
+							background-color: white;
+							border-radius: 4px;
+							pointer-events: none;
+							align-self: flex-end;
+						}
+					}
+				}
 			}
 		}
 	}
@@ -517,6 +547,11 @@ img {
 	.video-advanced-time-increase::after { content: '\f16e'; }
 	.video-advanced-speed-decrease::after { content: '\f14d'; }
 	.video-advanced-speed-increase::after { content: '\f14c'; }
+
+	.video-advanced-volume[level='0']::after { content: '\f038'; }
+	.video-advanced-volume[level='1']::after { content: '\f039'; }
+	.video-advanced-volume[level='2']::after { content: '\f03a'; }
+	.video-advanced-volume[level='3']::after { content: '\f03b'; }
 }
 
 // style expando text content in comments

--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -362,14 +362,6 @@ img {
 		overflow: hidden;
 		position: relative;
 		display: inline-block;
-
-		&:hover .video-advanced-interface:not(.video-advanced-push-below) {
-			display: block;
-			background: linear-gradient(rgba(255, 255, 255, 0), rgba(0, 0, 0, .6));
-			position: absolute;
-			bottom: 0;
-			width: 100%;
-		}
 	}
 
 	video {
@@ -493,16 +485,25 @@ img {
 				}
 			}
 		}
+	}
 
-		&.video-advanced-push-below {
-			display: block;
-			background: rgba(52, 47, 38, 1);
+	&:not(&-has-native-controls):hover .video-advanced-interface {
+		display: block;
+		background: linear-gradient(rgba(255, 255, 255, 0), rgba(0, 0, 0, .6));
+		position: absolute;
+		bottom: 0;
+		width: 100%;
+	}
 
-			.video-advanced-toggle-pause,
-			.video-advanced-position-thumb,
-			.video-advanced-position {
-				display: none !important;
-			}
+	// Push below and remove hide progress bar if native controls are visible
+	&-has-native-controls .video-advanced-interface {
+		display: block;
+		background: rgba(52, 47, 38, 1);
+
+		.video-advanced-toggle-pause,
+		.video-advanced-position-thumb,
+		.video-advanced-position {
+			display: none !important;
 		}
 	}
 

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1977,7 +1977,7 @@ class Video extends Media {
 			controls: !advancedControls,
 			advancedControls,
 			openInNewWindow: module.options.openInNewWindow.value,
-			formattedPlaybackRate: this.formatRateNumber(playbackRate),
+			formattedPlaybackRate: this.formatMultilineNumber(playbackRate, 'x'),
 		});
 		this.video = downcast(this.element.querySelector('video'), HTMLVideoElement);
 		const container = this.element.querySelector('.video-advanced-container');
@@ -2081,8 +2081,8 @@ class Video extends Media {
 		this.element.classList.toggle('reversed');
 	}
 
-	formatRateNumber(value: number) {
-		return `${value.toFixed(2).replace('.', '.\u200B'/* zwsp */)}x`;
+	formatMultilineNumber(value: number, suffix: string) {
+		return `${value.toFixed(2).replace('.', '.\u200B'/* zwsp */)}${suffix}`;
 	}
 
 	addAdvancedControls() {
@@ -2112,10 +2112,12 @@ class Video extends Media {
 		ctrlTimeDecrease.addEventListener('click', () => { this.video.currentTime -= 1 / this.frameRate; });
 		ctrlTimeIncrease.addEventListener('click', () => { this.video.currentTime += 1 / this.frameRate; });
 
-		this.video.addEventListener('ratechange', () => { msgSpeed.textContent = this.formatRateNumber(this.video.playbackRate); });
+		this.video.addEventListener('ratechange', () => {
+			msgSpeed.textContent = this.formatMultilineNumber(this.video.playbackRate, 'x');
+		});
 		this.video.addEventListener('timeupdate', () => {
 			indicatorPosition.style.left = `${(this.video.currentTime / this.video.duration) * 100}%`;
-			msgTime.textContent = this.formatRateNumber(this.video.currentTime);
+			msgTime.textContent = this.formatMultilineNumber(this.video.currentTime, 's');
 		});
 
 		progress.addEventListener('mousemove', (e: MouseEvent) => {

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -2039,6 +2039,10 @@ class Video extends Media {
 		if (advancedControls) {
 			Promise.all([waitForEvent(this.element, 'mouseenter'), waitForEvent(this.video, 'loadedmetadata')])
 				.then(() => this.addAdvancedControls());
+
+			new MutationObserver(() =>
+				this.element.classList.toggle('video-advanced-has-native-controls', this.video.hasAttribute('controls'))
+			).observe(this.video, { attributes: true });
 		}
 
 		if (!loop && this.autoplay) {

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -44,6 +44,7 @@ import {
 	isPrivateBrowsing,
 	openNewTab,
 	Permissions,
+	Storage,
 } from '../environment';
 import * as Options from '../core/options';
 import * as NeverEndingReddit from './neverEndingReddit';
@@ -1925,6 +1926,8 @@ const mutedVideoManager = _.once(() => {
 	};
 });
 
+const volumeStorage = Storage.wrap('showImages.video.volume', (1: number));
+
 class Video extends Media {
 	video: HTMLVideoElement;
 	autoplay: boolean;
@@ -2049,6 +2052,12 @@ class Video extends Media {
 			waitForEvent(this.video, 'ended').then(() => this.stopAutoplay());
 		}
 
+		if (!muted) {
+			Promise.all([waitForEvent(this.video, 'canplay'), volumeStorage.get()]).then(([, volume]) => {
+				this.video.volume = volume;
+			});
+		}
+
 		setMediaMaxSize(this.video);
 		makeMediaZoomable(this.element, this.video);
 		setMediaControls(this.video, undefined, sources[0].source);
@@ -2131,6 +2140,7 @@ class Video extends Media {
 				const base = ctrlVolumeLevel.clientHeight;
 				const click = base - e.offsetY;
 				this.video.volume = previousLevel = Math.min(click / base, 1);
+				volumeStorage.set(this.video.volume);
 			};
 
 			ctrlVolume.addEventListener('click', () => {

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1971,7 +1971,7 @@ class Video extends Media {
 			muted,
 			loop,
 			reversable,
-			controls: !muted,
+			controls: !advancedControls,
 			advancedControls,
 			openInNewWindow: module.options.openInNewWindow.value,
 			formattedPlaybackRate: this.formatRateNumber(playbackRate),
@@ -2120,6 +2120,40 @@ class Video extends Media {
 			const percentage = (e.target.offsetLeft + e.target.clientWidth / 2) / progress.clientWidth;
 			this.video.currentTime = this.video.duration * percentage;
 		});
+
+		const ctrlVolume = ctrlContainer.querySelector('.video-advanced-volume');
+		if (ctrlVolume) {
+			const ctrlVolumeLevel = ctrlVolume.querySelector('.video-advanced-volume-level');
+			const volumePercentage = ctrlVolume.querySelector('.video-advanced-volume-percentage');
+
+			let previousLevel = 0;
+			const updateVolume = e => {
+				const base = ctrlVolumeLevel.clientHeight;
+				const click = base - e.offsetY;
+				this.video.volume = previousLevel = Math.min(click / base, 1);
+			};
+
+			ctrlVolume.addEventListener('click', () => {
+				// $FlowIssue
+				if (this.video.volume) [previousLevel, this.video.volume] = [this.video.volume, 0];
+				else this.video.volume = previousLevel;
+			});
+			ctrlVolumeLevel.addEventListener('mousemove', (e: MouseEvent) => {
+				if (e.buttons === 1 /* left mouse button */) updateVolume(e);
+			});
+			ctrlVolumeLevel.addEventListener('click', (e: MouseEvent) => {
+				updateVolume(e);
+				e.stopPropagation();
+			});
+
+			const refresh = () => {
+				ctrlVolume.setAttribute('level', String(Math.ceil(this.video.volume * 3)));
+				volumePercentage.style.height = `${this.video.volume * 100}%`;
+			};
+
+			this.video.addEventListener('volumechange', refresh);
+			refresh();
+		}
 	}
 
 	stopAutoplay() {

--- a/lib/modules/showImages/templates.js
+++ b/lib/modules/showImages/templates.js
@@ -131,7 +131,7 @@ export const videoAdvancedTemplate = ({
 			</a>
 			`}
 			${advancedControls ? string._html`
-			<div class="video-advanced-interface ${controls && 'video-advanced-push-below'}">
+			<div class="video-advanced-interface">
 				<div class="video-advanced-progress">
 					<div class="video-advanced-position"></div>
 					<div class="video-advanced-position-thumb"></div>

--- a/lib/modules/showImages/templates.js
+++ b/lib/modules/showImages/templates.js
@@ -142,6 +142,13 @@ export const videoAdvancedTemplate = ({
 						${reversable && string._html`
 						<div title="Reverse video" class="res-icon video-advanced-button video-advanced-reverse"></div>
 						`}
+						${!muted && string._html`
+							<div title="Adjust volume" class="res-icon video-advanced-button video-advanced-volume">
+								<div class="video-advanced-volume-level">
+									<div class="video-advanced-volume-percentage"></div>
+								</div>
+							</div>
+						`}
 						<div class="video-advanced-controls-group video-advanced-current-time">
 							<div title="Select previous frame" class="res-icon video-advanced-button video-advanced-time-decrease"></div>
 							<div class="video-advanced-time">1.00s</div>


### PR DESCRIPTION
Since the nightly / betas of Firefox and Chrome no longer provides a granular volume control in their video controls, we might as well integrate it.

Basic volume controller:
- Icon has four levels: muted / low / middle / high
- Slider displays on hover, clicking the icon toggles mute
- Volume is stored globally when changed (it might be more desirable to have a setting)

![image](https://user-images.githubusercontent.com/1748521/41602166-7d396bfa-73da-11e8-8e6e-3099bca54cad.png)

Relevant issue: Closes #799, 
Tested in browser: Chrome 68, Firefox 62
