### PR TITLE
Fix account switcher and other ajax requests to Reddit API from new.reddit.com

### DIFF
--- a/lib/environment/background/ajax.js
+++ b/lib/environment/background/ajax.js
@@ -3,11 +3,11 @@
 import _ from 'lodash';
 import { addListener } from './messaging';
 
-addListener('ajax', async ({ method, url, headers, data }) => {
+addListener('ajax', async ({ method, url, headers, data, sendCredentials }) => {
 	const rawResponse = await fetch(url, {
 		method,
 		headers,
-		credentials: 'omit', // never send credentials cross-origin
+		credentials: sendCredentials ? 'include' : 'omit',
 		body: data,
 	});
 

--- a/lib/environment/foreground/ajax.js
+++ b/lib/environment/foreground/ajax.js
@@ -119,6 +119,9 @@ function buildRequestParams({ method = 'GET', url, query = {}, headers = {}, dat
 	}
 	let sameOrigin = sameSite;
 	if (sameSite && urlObj.hostname.startsWith('new.')) {
+		// new.reddit.com specifically selects the reddit desktop web frontend service.
+		// AJAX requests should be sent to www.reddit.com, which will select the correct
+		// service based on the path.
 		sameOrigin = false;
 		urlObj.hostname = urlObj.hostname.replace(/new\./, 'www.');
 	}

--- a/lib/environment/foreground/ajax.js
+++ b/lib/environment/foreground/ajax.js
@@ -49,7 +49,7 @@ declare function ajax(opt: AjaxOptions<'raw'>): Promise<{
  * `cacheFor` is a TTL, in milliseconds.
  */
 export async function ajax(options: AjaxOptions<*>) {
-	const { method, url, headers, data, type, cacheFor, sameOrigin } = buildRequestParams(options);
+	const { method, url, headers, data, type, cacheFor, sameOrigin, sameSite } = buildRequestParams(options);
 
 	if (cacheFor) {
 		const cached = await XhrCache.check(url, cacheFor);
@@ -58,7 +58,7 @@ export async function ajax(options: AjaxOptions<*>) {
 		}
 	}
 
-	if (sameOrigin) {
+	if (sameSite) {
 		if (method !== 'GET' && method !== 'HEAD') {
 			// Send modhash for same-origin non-GET requests
 			const hash = await loggedInUserHash();
@@ -78,7 +78,7 @@ export async function ajax(options: AjaxOptions<*>) {
 			headers: _.fromPairs(Array.from(r.headers.entries())),
 			text: await r.text(),
 		})) :
-		sendMessage('ajax', { method, url, headers, data })
+		sendMessage('ajax', { method, url, headers, data, sendCredentials: sameSite })
 	);
 
 	if (!response.ok) {
@@ -112,10 +112,15 @@ function buildRequestParams({ method = 'GET', url, query = {}, headers = {}, dat
 		urlObj.searchParams.set(key, String(val));
 	}
 
-	const sameOrigin = urlObj.hostname.includes(location.hostname.split('.').slice(-2).join('.'));
-	if (sameOrigin) {
+	const sameSite = urlObj.hostname.includes(location.hostname.split('.').slice(-2).join('.'));
+	if (sameSite) {
 		// Add `app=res` to same-origin request URLs
 		urlObj.searchParams.set('app', 'res');
+	}
+	let sameOrigin = sameSite;
+	if (sameSite && urlObj.hostname.startsWith('new.')) {
+		sameOrigin = false;
+		urlObj.hostname = urlObj.hostname.replace(/new\./, 'www.');
 	}
 
 	// Convert plain data objects to application/x-www-form-urlencoded
@@ -134,6 +139,7 @@ function buildRequestParams({ method = 'GET', url, query = {}, headers = {}, dat
 		type,
 		cacheFor,
 		sameOrigin,
+		sameSite,
 	};
 }
 

--- a/lib/environment/foreground/ajax.js
+++ b/lib/environment/foreground/ajax.js
@@ -104,6 +104,7 @@ function buildRequestParams({ method = 'GET', url, query = {}, headers = {}, dat
 	type: ResponseType,
 	cacheFor: number,
 	sameOrigin: boolean,
+	sameSite: boolean,
 |} {
 	// Expand relative URLs
 	const urlObj = new URL(url, location.href);

--- a/lib/utils/user.js
+++ b/lib/utils/user.js
@@ -39,8 +39,7 @@ export const loggedInUserHash = _.once(async (): Promise<?string> => {
 });
 
 export const loggedInUserInfo = _.once((): Promise<CurrentRedditUser | void> =>
-	!isLoggedIn() ? Promise.resolve() : fetch('/api/me.json', { credentials: 'include' })
-		.then(r => r.json())
+	!isLoggedIn() ? Promise.resolve() : ajax({ url: '/api/me.json', type: 'json' })
 		.then(data => data.data && data.data.modhash ? data : undefined));
 
 export function getUserInfo(username: ?string = loggedInUser()): Promise<RedditAccount> {


### PR DESCRIPTION
new.reddit.com always routes to the new reddit web desktop service (desktop2x). Unlike www.reddit.com, api (.json) requests are not routed to the reddit api public service. Thus, sending ajax requests to, e.g. `/api/login` from new.reddit.com will 404.  To fix this, when sending an ajax request to the reddit api from new.reddit.com, that request will now be sent to www.reddit.com and sent via the background page, including credentials.

Tested on Chrome 68 and Firefox 61. Was not tested with Firefox's third-party cookies option disabled.

nb: new.reddit.com/....json?embedded=true currently selects r2, i.e. the public reddit API. (This is currently leveraged by first-party ajax api requests from new.reddit.com/message/inbox). However, I decided against it for RES as that routing may be deprecated unexpectedly.

edit(erikdesjardins): closes #4819