### PR TITLE
Fixes error for when `customFiltersP/C` is null

### DIFF
--- a/lib/core/migrate/migrate.js
+++ b/lib/core/migrate/migrate.js
@@ -692,7 +692,7 @@ const migrations = [
 		async go() {
 			const { customFiltersP, customFiltersC } = await Options.loadRaw('filteReddit') || {};
 			let i = Date.now();
-			for (const v of [...(customFiltersP.value || []), ...(customFiltersC.value || [])]) {
+			for (const v of [...((customFiltersP && customFiltersP.value) || []), ...((customFiltersC && customFiltersC.value) || [])]) {
 				const { body: { name }, ondemand } = v;
 				v.opts = { ondemand, name };
 				v.id = `customFilter-${String(i++)}`;


### PR DESCRIPTION
This has been throwing errors for me when `customFiltersP` or `customFiltersC` is null, so I added an additional check. 
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: Unknown
Tested in browser: Yes
