### PR TITLE
userTagger watches expanded selfText

### DIFF
--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -156,7 +156,7 @@ const getTagBatched = batch(async users => {
 }, { size: Infinity, delay: 0 });
 
 module.beforeLoad = () => {
-	watchForElements(['siteTable', 'newComments'], usernameSelector, applyToUser);
+	watchForElements(['siteTable', 'newComments', 'selfText'], usernameSelector, applyToUser);
 	watchForRedditEvents('postAuthor', (element, { author, _: { update } }) => {
 		if (update) return;
 		applyToUser(element, { username: author });


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: N/A (found the bug myself)
Tested in browser: Chrome 68

Previously the userTagger wouldn't watch expanded selfTexts like [this.](https://www.reddit.com/by_id/t3_99dz4z/)