### PR TITLE
newCommentCount: Make more robust

### DIFF
--- a/lib/modules/commentDepth.js
+++ b/lib/modules/commentDepth.js
@@ -92,7 +92,7 @@ module.go = () => {
 		const minimumCount = parseInt(minimumComments, 10);
 		if (minimumCount) {
 			const thing = Thing.from(e.target);
-			if (thing && thing.isPost() && thing.getCommentCount() < minimumCount) return;
+			if (thing && thing.isPost() && (thing.getCommentCount() || 0) < minimumCount) return;
 		}
 
 		url.searchParams.set('depth', commentDepth);

--- a/lib/modules/filteReddit/postCases/CommentCount.js
+++ b/lib/modules/filteReddit/postCases/CommentCount.js
@@ -7,7 +7,7 @@ export class CommentCount extends Case {
 	static text = 'Comment count';
 
 	static parseCriterion(input: *) { return { op: '>=', val: parseInt(input, 10) }; }
-	static thingToCriterion(thing: *) { return String(thing.getCommentCount()); }
+	static thingToCriterion(thing: *) { return String(thing.getCommentCount() || 0); }
 
 	static defaultConditions = { op: '>', val: 0 };
 	static fields = ['post has ', { type: 'select', options: 'COMPARISON', id: 'op' }, ' ', { type: 'number', id: 'val' }, ' comments'];

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-import _ from 'lodash';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
 import {
@@ -18,6 +17,7 @@ import {
 	isPageType,
 	loggedInUser,
 	regexes,
+	string,
 	watchForThings,
 	mutex,
 	waitForEvent,
@@ -76,7 +76,6 @@ module.options = {
 	},
 };
 
-const currentId: ?string = (execRegexes.comments(location.pathname) || [])[2];
 const lastCleanStorage = Storage.wrap('RESmodules.newCommentCount.lastClean', 0);
 const entryStorage = Storage.wrapPrefix('newCommentCount.', (): {|
 	count: number,
@@ -94,23 +93,30 @@ const subscriptionStorage = Storage.wrapBlob('RESmodules.newCommentCount.subscri
 	title: string,
 |} => { throw new Error('Subscription not found'); });
 
+let subscriptionButton: ?HTMLElement;
+
 module.beforeLoad = () => {
-	updateToggleSubscriptionButton();
+	if (isPageType('comments') && module.options.showSubscribeButton.value) {
+		subscriptionButton = string.html`<span id="REScommentSubToggle" class="RESSubscriptionButton"></span>`;
+		refreshSubscriptionButton();
+	}
 
 	// Immediate in order to avoid many entry lookups
 	watchForThings(['post'], displayNewCommentCount, { immediate: true });
 };
 
 module.go = () => {
-	if (isPageType('comments')) {
-		watchForThings(['comment'], updateCurrentCommentCountFromMyComment);
-		if (module.options.showSubscribeButton.value) {
-			getToggleSubscriptionButton().appendTo('.commentarea .panestack-title');
-		}
-	} else if (isCurrentSubreddit('dashboard')) {
+	if (subscriptionButton) {
+		$('.commentarea .panestack-title').append(subscriptionButton);
+	}
+
+	if (isCurrentSubreddit('dashboard')) {
 		addDashboardFunctionality();
 	}
 };
+
+let listingThing: ?Thing;
+let currentCommentCount: ?number;
 
 module.afterLoad = () => {
 	// Avoid missing notifications by only running the check when document is visible
@@ -119,18 +125,30 @@ module.afterLoad = () => {
 	}
 
 	if (isPageType('comments')) {
-		updateCurrentEntry();
+		listingThing = Thing.from(document.querySelector('#siteTable a.comments'));
+		if (listingThing) {
+			currentCommentCount = listingThing.getCommentCount();
+			if (typeof currentCommentCount === 'number') {
+				// Save current comment count
+				setEntry(getId(listingThing), currentCommentCount);
+
+				// Increment comment count when posting comment
+				watchForThings(['comment'], updateCurrentCommentCountFromMyComment);
+			}
+		}
 	}
 
 	maybePruneOldEntries();
 };
+
+const getId = thing => thing.getFullname().split('_').slice(-1)[0];
 
 const getEntryBatched = batch(async ids => {
 	const entries = await entryStorage.getMultipleNullable(ids);
 	return ids.map(id => entries[id]);
 }, { size: Infinity, delay: 0 });
 
-function setEntry(id: string, newCommentCount) {
+function setEntry(id: string, newCommentCount: number) {
 	if (!module.options.monitorPostsVisited.value) return false;
 	if (!module.options.monitorPostsVisitedIncognito.value && isPrivateBrowsing()) return false;
 
@@ -141,13 +159,13 @@ function setEntry(id: string, newCommentCount) {
 }
 
 export async function hasEntry(thing: Thing): Promise<boolean> {
-	return !!(await getEntryBatched(thing.getFullname().split('_').slice(-1)[0]));
+	return !!(await getEntryBatched(getId(thing)));
 }
 
 export async function getNewCount(thing: Thing): Promise<?number> {
 	const currentCount = thing.getCommentCount();
 
-	const countObj = await getEntryBatched(thing.getFullname().split('_').slice(-1)[0]);
+	const countObj = await getEntryBatched(getId(thing));
 	const lastOpenedCount = countObj && countObj.count;
 
 	if (typeof currentCount !== 'number' || typeof lastOpenedCount !== 'number') return;
@@ -165,26 +183,12 @@ async function displayNewCommentCount(thing) {
 		.append(`<span class="newComments">&nbsp;(${newCount} new)</span>`);
 }
 
-function getListingThing() {
-	return Thing.checkedFrom(document.querySelector('#siteTable a.comments'));
-}
-
-/**
- * Handle updating page's comment counts
- */
-function updateCurrentEntry() {
-	if (!currentId) return;
-	setEntry(currentId, getListingThing().getCommentCount());
-}
-
 function updateCurrentCommentCountFromMyComment(thing) {
-	if (!currentId) return;
-
 	const timestamp = thing.getTimestamp();
 	const isRecent = timestamp && (Date.now() - timestamp.getTime()) < 10000;
 	const isMine = loggedInUser() === thing.getAuthor();
-	if (isRecent && isMine) {
-		setEntry(currentId, getListingThing().getCommentCount() + 1);
+	if (isRecent && isMine && listingThing && typeof currentCommentCount === 'number') {
+		setEntry(getId(listingThing), ++currentCommentCount);
 	}
 }
 
@@ -202,42 +206,35 @@ async function maybePruneOldEntries() {
 	}
 }
 
-const getToggleSubscriptionButton = _.once(() =>
-	$('<span>', {
-		id: 'REScommentSubToggle',
-		class: 'RESSubscriptionButton',
-		click: updateToggleSubscriptionButton,
-	})
-);
+const refreshSubscriptionButton = mutex(async () => {
+	const id = (execRegexes.comments(location.pathname) || [])[2];
+	const button = subscriptionButton;
+	if (!id || !button) return;
 
-const updateToggleSubscriptionButton = mutex(async () => {
-	if (!currentId) throw new Error('No currentId');
-
-	const $button = getToggleSubscriptionButton();
 	const subscriptions = await subscriptionStorage.getAll();
-	if (subscriptions.hasOwnProperty(currentId)) {
+
+	if (subscriptions.hasOwnProperty(id)) {
 		// Unsubscribe.
-		$button
+		$(button)
 			.html('<span class="res-icon">&#xF038;</span> unsubscribe')
 			.attr('title', 'stop receiving notifications')
 			.addClass('unsubscribe');
-		return waitForEvent($button.get(0), 'click').then(async () => {
-			await unsubscribe(currentId);
+		waitForEvent(button, 'click').then(async () => {
+			await unsubscribe(id);
 			Notifications.showNotification({
 				notificationID: 'newCommentCountUnsubscribe',
 				moduleID: 'newCommentCount',
 				message: 'You are now unsubscribed from this thread.',
 			}, 3000);
-		});
+		}).then(refreshSubscriptionButton);
 	} else {
 		// Subscribe.
-		$button
+		$(button)
 			.html('<span class="res-icon">&#xF03B;</span> subscribe')
 			.attr('title', 'notify me of new comments')
 			.removeClass('unsubscribe');
-		return waitForEvent($button.get(0), 'click').then(async () => {
-			const listingThing = getListingThing();
-			await subscribe(currentId, listingThing.getCommentCount(), listingThing.getPostEditTimestamp());
+		waitForEvent(button, 'click').then(async () => {
+			await subscribe(id, currentCommentCount || 0, listingThing && listingThing.getPostEditTimestamp() || 0);
 			Notifications.showNotification({
 				notificationID: 'newCommentCountSubscribe',
 				moduleID: 'newCommentCount',
@@ -250,7 +247,7 @@ const updateToggleSubscriptionButton = mutex(async () => {
 					<p><a href="/r/Dashboard#newCommentsContents">Manage subscriptions</a></p>
 				`,
 			}, 5000);
-		});
+		}).then(refreshSubscriptionButton);
 	}
 });
 

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -401,12 +401,12 @@ export class Thing {
 		return text.replace(/[\(\)\s]/g, '');
 	}
 
-	getCommentCount(): number {
+	getCommentCount(): ?number {
 		const element = this.getCommentCountElement();
 		return element && parseInt((/\d+/).exec(
 			element.textContent ||
 			element.getAttribute('data-text') // In case noCtrlF is applied
-		), 10) || 0;
+		), 10);
 	}
 
 	getCommentCountElement(): ?HTMLElement {


### PR DESCRIPTION
Keeps track of the comment count locally in order to avoid:
 - Don't updating the entry to 0 when it is not found, as may happen when noCtlF is applied
 - Commenting multiple times causing false-positive subscription notification
 
Relevant issue: https://www.reddit.com/r/RESissues/comments/98ezk5/bug_comment_count_broken_when_no_ctrlf_is_on/
Tested in browser: Chrome 69
