### PR TITLE
showImages gallery: Propagate collapse events

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -965,7 +965,7 @@ async function checkElementForMedia(element) {
 
 	// Start loading media early to make it snappier
 	expando.button.addEventListener('mousedown', () => {
-		if (!expando.media && expando.generateMedia) expando.generateMedia();
+		if (!expando.media && expando.generateMedia) expando.media = expando.generateMedia();
 	});
 
 	expando.button.addEventListener('click', () => {

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1362,6 +1362,12 @@ class Gallery extends Media {
 
 		return this.preloadAhead();
 	}
+
+	collapse() {
+		for (const { media } of this.pieces.values()) {
+			if (media) media.collapse();
+		}
+	}
 }
 
 class Image extends Media {


### PR DESCRIPTION
Relevant issue: Fixes https://www.reddit.com/r/RESissues/comments/8uea0e/imgur_link_with_audio_double_plays_upon_expando/
Tested in browser: Chrome 68