### PR TITLE
Fixes relatively addressed anchor links causing page refreshes

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -908,6 +908,16 @@ function shouldLinkBeDeferred(element) {
 const inText = element => !!element.closest('.md, .search-result-footer');
 
 async function checkElementForMedia(element) {
+	// Prevents relatively addressed anchor link urls from refreshing the page,
+	// while also opening all #res:settings urls on the current page
+	let hash = /^#.*|#res:settings.*/gi.exec(element.getAttribute('href'));
+	if (hash) {
+		element.addEventListener('click', function(e) {
+			e.preventDefault();
+			document.location.href = hash[0];
+		});
+	}
+
 	if (shouldLinkBeDeferred(element)) {
 		await new Promise(resolve => deferredLinks.set(element, resolve));
 		deferredLinks.delete(element);

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -910,9 +910,9 @@ const inText = element => !!element.closest('.md, .search-result-footer');
 async function checkElementForMedia(element) {
 	// Prevents relatively addressed anchor link urls from refreshing the page,
 	// while also opening all #res:settings urls on the current page
-	let hash = /^#.*|#res:settings.*/gi.exec(element.getAttribute('href'));
+	const hash = (/^#.*|#res:settings.*/gi).exec(element.getAttribute('href'));
 	if (hash) {
-		element.addEventListener('click', function(e) {
+		element.addEventListener('click', e => {
 			e.preventDefault();
 			document.location.href = hash[0];
 		});


### PR DESCRIPTION
Reddit seems to have introduced some link handling that causes relatively addressed anchor urls like:
`[Link To RES Setting](#res:settings/showImages/autoplayVideo)`
to invoke a page refresh instead of just jumping to the anchor or opening the RES settings.

In addition, this change also makes all #res:settings links open on the current page, even if it's absolute path isn't the same.

Doing this in the `showImages` module might not be an ideal spot for it, but links are already being monitored and processed at that point, so it limits the required overhead. 