### PR TITLE
remove @babel/plugin-proposal-export-default-from

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,5 @@
 {
 	"plugins": [
-		"@babel/plugin-proposal-export-default-from",
 		"@babel/plugin-proposal-export-namespace-from",
 		["@babel/plugin-proposal-class-properties", { "loose": true }],
 		["@babel/plugin-proposal-object-rest-spread", { "loose": true, "useBuiltIns": true }],

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
   "devDependencies": {
     "@babel/core": "7.0.0",
     "@babel/plugin-proposal-class-properties": "7.0.0",
-    "@babel/plugin-proposal-export-default-from": "7.0.0",
     "@babel/plugin-proposal-export-namespace-from": "7.0.0",
     "@babel/plugin-proposal-object-rest-spread": "7.0.0",
     "@babel/plugin-transform-flow-strip-types": "7.0.0",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -74,7 +74,6 @@ export default (env = {}, argv = {}) => {
 						loader: 'babel-loader',
 						options: {
 							plugins: [
-								'@babel/plugin-proposal-export-default-from',
 								'@babel/plugin-proposal-export-namespace-from',
 								['@babel/plugin-proposal-class-properties', { loose: true }],
 								['@babel/plugin-proposal-object-rest-spread', { loose: true, useBuiltIns: true }],

--- a/yarn.lock
+++ b/yarn.lock
@@ -269,13 +269,6 @@
     "@babel/helper-replace-supers" "^7.0.0"
     "@babel/plugin-syntax-class-properties" "^7.0.0"
 
-"@babel/plugin-proposal-export-default-from@7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.0.0.tgz#a057bbfd4649facfe39f33a537e18554bdd2b5da"
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-syntax-export-default-from" "^7.0.0"
-
 "@babel/plugin-proposal-export-namespace-from@7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.0.0.tgz#ce847cc62c3626547107a1b835592b8ee494af51"
@@ -306,12 +299,6 @@
 "@babel/plugin-syntax-class-properties@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0.tgz#e051af5d300cbfbcec4a7476e37a803489881634"
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-
-"@babel/plugin-syntax-export-default-from@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.0.0.tgz#084b639bce3d42f3c5bf3f68ccb42220bb2d729d"
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 


### PR DESCRIPTION
Flow can't parse this syntax so we can't use it anyways.

Also, the equivalent syntax:
`export Foo from './foo'` -> `export { default as Foo } from './foo'`
isn't much longer and is clearer IMO (i.e. does the first one export something called `Foo` or the default export?)