### PR TITLE
userTagger and userInfo ignore invalid usernames

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1623,17 +1623,7 @@ function setMediaControls(media, lookupUrl, downloadUrl) {
 				updateRotation();
 				break;
 			case 'download':
-				Permissions.request(['downloads']).then(() => {
-					const re = /(?:\.([^.]+))?$/;
-					const ext = re.exec(downloadUrl);
-					const thing = Thing.from(media);
-					let title;
-					if (thing) title = thing.getTitle();
-					if (title && ext) {
-						const filename = `${title}.${ext[1]}`;
-						download(downloadUrl, filename);
-					} else download(downloadUrl);
-				});
+				Permissions.request(['downloads']).then(() => download(downloadUrl));
 				break;
 			case 'imageLookup':
 				// Google doesn't like image url's without a protacol

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1086,7 +1086,6 @@ const retrieveExpandoOptions = _.memoize(async (thing, { siteModule, detectResul
 		].filter(v => v).map(s => s.toLowerCase()),
 		buttonInfo: getMediaButtonInfo(mediaOptions),
 		generateMedia() {
-			if (thing) mediaOptions.title = thing.getTitle();
 			const media = generateMedia(mediaOptions, { href });
 			if (module.options.crossposts.value === 'withMetadata' && thing && thing.isCrosspost()) {
 				media.element.prepend(crosspostMetadataTemplate(thing.element.dataset));
@@ -1411,7 +1410,7 @@ class Image extends Media {
 
 		setMediaMaxSize(this.image);
 		makeMediaZoomable(this.element, this.image);
-		const wrapper = setMediaControls(anchor, src, src, title);
+		const wrapper = setMediaControls(anchor, src, src);
 		makeMediaMovable(this.element, wrapper);
 		keepMediaVisible(wrapper);
 		makeMediaIndependent(wrapper);
@@ -1583,7 +1582,7 @@ function trackMediaLoad(link, thing) {
 	}
 }
 
-function setMediaControls(media, lookupUrl, downloadUrl, title) {
+function setMediaControls(media, lookupUrl, downloadUrl) {
 	if (!module.options.mediaControls.value) return media;
 
 	const [y, x] = module.options.mediaControlsPosition.value.split('-');
@@ -1627,6 +1626,9 @@ function setMediaControls(media, lookupUrl, downloadUrl, title) {
 				Permissions.request(['downloads']).then(() => {
 					const re = /(?:\.([^.]+))?$/;
 					const ext = re.exec(downloadUrl);
+					const thing = Thing.from(media);
+					let title;
+					if (thing) title = thing.getTitle();
 					if (title && ext) {
 						const filename = `${title}.${ext[1]}`;
 						download(downloadUrl, filename);
@@ -2055,7 +2057,7 @@ class Video extends Media {
 
 		setMediaMaxSize(this.video);
 		makeMediaZoomable(this.element, this.video);
-		setMediaControls(this.video, undefined, sources[0].source, title);
+		setMediaControls(this.video, undefined, sources[0].source);
 		makeMediaMovable(this.element, container);
 		keepMediaVisible(container);
 		makeMediaIndependent(container);

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1086,6 +1086,7 @@ const retrieveExpandoOptions = _.memoize(async (thing, { siteModule, detectResul
 		].filter(v => v).map(s => s.toLowerCase()),
 		buttonInfo: getMediaButtonInfo(mediaOptions),
 		generateMedia() {
+			if (thing) mediaOptions.title = thing.getTitle();
 			const media = generateMedia(mediaOptions, { href });
 			if (module.options.crossposts.value === 'withMetadata' && thing && thing.isCrosspost()) {
 				media.element.prepend(crosspostMetadataTemplate(thing.element.dataset));
@@ -1410,7 +1411,7 @@ class Image extends Media {
 
 		setMediaMaxSize(this.image);
 		makeMediaZoomable(this.element, this.image);
-		const wrapper = setMediaControls(anchor, src, src);
+		const wrapper = setMediaControls(anchor, src, src, title);
 		makeMediaMovable(this.element, wrapper);
 		keepMediaVisible(wrapper);
 		makeMediaIndependent(wrapper);
@@ -1582,7 +1583,7 @@ function trackMediaLoad(link, thing) {
 	}
 }
 
-function setMediaControls(media, lookupUrl, downloadUrl) {
+function setMediaControls(media, lookupUrl, downloadUrl, title) {
 	if (!module.options.mediaControls.value) return media;
 
 	const [y, x] = module.options.mediaControlsPosition.value.split('-');
@@ -1623,7 +1624,14 @@ function setMediaControls(media, lookupUrl, downloadUrl) {
 				updateRotation();
 				break;
 			case 'download':
-				Permissions.request(['downloads']).then(() => download(downloadUrl));
+				Permissions.request(['downloads']).then(() => {
+					const re = /(?:\.([^.]+))?$/;
+					const ext = re.exec(downloadUrl);
+					if (title && ext) {
+						const filename = `${title}.${ext[1]}`;
+						download(downloadUrl, filename);
+					} else download(downloadUrl);
+				});
 				break;
 			case 'imageLookup':
 				// Google doesn't like image url's without a protacol
@@ -2047,7 +2055,7 @@ class Video extends Media {
 
 		setMediaMaxSize(this.video);
 		makeMediaZoomable(this.element, this.video);
-		setMediaControls(this.video, undefined, sources[0].source);
+		setMediaControls(this.video, undefined, sources[0].source, title);
 		makeMediaMovable(this.element, container);
 		keepMediaVisible(container);
 		makeMediaIndependent(container);

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -139,7 +139,7 @@ module.options = {
 	},
 };
 
-export const usernameRE = /(?:u|user)\/([\w\-]+)/;
+export const usernameRE = /(?:u|user)\/([\w\-]{3,20})/;
 
 export const tagStorage = Storage.wrapPrefix('tag.', () => (({}: any): {|
 	text?: string,

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -139,7 +139,7 @@ module.options = {
 	},
 };
 
-export const usernameRE = /(?:u|user)\/([\w\-]{3,})/;
+export const usernameRE = /(?:u|user)\/([\w\-]{3,20}(?![\w\-]))/;
 
 export const tagStorage = Storage.wrapPrefix('tag.', () => (({}: any): {|
 	text?: string,
@@ -227,7 +227,7 @@ export async function applyToUser(element: HTMLAnchorElement | HTMLElement, opti
 function getUsername(element: HTMLAnchorElement): string {
 	if (element.href) {
 		const test = element.href.match(usernameRE);
-		if (test && test[1].length <= 20) {
+		if (test) {
 			return test[1];
 		} else {
 			throw new Error(`Regex failed on ${element.href}`);

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -139,7 +139,7 @@ module.options = {
 	},
 };
 
-export const usernameRE = /(?:u|user)\/([\w\-]{3,20})/;
+export const usernameRE = /(?:u|user)\/([\w\-]{3,})/;
 
 export const tagStorage = Storage.wrapPrefix('tag.', () => (({}: any): {|
 	text?: string,
@@ -227,7 +227,7 @@ export async function applyToUser(element: HTMLAnchorElement | HTMLElement, opti
 function getUsername(element: HTMLAnchorElement): string {
 	if (element.href) {
 		const test = element.href.match(usernameRE);
-		if (test) {
+		if (test && test[1].length <= 20) {
 			return test[1];
 		} else {
 			throw new Error(`Regex failed on ${element.href}`);


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: fixes #4792
Tested in browser: Chrome 68

Usernames should be 3-20 characters in length so I updated userTagger to ignore usernames that are out of bounds as well.

Edit: I see the importance in making new branches for PRs now. Ignore all those extra commits.

Edit 2: Now I know more about regex so I only needed to change the RE in the first place 😃 
This change also allows the userInfo module to ignore invalid usernames since the RE is exported.