### PR TITLE
Flair emojis as text option #4924

### DIFF
--- a/lib/css/modules/_styleTweaks.scss
+++ b/lib/css/modules/_styleTweaks.scss
@@ -152,7 +152,7 @@ blockquote.twitter-tweet {
 		width: auto;
 		vertical-align: initial;
 	}
-	
+
 	.flairemoji::after {
 		content: attr(title);
 	}

--- a/lib/css/modules/_styleTweaks.scss
+++ b/lib/css/modules/_styleTweaks.scss
@@ -146,13 +146,13 @@ blockquote.twitter-tweet {
 }
 
 .res-styleTweaks-flairEmojiAsText-always,
-.res-styleTweaks-flairEmojiAsText-nosubstyle body.res-srstyle-disabled {
-    .flairemoji[style]  {
-        background-image: none !important;
-        width: auto;
-        vertical-align: initial;
-    }
-    .flairemoji:after {
-        content: attr(title);
-    }
+.res-styleTweaks-flairEmojiAsText-nosubstyle.res-srstyle-disabled {
+	.flairemoji[style]  {
+		background-image: none !important;
+		width: auto;
+		vertical-align: initial;
+	}
+	.flairemoji:after {
+		content: attr(title);
+	}
 }

--- a/lib/css/modules/_styleTweaks.scss
+++ b/lib/css/modules/_styleTweaks.scss
@@ -144,3 +144,15 @@ blockquote.twitter-tweet {
 		display: none;
 	}
 }
+
+.res-styleTweaks-flairEmojiAsText-always,
+.res-styleTweaks-flairEmojiAsText-nosubstyle body.res-srstyle-disabled {
+    .flairemoji[style]  {
+        background-image: none !important;
+        width: auto;
+        vertical-align: initial;
+    }
+    .flairemoji:after {
+        content: attr(title);
+    }
+}

--- a/lib/css/modules/_styleTweaks.scss
+++ b/lib/css/modules/_styleTweaks.scss
@@ -152,7 +152,8 @@ blockquote.twitter-tweet {
 		width: auto;
 		vertical-align: initial;
 	}
-	.flairemoji:after {
+	
+	.flairemoji::after {
 		content: attr(title);
 	}
 }

--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -171,6 +171,23 @@ module.options = {
 		description: 'styleTweaksHideDomainLinkDesc',
 		bodyClass: true,
 	},
+	flairEmojiAsText: {
+		title: 'styleTweaksflairEmojiAsText',
+		description: 'styleTweaksflairEmojiAsTextDesc',
+		type: 'enum',
+		value: 'never',
+		values: [{
+			name: 'Never',
+			value: 'never',
+		}, {
+			name: 'Subreddit Style Disabled',
+			value: 'nosubstyle',
+		}, {
+			name: 'Always',
+			value: 'always',
+		}],
+		bodyClass: true,
+	},
 };
 
 const ignoredSubredditStyleStorage = Storage.wrap('RESmodules.styleTweaks.ignoredSubredditStyles', ([]: string[]));

--- a/lib/modules/styleTweaks.js
+++ b/lib/modules/styleTweaks.js
@@ -172,18 +172,18 @@ module.options = {
 		bodyClass: true,
 	},
 	flairEmojiAsText: {
-		title: 'styleTweaksflairEmojiAsText',
-		description: 'styleTweaksflairEmojiAsTextDesc',
+		title: 'styleTweaksFlairEmojiAsText',
+		description: 'styleTweaksFlairEmojiAsTextDesc',
 		type: 'enum',
 		value: 'never',
 		values: [{
-			name: 'Never',
+			name: 'styleTweaksFlairEmojiAsTextNever',
 			value: 'never',
 		}, {
-			name: 'Subreddit Style Disabled',
+			name: 'styleTweaksFlairEmojiAsTextNoSubStyle',
 			value: 'nosubstyle',
 		}, {
-			name: 'Always',
+			name: 'styleTweaksFlairEmojiAsTextAlways',
 			value: 'always',
 		}],
 		bodyClass: true,

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -3462,11 +3462,20 @@
 	"styleTweaksHideDomainLinkDesc":{
 		"message": "Hides the domain link in post taglines."
 	},
-    "styleTweaksflairEmojiAsText": {
+    "styleTweaksFlairEmojiAsText": {
         "message": "Flair Emoji As Text"
     },
-    "styleTweaksflairEmojiAsTextDesc":{
+    "styleTweaksFlairEmojiAsTextDesc":{
         "message": "Show emoji flairs as text instead of icons"
+    },
+    "styleTweaksFlairEmojiAsTextNever": {
+        "message": "Never"
+    },
+    "styleTweaksFlairEmojiAsTextNoSubStyle": {
+        "message": "Subreddit Style Disabled"
+    },
+    "styleTweaksFlairEmojiAsTextAlways": {
+        "message": "Always"
     },
 	"subRedditTaggerSubRedditsTitle": {
 		"message": "Sub Reddits"

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -3462,6 +3462,12 @@
 	"styleTweaksHideDomainLinkDesc":{
 		"message": "Hides the domain link in post taglines."
 	},
+    "styleTweaksflairEmojiAsText": {
+        "message": "Flair Emoji As Text"
+    },
+    "styleTweaksflairEmojiAsTextDesc":{
+        "message": "Show emoji flairs as text instead of icons"
+    },
 	"subRedditTaggerSubRedditsTitle": {
 		"message": "Sub Reddits"
 	},


### PR DESCRIPTION
Relevant issue: fixes #4924
Relevant Reddit post:  https://old.reddit.com/r/Enhancement/comments/9xmmg7/force_user_flair_to_be_text_only/
Tested in browser: Firefox (63.0.3)

Option was placed in the Style Tweaks module:

<img width="1007" alt="screen shot 2018-11-16 at 3 38 45 pm" src="https://user-images.githubusercontent.com/33071129/48650952-d6fc2000-e9b5-11e8-8450-33ed328ca6b4.png">

Before and after example from r/soccer:

<img width="955" alt="before" src="https://user-images.githubusercontent.com/33071129/48651185-e760ca80-e9b6-11e8-96ae-95eaadc339b6.png">
<img width="956" alt="after" src="https://user-images.githubusercontent.com/33071129/48651191-edef4200-e9b6-11e8-9c68-c0f694687d95.png">



