### PR TITLE
Added a preintegration script to package.json to ensure availability …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ matrix:
     - env: RES_JOB=test
       script:
         - yarn run coverage && yarn run report-coverage
-        - yarn run build chrome,firefox
         - yarn run integration chrome --retries 2 # && yarn run integration firefox --retries 2
     - env: RES_JOB=build_deploy
       script:

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test": "cross-env NODE_ENV=test ava",
     "coverage": "cross-env NODE_ENV=test nyc ava",
     "report-coverage": "nyc report --reporter=text-lcov | coveralls",
+    "preintegration": "npm run build all",
     "integration": "nightwatch --env",
     "deploy": "node build/deploy.js",
     "deploy-changelog": "node build/deployChangelog.js",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "cross-env NODE_ENV=test ava",
     "coverage": "cross-env NODE_ENV=test nyc ava",
     "report-coverage": "nyc report --reporter=text-lcov | coveralls",
-    "preintegration": "npm run build all",
+    "preintegration": "npm run build chrome,firefox",
     "integration": "nightwatch --env",
     "deploy": "node build/deploy.js",
     "deploy-changelog": "node build/deployChangelog.js",


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: Not applicable
Tested in browser: Not applicable

RES must be built for both chrome and firefox before integration tests can be run, which means contributors must execute `npm run build chrome,firefox` manually every time they want to run integration tests locally.

The preintegration script introduced in this PR takes care of this.