### PR TITLE
Add /me/f/mod/about to the modqueue pagetype, fixes #4864

### DIFF
--- a/lib/utils/location.js
+++ b/lib/utils/location.js
@@ -34,7 +34,7 @@ export const regexes: { [string]: RegExp } = {
 	duplicates:       /^\/r\/[\w\.\+]+\/duplicates\/([a-z0-9]+)/i,
 	subreddit:        /^\/r\/([\w\.\+]+)(?:\/|$)/i,
 	subredditAbout:   /^\/r\/([\w\.]+)\/about(?:\/(?!modqueue|reports|spam|unmoderated|edited)|$)/i,
-	modqueue:         /^\/r\/([\w\.\+]+)\/about\/(?:modqueue|reports|spam|unmoderated|edited)(?:\/|$)/i,
+	modqueue:         /^\/(?:r|me\/f)\/([\w\.\+]+)\/about\/(?:modqueue|reports|spam|unmoderated|edited)(?:\/|$)/i,
 	multireddit:      /^\/((?:me|user\/[\w\-]+)\/[mf]\/[\w\.\+]+)(?:\/|$)/i,
 	domain:           /^\/domain\/([\w\.]+)(?:\/|$)/i,
 	composeMessage:   /^\/(?:r\/([\w\.\+]+)\/)?message\/compose(?:\/|$)/i,


### PR DESCRIPTION
/r/mod can be filtered to by certain types of moderation actions
(reports, unmoderated, etc). When this is done, the url changes to
`/me/f/mod/about/<type>`. This change expands the modqueue regex to include
the `/me/f` file path.

<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: #4864 
Tested in browser: Chrome 70
