### PR TITLE
On-save-settings hook

### DIFF
--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -22,6 +22,7 @@ export class Module<RawOpt: { [string]: any }, Opt: { [string]: ModuleOption<Raw
 	exclude: Array<PageType | AppType | RegExp> = [];
 	shouldRun: () => boolean = () => true;
 	onToggle: (enabling: boolean) => void = () => {};
+	onSaveSettings: (savedSettings: any) => void = () => {}; // savedSettings will only contain options that were just changed
 
 	hidden: boolean = false;
 	disabledByDefault: boolean = false;

--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -22,7 +22,7 @@ export class Module<RawOpt: { [string]: any }, Opt: { [string]: ModuleOption<Raw
 	exclude: Array<PageType | AppType | RegExp> = [];
 	shouldRun: () => boolean = () => true;
 	onToggle: (enabling: boolean) => void = () => {};
-	onSaveSettings: (savedSettings: any) => void = () => {}; // savedSettings will only contain options that were just changed
+	onSaveSettings: (changedSettings: any) => void = () => {};
 
 	hidden: boolean = false;
 	disabledByDefault: boolean = false;

--- a/lib/core/options/stage.js
+++ b/lib/core/options/stage.js
@@ -36,6 +36,7 @@ function commitStagedOptions() {
 		for (const [optionName, option] of Object.entries(options)) {
 			set(modId, optionName, option.value);
 		}
+		Modules.get(modId).onSaveSettings(options);
 	}
 	clearStagedOptions();
 }


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: NA
Tested in browser: chrome, firefox

This PR adds a module-level hook (onSaveSettings) that runs when the module's options are changes in RES settings console