### PR TITLE
Temporarily disable FF integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ matrix:
       script:
         - yarn run coverage && yarn run report-coverage
         - yarn run build chrome,firefox
-        - yarn run integration chrome --retries 2 && yarn run integration firefox --retries 2
+        - yarn run integration chrome --retries 2 # && yarn run integration firefox --retries 2
     - env: RES_JOB=build_deploy
       script:
         - yarn run build all


### PR DESCRIPTION
re #4827

On second thought, it's annoying to have to wait for the job to timeout (or cancel it) when we know it's going to fail.
