### PR TITLE
settingsConsole search fixes

### DIFF
--- a/lib/css/res.scss
+++ b/lib/css/res.scss
@@ -1000,6 +1000,15 @@ span.multi-count {
 #SearchRES-input-container {
 	position: relative;
 	margin-bottom: 10px;
+
+	&::after {
+		position: absolute;
+		right: 0;
+		padding: 5px;
+		color: rgb(130, 177, 210);
+		font: normal 16px/1 'Batch';
+		content: '\f094';
+	}
 }
 
 #SearchRES-input {
@@ -1009,24 +1018,6 @@ span.multi-count {
 	padding: 5px 25px 5px 3px;
 	border: 1px solid rgb(171, 204, 227);
 	border-radius: 2px;
-}
-
-#SearchRES-input-submit {
-	position: absolute;
-	border: none;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	width: 25px;
-	height: auto;
-	margin: 0;
-	padding: 0;
-	background: transparent;
-	box-shadow: none;
-
-	span {
-		color: rgb(130, 177, 210);
-	}
 }
 
 .RESMenuItemButton {

--- a/lib/modules/search.js
+++ b/lib/modules/search.js
@@ -5,7 +5,7 @@ import { markdown } from 'snudown-js';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
 import * as Modules from '../core/modules';
-import { Alert, CreateElement, empty, frameThrottle, string } from '../utils';
+import { Alert, CreateElement, downcast, empty, frameThrottle, string } from '../utils';
 import { i18n } from '../environment';
 import * as CommandLine from './commandLine';
 import * as Menu from './menu';
@@ -44,7 +44,9 @@ module.go = () => {
 		click: e => {
 			e.preventDefault();
 			e.stopPropagation();
-			showSearch();
+			Menu.hidePrefsDropdown();
+			displayResults();
+			input().focus();
 		},
 	});
 	$menuItem.appendTo(SettingsConsole.$menuItem());
@@ -61,22 +63,17 @@ module.go = () => {
 	);
 };
 
