### PR TITLE
Fix faulty XKCD alt text

### DIFF
--- a/lib/modules/hosts/xkcd.js
+++ b/lib/modules/hosts/xkcd.js
@@ -23,7 +23,15 @@ export default new Host('xkcd', {
 		return {
 			type: 'IMAGE',
 			title,
-			caption: escapeHTML(decodeURIComponent(escape(alt))),
+			caption: escapeHTML(
+				// The XKCD API is broken for unicode characters which are multibyte in utf8,
+				// in that it escapes each byte individually (bytes are not codepoints!).
+				// For example, ↘ is code point 0x2198, which is `E2 86 98` in utf8 bytes,
+				// so the API returns `\u00e2\u0086\u0098`.
+				// Luckily (?) the `escape` function also doesn't understand multibyte characters,
+				// so it cancels out the bug.
+				decodeURIComponent(escape(alt))
+			),
 			src: img,
 		};
 	},

--- a/lib/modules/hosts/xkcd.js
+++ b/lib/modules/hosts/xkcd.js
@@ -2,6 +2,7 @@
 
 import { Host } from '../../core/host';
 import { ajax } from '../../environment';
+import { escapeHTML } from '../../utils';
 
 export default new Host('xkcd', {
 	name: 'xkcd',
@@ -22,7 +23,7 @@ export default new Host('xkcd', {
 		return {
 			type: 'IMAGE',
 			title,
-			caption: decodeURIComponent(escape(alt)),
+			caption: escapeHTML(decodeURIComponent(escape(alt))),
 			src: img,
 		};
 	},

--- a/lib/modules/hosts/xkcd.js
+++ b/lib/modules/hosts/xkcd.js
@@ -2,7 +2,6 @@
 
 import { Host } from '../../core/host';
 import { ajax } from '../../environment';
-import { escapeHTML } from '../../utils';
 
 export default new Host('xkcd', {
 	name: 'xkcd',
@@ -23,7 +22,7 @@ export default new Host('xkcd', {
 		return {
 			type: 'IMAGE',
 			title,
-			caption: escapeHTML(alt),
+			caption: decodeURIComponent(escape(alt)),
 			src: img,
 		};
 	},


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: N/A
Tested in browser: Chrome 70

Fixes [this bug](https://www.reddit.com/r/RESissues/comments/9asuvg/res_doesnt_display_xkcd_alt_texts_with_emojis/) found by [/u/DonaldLovesJong](https://www.reddit.com/user/DonaldLovesJong) and [/u/LevelSevenLaserLotus](https://www.reddit.com/user/LevelSevenLaserLotus).

Examples:
![image](https://user-images.githubusercontent.com/22380991/44705787-a4552200-aa6d-11e8-9191-ed3804867ad6.png)
![image](https://user-images.githubusercontent.com/22380991/44705828-bf279680-aa6d-11e8-94aa-57b2bcc54b7e.png)
