### PR TITLE
Better intergrate floaters in redesign

### DIFF
--- a/lib/css/modules/_accountSwitcher.scss
+++ b/lib/css/modules/_accountSwitcher.scss
@@ -20,10 +20,13 @@ div.RESAccountSwitcherDropdown {
 
 #RESAccountSwitcherIcon {
 	cursor: pointer;
-	margin-left: 3px;
 	display: inline-block;
 	width: 12px;
 	height: 16px;
+
+	.user & {
+		margin-left: 3px;
+	}
 }
 
 .res-accountSwitcher-dropDownStyle-alien {
@@ -31,6 +34,7 @@ div.RESAccountSwitcherDropdown {
 		vertical-align: middle;
 		background-image: url('../images/accountSwitcherSnoo.png');
 		background-repeat: no-repeat;
+		background-origin: content-box;
 	}
 }
 

--- a/lib/css/modules/_floater.scss
+++ b/lib/css/modules/_floater.scss
@@ -1,3 +1,28 @@
+.res-floater-list {
+	all: initial;
+
+	display: inline-flex;
+	align-items: center;
+	float: right;
+
+	font-size: 10px;
+
+	&:empty {
+		display: none;
+	}
+
+	> li {
+		display: flex;
+		opacity: .7;
+		&:hover { opacity: 1; }
+
+		// The child element may be hidden, so avoid
+		> * {
+			padding: 2px;
+		}
+	}
+}
+
 .res-floater-visibleAfterScroll {
 	position: fixed;
 	will-change: transform;
@@ -5,42 +30,12 @@
 	right: 8px;
 }
 
-.res-floater-visibleAfterScroll > ul {
-	display: inline-flex;
-	align-items: center;
-	float: right;
-}
-
-.res-floater-visibleAfterScroll > ul > li {
-	display: flex;
-	opacity: .7;
-	&:hover { opacity: 1; }
-}
-
 .res-floater-belowNavbar {
 	position: fixed;
 	z-index: 5;
 	right: 8px;
 	top: 60px;
-
-	> ul {
-		display: inline-flex;
-		align-items: center;
-		float: right;
-
-		padding: 0.2em 0.1em;
-		background: white;
-		border: 1px #ccc solid;
-
-		&:empty {
-			display: none;
-		}
-	}
-
-	> ul > li {
-		display: flex;
-		opacity: .7;
-		margin: 0.2em;
-		&:hover { opacity: 1; }
-	}
+	padding: 0.2em 0.1em;
+	background: white;
+	border: 1px #ccc solid;
 }

--- a/lib/css/modules/_floater.scss
+++ b/lib/css/modules/_floater.scss
@@ -39,3 +39,10 @@
 	background: white;
 	border: 1px #ccc solid;
 }
+
+.res-floater-inNavbar {
+	position: fixed;
+	right: 6px;
+	top: 14px;
+	z-index: 100;
+}

--- a/lib/css/modules/_neverEndingReddit.scss
+++ b/lib/css/modules/_neverEndingReddit.scss
@@ -79,7 +79,6 @@
 
 #NREPause {
 	cursor: pointer;
