### PR TITLE
Filterline: Make all filters deletable & tweak right click behavior

### DIFF
--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -17,7 +17,6 @@ import {
 	CreateElement,
 	extendDeep,
 	fastAsync,
-	filterMap,
 	loggedInUser,
 	indexOptionTable,
 	isCurrentMultireddit,
@@ -383,7 +382,6 @@ export type FilterStorageValues = {|
 	criterion?: string,
 	name?: string,
 	conditions?: {},
-	undeletable?: boolean,
 	sideEffects?: {},
 |};
 
@@ -396,6 +394,13 @@ const pageID = fullLocation();
 const filterlineStorage = Storage.wrap(`filterline.${pageID}`, ({}: LineState));
 const thingType = isPageType('comments', 'commentsLinklist') ? 'comment' : 'post';
 const customFilterVariant = thingType === 'post' ? 'customFiltersP' : 'customFiltersC';
+
+const createStateFromTypes = types => (
+	types.reduce((acc, v, i) => {
+		if (v) acc[`~${i}`] = { type: v, state: null };
+		return acc;
+	}, {})
+);
 
 // If filterlineStorage is empty, look for default filters
 export const defaultFilters: Array<{| type: string, text: string, storage: * |}> = []; // Decreasing precedense
@@ -410,13 +415,24 @@ if (thingType === 'comment') {
 	defaultFilters.push({
 		type: 'everywhere',
 		text: 'Everywhere',
-		storage: Storage.wrap('RESmodules.filteReddit.commentDefault', (null: null | *)),
+		storage: Storage.wrap('RESmodules.filteReddit.commentDefault', createStateFromTypes([
+			'hasExpando',
+			'score',
+			'isRead',
+		])),
 	});
 } else if (thingType === 'post') {
 	defaultFilters.push({
 		type: 'everywhere',
 		text: 'Everywhere',
-		storage: Storage.wrap('RESmodules.filteReddit.postDefault', (null: null | *)),
+		storage: Storage.wrap('RESmodules.filteReddit.postDefault', createStateFromTypes([
+			'isNSFW',
+			'isSpoiler',
+			'isVisited',
+			'commentsOpened',
+			'hasExpando',
+			'score',
+		])),
 	});
 }
 
@@ -427,10 +443,11 @@ async function getDefaultFilters() {
 	}
 }
 
-const initialFilterlineState = reifyPromise((async () =>
-	// eslint-disable-next-line prefer-spread/prefer-object-spread
-	Object.assign({}, ...(await Promise.resolve().then(() => Promise.all([getDefaultFilters(), filterlineStorage.get()]))))
-)());
+const initialFilterlineState = reifyPromise((async () => {
+	const specific = await filterlineStorage.get();
+	if (Object.keys(specific).length) return specific;
+	return getDefaultFilters();
+})());
 
 let nsfwToggle;
 
