### PR TITLE
commentNavigator: Don't reset when collapsing current comment thread

### DIFF
--- a/lib/modules/commentNavigator.js
+++ b/lib/modules/commentNavigator.js
@@ -124,18 +124,18 @@ const sortTypes: {
 		title: 'Navigate comments made by highlighted user',
 		getElements() {
 			const highlightedUserSelector = Object.keys(UserInfo.highlightedUsers)
-				.map(key => `.noncollapsed .author.id-t2_${key}`)
+				.map(key => `.author.id-t2_${key}`)
 				.join(', ');
 			return highlightedUserSelector ? document.querySelectorAll(highlightedUserSelector) : [];
 		},
 	},
 	tagged: {
 		title: 'Navigate comments made by tagged users',
-		getElements: () => document.querySelectorAll('.noncollapsed .tagline .userTagLink.hasTag'),
+		getElements: () => document.querySelectorAll('.tagline .userTagLink.hasTag'),
 	},
 	gilded: {
 		title: 'Navigate through gilded comments',
-		getElements: () => document.querySelectorAll('.noncollapsed .gilded-icon'),
+		getElements: () => document.querySelectorAll('.gilded-icon'),
 	},
 	IAmA: {
 		title: 'Navigate through questions that have been answered by the submitter (most useful in /r/IAmA)',
@@ -187,7 +187,7 @@ function getCategories() {
 			.map(async ([category, { title }]) => ({
 				category,
 				selected: category === currentCategory,
-				size: (await getPosts(category)).length,
+				size: (await getVisiblePosts(category)).length,
 				title,
 			}))
 	).then(v =>
@@ -198,22 +198,20 @@ function getCategories() {
 const _memoized = _.memoize(async (category: Category): Promise<Thing[]> => {
 	const { getElements, getThings, conditions } = sortTypes[category];
 
-	let things = [];
+	let things;
 
 	if (getThings) {
 		things = _.uniq(await getThings());
 	} else if (getElements) {
-		things = _.uniq(Array.from(getElements()).map(e => Thing.checkedFrom(e)));
+		things = _.uniq(Array.from(getElements()).map(e => Thing.from(e)).filter(Boolean));
 	} else {
 		things = Thing.things().filter(thing => thing.isComment());
 	}
 
 	return Cases.filterThings(things, conditions);
 });
-const getPosts = (category: Category) => _memoized(category).then(v =>
-	v.filter(thing => thing.isContentVisible())
-);
-const currentPosts = () => getPosts(currentCategory);
+const getPosts = (category: Category = currentCategory) => _memoized(category);
+const getVisiblePosts = category => getPosts(category).then(v => v.filter(thing => thing.isContentVisible()));
 let lastNavigatedTo: ?Thing = null;
 
 type Category = $Keys<typeof sortTypes>;
@@ -303,7 +301,7 @@ function installEntryElement() {
 }
 
 export async function updateFromSelected(selected = SelectedEntry.selectedThing) {
-	const posts = await currentPosts();
+	const posts = await getVisiblePosts();
 
 	if (
 		posts.includes(selected) &&
@@ -345,12 +343,12 @@ export async function move(change: 'up' | 'down' | 'top') {
 	initialize();
 
 	if (!sortTypes[currentCategory].nonlinear) {
+		// Return to the last navigated post if currently moved beyond it in the opposite direction
 		const all = Thing.things();
 		const lastNavigatedToIndex = all.indexOf(lastNavigatedTo);
 		const selectedIndex = all.indexOf(SelectedEntry.selectedThing);
 
 		if (
-			// Return to the last navigated to post if currently moved it beyond in the opposite direction
 			change === 'down' && selectedIndex < lastNavigatedToIndex ||
 			change === 'up' && selectedIndex > lastNavigatedToIndex
 		) {
@@ -359,10 +357,17 @@ export async function move(change: 'up' | 'down' | 'top') {
 		}
 	}
 
-	const posts = await currentPosts();
-	if (change === 'top') moveTo(posts[0]);
-	else if (change === 'down') moveTo(posts[posts.indexOf(lastNavigatedTo) + 1]);
-	else if (change === 'up') moveTo(posts[posts.indexOf(lastNavigatedTo) - 1]);
+	const visible = await getVisiblePosts();
+
+	if (change === 'top') {
+		moveTo(visible[0]);
+	} else {
+		// Look through all posts in case the current post is not visible anymore
+		const all = [...(await getPosts())]; // Prevent `reverse` from mutatating source
+		if (change === 'up') all.reverse();
+		const comment = all.slice(all.indexOf(lastNavigatedTo) + 1).find(v => visible.includes(v));
+		moveTo(comment);
+	}
 }
 
 function moveTo(thing: ?Thing) {


### PR DESCRIPTION
Makes the comment navigator better tolerate changes in what comments are visible.

Tested in browser: Firefox 63, Chrome 72