-export function search(query?: string) {
-	getSearchResults(query);
-	SettingsNavigation.setUrlHash(module.moduleID, query);
-}
-
-const throttledSearch = _.throttle(frameThrottle(search), 250);
-
-function showSearch() {
-	Menu.hidePrefsDropdown();
-	drawSearchResults();
-	$('#SearchRES-input').focus();
+export function search(query: string = '') {
+	input().value = query;
+	displayResults();
 }
 
 const PRESERVE_SPACES = true;
 
-function getSearchResults(query) {
+function displayResults() {
+	const query = input().value;
+	SettingsNavigation.setUrlHash(module.moduleID, query);
+
 	if (!query || !query.toString().length) {
 		drawSearchResults(query, []);
 		return;
@@ -232,29 +229,17 @@ function onSearchResultSelected(moduleID, optionKey) {
 }
 
 // ---------- View ------
-export function renderSearchForm(container: HTMLElement) {
-	$(container).find('#SearchRES-input-container').replaceWith(`
-		<form id="SearchRES-input-container">
-			<input id="SearchRES-input" type="text" placeholder="${i18n('searchRESSettings')}" />
-			<button id="SearchRES-input-submit" type="submit">
-				<span class="res-icon">&#xF094;</span>
-			</button>
-		</form>
-	`);
+export const input = _.once(() => {
+	const input = downcast(string.html`
+		<input id="SearchRES-input" type="text" placeholder="${i18n('searchRESSettings')}">
+	`, HTMLInputElement);
 
-	$(container).on('input submit', '#SearchRES-input-container', event => {
-		// Prevent from submitting the form
-		if (event.type === 'submit') {
-			event.preventDefault();
-		}
-		const RESSearchBox: HTMLInputElement = (container.querySelector('#SearchRES-input'): any);
-		throttledSearch(RESSearchBox.value);
+	input.addEventListener('input', frameThrottle(displayResults));
 
-		return false;
-	});
-}
+	return input;
+});
 
-function drawSearchResults(query, results) {
+function drawSearchResults(query, results: Array<*>) {
 	SettingsConsole.open(module.moduleID);
 
 	const $resultsContainer = $('#SearchRES-results-container');
@@ -266,17 +251,8 @@ function drawSearchResults(query, results) {
 		return;
 	}
 
-	let count = 0;
-	let advancedResults = 0;
-	if (results) {
-		for (const result of results) {
-			if (result.advanced) {
-				advancedResults++;
-			} else {
-				count++;
-			}
-		}
-	}
+	const advancedResults = results.filter(({ advanced }) => advanced).length;
+	const count = results.length - advancedResults;
 
 	// display number of results.
 	const plural = (count !== 1 ? 's' : '');
@@ -290,14 +266,14 @@ function drawSearchResults(query, results) {
 		$resultsContainer.find('#SearchRES-results-hidden').addClass('advancedResults');
 		$('#SearchRES-results-hidden a').off('click').on('click', () => {
 			$(document.getElementById('RESAllOptions')).click();
-			getSearchResults(query);
+			displayResults();
 			return false;
 		});
 	} else {
 		$resultsContainer.find('#SearchRES-results-hidden').removeClass('advancedResults');
 	}
 
-	if (!results || !results.length) {
+	if (!results.length) {
 		$resultsContainer.find('#SearchRES-results').hide();
 	} else {
 		$resultsContainer.find('#SearchRES-results').show();
@@ -305,10 +281,7 @@ function drawSearchResults(query, results) {
 		const resultsList = document.getElementById('SearchRES-results');
 
 		empty(resultsList);
-		for (const result of results) {
-			const element = drawSearchResultItem(result);
-			resultsList.appendChild(element);
-		}
+		resultsList.append(...results.map(drawSearchResultItem));
 	}
 }
 
@@ -328,7 +301,7 @@ const searchResultTemplate = ({ title, category, description, moduleName, module
 	</div>
 `;
 
-function drawSearchResultItem(result) {
+const drawSearchResultItem = _.memoize(result => {
 	const element = document.createElement('li');
 	element.classList.add('SearchRES-result-item');
 	if (result.advanced) {
@@ -351,7 +324,7 @@ function drawSearchResultItem(result) {
 	element.insertBefore(copybutton, element.firstChild);
 
 	return element;
-}
+});
 
 function handleSearchResultClick(event: Event) {
 	const moduleID = this.getAttribute('data-module-id');

--- a/lib/modules/settingsConsole.js
+++ b/lib/modules/settingsConsole.js
@@ -140,7 +140,7 @@ function create() {
 	}
 	RESConfigPanelOptions = RESConsoleContainer.querySelector('#RESConfigPanelOptions');
 
-	Search.renderSearchForm(RESConsoleContainer);
+	$(RESConsoleContainer).find('#SearchRES-input-container').append(Search.input());
 
 	// Okay, the console is done. Add it to the document body.
 	document.body.appendChild(RESConsoleContainer);
@@ -925,9 +925,11 @@ export function open(moduleIdOrCategory?: string) {
 		DEFAULT_MODULE
 	);
 
-	// Draw the config panel
-	showConfigOptions(mod);
+	if (mod !== currentModule) {
+		showConfigOptions(mod);
+	}
 
+	if (isOpen) return;
 	isOpen = true;
 
 	// add a class to body to hide the scrollbar.
@@ -946,10 +948,12 @@ export function open(moduleIdOrCategory?: string) {
 	$(window)
 		.off('beforeunload', handleBeforeUnload)
 		.on('beforeunload', handleBeforeUnload);
-	$('#SearchRES-input').focus();
 	$(RESConsoleContainer)
 		.on('keyup', autostageDebounce)
 		.on('change', stageCurrentModuleOptions);
+
+	// Don't focus at once, as to prevent the input element reacting to events when may have opened the console
+	requestAnimationFrame(() => { Search.input().focus(); });
 }
 
 function handleEscapeKey(event: KeyboardEvent) {
@@ -982,6 +986,10 @@ export function close({ promptIfStagedOptions = true, resetUrl = true }: {| prom
 	const adFrame = document.getElementById('ad-frame');
 	if ((typeof adFrame !== 'undefined') && (adFrame !== null)) {
 		adFrame.style.display = 'block';
+	}
+
+	if (document.activeElement && RESConsoleContainer.contains(document.activeElement)) {
+		document.activeElement.blur();
 	}
 
 	$modalOverlay.removeClass('fadeIn');


### PR DESCRIPTION
- Updates search field when opened externally
- Blurs search field when closing settingsConsole
- Fixes navigation when searching
- Removes throttle on search (by memoizing results)
- Avoids reinitalizing console on every search / changing module

Tested in browser: Chrome 69