### PR TITLE
Add navigation links to neverEndingReddit feature

### DIFF
--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -103,6 +103,7 @@ const dupeSet = new Set();
 const siteTable = _.once(() => Thing.thingsContainer());
 let currentPageNumber = 1;
 let nextPageUrl;
+let prevPageUrl;
 let $NREPause, isPaused, pauseReason, pauseAfterPages, nextPausePage;
 
 let initAutoNextPage: ?() => void;
@@ -138,8 +139,9 @@ module.go = () => {
 
 	if (!nextPageUrl) { // May be restored from returnToPrevPage
 		try {
-			const nextLink = getNextPrevLinks(siteTable()).next;
+			const { next: nextLink, prev: prevLink} = getNextPrevLinks(siteTable());
 			nextPageUrl = nextLink && nextLink.getAttribute('href');
+			prevPageUrl = prevLink && prevLink.getAttribute('href');
 		} catch (e) { /* empty */ }
 	}
 
@@ -348,14 +350,24 @@ function setLoaderWidgetActionText(widget) {
 		.text(text)
 		.appendTo(widget);
 
-	const nextpage = $('<a id="NERStaticLink">or open next page</a>')
+	const prevpage = $('<a id="NERPrevStaticLink">open prev page</a>')
+		.attr('href', prevPageUrl || '')
+		.click(() => {
+			loadPromise = true; // avoid trying to load a new page before we navigate
+			if (pauseReason === 'pauseAfterEvery') togglePause(false);
+		});
+
+	const nextpage = $('<a id="NERNextStaticLink">open next page</a>')
 		.attr('href', nextPageUrl || '')
 		.click(() => {
 			loadPromise = true; // avoid trying to load a new page before we navigate
 			if (pauseReason === 'pauseAfterEvery') togglePause(false);
 		});
 
-	$('<p class="NERWidgetText" />').append(nextpage)
+	$('<p class="NERWidgetText" />')
+		.append(prevpage)
+		.append(' or ')
+		.append(nextpage)
 		.append('&nbsp;(and clear Never-Ending stream)')
 		.appendTo(widget);
 }
@@ -425,8 +437,9 @@ const loadPage = mutex(async (url: string) => {
 		Orangered.updateFromPage(tempDiv);
 
 		try {
-			const nextLink = getNextPrevLinks(tempDiv).next;
+			const { next: nextLink, prev: prevLink } = getNextPrevLinks(tempDiv);
 			nextPageUrl = nextLink && nextLink.getAttribute('href');
+			prevPageUrl = prevLink && prevLink.getAttribute('href');
 		} catch (e) {
 			const noresults = tempDiv.querySelector('#noresults');
 			if (noresults) {
@@ -457,7 +470,7 @@ const loadPage = mutex(async (url: string) => {
 
 const appendPage = fastAsync(function*(newSiteTable) {
 	const pageMarker = string.html`<div class="NERPageMarker" data-number="${currentPageNumber}">
-		Page ${currentPageNumber}
+		<a href="${prevPageUrl}">previous page</a> Page ${currentPageNumber} <a href="${nextPageUrl}">next page</a>
 		${string.safe(SettingsNavigation.makeUrlHashLink(module.moduleID, undefined, ' ', 'gearIcon'))}
 	</div>`;
 


### PR DESCRIPTION
Hello!
I'm very fond of neverEndingReddit feature, but I find it problematic that prev/next page links are not available in GUI boxes. My workaround so far was to disable autoloading, and then click ‘open next page’ URL. I think it makes sense to always show prev/next, and this PR adds this.