### PR TITLE
Fix for JSON API 404ing on 'new.reddit' subdomain

### DIFF
--- a/lib/environment/foreground/ajax.js
+++ b/lib/environment/foreground/ajax.js
@@ -106,7 +106,8 @@ function buildRequestParams({ method = 'GET', url, query = {}, headers = {}, dat
 	sameOrigin: boolean,
 |} {
 	// Expand relative URLs
-	const urlObj = new URL(url, location.href);
+	// The new.reddit.com subdomain returns 404's for JSON calls, so replace with 'www'
+	const urlObj = new URL(url, location.href.replace('//new.', '//www.'));
 	// Append query string to URL
 	for (const [key, val] of Object.entries(query)) {
 		urlObj.searchParams.set(key, String(val));


### PR DESCRIPTION
Currently, for whatever reason, the 'new.reddit.com' subdomain 404s if you use any of the JSON API paths. 

**For example:**  
https://www.reddit.com/r/todayilearned/about.json **(200 OK)**  
https://old.reddit.com/r/todayilearned/about.json **(200 OK)**  
https://np.reddit.com/r/todayilearned/about.json **(200 OK)**  
https://new.reddit.com/r/todayilearned/about.json **(404 NOT FOUND)**  

It's probably a rare issue that would only affect a few people, but I figured I could attempt to solve it globally by swapping out the `new.` paths with `www.` in the `buildRequestParams()` function.

<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: **N/A**
Tested in browser: **Yes**
