### PR TITLE
 added support for imgur subreddit links

### DIFF
--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -86,8 +86,7 @@ export default new Host('imgur', {
 			const hash = groups[2];
 			return () => _handleImage(hash, href);
 		} else if ((groups = hashRe.exec(href))) {
-			const subreddit = groups[1];
-			const hash = groups[2];
+			const [, subreddit, hash] = groups;
 			if (subreddit) return () => _api(string.encode`gallery/${subreddit}${hash}`);
 			if (hash.search(/[&,]/) > -1) {
 				// handle separated list of IDs

--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -123,7 +123,7 @@ export default new Host('imgur', {
 				thisCdnUrl = matches[1];
 				extension = matches[3];
 			} else if ((matches = hashRe.exec(url))) {
-				extension = matches[2];
+				extension = matches[3];
 			}
 
 			if (!extension) {
@@ -144,7 +144,7 @@ export default new Host('imgur', {
 		}
 
 		function _handleImage(hash, url) {
-			const [,, extension] = hashRe.exec(url) || [];
+			const [,,, extension] = hashRe.exec(url) || [];
 
 			if (['.png', '.jpg', '.jpeg'].includes(extension)) {
 				// Extension is given and hopefully correct, so we can intuit the mimetype

--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -61,7 +61,7 @@ export default new Host('imgur', {
 		const cdnUrl = 'https://i.imgur.com/';
 		const apiPrefix = 'https://api.imgur.com/3/';
 		const apiId = '1d8d9b36339e0e2';
-		const hashRe = /^https?:\/\/(?:i\.|m\.|edge\.|www\.)*imgur\.com\/(?:r\/\w+\/)*(?!gallery)(?!removalrequest)(?!random)(?!memegen)((?:\w{5}|\w{7})(?:[&,](?:\w{5}|\w{7}))*)(?:#\d+)?[a-z]?(\.(?:jpe?g|gifv?|png))?(\?.*)?$/i;
+		const hashRe = /^https?:\/\/(?:i\.|m\.|edge\.|www\.)*imgur\.com\/(r\/\w+\/)*(?!gallery)(?!removalrequest)(?!random)(?!memegen)((?:\w{5}|\w{7})(?:[&,](?:\w{5}|\w{7}))*)(?:#\d+)?[a-z]?(\.(?:jpe?g|gifv?|png))?(\?.*)?$/i;
 		const hostedHashRe = /^https?:(\/\/i\.\w+\.*imgur\.com\/)((?:\w{5}|\w{7})(?:[&,](?:\w{5}|\w{7}))*)(?:#\d+)?[a-z]?(\.(?:jpe?g|gif|png))?(\?.*)?$/i;
 		const galleryHashRe = /^https?:\/\/(?:m\.|www\.)?imgur\.com\/gallery\/(\w+)(?:[/#]|$)/i;
 		const albumHashRe = /^https?:\/\/(?:m\.|www\.)?imgur\.com\/a\/(\w+)(?:[/#]|$)/i;
@@ -86,7 +86,9 @@ export default new Host('imgur', {
 			const hash = groups[2];
 			return () => _handleImage(hash, href);
 		} else if ((groups = hashRe.exec(href))) {
-			const hash = groups[1];
+			const subreddit = groups[1];
+			const hash = groups[2];
+			if (subreddit) return () => _api(string.encode`gallery/${subreddit}${hash}`);
 			if (hash.search(/[&,]/) > -1) {
 				// handle separated list of IDs
 				return () => _handleImageCollection(hash.split(/[&,]/), href);


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: fixes #4826
Tested in browser: Chrome 70

I only really had [this example](https://www.reddit.com/r/DDLC/comments/99yss1/oh_no/) to go off of, although it should fix most cases in the meantime.

Even though it's returning an endpoint with 'gallery' in it, the imgur API still uses 'gallery' for single subreddit images.