### PR TITLE
v5.12.6

### DIFF
--- a/changelog/v5.12.6.md
+++ b/changelog/v5.12.6.md
@@ -1,0 +1,13 @@
+## [v5.12.6](https://github.com/honestbleeps/Reddit-Enhancement-Suite/releases/v5.12.6)
+
+### New Features
+
+- None (thanks nobody)
+
+### Bug Fixes
+
+- None (thanks nobody)
+
+### Housekeeping / Other
+
+- Re-releasing v5.12.5 to fix AMO store listing (thanks @andytuba)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "title": "Reddit Enhancement Suite",
   "name": "reddit-enhancement-suite",
-  "version": "5.12.5",
+  "version": "5.12.6",
   "description": "A suite of modules that enhance your Reddit browsing experience",
   "author": "Reddit Enhancement Suite contributors",
   "license": "GPL-3.0",


### PR DESCRIPTION
AMO (Firefox) stable channel needs a v5.12 release for good bookkeeping.  This requires a version bump, but no code changes. I plan to re-release v5.12.5 as v5.12.6 with just a version bump and changelog.

Because `master` is already at v5.13, my release plan is:

1. Create a `release-temp` branch.
1. Merge `v5.12.6` version bump into `release-temp`
1. Tag that commit as `v5.12.6`.
1. Await the Firefox deploy.
1. **Finish the paperwork for this release on the AMO website.**
1. Delete `release-temp` branch
1. Cherry-pick the `v5.12.6` commit into `master`, but retain the version number in `package.json` that's currently on `master`.