### PR TITLE
Fix `Thing#isVisible` when parent comment is filtered

### DIFF
--- a/lib/css/modules/_filteReddit.scss
+++ b/lib/css/modules/_filteReddit.scss
@@ -1,23 +1,22 @@
 body.hideOver18 {
-	.thing.over18:not(.allowOver18),
-	.search-result.over18:not(.allowOver18) {
+	.over18:not(.allowOver18) {
 		display: none !important;
 	}
 }
 
-.thing.RESFiltered,
-.search-result.RESFiltered {
-	// For some reason does the scss linter complain on body:not()
-	body.res:not(.res-filters-disabled):not(.res-show-filter-reason) &:not(.res-filterline-highlight-match) {
-		&:not(.res-thing-has-visible-child),
-		&.res-thing-filter-propagate {
+body:not(.res-filters-disabled):not(.res-show-filter-reason) {
+	.RESFiltered:not(.res-filterline-highlight-match) {
+		&:not(.res-thing-partial),
+		&.res-thing-partial.res-thing-hide-children,
+		&.res-thing-hide-children > .child {
 			// !important since many custom stylesheets overrides it otherwise
 			display: none !important;
 		}
 
-		&.res-thing-has-visible-child:not(.res-selected) {
+		&.res-thing-partial:not(.res-selected) {
 			> .entry {
 				max-height: 60px;
+				overflow: hidden !important;
 				position: relative; // Make sure that all children are confined
 				opacity: .3;
 			}
@@ -27,27 +26,27 @@ body.hideOver18 {
 			}
 		}
 	}
+}
 
-	&.res-filterline-highlight-match > .entry {
-		background-color: rgba(255, 155, 155, .16);
+.res-filterline-highlight-match > .entry {
+	background-color: rgba(255, 155, 155, .16);
+}
+
+body.res-show-filter-reason .RESFiltered {
+	> .entry {
+		opacity: .7;
 	}
 
-	body.res-show-filter-reason & {
-		> .entry {
-			opacity: .7;
-		}
-
-		&::before {
-			content: attr(filter-reason);
-		}
+	&::before {
+		content: attr(filter-reason);
 	}
+}
 
-	.res-filter-remove-entry {
-		cursor: pointer;
+.res-filter-remove-entry {
+	cursor: pointer;
 
-		&::after {
-			content: ' — click here to remove matching filter entry';
-		}
+	&::after {
+		content: ' — click here to remove matching filter entry';
 	}
 }
 

--- a/lib/modules/filteReddit/Filterline.js
+++ b/lib/modules/filteReddit/Filterline.js
@@ -495,7 +495,7 @@ export class Filterline {
 		[key: string]: (Thing, Array<boolean>) => void,
 	} = {
 		propagate: (thing, results) => {
-			thing.element.classList.toggle('res-thing-filter-propagate', results.includes(true));
+			thing.element.classList.toggle('res-thing-hide-children', results.includes(true));
 		},
 		highlight: (thing, results) => {
 			// XXX If a parent comment is hidden and that is propagated, then this comment won't be highlighted

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -112,14 +112,15 @@ export class Thing {
 		this.element.classList.toggle('RESFiltered', !!filter);
 
 		if (this.isComment()) {
-			if (this.children.size) this.refreshChildFilterVisibility();
-			for (const p of this.getParents()) p.refreshChildFilterVisibility();
+			if (this.children.size) this.refreshPartialVisibility();
+			for (const p of this.getParents()) p.refreshPartialVisibility();
 		}
 	}
 
 	// `frameThrottleQueuePositionReset` ensures that children will be evaluated first
-	refreshChildFilterVisibility = frameThrottleQueuePositionReset(() => {
-		this.element.classList.toggle('res-thing-has-visible-child', Array.from(this.children).some(v => v.isVisible()));
+	// Class is applied when a thing is hidden by a filter, but has descendants that are not
+	refreshPartialVisibility = frameThrottleQueuePositionReset(() => {
+		this.element.classList.toggle('res-thing-partial', this.isFiltered() && Array.from(this.children).some(v => !v.isFiltered()));
 	});
 
 	getThreadTop(): Thing {
@@ -552,37 +553,40 @@ export class Thing {
 		return this.element.classList.contains('deleted');
 	}
 
-	isFiltered(alsoPartially: boolean = true): boolean {
-		return !document.body.classList.contains('res-filters-disabled') &&
-			(
-				this.element.classList.contains('RESFiltered') &&
-				!(alsoPartially && this.element.classList.contains('res-thing-has-visible-child'))
-			);
+	isFiltered(partialAsFiltered: boolean = false): boolean {
+		// Keep in sync with the CSS rules
+		if (this.element.matches('body.hideOver18 .over18:not(.allowOver18)')) return true;
+		if (!this.element.classList.contains('RESFiltered')) return false;
+		if (this.element.classList.contains('res-filterline-highlight-match')) return false;
+		if (!partialAsFiltered) {
+			if (this.element.classList.contains('res-thing-hide-children')) return true;
+			else return !this.element.classList.contains('res-thing-partial');
+		}
+		return true;
 	}
 
 	isCollapsed(): boolean {
 		return this.element.classList.contains('collapsed');
 	}
 
-	isInCollapsed(): boolean {
-		const parent_ = this.getParent();
-		return !!(parent_ && parent_.getClosest(function() {
-			return this.isCollapsed() || this.element.classList.contains('res-children-hidden');
-		}));
-	}
-
+	// Should be equivalent to `this.element.offsetParent !== null`
 	isVisible(): boolean {
-		return !(
-			this.isFiltered() ||
-			this.isInCollapsed()
-		);
+		if (!document.body.classList.contains('res-filters-disabled') && this.isFiltered()) return false;
+		const { parent } = this;
+		if (parent) {
+			if (parent.isCollapsed()) return false;
+			if (parent.element.classList.contains('res-children-hidden')) return false; // `hideChildComments` module
+			if (!parent.isVisible()) return false;
+		}
+
+		return true;
 	}
 
 	isContentVisible(): boolean {
 		return !(
-			this.isFiltered(false) ||
+			(!document.body.classList.contains('res-filters-disabled') && this.isFiltered(true)) ||
 			this.isCollapsed() ||
-			this.isInCollapsed()
+			!this.isVisible()
 		);
 	}
 


### PR DESCRIPTION
It would sometimes return wrong result, causing commentNavigator to browse to a hidden comments.

This can be used to check that it returns correct results:
`Array.from(things).filter(v => v.isComment() && v.isVisible() === !v.element.offsetParent).length == 0`

Tested in browser: Firefox 64, Chrome 71
