### PR TITLE
Small fixes / adjustments to video info stats

### DIFF
--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -204,7 +204,7 @@ module.beforeLoad = () => {
 		watchForElements(['newComments', 'siteTable'], 'ul.flat-list.buttons li a, .side a.reddit-comment-link', applyNoCtrlF);
 	}
 
-	if (module.options.videoTimes.value) {
+	if (module.options.videoTimes.value || module.options.videoUploaded.value || module.options.videoViewed.value) {
 		watchForThings(['post'], getVideoTimes);
 	}
 
@@ -359,13 +359,15 @@ async function getVideoTimes(thing) {
 	const { info, duration, title } = await getVideoInfo(match[1]);
 
 	requestAnimationFrame(() => {
-		if (info.length) link.textContent += ` - ${info.join(' ')}`;
+		if (info.length) link.appendChild(string.html`<span class="gray pay-link">${info.join(' ')}</span>`);
 		link.setAttribute('title', i18n('betteRedditVideoYouTubeTitle', title));
 
-		// Add native Reddit duration overlay on video thumbnail
-		const thumbnail = thing.element.querySelector('a.thumbnail');
-		if (thumbnail) {
-			thumbnail.appendChild(string.html`<div class="duration-overlay">${duration}${startTime ? ` (@${startTime})` : ''}</div>`);
+		if (module.options.videoTimes.value) {
+			// Add native Reddit duration overlay on video thumbnail
+			const thumbnail = thing.element.querySelector('a.thumbnail');
+			if (thumbnail) {
+				thumbnail.appendChild(string.html`<div class="duration-overlay">${duration}${startTime ? ` (@${startTime})` : ''}</div>`);
+			}
 		}
 	});
 }

--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -380,7 +380,7 @@ const getVideoInfo = batch(async videoIds => {
 	const fields = ['id', 'contentDetails(duration)', 'snippet(title,publishedAt)'];
 	if (module.options.videoViewed.value) {
 		parts.push('statistics');
-		fields.push('statistics(viewCount)')
+		fields.push('statistics(viewCount)');
 	}
 
 	const { items } = await ajax({

--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -410,7 +410,7 @@ const getVideoInfo = batch(async videoIds => {
 			const uploaded = new Date(snippet.publishedAt); // 2016-01-27T05:49:48.000Z
 			const dt = `${uploaded.toDateString()} ${uploaded.toTimeString()}`;
 			const timeAgo = i18n('submitHelperTimeAgo', formatDateDiff(uploaded));
-			info.push(`[<time title="${dt}" datetime="${snippet.publishedAt}" class="live-timestamp">${timeAgo}</time>]`); //.match(/[^.]*/)}]
+			info.push(`[<time title="${dt}" datetime="${snippet.publishedAt}" class="live-timestamp">${timeAgo}</time>]`);
 		}
 
 		if (module.options.videoViewed.value) {

--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -18,6 +18,7 @@ import {
 	loggedInUser,
 	watchForThings,
 	watchForElements,
+	formatDateDiff,
 	fromSecondsToTime,
 	string,
 } from '../utils';
@@ -359,7 +360,9 @@ async function getVideoTimes(thing) {
 	const { info, duration, title } = await getVideoInfo(match[1]);
 
 	requestAnimationFrame(() => {
-		if (info.length) link.appendChild(string.html`<span class="gray pay-link">${info.join(' ')}</span>`);
+		if (info.length) {
+			link.appendChild(string.html`<span class="gray pay-link">${string.safe(info.join(' '))}</span>`);
+		}
 		link.setAttribute('title', i18n('betteRedditVideoYouTubeTitle', title));
 
 		if (module.options.videoTimes.value) {
@@ -374,13 +377,18 @@ async function getVideoTimes(thing) {
 
 const getVideoInfo = batch(async videoIds => {
 	const parts = ['id', 'contentDetails', 'snippet'];
-	if (module.options.videoViewed.value) parts.push('statistics');
+	const fields = ['id', 'contentDetails(duration)', 'snippet(title,publishedAt)'];
+	if (module.options.videoViewed.value) {
+		parts.push('statistics');
+		fields.push('statistics(viewCount)')
+	}
 
 	const { items } = await ajax({
 		url: 'https://www.googleapis.com/youtube/v3/videos',
 		query: {
 			id: videoIds.join(','),
 			part: parts.join(','),
+			fields: `items(${fields.join(',')})`,
 			key: 'AIzaSyB8ufxFN0GapU1hSzIbuOLfnFC0XzJousw',
 		},
 		type: 'json',
@@ -399,8 +407,10 @@ const getVideoInfo = batch(async videoIds => {
 		const info = [];
 
 		if (module.options.videoUploaded.value) {
-			const uploaded = snippet.publishedAt; // 2016-01-27T05:49:48.000Z
-			info.push(`[${uploaded.match(/[^T]*/)}]`);
+			const uploaded = new Date(snippet.publishedAt); // 2016-01-27T05:49:48.000Z
+			const dt = `${uploaded.toDateString()} ${uploaded.toTimeString()}`;
+			const timeAgo = i18n('submitHelperTimeAgo', formatDateDiff(uploaded));
+			info.push(`[<time title="${dt}" datetime="${snippet.publishedAt}" class="live-timestamp">${timeAgo}</time>]`); //.match(/[^.]*/)}]
 		}
 
 		if (module.options.videoViewed.value) {


### PR DESCRIPTION
* Previously, `videoUploaded` and `videoViewed` would only work if `videoTimes` was enabled. **FIXED**
* Also made the `videoUploaded`/`videoViewed` text a little bit more distinguishable from the title.
    **Comparison Screenshot:**
![](https://i.imgur.com/x7aJC8S.png)

**EDIT:**
* Replaced date-stamp with `<time class="live-timestamp">` field to make it more feature rich (as described below)
* Added a fields parameter to the Youtube API query to minimize the return data to just the essentials.