### PR TITLE
tests: Suppress console.error/warn more robustly

### DIFF
--- a/lib/environment/utils/__tests__/messaging.js
+++ b/lib/environment/utils/__tests__/messaging.js
@@ -1,8 +1,24 @@
-/* @noflow */
+/* @flow */
 
-import test from 'ava';
+/* eslint-disable ava/use-test */
+import anyTest from 'ava';
+import type { TestInterface } from 'ava';
+/* eslint-enable ava/use-test */
 
 import { createMessageHandler } from '../messaging';
+
+const test: TestInterface<{ _realConsoleError: * }> = (anyTest: any);
+
+test.before(t => {
+	t.context._realConsoleError = console.error;
+	// $FlowIgnore
+	console.error = () => {};
+});
+
+test.after(t => {
+	// $FlowIgnore
+	console.error = t.context._realConsoleError;
+});
 
 function createPair() {
 	const { _handleMessage: _handleMessageA, ...a } = createMessageHandler((info, context) =>
@@ -15,17 +31,6 @@ function createPair() {
 
 	return { a, b };
 }
-
-test.beforeEach(t => {
-	t.context._realConsoleError = console.error;
-	// $FlowIgnore
-	console.error = () => {};
-});
-
-test.afterEach(t => {
-	// $FlowIgnore
-	console.error = t.context._realConsoleError;
-});
 
 test('adding duplicate listener', t => {
 	const { a: { addListener } } = createPair();

--- a/lib/modules/backupAndRestore/__tests__/serialization.js
+++ b/lib/modules/backupAndRestore/__tests__/serialization.js
@@ -1,9 +1,26 @@
 /* @flow */
 
-import test from 'ava';
+/* eslint-disable ava/use-test */
+import anyTest from 'ava';
+import type { TestInterface } from 'ava';
+/* eslint-enable ava/use-test */
+
 import _ from 'lodash';
 
 import { serialize, deserialize } from '../serialization';
+
+const test: TestInterface<{ _realConsoleWarn: * }> = (anyTest: any);
+
+test.before(t => {
+	t.context._realConsoleWarn = console.warn;
+	// $FlowIgnore
+	console.warn = () => {};
+});
+
+test.after(t => {
+	// $FlowIgnore
+	console.warn = t.context._realConsoleWarn;
+});
 
 test('throws on invalid json', t => {
 	t.throws(() => deserialize('{ foo: 1 }'));

--- a/lib/utils/__tests__/array.js
+++ b/lib/utils/__tests__/array.js
@@ -1,4 +1,4 @@
-/* @noflow */
+/* @flow */
 
 import test from 'ava';
 

--- a/lib/utils/__tests__/async.js
+++ b/lib/utils/__tests__/async.js
@@ -1,4 +1,4 @@
-/* @noflow */
+/* @flow */
 
 import test from 'ava';
 


### PR DESCRIPTION
This suppresses the two messages from `console.error` and `console.warn` that show up on all test runs.