@@ -479,16 +496,10 @@ const createFilterline = _.once(({
 	const filterline = new Filterline(filterlineStorage, thingType);
 
 	const filters = {};
-	const addDefaultFilter = (id, opts: { type: string }) => { filters[id] = { undeletable: true, ...opts }; };
 
 	function addExternalFilter(key, name, getConditions, Filter, source) {
 		const cased = Cases.createAdHoc(key, name, getConditions, 'external', thingType, source);
-		addDefaultFilter(key, { Filter, type: cased.type, state: false });
-	}
-
-	function addLineDefaults(types) {
-		filterMap(types, v => Cases.isUseful(v) ? [v] : undefined)
-			.forEach(type => addDefaultFilter(type, { type }));
+		filters[key] = { Filter, type: cased.type, state: false };
 	}
 
 	const customFilters = _.groupBy(
@@ -539,7 +550,7 @@ const createFilterline = _.once(({
 		addExternalFilter(externalKey, i18n(module.options[externalKey].title), getConditions, Filter);
 	}
 
-	function addPostFilters() {
+	if (thingType === 'post') {
 		addListFilter('keywords', 'postTitle');
 		addListFilter('domains', 'domain', { fullMatch: false });
 		if (
@@ -552,27 +563,7 @@ const createFilterline = _.once(({
 			addListFilter('subreddits', 'subreddit');
 		}
 		addListFilter('flair', 'linkFlair', { fullMatch: false });
-
-		addLineDefaults([
-			!module.options.NSFWfilter.value && 'isNSFW',
-			'isSpoiler',
-			'isVisited',
-			'commentsOpened',
-			'hasExpando',
-			'score',
-		]);
 	}
-
-	function addCommentFilters() {
-		addLineDefaults([
-			'hasExpando',
-			'score',
-			'isRead',
-		]);
-	}
-
-	if (thingType === 'post') addPostFilters();
-	else if (thingType === 'comment') addCommentFilters();
 
 	if (storedFilters) _.merge(filters, storedFilters);
 	filterline.restoreState(filters);

--- a/lib/modules/filteReddit/Filter.js
+++ b/lib/modules/filteReddit/Filter.js
@@ -13,7 +13,6 @@ export class Filter {
 	id: string;
 	name: string;
 	parent: ?Filterline;
-	undeletable: boolean;
 
 	updatePromise: ?Promise<*>;
 
@@ -25,13 +24,12 @@ export class Filter {
 
 	sideEffects: { [key: string]: boolean };
 
-	constructor(id: *, BaseCase: *, name: *, conditions: * = null, state: * = null, undeletable: * = false, sideEffects: * = {}) {
+	constructor(id: *, BaseCase: *, name: *, conditions: * = null, state: * = null, sideEffects: * = {}) {
 		this.id = id;
 		this.BaseCase = BaseCase;
 		this.name = name;
 		this.state = state;
 		this.setCase(BaseCase.fromConditions(conditions));
-		this.undeletable = undeletable;
 		this.sideEffects = sideEffects;
 	}
 
@@ -61,13 +59,9 @@ export class Filter {
 		return values;
 	}
 
-	clear() {
-		if (this.undeletable) {
-			this.update(null, null);
-		} else {
-			this.state = null;
-			if (this.parent) this.parent.removeFilter(this);
-		}
+	remove() {
+		this.state = null;
+		if (this.parent) this.parent.removeFilter(this);
 	}
 
 	setCase(newCase: Case) {
@@ -99,18 +93,18 @@ export class Filter {
 
 	async updateByInputConstruction({
 		criterion,
-		clearFilter,
+		disableFilter,
 		reverseActive,
 		fromSelected,
 	}: {
 		criterion?: string,
-		clearFilter?: boolean,
+		disableFilter?: boolean,
 		reverseActive?: boolean,
 		fromSelected?: boolean,
 	}, describeOnly?: boolean = false): Promise<?string> {
-		if (clearFilter) {
-			if (describeOnly) return 'Clear filter';
-			return this.clear();
+		if (disableFilter) {
+			if (describeOnly) return 'Disable filter';
+			return this.update(null);
 		}
 
 		let state, conditions;

--- a/lib/modules/filteReddit/Filterline.js
+++ b/lib/modules/filteReddit/Filterline.js
@@ -164,7 +164,15 @@ export class Filterline {
 				const e = string.html`<div class="res-filterline-dropdown-action">${text}</div>`;
 				e.addEventListener('click', () => FilteReddit.saveFilterlineStateAsDefault(type));
 				return e;
-			})
+			}),
+			(() => {
+				const e = string.html`<div class="res-filterline-dropdown-action">Reset this Filterline</div>`;
+				e.addEventListener('click', () => {
+					this.storage.delete();
+					if (confirm('Reload page to restore default')) location.reload();
+				});
+				return e;
+			})()
 		);
 
 		const showFilterReasonCheckbox = downcast(element.querySelector('.res-filterline-show-reason input'), HTMLInputElement);
@@ -301,7 +309,7 @@ export class Filterline {
 			return {
 				key,
 				criterion: criterion.trim(),
-				clearFilter: !!modifiers.match('/'),
+				disableFilter: !!modifiers.match('/'),
 				reverseActive: !!modifiers.match('!'),
 				asNewFilter: !!modifiers.match('\\+'),
 				fromSelected: !!modifiers.match('='),
@@ -358,7 +366,7 @@ export class Filterline {
 				),
 				'',
 				'Modifiers:',
-				' / — clear the filter',
+				' / — disable the filter',
 				' ! — reverse the active state',
 				' + — create as new filter',
 				' = — use the currently selected post\'s data as criterion',
@@ -390,7 +398,6 @@ export class Filterline {
 		name,
 		conditions,
 		state,
-		undeletable,
 		sideEffects,
 	}: $Shape<NewFilterOpts>) {
 		const CaseClass = Cases.get(type);
@@ -412,7 +419,7 @@ export class Filterline {
 			if (state === undefined) state = false;
 		}
 
-		const filter = new Filter(id, CaseClass, name, conditions, state, undeletable, sideEffects);
+		const filter = new Filter(id, CaseClass, name, conditions, state, sideEffects);
 
 		if (add) {
 			this.addFilter(filter);

--- a/lib/modules/filteReddit/LineFilter.js
+++ b/lib/modules/filteReddit/LineFilter.js
@@ -50,7 +50,8 @@ export class LineFilter extends Filter {
 		});
 
 		this.element.addEventListener('contextmenu', (e: Event) => { // Right click
-			this.clear();
+			if (this.state === null) this.remove();
+			else this.update(null);
 			e.preventDefault(); // Do not show context menu
 		});
 
@@ -235,9 +236,9 @@ export class LineFilter extends Filter {
 			}).then(redraw);
 		}
 
-		addButton(head, this.undeletable ? 'Clear' : 'Remove', 'case-actions', 'clear')
-			.then(() => { this.clear(); })
-			.then(this.undeletable ? redraw : card.close.bind(card));
+		addButton(head, 'Remove', 'case-actions', 'remove')
+			.then(() => { this.remove(); })
+			.then(card.close.bind(card));
 
 		if (this.state !== null) addButton(body, 'Do nothing', 'state-actions', 'state-null').then(() => { this.update(null); }).then(redraw);
 		if (this.state !== false) addButton(body, 'Hide matching posts', 'state-actions', 'state-false').then(() => { this.update(false); }).then(redraw);

--- a/tests/Filterline.js
+++ b/tests/Filterline.js
@@ -185,11 +185,11 @@ module.exports = {
 			.keys(['!exp', browser.Keys.ENTER])
 			.waitForElementNotVisible(thing)
 
-			// clear criterion
+			// disable
 			.keys(['f'])
 			.waitForElementVisible('#keyCommandLineWidget')
 			.keys(['/exp', browser.Keys.ENTER])
-			.assert.elementNotPresent(`${filter}[type="hasExpando"].res-filterline-filter-active`)
+			.assert.elementPresent(`${filter}[type="hasExpando"]:not(.res-filterline-filter-active)`)
 
 			.end();
 	},
@@ -298,9 +298,9 @@ module.exports = {
 			.waitForElementVisible(`${filter}[type="group"]`)
 			.moveToElement(`${filter}[type="group"]`, 0, 0)
 			.pause(1000)
-			.waitForElementVisible(`${cardButton}[action="clear"]`)
-			.click(`${cardButton}[action="clear"]`)
-			.waitForElementNotVisible(`${cardButton}[action="clear"]`)
+			.waitForElementVisible(`${cardButton}[action="remove"]`)
+			.click(`${cardButton}[action="remove"]`)
+			.waitForElementNotVisible(`${cardButton}`)
 			.waitForElementVisible(nsfwPost)
 			.end();
 	},


### PR DESCRIPTION
There was really no good reason to limit deleting default filters, as they can easily be reinstated via the dropdown.

Right click will now disable filter if active, or remove filter if inactive.

Tested in browser: Chrome 69
