### PR TITLE
Issue-4786: Made dismiss pinnable tooltip easier to see in night mode

### DIFF
--- a/lib/css/modules/_nightMode.scss
+++ b/lib/css/modules/_nightMode.scss
@@ -1554,7 +1554,7 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 		background-color: $background-color !important;
 
 		.c-close {
-			background-color: inherit;
+			background-color: $header-background-color;
 		}
 	}
 


### PR DESCRIPTION
Relevant issue: Fixes #4786 
Tested in browser: Yes (In Firefox 63 on macOS (High Sierra))
Before:
![image](https://user-images.githubusercontent.com/12150428/46370805-46d37700-c6a4-11e8-967d-034df5ad8198.png)
After:
<img width="454" alt="image" src="https://user-images.githubusercontent.com/12150428/46370829-5357cf80-c6a4-11e8-911a-43535e6bf81a.png">

