### PR TITLE
 redesign: Add expandos in comments

### DIFF
--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -60,8 +60,17 @@ img {
 	margin-right: 5px;
 	padding: 0;
 
+	background-image: url('../images/expandoEmpty.svg');
+
 	&-duplicate {
 		filter: sepia(1);
+	}
+
+	// TODO Use a better icon for the catch-all button
+	&.video.collapsed::after {
+		content: '▷';
+		color: white;
+		padding-left: 6px;
 	}
 
 	&.image.collapsed {
@@ -102,10 +111,6 @@ img {
 		&:hover {
 			background-image: url('../images/expandoClose-active.svg');
 		}
-	}
-
-	&.expando-button-loading {
-		background-image: url('../images/expandoEmpty.svg');
 	}
 }
 

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -35,6 +35,7 @@ import {
 	waitForEvent,
 	watchForElements,
 	watchForThings,
+	watchForRedditEvents,
 	getPercentageVisibleYAxis,
 	getViewportSize,
 } from '../utils';
@@ -454,7 +455,6 @@ module.exclude = [
 	/^\/ads\/[\-\w\._\?=]*/i,
 	'submit',
 	/^\/subreddits/i,
-	'd2x',
 ];
 
 module.beforeLoad = () => {
@@ -484,6 +484,23 @@ module.beforeLoad = () => {
 	watchForElements(['selfText'], null, scanBody);
 	watchForThings(['comment', 'message'], thing => scanBody(thing.getTextBody()));
 	watchForThings(['post'], thing => checkElementForMedia(thing.getPostLink()));
+
+	watchForRedditEvents('comment', (placeholder, { _: { update } }) => {
+		if (update) return;
+		const comment = placeholder.closest('.Comment');
+		// TODO `comment` should be refined to the text body, but it doesn't yet have a class
+		scanBody(comment);
+	});
+
+	// selftexts in comment pages evidently does not emit an event
+	// TODO this prevent expando from being added when there's already media there
+	watchForRedditEvents('postAuthor', (placeholder, { _: { update } }) => {
+		if (update) return;
+		const body = placeholder.closest('[data-test-id="post-content"]');
+		// Ignore posts that has native media
+		if (body && body.querySelector('.media-element')) return;
+		scanBody(body);
+	});
 };
 
 module.go = () => {
@@ -996,6 +1013,12 @@ async function completeExpando(expando, thing, mediaInfo) {
 				});
 		}));
 	}
+
+	// The d2x lightbox hides overflowing media
+	expando.onExpand(() => {
+		const lightbox = expando.media.element.closest('#overlayScrollContainer');
+		if (lightbox) lightbox.firstChild.style.overflowY = 'initial';
+	});
 
 	// Start loading media early to make it snappier
 	expando.button.addEventListener('mousedown', () => { preloadMedia([expando]); });

--- a/lib/types/events.js
+++ b/lib/types/events.js
@@ -13,6 +13,11 @@ export type SubredditEventData = {|
 	url: string,
 |};
 
+export type CommentEventData = {
+	_: EventMetadata,
+	// Not complete
+};
+
 export type CommentAuthorEventData = {|
 	_: EventMetadata,
 	author: string,

--- a/lib/utils/watchers_d2x.js
+++ b/lib/utils/watchers_d2x.js
@@ -1,6 +1,7 @@
 // @flow
 import { JSAPI_CONSUMER_NAME } from '../constants/jsapi';
 import type {
+	CommentEventData, // eslint-disable-line no-unused-vars
 	CommentAuthorEventData, // eslint-disable-line no-unused-vars
 	PostAuthorEventData, // eslint-disable-line no-unused-vars
 	PostEventData, // eslint-disable-line no-unused-vars
@@ -16,6 +17,7 @@ const callbacks = {
 };
 
 /* eslint-disable no-redeclare, no-unused-vars */
+declare function watchForRedditEvents(type: 'comment', callback: (HTMLElement, CommentEventData) => void | Promise<void>): void;
 declare function watchForRedditEvents(type: 'subreddit', callback: (HTMLElement, SubredditEventData) => void | Promise<void>): void;
 declare function watchForRedditEvents(type: 'postAuthor', callback: (HTMLElement, PostAuthorEventData) => void | Promise<void>): void;
 declare function watchForRedditEvents(type: 'post', callback: (HTMLElement, PostEventData) => void | Promise<void>): void;


### PR DESCRIPTION
- Adds expandos to comments and selftext when the comment page / lightbox
- The catch-all expando (`video`) button is not native to d2x, so I just added a placeholder button

Tested in browser: Chrome 71