### PR TITLE
Highlight users mentioned in self-posts

### DIFF
--- a/lib/modules/userHighlight.js
+++ b/lib/modules/userHighlight.js
@@ -5,12 +5,14 @@ import {
 	Alert,
 	addCSS,
 	hashCode,
+	isPageType,
 	loggedInUser,
 	watchForThings,
 } from '../utils';
 import { i18n } from '../environment';
 import * as SettingsConsole from './settingsConsole';
 import * as UserInfo from './userInfo';
+import { usernameRE } from './userTagger';
 
 export const module: Module<*> = new Module('userHighlight');
 
@@ -151,6 +153,28 @@ module.options = {
 		advanced: true,
 		dependsOn: options => options.highlightMod.value,
 	},
+	highlightOpMentions: {
+		title: 'userHighlightOpMentionsTitle',
+		type: 'boolean',
+		value: true,
+		description: 'userHighlightOpMentionsDesc',
+	},
+	opMentionsColor: {
+		title: 'userHighlightOpMentionsColorTitle',
+		type: 'color',
+		value: '#6D4731',
+		description: 'userHighlightOpMentionsColorDesc',
+		advanced: true,
+		dependsOn: options => options.highlightOpMentions.value,
+	},
+	opMentionsHover: {
+		title: 'userHighlightOpMentionsHoverTitle',
+		type: 'color',
+		value: '#C4946E',
+		description: 'userHighlightOpMentionsHoverDesc',
+		advanced: true,
+		dependsOn: options => options.highlightOpMentions.value,
+	},
 	highlightFirstCommenter: {
 		title: 'userHighlightHighlightFirstCommenterTitle',
 		type: 'boolean',
@@ -256,7 +280,34 @@ module.go = () => {
 	if (module.options.highlightSelf.value && username) {
 		highlight(`author[href$="/${username}"]`, module.options.selfColor.value, module.options.selfColorHover.value);
 	}
+	if (module.options.highlightOpMentions.value && isPageType('comments')) {
+		highlightMentionedUsers();
+	}
 };
+
+function highlightMentionedUsers() {
+	const links = getLinksFromContainer('#siteTable .usertext-body');
+	const usernames = getUsernamesFromLinks(links);
+	usernames.forEach(user => {
+		highlight(`author[href$="/${user}" i]`, module.options.opMentionsColor.value, module.options.opMentionsHover.value);
+	});
+}
+
+function getLinksFromContainer(containerSelector: string): NodeList<HTMLElement> {
+	return document.querySelectorAll(`${containerSelector} a`);
+}
+
+function getUsernamesFromLinks(links: NodeList<HTMLElement>): Set<string> {
+	const usernames = new Set();
+	links.forEach(link => {
+		const { hostname, pathname } = ((link: any): HTMLAnchorElement);
+		const match = usernameRE.exec(pathname);
+		if (match !== null && (/^(.+\.)?reddit\.com$/).test(hostname)) {
+			usernames.add(match[1]);
+		}
+	});
+	return usernames;
+}
 
 function updateFirstComments(thing) {
 	if (!thing.isTopLevelComment()) return;

--- a/lib/modules/userHighlight.js
+++ b/lib/modules/userHighlight.js
@@ -12,7 +12,7 @@ import {
 import { i18n } from '../environment';
 import * as SettingsConsole from './settingsConsole';
 import * as UserInfo from './userInfo';
-import { usernameRE } from './userTagger';
+import { getUsername } from './userTagger';
 
 export const module: Module<*> = new Module('userHighlight');
 
@@ -280,33 +280,18 @@ module.go = () => {
 	if (module.options.highlightSelf.value && username) {
 		highlight(`author[href$="/${username}"]`, module.options.selfColor.value, module.options.selfColorHover.value);
 	}
+
 	if (module.options.highlightOpMentions.value && isPageType('comments')) {
-		highlightMentionedUsers();
+		const selftext = document.querySelector('#siteTable .usertext-body');
+		if (selftext) highlightMentionedUsers(selftext, module.options.opMentionsColor.value, module.options.opMentionsHover.value);
 	}
 };
 
-function highlightMentionedUsers() {
-	const links = getLinksFromContainer('#siteTable .usertext-body');
-	const usernames = getUsernamesFromLinks(links);
-	usernames.forEach(user => {
-		highlight(`author[href$="/${user}" i]`, module.options.opMentionsColor.value, module.options.opMentionsHover.value);
-	});
-}
-
-function getLinksFromContainer(containerSelector: string): NodeList<HTMLElement> {
-	return document.querySelectorAll(`${containerSelector} a`);
-}
-
-function getUsernamesFromLinks(links: NodeList<HTMLElement>): Set<string> {
-	const usernames = new Set();
-	links.forEach(link => {
-		const { hostname, pathname } = ((link: any): HTMLAnchorElement);
-		const match = usernameRE.exec(pathname);
-		if (match !== null && (/^(.+\.)?reddit\.com$/).test(hostname)) {
-			usernames.add(match[1]);
-		}
-	});
-	return usernames;
+function highlightMentionedUsers(element, color, hoverColor) {
+	Array.from(element.querySelectorAll('a'))
+		.map(getUsername)
+		.filter(Boolean)
+		.forEach(user => highlight(`author[href$="/${user}" i]`, color, hoverColor));
 }
 
 function updateFirstComments(thing) {

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -141,6 +141,18 @@ module.options = {
 
 export const usernameRE = /(?:u|user)\/([\w\-]{3,20}(?![\w\-]))/;
 
+export function getUsername(element: HTMLElement): ?string {
+	if (!(element instanceof HTMLAnchorElement)) return;
+
+	const { href, origin } = element;
+
+	// The link should refer to this site
+	if (!location.origin.endsWith(origin.split('.').slice(-2).join('.'))) return;
+
+	const [, username] = href.match(usernameRE) || [];
+	if (username) return username;
+}
+
 export const tagStorage = Storage.wrapPrefix('tag.', () => (({}: any): {|
 	text?: string,
 	link?: string,
@@ -221,19 +233,6 @@ export async function applyToUser(element: HTMLAnchorElement | HTMLElement, opti
 	if (tag.ignored && element.classList.contains('author') && !isPageType('profile')) {
 		const thing = Thing.from(element);
 		if (thing) ignore(thing);
-	}
-}
-
-function getUsername(element: HTMLAnchorElement): string {
-	if (element.href) {
-		const test = element.href.match(usernameRE);
-		if (test) {
-			return test[1];
-		} else {
-			throw new Error(`Regex failed on ${element.href}`);
-		}
-	} else {
-		return element.getAttribute('data-user') || element.innerText || '';
 	}
 }
 

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -3704,6 +3704,24 @@
 	"userHighlightOPColorHoverDesc": {
 		"message": "Color used to highlight OP on hover."
 	},
+	"userHighlightOpMentionsTitle": {
+		"message": "Highlight OP mentions"
+	},
+	"userHighlightOpMentionsDesc": {
+		"message": "Highlight users who are mentioned by the OP in self-posts."
+	},
+	"userHighlightOpMentionsColorTitle": {
+		"message": "Mentioned User Color"
+	},
+	"userHighlightOpMentionsColorDesc": {
+		"message": "Color to use to highlight mentioned users."
+	},
+	"userHighlightOpMentionsHoverTitle": {
+		"message": "Mentioned User Hover"
+	},
+	"userHighlightOpMentionsHoverDesc": {
+		"message": "Color to use to highlight mentioned users on hover."
+	},
 	"userHighlightHighlightAdminTitle": {
 		"message": "Highlight Admin"
 	},


### PR DESCRIPTION
<!-- fixes #4822  -->
Relevant issue: #4822
Tested in browser: Chrome 69

Here are WIP changes for implementing the feature described in #4822 .
Still on the to-do list:
- ~Need to add descriptions and titles to [locales](https://github.com/honestbleeps/Reddit-Enhancement-Suite/tree/master/locales/locales) (How is this usually done? Is there a tool?)~ Added to English locale.
- What default colors should be used for the highlights? I went with brown since it seems to have not be used yet. 
- ~Still needs to be tested.~ Tested in Chrome 69.