### PR TITLE
appveyor: Set image to Visual Studio 2017

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 build: off
 version: '{build}'
+image: Visual Studio 2017
 environment:
   nodejs_version: 8
 cache:


### PR DESCRIPTION
This fixes the current AppVeyor build failures.