### PR TITLE
"Night Mode" for redesign (with backward compat)

### DIFF
--- a/lib/css/modules/_nightMode.scss
+++ b/lib/css/modules/_nightMode.scss
@@ -7,7 +7,7 @@ $link-color: hsl(210, 50%, 70%);
 $title-link-color: hsl(0, 0%, 87%);
 $title-link-visited-color: hsl(0, 0%, 65%);
 
-.res-nightmode {
+.res-nightmode, .res-d2x-nightmode {
 	body,
 	body .content,
 	.modal-body,
@@ -420,16 +420,6 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 		z-index: 1;
 	}
 
-	button,
-	submit,
-	input[type='button'],
-	input[type='submit'],
-	input[type='reset'] {
-		color: #fff;
-		border: 1px outset hsl(0, 0%, 50%);
-		background-color: hsl(0, 0%, 30%);
-	}
-
 	.create-reddit .title {
 		background-color: rgba(24, 24, 24, .2);
 		color: #8AD;
@@ -571,30 +561,6 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 
 	&.res-searchHelper-searchPageTabs .combined-search-page .search-result-group .search-result-group-header {
 		border-bottom-color: rgb(128, 128, 128);
-	}
-
-	a,
-	.md a,
-	.share-button .option,
-	#subscribe a,
-	.share .option,
-	.wired a,
-	.side a,
-	.link .score.dislikes,
-	.linkcompressed .score.dislikes,
-	a[rel='tag'],
-	.dsq-help,
-	#authorInfoToolTip h3 a,
-	.reddiquette,
-	.parent .author,
-	.parent .subreddit,
-	.combined-search-page .search-result a,
-	.combined-search-page .search-result a > mark,
-	.hoverHelp,
-	.deepthread a,
-	.policy-page .md h1 a,
-	.policy-page .md h3 a {
-		color: $link-color;
 	}
 
 	.flairselector li a {
@@ -1739,5 +1705,42 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 
 	.ProfileVoiceAd {
 		background-color: #202020;
+	}
+}
+
+// Old redesign has extra styling
+.res-nightmode {
+	button,
+	submit,
+	input[type='button'],
+	input[type='submit'],
+	input[type='reset'] {
+		color: #fff;
+		border: 1px outset hsl(0, 0%, 50%);
+		background-color: hsl(0, 0%, 30%);
+	}
+
+	a,
+	.md a,
+	.share-button .option,
+	#subscribe a,
+	.share .option,
+	.wired a,
+	.side a,
+	.link .score.dislikes,
+	.linkcompressed .score.dislikes,
+	a[rel='tag'],
+	.dsq-help,
+	#authorInfoToolTip h3 a,
+	.reddiquette,
+	.parent .author,
+	.parent .subreddit,
+	.combined-search-page .search-result a,
+	.combined-search-page .search-result a > mark,
+	.hoverHelp,
+	.deepthread a,
+	.policy-page .md h1 a,
+	.policy-page .md h3 a {
+		color: $link-color;
 	}
 }

--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -13,6 +13,7 @@ import {
 	currentSubreddit,
 	HOUR,
 	MINUTE,
+	isAppType,
 } from '../utils';
 import { Session, Storage, i18n } from '../environment';
 import { RedditUserCookie } from '../types/reddit';
@@ -111,7 +112,7 @@ module.onToggle = enabled => {
 module.loadDynamicOptions = () => {
 	// Old design needs to hook into the document object as early as possible. this is not needed
 	// in the redesign, as it's initialized within the Reddit React application as soon as page loads
-	if (className() === 'res-nightmode') {
+	if (isAppType("r2")) {
 		// To avoid the flash of unstyled content, the very first thing we should do is get a hold
 		// of the document object and add necessary classes...
 		if (typeof localStorage === 'object' && localStorage.getItem(localStorageKey)) {
@@ -128,7 +129,7 @@ module.beforeLoad = () => {
 	}
 
 	// Add the night mode toggle in the gear menu *only for the old design*
-	if (className() === 'res-nightmode') {
+	if (isAppType("r2")) {
 		toggle = new CustomToggles.Toggle('nightMode', i18n('nightModeToggleText'), module.options.nightModeOn.value);
 		toggle.onToggle(type => {
 			if (type === 'manual') overrideNightMode();
@@ -165,7 +166,7 @@ export function isNightModeOn(): boolean {
 
 	// `toggle` contains the current nightMode state
 	// `userCookie` contains the decoded "USER" cookie data
-	return (toggle ? toggle.enabled : module.options.nightModeOn.value) || (userCookie.prefs.nightmode && className() === 'res-d2x-nightmode');
+	return (toggle ? toggle.enabled : module.options.nightModeOn.value) || (userCookie.prefs.nightmode && isAppType("d2x"));
 }
 
 export function getUserCookie(): RedditUserCookie {

--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -15,9 +15,9 @@ import {
 	MINUTE,
 } from '../utils';
 import { Session, Storage, i18n } from '../environment';
+import { RedditUserCookie } from '../types/reddit';
 import * as CustomToggles from './customToggles';
 import * as StyleTweaks from './styleTweaks';
-import { RedditUserCookie } from '../types/reddit';
 
 export const module: Module<*> = new Module('nightMode');
 
@@ -111,7 +111,7 @@ module.onToggle = enabled => {
 module.loadDynamicOptions = () => {
 	// Old design needs to hook into the document object as early as possible. this is not needed
 	// in the redesign, as it's initialized within the Reddit React application as soon as page loads
-	if(className() === "res-nightmode") {
+	if (className() === 'res-nightmode') {
 		// To avoid the flash of unstyled content, the very first thing we should do is get a hold
 		// of the document object and add necessary classes...
 		if (typeof localStorage === 'object' && localStorage.getItem(localStorageKey)) {
@@ -128,7 +128,7 @@ module.beforeLoad = () => {
 	}
 
 	// Add the night mode toggle in the gear menu *only for the old design*
-	if(className() === "res-nightmode") {
+	if (className() === 'res-nightmode') {
 		toggle = new CustomToggles.Toggle('nightMode', i18n('nightModeToggleText'), module.options.nightModeOn.value);
 		toggle.onToggle(type => {
 			if (type === 'manual') overrideNightMode();
@@ -141,7 +141,6 @@ module.beforeLoad = () => {
 		});
 		toggle.addCLI('ns');
 	}
-
 };
 
 module.always = () => {
@@ -154,7 +153,7 @@ module.always = () => {
 module.go = () => {
 	handleAutomaticNightMode();
 
-	if (module.options.nightSwitch.value && className() === "res-nightmode") {
+	if (module.options.nightSwitch.value && className() === 'res-nightmode') {
 		toggle.addMenuItem(i18n('nightModeToggleTitle'), '☽', '☀');
 	}
 };
@@ -166,12 +165,12 @@ export function isNightModeOn(): boolean {
 
 	// `toggle` contains the current nightMode state
 	// `userCookie` contains the decoded "USER" cookie data
-	return (toggle ? toggle.enabled : module.options.nightModeOn.value) || (userCookie.prefs.nightmode && className() === "res-d2x-nightmode");
+	return (toggle ? toggle.enabled : module.options.nightModeOn.value) || (userCookie.prefs.nightmode && className() === 'res-d2x-nightmode');
 }
 
 export function getUserCookie(): RedditUserCookie {
-	const redditCookie = document.cookie.split("; ").filter(((item: string) => item.includes(redditNightModeCookie + '='))).toString();
-	const cookieData = atob(redditCookie.substring(redditCookie.indexOf("=")+1));
+	const redditCookie = document.cookie.split('; ').filter(((item: string) => item.includes(redditNightModeCookie + '='))).toString();
+	const cookieData = atob(redditCookie.substring(redditCookie.indexOf('=') + 1));
 
 	return JSON.parse(cookieData);
 }

--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -17,6 +17,7 @@ import {
 import { Session, Storage, i18n } from '../environment';
 import * as CustomToggles from './customToggles';
 import * as StyleTweaks from './styleTweaks';
+import { RedditUserCookie } from '../types/reddit';
 
 export const module: Module<*> = new Module('nightMode');
 
@@ -98,6 +99,7 @@ module.options = {
 };
 
 const localStorageKey = 'RES_nightMode';
+const redditNightModeCookie = 'USER';
 const nightmodeOverrideStorage = Storage.wrap('RESmodules.nightMode.nightModeOverrideStart', (null: null | number));
 let toggle;
 
@@ -107,10 +109,14 @@ module.onToggle = enabled => {
 };
 
 module.loadDynamicOptions = () => {
-	// To avoid the flash of unstyled content, the very first thing we should do is get a hold
-	// of the document object and add necessary classes...
-	if (typeof localStorage === 'object' && localStorage.getItem(localStorageKey)) {
-		addNightMode();
+	// Old design needs to hook into the document object as early as possible. this is not needed
+	// in the redesign, as it's initialized within the Reddit React application as soon as page loads
+	if(className() === "res-nightmode") {
+		// To avoid the flash of unstyled content, the very first thing we should do is get a hold
+		// of the document object and add necessary classes...
+		if (typeof localStorage === 'object' && localStorage.getItem(localStorageKey)) {
+			addNightMode();
+		}
 	}
 };
 
@@ -121,17 +127,21 @@ module.beforeLoad = () => {
 		removeNightMode();
 	}
 
-	toggle = new CustomToggles.Toggle('nightMode', i18n('nightModeToggleText'), module.options.nightModeOn.value);
-	toggle.onToggle(type => {
-		if (type === 'manual') overrideNightMode();
-		Options.set(module, 'nightModeOn', toggle.enabled);
-	});
-	toggle.onStateChange(() => {
-		if (toggle.enabled) addNightMode();
-		else removeNightMode();
-		StyleTweaks.toggleSubredditStyleIfNecessary();
-	});
-	toggle.addCLI('ns');
+	// Add the night mode toggle in the gear menu *only for the old design*
+	if(className() === "res-nightmode") {
+		toggle = new CustomToggles.Toggle('nightMode', i18n('nightModeToggleText'), module.options.nightModeOn.value);
+		toggle.onToggle(type => {
+			if (type === 'manual') overrideNightMode();
+			Options.set(module, 'nightModeOn', toggle.enabled);
+		});
+		toggle.onStateChange(() => {
+			if (toggle.enabled) addNightMode();
+			else removeNightMode();
+			StyleTweaks.toggleSubredditStyleIfNecessary();
+		});
+		toggle.addCLI('ns');
+	}
+
 };
 
 module.always = () => {
@@ -144,15 +154,26 @@ module.always = () => {
 module.go = () => {
 	handleAutomaticNightMode();
 
-	if (module.options.nightSwitch.value) {
+	if (module.options.nightSwitch.value && className() === "res-nightmode") {
 		toggle.addMenuItem(i18n('nightModeToggleTitle'), '☽', '☀');
 	}
 };
 
 export function isNightModeOn(): boolean {
 	if (!Modules.isRunning(module)) return false;
+
+	const userCookie = getUserCookie();
+
 	// `toggle` contains the current nightMode state
-	return toggle ? toggle.enabled : module.options.nightModeOn.value;
+	// `userCookie` contains the decoded "USER" cookie data
+	return (toggle ? toggle.enabled : module.options.nightModeOn.value) || (userCookie.prefs.nightmode && className() === "res-d2x-nightmode");
+}
+
+export function getUserCookie(): RedditUserCookie {
+	const redditCookie = document.cookie.split("; ").filter(((item: string) => item.includes(redditNightModeCookie + '='))).toString();
+	const cookieData = atob(redditCookie.substring(redditCookie.indexOf("=")+1));
+
+	return JSON.parse(cookieData);
 }
 
 export async function isNightmodeCompatible(): Promise<boolean> {

--- a/lib/types/reddit.js
+++ b/lib/types/reddit.js
@@ -176,3 +176,14 @@ export type RedditWikiPage = {
 		revision_date: number,
 	},
 };
+
+export type RedditUserCookie = {
+	prefs: {
+		nightmode: boolean,
+		globalTheme: string,
+		profileLayout: string,
+		commentMode: string,
+		editorMode: string
+	},
+	language: string
+};


### PR DESCRIPTION
Alters RES's "Night Mode" module. This change gives dark styling to the extra interfaces that are added by RES, such as the settings menu and the subreddit info dialogs. 

It also gets rid of the gear menu's "night mode" toggle: now the toggle is delegatated to the official Reddit toggle.

It keeps everything the same on the old redesign: the cog menu is untouched, and the styling for buttons is kept, the only change is for the new design.


Fixes https://github.com/honestbleeps/Reddit-Enhancement-Suite/issues/4927