### PR TITLE
userTagger: Use Filterline to hide ignored users

### DIFF
--- a/lib/core/migrate/migrate.js
+++ b/lib/core/migrate/migrate.js
@@ -702,15 +702,12 @@ const migrations = [
 			if (customFiltersC)	await Options.set('filteReddit', 'customFiltersC', customFiltersC.value);
 		},
 	}, {
-		versionNumber: '5.13.3-userTagger-ignored-separate',
+		versionNumber: '5.13.3-userTagger-ignored-to-filteReddit',
 		async go() {
-			const f = await Storage.wrapPrefix('tag.', (): any => ({})).getAll();
-			const ignoredUsers = {};
-			for (const [key, value] of Object.entries(f)) {
-				const { ignored } = value;
-				if (ignored) ignoredUsers[key] = true;
-			}
-			await Storage.set('RESmodules.userTagger.ignoredUsers', ignoredUsers);
+			const ignoredUsers = Object.entries(await Storage.wrapPrefix('tag.', (): any => ({})).getAll())
+				.filter(([, { ignored }]) => ignored)
+				.map(([username]) => [username]);
+			await Options.set('filteReddit', 'users', ignoredUsers);
 		},
 	},
 

--- a/lib/core/migrate/migrate.js
+++ b/lib/core/migrate/migrate.js
@@ -701,6 +701,17 @@ const migrations = [
 			if (customFiltersP)	await Options.set('filteReddit', 'customFiltersP', customFiltersP.value);
 			if (customFiltersC)	await Options.set('filteReddit', 'customFiltersC', customFiltersC.value);
 		},
+	}, {
+		versionNumber: '5.13.3-userTagger-ignored-separate',
+		async go() {
+			const f = await Storage.wrapPrefix('tag.', (): any => ({})).getAll();
+			const ignoredUsers = {};
+			for (const [key, value] of Object.entries(f)) {
+				const { ignored } = value;
+				if (ignored) ignoredUsers[key] = true;
+			}
+			await Storage.set('RESmodules.userTagger.ignoredUsers', ignoredUsers);
+		},
 	},
 
 ]; // ^^ Add new migrations ^^