-	margin-left: 4px;
 
 	&::after {
 		font: normal 100% Batch;

--- a/lib/css/modules/_orangered.scss
+++ b/lib/css/modules/_orangered.scss
@@ -1,7 +1,6 @@
 #NREMail {
 	width: 15px;
 	height: 10px;
-	margin-left: 4px;
 	background: center center no-repeat;
 
 	&.nohavemail {

--- a/lib/css/modules/_pageNavigator.scss
+++ b/lib/css/modules/_pageNavigator.scss
@@ -6,7 +6,6 @@ $page-offsetleft: 15px;
 
 .pageNavigator {
 	color: #888;
-	margin-left: 4px;
 }
 
 .res-show-link {

--- a/lib/css/modules/_wheelBrowse.scss
+++ b/lib/css/modules/_wheelBrowse.scss
@@ -5,7 +5,6 @@ $full-width: 32px;
 	width: 16px;
 	height: 16px;
 	transition: width .1s linear;
-	margin-left: 4px;
 	border-radius: 5px;
 	cursor: crosshair;
 	background-color: rgba(0, 0, 0, .24);

--- a/lib/modules/floater.js
+++ b/lib/modules/floater.js
@@ -5,6 +5,7 @@ import { $ } from '../vendor';
 import * as Modules from '../core/modules';
 import { Module } from '../core/module';
 import {
+	frameThrottle,
 	getD2xBodyOffset,
 	getHeaderOffset,
 	isAppType,
@@ -44,6 +45,26 @@ class Container {
 }
 
 const containers = {
+	inNavbar: class extends Container {
+		static isAvailable() { return isAppType('d2x') && !!document.querySelector('.header-user-dropdown'); }
+
+		go() {
+			this.element.classList.add('res-floater-inNavbar');
+			document.body.append(this.element);
+		}
+
+		add(element: *, opts: *) {
+			super.add(element, opts);
+			this.updateHeaderWidth();
+		}
+
+		updateHeaderWidth = frameThrottle(() => {
+			const { width } = this.element.getBoundingClientRect();
+			const headerButton = document.querySelector('.header-user-dropdown');
+			headerButton.style.marginRight = `${width}px`;
+		});
+	},
+
 	belowFixedNavbar: class extends Container {
 		static isAvailable() { return isAppType('d2x'); }
 
@@ -80,7 +101,7 @@ const getContainer: * => Container = _.memoize(name => new (containers[name].isA
 export function addElement(
 	element: HTMLElement | JQuery,
 	{
-		container: containerName = ['belowFixedNavbar', 'visibleAfterScroll'].find(name => containers[name].isAvailable()) || 'inert',
+		container: containerName = ['inNavbar', 'belowFixedNavbar', 'visibleAfterScroll'].find(name => containers[name].isAvailable()) || 'inert',
 		separate = false,
 		order = 0,
 	}: {|

--- a/lib/modules/floater.js
+++ b/lib/modules/floater.js
@@ -4,7 +4,12 @@ import _ from 'lodash';
 import { $ } from '../vendor';
 import * as Modules from '../core/modules';
 import { Module } from '../core/module';
-import { getD2xBodyOffset, getHeaderOffset, isAppType, matchesPageLocation } from '../utils';
+import {
+	getD2xBodyOffset,
+	getHeaderOffset,
+	isAppType,
+	string,
+} from '../utils';
 
 export const module: Module<*> = new Module('floater');
 
@@ -14,87 +19,77 @@ module.description = 'floaterDesc';
 module.alwaysEnabled = true;
 module.hidden = true;
 
-const defaultContainer = isAppType('d2x') ? 'belowFixedNavbar' : 'visibleAfterScroll';
-const containers = {
-	belowFixedNavbar: {
-		include: ['d2x'],
+class Container {
+	static isAvailable() { return true; }
 
-		$element: _.once(() =>
-			$('<div>', { class: 'res-floater-belowNavbar' })
-				.append('<ul>')
-		),
-		go() {
-			this.$element().css('top', 5 + getD2xBodyOffset());
-		},
-		add(element: *, { separate, order }: {| separate: boolean, order: number |}) {
-			if (separate) {
-				this.$element().append(element);
-			} else {
-				const $container = $('<li />');
-				$container.css('order', order);
-				$container.append(element);
-				this.$element().find('> ul').append($container);
-			}
-		},
-	},
+	element: HTMLElement = document.createElement('div');
+	list: HTMLElement = string.html`<ul class="res-floater-list"></ul>`;
 
-	visibleAfterScroll: {
-		exclude: ['d2x'],
+	constructor() {
+		this.element.append(this.list);
+		if (this.go) this.go();
+	}
 
-		$element: _.once(() =>
-			$('<div>', { id: 'NREFloat', class: 'res-floater-visibleAfterScroll' })
-				.append('<ul>')
-		),
-		go() {
-			this.$element().css('top', 8 + getHeaderOffset(true));
+	go() {}
 
-			if (!document.querySelector('#RESPinnedHeaderSpacer')) { // No need to hide the floater if whole header is pinned
-				// $FlowIssue https://github.com/facebook/flow/pull/4664
-				new IntersectionObserver(entries => {
-					this.$element().get(0).hidden = entries[0].isIntersecting;
-				}).observe(document.querySelector('#header'));
-			}
-		},
-		add(element: *, { separate, order }: {| separate: boolean, order: number |}) {
-			if (separate) {
-				this.$element().append(element);
-			} else {
-				const $container = $('<li />');
-				$container.css('order', order);
-				$container.append(element);
-				this.$element().find('> ul').append($container);
-			}
-		},
-	},
-};
-
-function isRunning(container): boolean {
-	return matchesPageLocation(container.include || [], container.exclude || []);
-}
-
-module.afterLoad = () => {
-	for (const container of Object.values(containers)) {
-		if (!isRunning(container)) {
-			continue;
-		}
-		$(document.body).append(container.$element());
-		if (typeof container.go === 'function') {
-			container.go();
+	add(element: JQuery | HTMLElement, { separate, order }: {| separate: boolean, order: number |}) {
+		if (separate) {
+			$(this.element).append(element);
+		} else {
+			const li = string.html`<li style="order: ${order}"></li>`;
+			$(li).append(element);
+			this.list.append(li);
 		}
 	}
+}
+
+const containers = {
+	belowFixedNavbar: class extends Container {
+		static isAvailable() { return isAppType('d2x'); }
+
+		go() {
+			this.element.classList.add('res-floater-belowNavbar');
+			this.element.style.top = `${5 + getD2xBodyOffset()}px`;
+			document.body.append(this.element);
+		}
+	},
+
+	visibleAfterScroll: class extends Container {
+		static isAvailable() { return !isAppType('d2x'); }
+
+		go() {
+			this.element.classList.add('res-floater-visibleAfterScroll');
+			document.body.append(this.element);
+			this.element.style.top = `${8 + getHeaderOffset(true)}px`;
+
+			if (!document.querySelector('#RESPinnedHeaderSpacer')) { // No need to hide the floater if whole header is pinned
+				this.element.hidden = true;
+				// $FlowIssue https://github.com/facebook/flow/pull/4664
+				new IntersectionObserver(entries => {
+					this.element.hidden = entries[0].isIntersecting;
+				}).observe(document.querySelector('#header'));
+			}
+		}
+	},
+
+	inert: Container,
 };
+
+const getContainer: * => Container = _.memoize(name => new (containers[name].isAvailable() ? containers[name] : containers.inert)());
 
 export function addElement(
 	element: HTMLElement | JQuery,
-	{ container: containerName = defaultContainer, separate = false, order = 0 }: {| container?: $Keys<typeof containers>, separate?: boolean, order?: number |} = {}
+	{
+		container: containerName = ['belowFixedNavbar', 'visibleAfterScroll'].find(name => containers[name].isAvailable()) || 'inert',
+		separate = false,
+		order = 0,
+	}: {|
+		container?: $Keys<typeof containers>,
+		separate?: boolean,
+		order?: number,
+	|} = {}
 ) {
-	if (!Modules.isRunning(module)) {
-		return;
-	}
-	const container = containers[containerName];
-	if (!isRunning(container)) {
-		return;
-	}
+	if (!Modules.isRunning(module)) return;
 
-	container.add(element, { separate, order });
+	getContainer(containerName).add(element, { separate, order });
 }

--- a/lib/modules/menu.js
+++ b/lib/modules/menu.js
@@ -4,6 +4,7 @@ import { $ } from '../vendor';
 import { Module } from '../core/module';
 import * as Modules from '../core/modules';
 import { i18n } from '../environment';
+import { isAppType } from '../utils';
 import * as Floater from './floater';
 import * as Hover from './hover';
 import * as SettingsConsole from './settingsConsole';
@@ -79,7 +80,7 @@ function addConsoleLink() {
 		.find('ul')
 		.after(RESPrefsLink)
 		.after('<span class="separator">|</span>');
-	Floater.addElement(RESPrefsLink, { container: 'belowFixedNavbar', order: 5 });
+	if (isAppType('d2x')) Floater.addElement(RESPrefsLink, { order: 5 });
 }
 
 function showPrefsDropdown(openDelay: number) {

--- a/lib/modules/pageNavigator.js
+++ b/lib/modules/pageNavigator.js
@@ -48,7 +48,7 @@ module.beforeLoad = () => {
 	}
 };
 
-module.afterLoad = () => {
+module.go = () => {
 	if (module.options.toComment.value && isPageType('comments')) {
 		backToNewCommentArea();
 	}


### PR DESCRIPTION
I am a little unsure about this solution's robustness, but this works by pushing the element `.header-user-dropdown` to the left by adding a margin. The margin may at some point be overwritten, which would cause to floater to overlay the profile button, though I didn't see that happen at any time while testing. It may be desirable to get a assigned element up there though.

The `belowFixedNavbar` style is kept as fallback in case the class name is changed.

![image](https://user-images.githubusercontent.com/1748521/47511588-d7a00b80-d87a-11e8-8ce9-02527866cfd3.png)

Tested in browser: Chrome 70
