### PR TITLE
Revert "Temporarily disable FF integration tests (#4830)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ matrix:
       script:
         - yarn run coverage && yarn run report-coverage
         - yarn run build chrome,firefox
-        - yarn run integration chrome --retries 2 # && yarn run integration firefox --retries 2
+        - yarn run integration chrome --retries 2 && yarn run integration firefox --retries 2
     - env: RES_JOB=build_deploy
       script:
         - yarn run build all


### PR DESCRIPTION
This reverts commit c0733ee813d89fa453c2b45de7e680349494d254.

<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: 
Tested in browser: 
