### PR TITLE
Thing#getCommentCount: Default to 0 when element exists

### DIFF
--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -403,10 +403,11 @@ export class Thing {
 
 	getCommentCount(): ?number {
 		const element = this.getCommentCountElement();
-		return element && parseInt((/\d+/).exec(
+		if (!element) return;
+		return parseInt((/\d+/).exec(
 			element.textContent ||
 			element.getAttribute('data-text') // In case noCtrlF is applied
-		), 10);
+		), 10) || 0;
 	}
 
 	getCommentCountElement(): ?HTMLElement {


### PR DESCRIPTION
Otherwise it breaks when a post has no comment (fixes regression from #4853)