### PR TITLE
 Makes video timeline control easier to click/use

### DIFF
--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -375,8 +375,9 @@ img {
 
 		.video-advanced-progress {
 			width: 100%;
-			height: 2px;
-			background-color: rgba(256, 256, 256, .06);
+			height: 16px;
+			padding: 7px 0;
+			background-image: linear-gradient(rgba(0, 0, 0, 0) 0%, rgba(255, 255, 255, 0) 43.75%, rgba(255, 255, 255, 0.15) 43.75%, rgba(255, 255, 255, 0.15) 56.25%, rgba(255, 255, 255, 0) 56.25%, rgba(0, 0, 0, 0) 100%);
 			box-sizing: border-box;
 
 			.video-advanced-position-thumb {


### PR DESCRIPTION
I frequently misclicked when trying to move the timeline position on desktop, as it's only a 2px area that you have to get over. So I adjusted it so that the clickable space is larger, but still appears as a 2px bar. 

I also made the timeline slightly more visible.

The adjustments shouldn't interfere with any of the other controls or features of the video player. 