--- a/lib/css/modules/_filteReddit.scss
+++ b/lib/css/modules/_filteReddit.scss
@@ -60,6 +60,10 @@ body.hideOver18 {
 	background-color: rgba(255, 255, 255, .9);
 	clear: left;
 
+	&[hidden] {
+		display: none;
+	}
+
 	.comments-page & {
 		margin-left: 10px;
 	}
@@ -91,10 +95,6 @@ body.hideOver18 {
 	font: normal 12px sans-serif, arial;
 	color: gray;
 
-	body:not(.res-filteReddit-show-filterline) & {
-		display: none;
-	}
-
 	&-preamble::before {
 		@extend %res-filterline-icon;
 		margin: 0 2px;
@@ -110,6 +110,8 @@ body.hideOver18 {
 		margin: 0 3px;
 		border-bottom: 1px solid #efefef;
 		padding-bottom: 1px;
+
+		&-hidden { display: none; }
 
 		&:hover { border-bottom: 1px solid #bfbfbf; }
 

--- a/lib/css/modules/_userTagger.scss
+++ b/lib/css/modules/_userTagger.scss
@@ -1,3 +1,17 @@
+.userTagger-dialog-head {
+	display: flex;
+
+	span { margin-right: 3px; }
+
+	.res-usertag-ignore {
+		margin-left: auto;
+		margin-right: 40px; // Don't overlap close button
+
+		// The icons are sufficient to toggle ignore
+		.toggleThumb { display: none; }
+	}
+}
+
 #userTaggerToolTip {
 	.fieldPair-label {
 		width: 85px;
@@ -44,48 +58,6 @@
 		margin-bottom: 0;
 		display: flex;
 		align-items: center;
-	}
-}
-
-.res-ignored-message {
-	color: rgb(170, 170, 170);
-	cursor: default;
-
-	.comment & {
-		line-height: 2;
-	}
-
-	.res-icon {
-		font-size: inherit;
-	}
-}
-
-.res-ignored-content {
-	&.link {
-		a.title,
-		.expando-button,
-		.expando {
-			display: none !important;
-		}
-
-		.thumbnail {
-			visibility: hidden !important;
-		}
-	}
-
-	&.comment > .entry {
-		.md {
-			display: none !important;
-		}
-	}
-
-	&.search-result {
-		a.search-title,
-		.search-expando,
-		.search-expando-button,
-		.search-result-footer {
-			display: none !important;
-		}
 	}
 }
 

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -47,10 +47,6 @@ module.category = 'subredditsCategory';
 module.description = 'filteRedditDesc';
 module.keywords = ['filterreddit'];
 module.options = {
-	// any configurable options you have go here...
-	// options must have a type and a value..
-	// valid types are: text, boolean (if boolean, value must be true or false)
-	// for example:
 	NSFWfilter: {
 		type: 'boolean',
 		value: false,
@@ -177,6 +173,18 @@ module.options = {
 		callback() {
 			reconcileNativeFilters({ warnNotLoggedIn: true });
 		},
+	},
+	users: {
+		type: 'table',
+		addRowText: 'filteRedditAddFilter',
+		fields: [{
+			key: 'username',
+			name: 'filteRedditUsername',
+			type: 'text',
+		}],
+		value: [],
+		description: 'filteRedditUsersDesc',
+		title: 'filteRedditUsersTitle',
 	},
 	domains: {
 		type: 'table',
@@ -560,6 +568,72 @@ function makeFilterlineInteractable() {
 	if (visible) insertFilterline();
 }
 
+class ListFilter {
+	externalKey: string;
+	get list() { return module.options[this.externalKey].value; }
+	filter: *;
+
+	constructor(externalKey: $Keys<typeof module.options>) {
+		this.externalKey = externalKey;
+	}
+
+	initialize(caseType: string, additionalCriteria: *) {
+		const _listFilter = this; // eslint-disable-line consistent-this
+		const sources = new Map();
+
+		const getConditions = () => {
+			sources.clear();
+			return Cases.resolveGroup(Cases.getGroup('any', this.list.map(v => {
+				const c = getStringMatchConditions(v, caseType, additionalCriteria);
+				sources.set(c, v);
+				return c;
+			})));
+		};
+
+		this.filter = addExternalFilter(this.externalKey, i18n(module.options[this.externalKey].title), getConditions, class extends ExternalFilter {
+			async getMatchingEntry(thing) {
+				return sources.get(
+					await asyncFind(sources.keys(), v => Case.fromConditions(v).evaluate(thing))
+				);
+			}
+
+			removeEntry(entry) { _listFilter.toggleEntry(entry, false); }
+		});
+	}
+
+	// Note this is only a basic search for the string; `getMatchingEntry` also tests regexes
+	findEntry(matchString: string): * {
+		return this.list.find(([str]) => str.toLowerCase() === matchString.toLowerCase());
+	}
+
+	toggleEntry(entry: *, newState: boolean = !this.list.includes(entry)) {
+		if (newState) {
+			if (!this.list.includes(entry)) this.list.push(entry);
+		} else {
+			_.pull(this.list, entry);
+		}
+
+		Options.set(module, this.externalKey, this.list);
+		if (this.filter) this.filter.update(undefined, null);
+	}
+
+	includesString(matchString: string): boolean {
+		return !!this.findEntry(matchString);
+	}
+
+	toggleString(matchString: string, newState?: boolean = !this.includesString(matchString)) {
+		this.toggleEntry(this.findEntry(matchString) || [matchString], newState);
+	}
+}
+
+export const listFilters = {
+	users: new ListFilter('users'),
+	subreddits: new ListFilter('subreddits'),
+	keywords: new ListFilter('keywords'),
+	domains: new ListFilter('domains'),
+	flair: new ListFilter('flair'),
+};
+
 export function addExternalFilter(id: string, name: string, getConditions: () => *, Filter: Class<ExternalFilter> = ExternalFilter) {
 	const cased = Cases.createAdHoc(id, getConditions, 'external', thingType);
 	return filterline.createFilter({ Filter, id, name, type: cased.type, state: false, add: true, save: false });
@@ -587,37 +661,13 @@ function populateFromOptions() {
 		});
 	}
 
-	function addListFilter(externalKey, caseType, additionalCriteria) {
-		const list = module.options[externalKey].value;
-		const sources = new Map();
-
-		function getConditions() {
-			sources.clear();
-			return Cases.resolveGroup(Cases.getGroup('any', list.map(v => {
-				const c = getStringMatchConditions(v, caseType, additionalCriteria);
-				sources.set(c, v);
-				return c;
-			})));
-		}
-
-		addExternalFilter(externalKey, i18n(module.options[externalKey].title), getConditions, class extends ExternalFilter {
-			async getMatchingEntry(thing) {
-				return sources.get(
-					await asyncFind(sources.keys(), v => Case.fromConditions(v).evaluate(thing))
-				);
-			}
-
-			removeEntry(entry) {
-				const newValueArray = _.pull(list, entry);
-				Options.set(module, externalKey, newValueArray);
-				this.update(this.state, null); // `null` in order to regenerate case from `getConditions`
-			}
-		});
+	if (!isPageType('profile')) { // Don't ignore users on profile pages
+		listFilters.users.initialize('username');
 	}
 
 	if (thingType === 'post') {
-		addListFilter('keywords', 'postTitle');
-		addListFilter('domains', 'domain', { fullMatch: false });
+		listFilters.keywords.initialize('postTitle');
+		listFilters.domains.initialize('domain', { fullMatch: false });
 		if (
 			module.options.filterSubredditsFrom.value === 'everywhere' ||
 			module.options.filterSubredditsFrom.value === 'everywhere-except-subreddit' && !currentSubreddit() ||
@@ -625,9 +675,9 @@ function populateFromOptions() {
 			currentDomain() ||
 			isCurrentMultireddit('me/f/all')
 		) {
-			addListFilter('subreddits', 'subreddit');
+			listFilters.subreddits.initialize('subreddit');
 		}
-		addListFilter('flair', 'linkFlair', { fullMatch: false });
+		listFilters.flair.initialize('linkFlair', { fullMatch: false });
 	}
 }
 
@@ -720,36 +770,6 @@ function getStringMatchConditions(source, caseType, additionalCriteria) {
 			...additionalCriteria,
 		}]) || null,
 	].filter(Boolean));
-}
-
-/**
- * @param {string} subreddit
- * @returns {boolean} Whether the subreddit was added (true) or removed (false) from the filter list.
- */
-export function toggleFilter(subreddit: string): boolean {
-	subreddit = subreddit.toLowerCase();
-
-	const filteredReddits = module.options.subreddits.value || [];
-	const subredditIndex = filteredReddits.findIndex(reddit => reddit && reddit[0].toLowerCase() === subreddit);
-
-	let message;
-	if (subredditIndex !== -1) {
-		filteredReddits.splice(subredditIndex, 1);
-		message = `No longer filtering submissions from /r/${subreddit}.`;
-	} else {
-		filteredReddits.push([subreddit, 'everywhere', '']);
-		message = `Submissions from /r/${subreddit} will be hidden from listings.`;
-	}
-
-	Notifications.showNotification({
-		moduleID: 'filteReddit',
-		notificationID: 'filterSubreddit',
-		message,
-	});
-
-	Options.set(module, 'subreddits', filteredReddits);
-
-	return (subredditIndex === -1);
 }
 
 const regexRegex = /^\/(.*)\/([gim]+)?$/;
@@ -951,7 +971,7 @@ function registerSubredditFilterCommand() {
 		(cmd, val) => {
 			const subreddit = getSubreddit(val);
 			if (!subreddit) return 'no subreddit specified or post selected';
-			toggleFilter(subreddit);
+			listFilters.subreddits.toggleString(subreddit);
 		}
 	);
 }

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -398,7 +398,7 @@ const customFilterVariant = thingType === 'post' ? 'customFiltersP' : 'customFil
 
 const createStateFromTypes = types => (
 	types.reduce((acc, v, i) => {
-		if (v) acc[`~${i}`] = { type: v, state: null };
+		if (v) acc[`!${i}`] = { type: v, state: null };
 		return acc;
 	}, {})
 );
@@ -440,40 +440,48 @@ if (thingType === 'comment') {
 async function getDefaultFilters() {
 	for (const { storage } of defaultFilters) {
 		const filters = await storage.get(); // eslint-disable-line no-await-in-loop
-		if (filters) return { filters };
+		if (filters) return filters;
 	}
 }
 
 const initialFilterlineState = reifyPromise((async () => {
-	const specific = await filterlineStorage.get();
-	if (Object.keys(specific).length) return specific;
-	return getDefaultFilters();
+	let { filters, visible } = await filterlineStorage.get(); // eslint-disable-line prefer-const
+	if (!filters || !Object.values(filters).length) filters = await getDefaultFilters();
+	return { filters, visible };
 })());
 
 let nsfwToggle;
+let filterline: Filterline;
+let visible: boolean;
 
-module.beforeLoad = fastAsync(function*() {
+module.beforeLoad = fastAsync(function*()	{
 	updateNsfwBodyClass(module.options.NSFWfilter.value);
-
 	nsfwToggle = new CustomToggles.Toggle('nsfwMode', i18n('nsfwSwitchToggleText'), module.options.NSFWfilter.value);
 	nsfwToggle.onToggle(() => { Options.set(module, 'NSFWfilter', nsfwToggle.enabled); });
 	nsfwToggle.onStateChange(() => { updateNsfwBodyClass(nsfwToggle.enabled); });
 	nsfwToggle.addCLI('nsfw');
-
-	// start initializing filterline early
-	createFilterline(yield initialFilterlineState.get());
-
 	watchForThings(['post'], updateNsfwThingClass, { immediate: true });
-	watchForThings([thingType], registerThing, { immediate: true });
-});
 
+	Cases.populatePrimitives(['browse', thingType]);
+	filterline = new Filterline(filterlineStorage, thingType);
+
+	const state = yield initialFilterlineState.get();
+	filterline.restoreState(state.filters);
+	populateFromOptions();
+
+	watchForThings([thingType], registerThing, { immediate: true });
+
+	// This must be done after `restoreState` and `populateFromOptions`
+	({ visible = module.options.showFilterline.value || filterline.hasActiveLineFilters() } = state);
+	if (visible) BodyClasses.add('res-filteReddit-filterline-pad-until-ready');
+});
 
 module.go = () => {
 	if (module.options.NSFWQuickToggle.value) {
 		nsfwToggle.addMenuItem(i18n('nsfwSwitchToggleTitle'));
 	}
 
-	createFilterline().go();
+	makeFilterlineInteractable();
 
 	registerSubredditFilterCommand();
 };
@@ -486,39 +494,97 @@ function registerThing(thing) {
 	) return;
 
 	// Returns a promise which resolves when initial filtering is done
-	return createFilterline().filterline.addThing(thing);
+	return filterline.addThing(thing);
 }
 
-const createFilterline = _.once(({
-	filters: storedFilters = {},
-	visible: initialVisibility = module.options.showFilterline.value,
-} = {}) => {
-	Cases.populatePrimitives(['browse', thingType]);
-	const filterline = new Filterline(filterlineStorage, thingType);
+function makeFilterlineInteractable() {
+	const insertFilterline = _.once(() => {
+		filterline.createElement();
 
-	const filters = {};
+		if (isPageType('comments')) {
+			document.querySelector('.comments-page .nestedlisting').before(filterline.element);
+		} else {
+			document.querySelector('#siteTable, .search-result-listing').before(filterline.element);
+		}
 
-	function addExternalFilter(key, name, getConditions, Filter, source) {
-		const cased = Cases.createAdHoc(key, name, getConditions, 'external', thingType, source);
-		filters[key] = { Filter, type: cased.type, state: false };
-	}
+		BodyClasses.remove('res-filteReddit-filterline-pad-until-ready');
 
+		RESTips.addFeatureTip('filterlineVisible', { ...featureTips.filterlineVisible, attachTo: filterline.element });
+	});
+
+	const filterlineTab = CreateElement.tabMenuItem({
+		text: '',
+		title: 'Toggle Filterline visibility',
+		className: 'res-toggle-filterline-visibility',
+		checked: visible,
+	});
+
+	filterlineTab.addEventListener('change', ({ detail: newVisibilityState }: any) => {
+		visible = newVisibilityState;
+
+		if (visible) {
+			insertFilterline();
+			scrollToElement(filterline.element, null, { scrollStyle: 'legacy' });
+		}
+
+		if (filterline.element) filterline.element.hidden = !visible;
+		filterlineStorage.patch({ visible });
+	});
+
+	const ensureVisible = () => { if (!visible) filterlineTab.click(); };
+
+	const { getTip, executeCommand } = filterline.getCLI();
+	CommandLine.registerCommand(
+		/(fl|filterline)/,
+		'fl - modify Filterline',
+		(cmd, val) => getTip(val),
+		(cmd, val) => { ensureVisible(); executeCommand(val); },
+	);
+
+	CommandLine.registerCommand(
+		/fp/,
+		'fp - toggle filtering',
+		() => 'Toggle filtering',
+		() => { ensureVisible(); filterline.poweredElement.click(); },
+	);
+
+	RESTips.addFeatureTip('filterline', {
+		...featureTips.filterline,
+		attachTo: filterlineTab,
+		continuation: () => {
+			ensureVisible();
+			return 'filterlineVisible';
+		},
+	});
+
+	if (visible) insertFilterline();
+}
+
+export function addExternalFilter(id: string, name: string, getConditions: () => *, Filter: Class<ExternalFilter> = ExternalFilter) {
+	const cased = Cases.createAdHoc(id, getConditions, 'external', thingType);
+	return filterline.createFilter({ Filter, id, name, type: cased.type, state: false, add: true, save: false });
+}
+
+function populateFromOptions() {
 	const customFilters = _.groupBy(
 		module.options[customFilterVariant].value,
 		({ opts: { ondemand } = {} }) => ondemand ? 'ondemand' : 'always'
 	);
 
 	if (customFilters.ondemand) {
-		customFilters.ondemand.forEach(v => addOndemandCase(v, true));
+		const cases = customFilters.ondemand.map(v => addOndemandCase(v, true));
+		filterline.resumeDeferredTypes(cases.map(({ type }) => type));
 	}
 
 	// Make customFilter(C|P) so that the settings link is available
-	addExternalFilter(customFilterVariant, i18n(module.options[customFilterVariant].title), () => ({ type: 'false' }), ExternalFilter);
+	addExternalFilter(customFilterVariant, i18n(module.options[customFilterVariant].title), () => ({ type: 'false' }));
 
 	for (const customFilter of (customFilters.always || [])) {
 		const conditions = Cases.resolveGroup(customFilter.body);
 		if (!Cases.isUseful(conditions.type)) continue;
-		addExternalFilter(customFilter.id, (customFilter.opts || {}).name, () => conditions, ExternalFilter, customFilter);
+		addExternalFilter(customFilter.id, (customFilter.opts || {}).name, () => conditions, class extends ExternalFilter {
+			sideEffects = thingType === 'comment' ? { propagate: customFilter.opts.propagate } : {};
+		});
 	}
 
 	function addListFilter(externalKey, caseType, additionalCriteria) {
@@ -534,7 +600,7 @@ const createFilterline = _.once(({
 			})));
 		}
 
-		const Filter = class ExternalFilterList extends ExternalFilter {
+		addExternalFilter(externalKey, i18n(module.options[externalKey].title), getConditions, class extends ExternalFilter {
 			async getMatchingEntry(thing) {
 				return sources.get(
 					await asyncFind(sources.keys(), v => Case.fromConditions(v).evaluate(thing))
@@ -546,9 +612,7 @@ const createFilterline = _.once(({
 				Options.set(module, externalKey, newValueArray);
 				this.update(this.state, null); // `null` in order to regenerate case from `getConditions`
 			}
-		};
-
-		addExternalFilter(externalKey, i18n(module.options[externalKey].title), getConditions, Filter);
+		});
 	}
 
 	if (thingType === 'post') {
@@ -565,108 +629,13 @@ const createFilterline = _.once(({
 		}
 		addListFilter('flair', 'linkFlair', { fullMatch: false });
 	}
-
-	if (storedFilters) _.merge(filters, storedFilters);
-	filterline.restoreState(filters);
-
-	let visible = initialVisibility || filterline.hasActiveLineFilters();
-
-	if (visible) {
-		BodyClasses.add('res-filteReddit-filterline-pad-until-ready');
-	}
-
-	function go() {
-		const insertFilterline = _.once(() => {
-			filterline.createElement();
-
-			if (isPageType('comments')) {
-				document.querySelector('.comments-page .nestedlisting').before(filterline.element);
-			} else {
-				document.querySelector('#siteTable, .search-result-listing').before(filterline.element);
-			}
-
-			BodyClasses.remove('res-filteReddit-filterline-pad-until-ready');
-		});
-
-		const filterlineTab = CreateElement.tabMenuItem({
-			text: '',
-			title: 'Toggle Filterline visibility',
-			className: 'res-toggle-filterline-visibility',
-			checked: visible,
-		});
-
-		filterlineTab.addEventListener('change', ({ detail: newVisibilityState }: any) => {
-			toggleVisibility(newVisibilityState);
-			if (visible) scrollToElement(filterline.element, null, { scrollStyle: 'legacy' });
-		});
-
-		const ensureVisible = () => { if (!visible) filterlineTab.click(); };
-
-		const { getTip, executeCommand } = filterline.getCLI();
-		CommandLine.registerCommand(
-			/(fl|filterline)/,
-			'fl - modify Filterline',
-			(cmd, val) => getTip(val),
-			(cmd, val) => { ensureVisible(); executeCommand(val); },
-		);
-
-		CommandLine.registerCommand(
-			/fp/,
-			'fp - toggle filtering',
-			() => 'Toggle filtering',
-			() => { ensureVisible(); filterline.poweredElement.click(); },
-		);
-
-		function toggleVisibility(newVisibilityState) {
-			if (newVisibilityState) {
-				insertFilterline();
-				filterlineTab.removeAttribute('aftercontent');
-				RESTips.addFeatureTip('filterlineVisible', { ...featureTips.filterlineVisible, attachTo: filterline.element });
-			} else if (filterline.hasActiveLineFilters()) {
-				filterlineTab.setAttribute('aftercontent', ' (active)');
-			}
-
-			BodyClasses.toggle(newVisibilityState, 'res-filteReddit-show-filterline');
-
-			if (visible !== newVisibilityState) {
-				filterlineStorage.patch({ visible: newVisibilityState });
-				visible = newVisibilityState;
-			}
-		}
-
-		RESTips.addFeatureTip('filterline', {
-			...featureTips.filterline,
-			attachTo: filterlineTab,
-			continuation: () => {
-				ensureVisible();
-				return 'filterlineVisible';
-			},
-		});
-
-		toggleVisibility(visible);
-	}
-
-	return { filterline, go };
-});
-
-function updateNsfwThingClass(thing) {
-	if (thing.isNSFW()) {
-		if (allowNSFW(thing.getSubreddit(), currentSubreddit())) {
-			thing.element.classList.add('allowOver18');
-		} else if (module.options.NSFWfilter.value) {
-			if (!thing.element.classList.contains('over18')) {
-				// backfill for new post layout
-				thing.element.classList.add('over18');
-			}
-		}
-	}
 }
 
 export function addOndemandCase(customFilter: BuilderRootValue, onlyUseful: boolean = false) {
 	const getConditions = () => Cases.resolveGroup(customFilter.body);
 
 	if (!onlyUseful || Cases.isUseful(getConditions().type)) {
-		return Cases.createAdHoc(customFilter.id, (customFilter.opts || {}).name, getConditions, 'ondemand', thingType, customFilter);
+		return Cases.createAdHoc(customFilter.id, getConditions, 'ondemand', thingType, customFilter);
 	} else {
 		return Cases.Inert;
 	}
@@ -949,6 +918,17 @@ function allowNSFW(postSubreddit, currSubreddit = currentSubreddit()) {
 		}
 	}
 	return false;
+}
+
+function updateNsfwThingClass(thing) {
+	if (thing.isNSFW()) {
+		if (allowNSFW(thing.getSubreddit(), currentSubreddit())) {
+			thing.element.classList.add('allowOver18');
+		}
+
+		// backfill for new post layout
+		thing.element.classList.add('over18');
+	}
 }
 
 function updateNsfwBodyClass(filterOn) {

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -337,14 +337,6 @@ module.include = [
 	'commentsLinklist',
 	'search',
 ];
-module.exclude = [
-	/^\/over18\b/i,
-];
-
-module.shouldRun = () => !(
-	module.options.excludeModqueue.value && isPageType('modqueue') ||
-	module.options.excludeUserPages.value && isPageType('profile')
-);
 
 const featureTips = {
 	filterline: {
@@ -476,6 +468,11 @@ module.beforeLoad = fastAsync(function*()	{
 	const state = yield initialFilterlineState.get();
 	filterline.restoreState(state.filters);
 	populateFromOptions();
+
+	if (
+		module.options.excludeModqueue.value && isPageType('modqueue') ||
+		module.options.excludeUserPages.value && isPageType('profile')
+	) filterline.togglePowered(false);
 
 	watchForThings([thingType], registerThing, { immediate: true });
 

--- a/lib/modules/filteReddit/Case.js
+++ b/lib/modules/filteReddit/Case.js
@@ -116,6 +116,7 @@ export class Case {
 	}
 
 	isValid(): boolean { return true; }
+	isEvaluatable() { return !(this instanceof Cases.Inert || this.constructor.disabled); }
 
 	hasType(type: string): boolean { return this.constructor.type === type; }
 	conditions: BuilderValue;

--- a/lib/modules/filteReddit/Filter.js
+++ b/lib/modules/filteReddit/Filter.js
@@ -22,7 +22,7 @@ export class Filter {
 
 	element: HTMLElement;
 
-	sideEffects: { [key: string]: boolean };
+	sideEffects: { [key: string]: boolean } = {};
 
 	constructor(id: *, BaseCase: *, name: *, conditions: * = null, state: * = null, sideEffects: * = {}) {
 		this.id = id;
@@ -30,7 +30,7 @@ export class Filter {
 		this.name = name;
 		this.state = state;
 		this.setCase(BaseCase.fromConditions(conditions));
-		this.sideEffects = sideEffects;
+		Object.assign(this.sideEffects, sideEffects);
 	}
 
 	createElement() {}
@@ -66,10 +66,10 @@ export class Filter {
 
 	setCase(newCase: Case) {
 		this.case = newCase;
-		this.case.observe(this);
+		if (this.case.isEvaluatable()) this.case.observe(this);
 	}
 
-	update(state: *, conditions?: *, describeOnly: boolean = false) {
+	update(state: ?*, conditions?: *, describeOnly: boolean = false) {
 		const cased = conditions === undefined ? this.case : this.BaseCase.fromConditions(conditions, true);
 		if (!cased.isValid()) throw new Error('Invalid conditions');
 
@@ -77,7 +77,7 @@ export class Filter {
 			return `Show only posts which matches "${this.getStateText(state, cased)}"`;
 		}
 
-		this.state = state;
+		if (state !== undefined) this.state = state;
 		this.setCase(cased);
 		this.refresh();
 	}
@@ -123,6 +123,8 @@ export class Filter {
 	}
 
 	matches = fastAsync(function*(thing: Thing) {
+		if (!this.case.isEvaluatable()) return false;
+
 		try {
 			const result = yield this.case.evaluate(thing);
 			return result === null ? false : this.state === !result;

--- a/lib/modules/filteReddit/Filterline.js
+++ b/lib/modules/filteReddit/Filterline.js
@@ -65,12 +65,19 @@ export class Filterline {
 		return !!this.things.size;
 	}
 
+	isPowered() { return !document.body.classList.contains('res-filters-disabled'); }
+
+	togglePowered = (powered: boolean = !this.isPowered()) => {
+		document.body.classList.toggle('res-filters-disabled', !powered);
+		this.poweredElement.checked = powered;
+	}
+
 	createElement() {
 		const element = this.element = string.html`
 			<div class="res-filterline">
 				<div class="res-filterline-preamble"></div>
 				<div class="res-filterline-filters">
-					<input type="checkbox" checked class="res-filterline-toggle-powered" title="Stop filtering temporarily"></input>
+					<input type="checkbox" ${this.isPowered() && 'checked'} class="res-filterline-toggle-powered" title="Stop filtering temporarily"></input>
 				</div>
 			</div>
 		`;
@@ -82,9 +89,7 @@ export class Filterline {
 		waitForEvent(this.preamble, 'mouseenter', 'click').then(() => this.createDropdown());
 
 		this.poweredElement = downcast(element.querySelector('.res-filterline-toggle-powered'), HTMLInputElement);
-		this.poweredElement.addEventListener('change', () => {
-			document.body.classList.toggle('res-filters-disabled', !this.poweredElement.checked);
-		});
+		this.poweredElement.addEventListener('change', () => { this.togglePowered(); });
 	}
 
 	addFilterElements(filters: Filter[]) {

--- a/lib/modules/filteReddit/Filterline.js
+++ b/lib/modules/filteReddit/Filterline.js
@@ -42,9 +42,8 @@ export class Filterline {
 	thingType: string;
 
 	storage: *;
-	filters: Filter[] = []; // Non-inert filters
+	filters: Filter[] = [];
 	sortedFilters: Filter[] = []; // Filters sorted by slowness
-	inertFilters: Filter[] = [];
 
 	hiddenThings: Set<Thing> = new Set();
 	showFilterReason: boolean = false;
@@ -90,7 +89,7 @@ export class Filterline {
 
 	addFilterElements(filters: Filter[]) {
 		for (const filter of filters) {
-			if (filter instanceof ExternalFilter) continue;
+			if (filter instanceof ExternalFilter) continue; // ExternalFilter elements are created when dropdown is bulit
 			filter.createElement();
 			this.filterContainer.appendChild(filter.element);
 		}
@@ -226,7 +225,7 @@ export class Filterline {
 				filter = downcast(this.createFilter({ type: CaseClass.type, add: true, ...newOpts }), LineFilter);
 			}
 
-			filter.updateByInputConstruction({ fromSelected });
+			if (fromSelected) filter.updateByInputConstruction({ fromSelected });
 			filter.showInfocard(true);
 		});
 
@@ -282,22 +281,49 @@ export class Filterline {
 		);
 	}
 
+	deferredFilters: { [id: string]: * } = {};
+
+	resumeDeferredTypes(types: Array<string>) {
+		Object.entries(this.deferredFilters)
+			.filter(([, { type }]) => types.includes(type))
+			.forEach(([id]) => this.createFilterFromStateValues(id));
+	}
+
 	restoreState(filters: *) {
 		for (const [id, opts] of Object.entries(filters)) {
 			try {
-				this.createFilter({ ...opts, id, add: true, save: false });
+				if (opts.type === 'inert') throw new Error('Requested inert filter. This state is likely due to a bug. Ignoring.');
+
+				const filter = this.getFilter(id);
+				if (filter) throw new Error(`Filter with id ${id} already exists`);
+
+				if (
+					Cases.has(opts.type) &&
+					// External filter needs a specific variant of `Filter`
+					!(Cases.get(opts.type).variant === 'external')
+				) {
+					this.createFilterFromStateValues(id, opts);
+				} else {
+					this.deferredFilters[id] = opts;
+				}
 			} catch (e) {
-				console.error('Could not create filter', opts, 'deleting', e);
+				console.error('Could not create filter', id, opts);
 				this.storage.deletePath('filters', id);
 			}
 		}
 	}
 
+	createFilterFromStateValues(id: *, opts: *) {
+		const deferredOpts = this.deferredFilters[id];
+		delete this.deferredFilters[id];
+		return this.createFilter({ id, ...opts, ...deferredOpts, add: true, save: false });
+	}
+
 	save = idleThrottle(async () => {
-		const filters = [...this.filters, ...this.inertFilters].reduce((acc, v) => {
+		const filters = this.filters.reduce((acc, v) => {
 			acc[v.id] = v.getSaveValues();
 			return acc;
-		}, {});
+		}, { ...this.deferredFilters });
 		await this.storage.deletePath('filters');
 		await this.storage.patch({ filters });
 	});
@@ -388,35 +414,28 @@ export class Filterline {
 		return { getTip: getTip.bind(this), executeCommand: executeCommand.bind(this) };
 	}
 
-	createFilter({
-		Filter = LineFilter,
-		id = `~${performance.timing.navigationStart + performance.now()}`, // timestamp, so that filters will restored in the same order as they initially were created
-		add = false,
-		save = true,
-		type,
-		criterion,
-		name,
-		conditions,
-		state,
-		sideEffects,
-	}: $Shape<NewFilterOpts>) {
+	createFilter(opts: $Shape<NewFilterOpts>) {
+		const {
+			Filter = LineFilter,
+			id = `~${performance.timing.navigationStart + performance.now()}`, // timestamp, so that filters will restored in the same order as they initially were created
+			add = false,
+			save = true,
+			type,
+			criterion,
+			name,
+			state,
+			sideEffects,
+		} = opts;
+		let { conditions } = opts;
+
+		if (this.deferredFilters.hasOwnProperty(id)) return this.createFilterFromStateValues(id, opts);
+
 		const CaseClass = Cases.get(type);
 		if (CaseClass.unique && this.getFiltersOfCase(CaseClass).length) throw new Error('Cannot create new instances of unique filters');
 
 		if (!conditions && criterion) {
+			// Legacy; `criterion` is no longer saved to storage
 			conditions = CaseClass.criterionToConditions(criterion);
-		}
-
-		const externOpts = CaseClass._customFilter && CaseClass._customFilter.opts;
-		if (externOpts) {
-			if (!name) ({ name } = externOpts);
-			const { propagate } = externOpts;
-			if (!sideEffects && typeof propagate === 'boolean') sideEffects = { propagate };
-		}
-
-		if (CaseClass.variant === 'ondemand') {
-			// customFilters hides posts that don't match; keep on-demand consistent
-			if (state === undefined) state = false;
 		}
 
 		const filter = new Filter(id, CaseClass, name, conditions, state, sideEffects);
@@ -430,11 +449,6 @@ export class Filterline {
 	}
 
 	addFilter(filter: Filter) {
-		if (filter.BaseCase === Cases.Inert || filter.BaseCase.disabled) {
-			this.inertFilters.push(filter);
-			return;
-		}
-
 		filter.setParent(this);
 
 		this.filters.push(filter);
@@ -455,6 +469,10 @@ export class Filterline {
 		_.pull(this.filters, filter);
 		_.pull(this.sortedFilters, filter);
 		this.save();
+	}
+
+	getFilter(id: string): ?Filter {
+		return this.filters.find(filter => filter.id === id);
 	}
 
 	getActiveFilters() {

--- a/lib/modules/filteReddit/LineFilter.js
+++ b/lib/modules/filteReddit/LineFilter.js
@@ -20,6 +20,22 @@ export class LineFilter extends Filter {
 	initialConditions: *;
 	inner: HTMLElement;
 
+	constructor(id: *, BaseCase: *, name: *, conditions: * = null, state: * = null, sideEffects: * = {}) {
+		if (BaseCase.variant === 'ondemand') {
+			// customFilters hides posts that don't match; keep on-demand consistent
+			if (state === undefined) state = false;
+
+			const externOpts = BaseCase._customFilter && BaseCase._customFilter.opts;
+			if (externOpts) {
+				if (!name) ({ name } = externOpts);
+				const { propagate } = externOpts;
+				if (!sideEffects.hasOwnProperty('propagate')) Object.assign(sideEffects, { propagate });
+			}
+		}
+
+		super(id, BaseCase, name, conditions, state, sideEffects);
+	}
+
 	update(state: * = this.state, conditions?: *, describeOnly: *) {
 		if (this.BaseCase.variant === 'ondemand' && conditions && !describeOnly) {
 			FilteReddit.updateCustomFilter(this.BaseCase.getCustomFilter(), { body: conditions });
@@ -71,7 +87,8 @@ export class LineFilter extends Filter {
 
 	refreshElement() {
 		this.inner.setAttribute('name', this.getStateText(this.state));
-		this.element.classList.toggle('res-filterline-filter-active', this.state !== null);
+		this.element.classList.toggle('res-filterline-filter-hidden', !this.BaseCase.variant === 'ondemand' && !this.case.isEvaluatable());
+		this.element.classList.toggle('res-filterline-filter-active', this.case.isEvaluatable() && this.state !== null);
 	}
 
 	getNextState() {

--- a/lib/modules/filteReddit/cases.js
+++ b/lib/modules/filteReddit/cases.js
@@ -134,7 +134,10 @@ export function resolveGroup(initial: GroupConditions, precompute: boolean = tru
 	let op = initial.op;
 
 	for (let v of initial.of) {
-		if (!has(v.type)) return inertConditions;
+		if (!has(v.type)) {
+			console.error(`Type ${v.type} is not available`);
+			return inertConditions;
+		}
 
 		if (v.type === 'group') v = resolveGroup(v, precompute);
 
@@ -217,9 +220,11 @@ export function getGroup(op: *, of: *): GroupConditions {
 	return getConditions('group', { op, of });
 }
 
-export function createAdHoc(type: string, name: ?string, getConditions: *, variant: *, context: *, customFilter: *) {
+export function createAdHoc(type: string, getConditions: *, variant: *, context: *, customFilter: *) {
+	const { opts: { name = type } = {} } = customFilter || {};
+
 	class AdHoc extends Case {
-		static text = name || 'Unnamed';
+		static text = name;
 
 		// Generate new conditions each time in order to avoid caching, as
 		// `getConditions` can return updated values, e.g. if a external filter has been removed

--- a/lib/modules/subredditInfo.js
+++ b/lib/modules/subredditInfo.js
@@ -173,32 +173,22 @@ async function showSubredditInfo(card, subreddit) {
 	if (Modules.isEnabled(FilteReddit)) {
 		const filterToggle = document.createElement('span');
 		filterToggle.setAttribute('class', 'res-fancy-toggle-button RESFilterToggle');
-		const subredditNameLowercase = jsonData.data.display_name.toLowerCase();
-		const filteredReddits = FilteReddit.module.options.subreddits.value;
-		const exists = filteredReddits.some(reddit =>
-			reddit && (reddit[0].toLowerCase() === subredditNameLowercase)
-		);
-		if (exists) {
-			filterToggle.textContent = `-${i18n('subredditInfoAddRemoveFilter')}`;
-			filterToggle.setAttribute('title', i18n('subredditInfoStopFilteringFromAllAndDomain'));
-			filterToggle.classList.add('remove');
-		} else {
-			filterToggle.textContent = `+${i18n('subredditInfoAddRemoveFilter')}`;
-			filterToggle.setAttribute('title', i18n('subredditInfoFilterFromAllAndDomain'));
-		}
-		filterToggle.addEventListener('click', (e: Event) => {
-			const added = FilteReddit.toggleFilter(subredditNameLowercase);
-
-			if (added) {
-				e.target.setAttribute('title', i18n('subredditInfoStopFilteringThisSubredditFromAllAndDomain'));
-				e.target.textContent = `-${i18n('subredditInfoAddRemoveFilter')}`;
-				e.target.classList.add('remove');
+		const updateButton = () => {
+			filterToggle.classList.remove('remove');
+			if (FilteReddit.listFilters.subreddits.includesString(subreddit)) {
+				filterToggle.textContent = `-${i18n('subredditInfoAddRemoveFilter')}`;
+				filterToggle.setAttribute('title', i18n('subredditInfoStopFilteringFromAllAndDomain'));
+				filterToggle.classList.add('remove');
 			} else {
-				e.target.setAttribute('title', i18n('subredditInfoFilterThisSubredditFromAllAndDomain'));
-				e.target.textContent = `+${i18n('subredditInfoAddRemoveFilter')}`;
-				e.target.classList.remove('remove');
+				filterToggle.textContent = `+${i18n('subredditInfoAddRemoveFilter')}`;
+				filterToggle.setAttribute('title', i18n('subredditInfoFilterFromAllAndDomain'));
 			}
+		};
+		filterToggle.addEventListener('click', () => {
+			FilteReddit.listFilters.subreddits.toggleString(subreddit);
+			updateButton();
 		});
+		updateButton();
 		$newBody.find('#subTooltipButtons').append(filterToggle);
 	}
 

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -396,11 +396,6 @@ export class Tag {
 	}
 }
 
-const ignoreIcons = {
-	IGNORED: '\uF038',
-	NORMAL: '\uF03B',
-};
-
 function populateDialog(tag: Tag, card) {
 	const head = string.html`<div class="userTagger-dialog-head">
 		<span class="res-icon">&#xF0AC;</span>
@@ -487,8 +482,8 @@ function populateDialog(tag: Tag, card) {
 			},
 			'userTaggerIgnore',
 			tag.ignored,
-			ignoreIcons.IGNORED,
-			ignoreIcons.NORMAL,
+			'\uF038' /* ignored */,
+			'\uF03B' /* normal */,
 			false,
 			true
 		)
@@ -754,7 +749,6 @@ async function addDashboardFunctionality() {
 				<tr>
 					<th sort="username" class="active">${i18n('userTaggerUsername')}<span class="sortAsc"></span></th>
 					<th sort="tag">${i18n('userTaggerTag')}</th>
-					<th sort="ignore">${i18n('userTaggerIgnored')}</th>
 					<th sort="color">${i18n('userTaggerColor')}</th>
 					<th sort="votesDown">${i18n('userTaggerVotesDown')}</th>
 					<th sort="votesUp">${i18n('userTaggerVotesUp')}</th>
@@ -798,9 +792,6 @@ async function drawUserTagTable(sortMethod, descending) {
 	switch (currentSortMethod) {
 		case 'tag':
 			tags.sort((a, b) => (a.text || '').localeCompare(b.text || ''));
-			break;
-		case 'ignore':
-			tags.sort((a, b) => Number(a.ignored) - Number(b.ignored));
 			break;
 		case 'color':
 			tags.sort((a, b) => (a.color || '').localeCompare(b.color || ''));
@@ -851,7 +842,6 @@ async function drawUserTagTable(sortMethod, descending) {
 						<a href="/user/${tag.id}">${tag.id}</a>
 					</td>
 					<td><a class="author" hidden></a></td>
-					<td class="res-icon">${tag.ignored ? ignoreIcons.IGNORED : ignoreIcons.NORMAL}</td>
 					<td><span style="color: ${tag.color || 'initial'}">${tag.color ? tag.color : ''}</span></td>
 					<td>${tag.votesDown}</td>
 					<td>${tag.votesUp}</td>

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -9,8 +9,9 @@ import {
 	CreateElement,
 	Thing,
 	batch,
-	click,
 	downcast,
+	fastAsync,
+	reifyPromise,
 	isCurrentSubreddit,
 	isPageType,
 	loggedInUser,
@@ -23,11 +24,12 @@ import {
 import { Storage, openNewTabs, i18n } from '../environment';
 import * as CommandLine from './commandLine';
 import * as Dashboard from './dashboard';
+import * as FilteReddit from './filteReddit';
+import { ExternalFilter } from './filteReddit/ExternalFilter';
 import * as Hover from './hover';
 import * as NightMode from './nightMode';
 import * as Notifications from './notifications';
 import * as SelectedEntry from './selectedEntry';
-import * as SettingsNavigation from './settingsNavigation';
 
 export const module: Module<*> = new Module('userTagger');
 
@@ -64,19 +66,6 @@ module.options = {
 		type: 'boolean',
 		value: true,
 		description: 'userTaggerShowTaggingIconDesc',
-	},
-	hardIgnore: {
-		title: 'userTaggerHardIgnoreTitle',
-		type: 'boolean',
-		value: true,
-		description: 'userTaggerHardIgnoreDesc',
-	},
-	showIgnored: {
-		title: 'userTaggerShowIgnoredTitle',
-		dependsOn: options => !options.hardIgnore.value,
-		type: 'boolean',
-		value: true,
-		description: 'userTaggerShowIgnoredDesc',
 	},
 	storeSourceLink: {
 		title: 'userTaggerStoreSourceLinkTitle',
@@ -157,17 +146,29 @@ export const tagStorage = Storage.wrapPrefix('tag.', () => (({}: any): {|
 	text?: string,
 	link?: string,
 	color?: string,
-	ignore?: boolean,
 	votesDown?: number,
 	votesUp?: number,
 |}), user => user.toLowerCase());
+
+const ignoredUsersStorage = Storage.wrap('RESmodules.userTagger.ignoredUsers', ({}: { [username: string]: true }));
+const ignoredUsers = reifyPromise(ignoredUsersStorage.get());
 
 const getTagBatched = batch(async users => {
 	const tags = await tagStorage.getMultipleNullable(users);
 	return users.map(user => tags[user.toLowerCase()]);
 }, { size: Infinity, delay: 0 });
 
+let filter;
+let data;
+
 module.beforeLoad = () => {
+	if (!isPageType('profile')) { // Don't ignore users on profile pages
+		(fastAsync(function*() {
+			data = yield ignoredUsers.get();
+			addFilters();
+		}))();
+	}
+
 	watchForElements(['siteTable', 'newComments', 'selfText'], usernameSelector, applyToUser);
 	watchForRedditEvents('postAuthor', (element, { author, _: { update } }) => {
 		if (update) return;
@@ -196,6 +197,22 @@ module.go = () => {
 	registerCommandLine();
 };
 
+async function refreshFilter() {
+	data = await ignoredUsersStorage.get();
+	filter.update(undefined, null);
+}
+
+function addFilters() {
+	filter = FilteReddit.addExternalFilter('userTagger.users', 'Users', () => ({
+		type: 'group',
+		op: 'any',
+		of: Object.keys(data).map(username => ({ type: 'username', patt: username })),
+	}), class extends ExternalFilter {
+		getMatchingEntry(thing) { return thing.getAuthor(); }
+		async removeEntry(username) { (await Tag.get(username)).unignore(); }
+	});
+}
+
 export const usernameSelector = '.contents .author, .noncollapsed a.author, p.tagline a.author, #friend-table span.user a, .sidecontentbox .author, div.md a[href^="/u/"]:not([href*="/m/"]), div.md a[href*="reddit.com/u/"]:not([href*="/m/"]), .usertable a.author, .usertable span.user a, div.wiki-page-content .author';
 
 type WatcherOptions = {|
@@ -203,6 +220,7 @@ type WatcherOptions = {|
 	renderTaggingIcon?: boolean,
 	renderVoteWeight?: boolean,
 |};
+
 export async function applyToUser(element: HTMLAnchorElement | HTMLElement, options?: WatcherOptions) {
 	let {
 		username,
@@ -229,11 +247,6 @@ export async function applyToUser(element: HTMLAnchorElement | HTMLElement, opti
 	const tag = Tag.getUnfilled(username);
 	tag.add(element, { renderVoteWeight, renderTaggingIcon });
 	await tag.fill();
-
-	if (tag.ignored && element.classList.contains('author') && !isPageType('profile')) {
-		const thing = Thing.from(element);
-		if (thing) ignore(thing);
-	}
 }
 
 export const tags: Map<string, Tag> = new Map();
@@ -282,9 +295,10 @@ export class Tag {
 	text: ?string = null;
 	link: ?string = null;
 	color: ?string = null;
-	ignored: boolean = false;
 	votesUp: number = 0;
 	votesDown: number = 0;
+
+	get ignored(): boolean { return data.hasOwnProperty(this.id); }
 
 	instances: Array<{
 		element: HTMLElement,
@@ -306,7 +320,6 @@ export class Tag {
 	load(data: *) {
 		if (data.color !== undefined) this.color = data.color;
 		else if (data.color === 'none' /* legacy value */) this.color = null;
-		if (data.ignored !== undefined) this.ignored = data.ignored;
 		if (data.link !== undefined) this.link = data.link;
 		if (data.text !== undefined) this.text = data.text;
 		if (data.votesDown !== undefined) this.votesDown = data.votesDown;
@@ -318,7 +331,6 @@ export class Tag {
 	extract() {
 		return {
 			color: this.color,
-			ignored: this.ignored,
 			link: this.link,
 			text: this.text,
 			votesDown: this.votesDown,
@@ -358,14 +370,18 @@ export class Tag {
 			});
 		}
 
-		this.ignored = true;
-		if (!this.text) this.text = 'ignored';
+		ignoredUsersStorage.patch({ [this.id]: true });
+		refreshFilter();
+
+		if (!this.text) this.load({ text: 'ignored' });
 		this.save();
 	}
 
 	unignore() {
-		this.ignored = false;
-		if (this.text === 'ignored') this.text = null;
+		ignoredUsersStorage.deletePath(this.id);
+		refreshFilter();
+
+		if (this.text === 'ignored') this.load({ text: null });
 		this.save();
 	}
 
@@ -422,7 +438,12 @@ const ignoreIcons = {
 };
 
 function populateDialog(tag: Tag, card) {
-	const head = string.html`<div><span class="res-icon">&#xF0AC;</span>&nbsp;<span>${tag.id}</span></div>`;
+	const head = string.html`<div class="userTagger-dialog-head">
+		<span class="res-icon">&#xF0AC;</span>
+		<span>${tag.id}</span>
+		<span class="res-usertag-ignore"></span>
+		</div>
+	</div>`;
 
 	const colors = Object.entries(bgToTextColorMap)
 		.map(([color, textColor]) => ({
@@ -450,10 +471,6 @@ function populateDialog(tag: Tag, card) {
 				<label class="fieldPair-label" for="userTaggerPreview">Preview</label>
 				<span id="userTaggerPreview"></span>
 				<a id="userTaggerPresetSaveAs" title="save as preset" href="javascript:void 0">save as preset</a>
-			</div>
-			<div class="fieldPair res-usertag-ignore">
-				<label class="fieldPair-label" for="userTaggerIgnore">Ignore</label>
-				${string.safe(SettingsNavigation.makeUrlHashLink(module.moduleID, 'hardIgnore', ' configure ', 'gearIcon'))}
 			</div>
 			<div class="fieldPair">
 				<label class="fieldPair-label" for="userTaggerLink">
@@ -496,16 +513,16 @@ function populateDialog(tag: Tag, card) {
 		votesUp: downcast(body.querySelector('#userTaggerVotesUp'), HTMLInputElement),
 	};
 
-	let ignored = tag.ignored;
-	body.querySelector('.res-usertag-ignore label').after(
+	head.querySelector('.res-usertag-ignore').append(
 		CreateElement.toggleButton(
 			ignore => {
-				if (ignore && !elements.text.value) elements.text.value = 'ignored';
-				if (!ignore && elements.text.value === 'ignored') elements.text.value = '';
-				ignored = ignore;
+				const textShouldBeUpdated = extract().text === tag.text; // Override text only if not manually changed
+				if (ignore) tag.ignore(); else tag.unignore();
+				if (textShouldBeUpdated) elements.text.value = tag.text || '';
+				updateTagPreview();
 			},
 			'userTaggerIgnore',
-			ignored,
+			tag.ignored,
 			ignoreIcons.IGNORED,
 			ignoreIcons.NORMAL,
 			false,
@@ -516,7 +533,6 @@ function populateDialog(tag: Tag, card) {
 	function extract() {
 		return {
 			color: elements.color.value !== 'none' ? elements.color.value : null,
-			ignored,
 			link: elements.link.value || null,
 			text: elements.text.value || null,
 			votesDown: parseInt(elements.votesDown.value, 10) || 0,
@@ -680,66 +696,6 @@ function getLinkBasedOnTagLocation(obj) {
 			return $(permaLink).attr('href');
 		}
 	}
-}
-
-// Ignore content from certain users.
-// For blocking users from sending messages to other users, see reddit's built-in block feature.
-function ignore(thing) {
-	thing.element.classList.add('res-ignored-content');
-
-	if (thing.isPost()) {
-		ignorePost(thing);
-	} else if (thing.isComment()) {
-		ignoreComment(thing);
-	}
-}
-
-function ignorePost(thing) {
-	if (module.options.hardIgnore.value) {
-		// hardIgnore, remove post completely
-		thing.element.remove();
-	} else {
-		// no hardIgnore, replace title with placeholder
-		const title = downcast(thing.getTitleElement(), HTMLElement);
-		ignoredPlaceholder(thing).insertAfter(title);
-	}
-}
-
-function ignoreComment(thing) {
-	if (module.options.hardIgnore.value) {
-		if ($(thing.element).children('.child').children().length === 0) {
-			// hardIgnore and no children, remove completely
-			thing.element.remove();
-			return;
-		} else if (thing.element.classList.contains('noncollapsed')) {
-			// hardIgnore and children, collapse
-			const toggleComment = downcast(thing.entry.querySelector('a.expand'), HTMLElement);
-			click(toggleComment);
-		}
-	}
-
-	// replace body with placeholder (both with/without hardIgnore)
-	const body = downcast(thing.entry.querySelector('.md'), HTMLElement);
-	ignoredPlaceholder(thing).insertAfter(body);
-}
-
-function ignoredPlaceholder(thing) {
-	const $wrapper = $('<span>', { class: 'res-ignored-message' }).append(
-		$('<span>', { class: 'res-icon', text: '\uF093' }),
-		$('<span>', { text: ` ${i18n('userTaggerIgnoredPlaceholder')} ` })
-	);
-
-	if (module.options.showIgnored.value) {
-		const $button = $('<a>', { href: '#', text: i18n('userTaggerShowAnyway') });
-		$button.click(e => {
-			e.preventDefault();
-			thing.element.classList.remove('res-ignored-content');
-			$wrapper.remove();
-		});
-		$button.appendTo($wrapper);
-	}
-
-	return $wrapper;
 }
 
 function getVoteWeightStyle({ votes, votesUp, votesDown }) {

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -10,8 +10,6 @@ import {
 	Thing,
 	batch,
 	downcast,
-	fastAsync,
-	reifyPromise,
 	isCurrentSubreddit,
 	isPageType,
 	loggedInUser,
@@ -25,7 +23,6 @@ import { Storage, openNewTabs, i18n } from '../environment';
 import * as CommandLine from './commandLine';
 import * as Dashboard from './dashboard';
 import * as FilteReddit from './filteReddit';
-import { ExternalFilter } from './filteReddit/ExternalFilter';
 import * as Hover from './hover';
 import * as NightMode from './nightMode';
 import * as Notifications from './notifications';
@@ -150,25 +147,12 @@ export const tagStorage = Storage.wrapPrefix('tag.', () => (({}: any): {|
 	votesUp?: number,
 |}), user => user.toLowerCase());
 
-const ignoredUsersStorage = Storage.wrap('RESmodules.userTagger.ignoredUsers', ({}: { [username: string]: true }));
-const ignoredUsers = reifyPromise(ignoredUsersStorage.get());
-
 const getTagBatched = batch(async users => {
 	const tags = await tagStorage.getMultipleNullable(users);
 	return users.map(user => tags[user.toLowerCase()]);
 }, { size: Infinity, delay: 0 });
 
-let filter;
-let data;
-
 module.beforeLoad = () => {
-	if (!isPageType('profile')) { // Don't ignore users on profile pages
-		(fastAsync(function*() {
-			data = yield ignoredUsers.get();
-			addFilters();
-		}))();
-	}
-
 	watchForElements(['siteTable', 'newComments', 'selfText'], usernameSelector, applyToUser);
 	watchForRedditEvents('postAuthor', (element, { author, _: { update } }) => {
 		if (update) return;
@@ -196,22 +180,6 @@ module.go = () => {
 
 	registerCommandLine();
 };
-
-async function refreshFilter() {
-	data = await ignoredUsersStorage.get();
-	filter.update(undefined, null);
-}
-
-function addFilters() {
-	filter = FilteReddit.addExternalFilter('userTagger.users', 'Users', () => ({
-		type: 'group',
-		op: 'any',
-		of: Object.keys(data).map(username => ({ type: 'username', patt: username })),
-	}), class extends ExternalFilter {
-		getMatchingEntry(thing) { return thing.getAuthor(); }
-		async removeEntry(username) { (await Tag.get(username)).unignore(); }
-	});
-}
 
 export const usernameSelector = '.contents .author, .noncollapsed a.author, p.tagline a.author, #friend-table span.user a, .sidecontentbox .author, div.md a[href^="/u/"]:not([href*="/m/"]), div.md a[href*="reddit.com/u/"]:not([href*="/m/"]), .usertable a.author, .usertable span.user a, div.wiki-page-content .author';
 
@@ -298,7 +266,7 @@ export class Tag {
 	votesUp: number = 0;
 	votesDown: number = 0;
 
-	get ignored(): boolean { return data.hasOwnProperty(this.id); }
+	get ignored(): boolean { return FilteReddit.listFilters.users.includesString(this.id); }
 
 	instances: Array<{
 		element: HTMLElement,
@@ -370,17 +338,13 @@ export class Tag {
 			});
 		}
 
-		ignoredUsersStorage.patch({ [this.id]: true });
-		refreshFilter();
-
+		FilteReddit.listFilters.users.toggleString(this.id, true);
 		if (!this.text) this.load({ text: 'ignored' });
 		this.save();
 	}
 
 	unignore() {
-		ignoredUsersStorage.deletePath(this.id);
-		refreshFilter();
-
+		FilteReddit.listFilters.users.toggleString(this.id, false);
 		if (this.text === 'ignored') this.load({ text: null });
 		this.save();
 	}

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -307,7 +307,7 @@
 		"message": "filteReddit"
 	},
 	"filteRedditDesc": {
-		"message": "Filter out NSFW content, or links by keyword, domain (use User Tagger to ignore by user) or subreddit (for /r/all or /domain/*).\n\nRegExp like `/(this|that|theother)/i` is allowed in text boxes. Find out more on the [/r/Enhancement wiki](/r/Enhancement/wiki/index/filters/filtereddit/regexp)."
+		"message": "Filter out NSFW content, or links by keyword, domain or subreddit (for /r/all or /domain/*).\n\nRegExp like `/(this|that|theother)/i` is allowed in text boxes. Find out more on the [/r/Enhancement wiki](/r/Enhancement/wiki/index/filters/filtereddit/regexp)."
 	},
 	"floaterName": {
 		"message": "Floating Islands"
@@ -1654,7 +1654,7 @@
 		"message": "User Tagger"
 	},
 	"userTaggerDesc": {
-		"message": "Adds a great deal of customization around users - tagging them, ignoring them, and more. You can manage tagged users on [Manage User Tags](/r/Dashboard/#userTaggerContents).\n\n**Ignoring users:** users will *not* be ignored in modmail, moderation queue or your inbox."
+		"message": "Adds a great deal of customization around users - tagging them, ignoring them, and more. You can manage tagged users on [Manage User Tags](/r/Dashboard/#userTaggerContents)."
 	},
 	"versionName": {
 		"message": "Version Manager"
@@ -2385,6 +2385,15 @@
 	"filteRedditFlairDesc": {
 		"message": "Hide posts where certain keywords are in the post's link flair."
 	},
+	"filteRedditUsername": {
+		"message": "Username"
+	},
+	"filteRedditUsersTitle": {
+		"message": "Users"
+	},
+	"filteRedditUsersDesc": {
+		"message": "Hide posts and commment from these users (except on user pages)."
+	},
 	"filteRedditAllowNSFWTitle": {
 		"message": "Allow NSFW"
 	},
@@ -2580,12 +2589,6 @@
 		"message": "Stop filtering from /r/all and /domain/*"
 	},
 	"subredditInfoFilterFromAllAndDomain": {
-		"message": "Filter this subreddit from /r/all and /domain/*"
-	},
-	"subredditInfoStopFilteringThisSubredditFromAllAndDomain": {
-		"message": "Stop filtering this subreddit from /r/all and /domain/*"
-	},
-	"subredditInfoFilterThisSubredditFromAllAndDomain": {
 		"message": "Filter this subreddit from /r/all and /domain/*"
 	},
 	"subredditInfoSubscribe": {

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -2702,9 +2702,6 @@
 	"userTaggerTag": {
 		"message": "Tag"
 	},
-	"userTaggerIgnored": {
-		"message": "Ignored"
-	},
 	"userTaggerColor": {
 		"message": "Color"
 	},

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -2730,14 +2730,6 @@
 	"userTaggerAreYouSureYouWantToDeleteTag": {
 		"message": "Are you sure you want to delete the tag for user: $1?"
 	},
-	"userTaggerIgnoredPlaceholder": {
-		"message": "ignored.",
-		"description": "Replaces the content of ignored comments."
-	},
-	"userTaggerShowAnyway": {
-		"message": "show anyway?",
-		"description": "for showing ignored comments"
-	},
 	"userTaggerYourVotesFor": {
 		"message": "your votes for $1: $2",
 		"description": "As in `your votes for username: 42`"
@@ -2925,12 +2917,6 @@
 	},
 	"userTaggerShowTaggingIconDesc": {
 		"message": "Always show a tag tool icon after every username."
-	},
-	"userTaggerHardIgnoreDesc": {
-		"message": "Completely remove links and comments posted by ignored users. If an ignored comment has replies, collapse it and hide its contents instead of removing it."
-	},
-	"userTaggerShowIgnoredDesc": {
-		"message": "Provide a link to reveal an ignored link or comment."
 	},
 	"userTaggerStoreSourceLinkDesc": {
 		"message": "By default, store a link to the link/comment you tagged a user on"
@@ -3199,12 +3185,6 @@
 	},
 	"userTaggerShowTaggingIconTitle": {
 		"message": "Show Tagging Icon"
-	},
-	"userTaggerHardIgnoreTitle": {
-		"message": "Hard Ignore"
-	},
-	"userTaggerShowIgnoredTitle": {
-		"message": "Show Ignored"
 	},
 	"userTaggerStoreSourceLinkTitle": {
 		"message": "Store Source Link"

--- a/tests/Filterline.js
+++ b/tests/Filterline.js
@@ -143,6 +143,7 @@ module.exports = {
 			.click('.res-filterline-new-group')
 			.click('.res-filterline-new-group .res-filterline-filter-new')
 			.waitForElementVisible(`${filter}[type="group"]`)
+			.perform(switchActiveState) // enable
 			.perform(switchActiveState)
 			.waitForElementNotVisible(thing)
 			.perform(switchActiveState)


### PR DESCRIPTION
- userTagger ignore states have been migrated to a list in filteReddit
  - Filtering of users are now as quick as other filteReddit filters (i.e. no additional FOUC while waiting for tags to load)
  - Makes ignoring users work with redesign when filteReddit becomes ported
  - Ignoring will no longer generate placeholders. To show content, power off Filterline / disable the `Users` filter
- Ignore button in dialog is moved to header
![image](https://user-images.githubusercontent.com/1748521/45440186-ef04aa00-b6bb-11e8-8a92-53c7effa3730.png)
- `hardIgnore` is removed; ignoring users now hides the post but not its replies, so if complete hiding is desired the user must be blocked (#2865) or a customFilters manually created


Fixes #4088 
Fixes #2399 (by disabling the filter via Filterline in the sub and saving the configuration as default)
Obsolete issues: Closes #1125, closes #2326, closes #4036 
Improves https://www.reddit.com/r/RESissues/comments/9e1t8m/ignore_hard_ignore_automod/

Tested in browser: Chrome 70
 