### PR TITLE
showImages: Downloading an image/GIF sets filename to post title

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1086,7 +1086,6 @@ const retrieveExpandoOptions = _.memoize(async (thing, { siteModule, detectResul
 		].filter(v => v).map(s => s.toLowerCase()),
 		buttonInfo: getMediaButtonInfo(mediaOptions),
 		generateMedia() {
-			if (thing) mediaOptions.title = thing.getTitle();
 			const media = generateMedia(mediaOptions, { href });
 			if (module.options.crossposts.value === 'withMetadata' && thing && thing.isCrosspost()) {
 				media.element.prepend(crosspostMetadataTemplate(thing.element.dataset));
@@ -1411,7 +1410,7 @@ class Image extends Media {
 
 		setMediaMaxSize(this.image);
 		makeMediaZoomable(this.element, this.image);
-		const wrapper = setMediaControls(anchor, src, src, title);
+		const wrapper = setMediaControls(anchor, src, src);
 		makeMediaMovable(this.element, wrapper);
 		keepMediaVisible(wrapper);
 		makeMediaIndependent(wrapper);
@@ -1583,7 +1582,7 @@ function trackMediaLoad(link, thing) {
 	}
 }
 
-function setMediaControls(media, lookupUrl, downloadUrl, title) {
+function setMediaControls(media, lookupUrl, downloadUrl) {
 	if (!module.options.mediaControls.value) return media;
 
 	const [y, x] = module.options.mediaControlsPosition.value.split('-');
@@ -1627,6 +1626,9 @@ function setMediaControls(media, lookupUrl, downloadUrl, title) {
 				Permissions.request(['downloads']).then(() => {
 					const re = /(?:\.([^.]+))?$/;
 					const ext = re.exec(downloadUrl);
+					const thing = Thing.from(media);
+					let title;
+					if (thing) title = thing.getTitle();
 					if (title && ext) {
 						const filename = `${title}.${ext[1]}`;
 						download(downloadUrl, filename);
@@ -2055,7 +2057,7 @@ class Video extends Media {
 
 		setMediaMaxSize(this.video);
 		makeMediaZoomable(this.element, this.video);
-		setMediaControls(this.video, undefined, sources[0].source, title);
+		setMediaControls(this.video, undefined, sources[0].source);
 		makeMediaMovable(this.element, container);
 		keepMediaVisible(container);
 		makeMediaIndependent(container);

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1086,6 +1086,7 @@ const retrieveExpandoOptions = _.memoize(async (thing, { siteModule, detectResul
 		].filter(v => v).map(s => s.toLowerCase()),
 		buttonInfo: getMediaButtonInfo(mediaOptions),
 		generateMedia() {
+			if (thing) mediaOptions.title = thing.getTitle();
 			const media = generateMedia(mediaOptions, { href });
 			if (module.options.crossposts.value === 'withMetadata' && thing && thing.isCrosspost()) {
 				media.element.prepend(crosspostMetadataTemplate(thing.element.dataset));
@@ -1410,7 +1411,7 @@ class Image extends Media {
 
 		setMediaMaxSize(this.image);
 		makeMediaZoomable(this.element, this.image);
-		const wrapper = setMediaControls(anchor, src, src);
+		const wrapper = setMediaControls(anchor, src, src, title);
 		makeMediaMovable(this.element, wrapper);
 		keepMediaVisible(wrapper);
 		makeMediaIndependent(wrapper);
@@ -1582,7 +1583,7 @@ function trackMediaLoad(link, thing) {
 	}
 }
 
-function setMediaControls(media, lookupUrl, downloadUrl) {
+function setMediaControls(media, lookupUrl, downloadUrl, title) {
 	if (!module.options.mediaControls.value) return media;
 
 	const [y, x] = module.options.mediaControlsPosition.value.split('-');
@@ -1623,7 +1624,14 @@ function setMediaControls(media, lookupUrl, downloadUrl) {
 				updateRotation();
 				break;
 			case 'download':
-				Permissions.request(['downloads']).then(() => download(downloadUrl));
+				Permissions.request(['downloads']).then(() => {
+					const re = /(?:\.([^.]+))?$/;
+					const ext = re.exec(downloadUrl);
+					if (title && ext) {
+						const filename = `${title}.${ext[1]}`;
+						download(downloadUrl, filename);
+					} else download(downloadUrl);
+				});
 				break;
 			case 'imageLookup':
 				// Google doesn't like image url's without a protacol
@@ -2047,7 +2055,7 @@ class Video extends Media {
 
 		setMediaMaxSize(this.video);
 		makeMediaZoomable(this.element, this.video);
-		setMediaControls(this.video, undefined, sources[0].source);
+		setMediaControls(this.video, undefined, sources[0].source, title);
 		makeMediaMovable(this.element, container);
 		keepMediaVisible(container);
 		makeMediaIndependent(container);

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1627,8 +1627,7 @@ function setMediaControls(media, lookupUrl, downloadUrl) {
 					const re = /(?:\.([^.]+))?$/;
 					const ext = re.exec(downloadUrl);
 					const thing = Thing.from(media);
-					let title;
-					if (thing) title = thing.getTitle();
+					const title = thing && thing.getTitle();
 					if (title && ext) {
 						const filename = `${title}.${ext[1]}`;
 						download(downloadUrl, filename);


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: N/A
Tested in browser: Chrome 68

Suggested by [/u/dracho](https://www.reddit.com/user/dracho) in [this post](https://www.reddit.com/r/RESissues/comments/94chjf/please_make_the_save_image_button_save_the_image/). 

This is my first time contributing to open source, so excuse any mistakes. I wasn't sure if there should've been a module option for this, but I don't see any reason to have this feature turned off. 