### PR TITLE
chore(gitignore): ignore npm and yarn debug logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 ## General ##
 node_modules/
-npm-debug.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
 
 # Browser extensions and certs
 *.crx


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: N/A but I would be happy to create one if that necessary.
Tested in browser: N/A

I noticed when running `npm install` that I got an error locally and an `npm-debug.log.1039210921` was generated. I'm not sure what happened to generate that although it seems to happen when my wifi connection is having issues.

This PR just updates the `.gitignore` file to match Githubs Node.gitignore for logs as can be seen [here](https://github.com/github/gitignore/blob/master/Node.gitignore#L4).
