### PR TITLE
 Filterline: Refactor effects and simplify widget

### DIFF
--- a/lib/core/migrate/migrate.js
+++ b/lib/core/migrate/migrate.js
@@ -684,8 +684,6 @@ const migrations = [
 				}
 				await Options.set('filteReddit', 'customFiltersP', customFilters.value);
 			}
-
-			// TODO Next stable: Remove `RESmodules.filteReddit` and option filteReddit customFilters
 		},
 	}, {
 		versionNumber: '5.11.1-settingsConsole-builder-tweak',
@@ -708,6 +706,41 @@ const migrations = [
 				.filter(([, { ignored }]) => ignored)
 				.map(([username]) => [username]);
 			await Options.set('filteReddit', 'users', ignoredUsers);
+		},
+	}, {
+		versionNumber: '5.13.3-filterline-effects-and-clean',
+		async go() {
+			function migrateFilters(filters = {}) {
+				for (const [id, filter] of Object.entries(filters)) {
+					if (!_.isObject(filter)) {
+						delete filters[id];
+						continue;
+					}
+					filter.effects = { hide: filter.state !== null, ...filter.sideEffects };
+					if (filter.state === null) filter.state = true;
+				}
+			}
+
+			let f = Storage.wrapPrefix('RESmodules.filteReddit.', (): any => ({}));
+			for (const [k, v] of Object.entries(await f.getAll())) {
+				if (k.startsWith('commentDefault') || k.startsWith('postDefault')) {
+					migrateFilters(v);
+					f.set(k, v);
+				} else {
+					f.delete(k);
+				}
+			}
+
+			f = Storage.wrapPrefix('filterline.', (): any => ({}));
+			for (const [k, v] of Object.entries(await f.getAll())) {
+				if (v) {
+					migrateFilters(v.filters);
+					v.lastUsed = Date.now();
+					f.set(k, v);
+				} else {
+					f.delete(k);
+				}
+			}
 		},
 	},
 

--- a/lib/css/modules/_filteReddit.scss
+++ b/lib/css/modules/_filteReddit.scss
@@ -4,8 +4,8 @@ body.hideOver18 {
 	}
 }
 
-body:not(.res-filters-disabled):not(.res-show-filter-reason) {
-	.RESFiltered:not(.res-filterline-highlight-match) {
+body:not(.res-filters-disabled):not(.res-display-match-reason) {
+	.res-thing-filter-hide {
 		&:not(.res-thing-partial),
 		&.res-thing-partial.res-thing-hide-children,
 		&.res-thing-hide-children > .child {
@@ -28,26 +28,8 @@ body:not(.res-filters-disabled):not(.res-show-filter-reason) {
 	}
 }
 
-.res-filterline-highlight-match > .entry {
-	background-color: rgba(255, 155, 155, .16);
-}
-
-body.res-show-filter-reason .RESFiltered {
-	> .entry {
-		opacity: .7;
-	}
-
-	&::before {
-		content: attr(filter-reason);
-	}
-}
-
-.res-filter-remove-entry {
+.res-thing-filter-remove-matching-entry {
 	cursor: pointer;
-
-	&::after {
-		content: ' — click here to remove matching filter entry';
-	}
 }
 
 @mixin filterline-basic-layout {
@@ -63,13 +45,14 @@ body.res-show-filter-reason .RESFiltered {
 		display: none;
 	}
 
-	.comments-page & {
+	body.comments-page & {
 		margin-left: 10px;
 	}
 }
 
-.res-filteReddit-filterline-pad-until-ready {
-	.listing-page .content[role=main] > .spacer:nth-of-type(2)::before {
+body.res-filteReddit-filterline-pad-until-ready {
+	&.comments-page .nestedlisting::before,
+	&.listing-page #siteTable::before {
 		@include filterline-basic-layout;
 		content: ' ';
 	}
@@ -110,19 +93,19 @@ body.res-show-filter-reason .RESFiltered {
 		border-bottom: 1px solid #efefef;
 		padding-bottom: 1px;
 
-		&-hidden { display: none; }
+		&::before {
+			content: attr(text);
+		}
 
 		&:hover { border-bottom: 1px solid #bfbfbf; }
 
-		&-active,
-		&-active:hover {
+		&-disabled { display: none; }
+
+		&-hiding,
+		&-hiding:hover {
 			border-bottom: 2px solid greenyellow;
 			padding-bottom: 0;
 			color: black;
-		}
-
-		&-name::before {
-			content: attr(name);
 		}
 
 		&-hover {

--- a/lib/css/modules/_nightMode.scss
+++ b/lib/css/modules/_nightMode.scss
@@ -1372,7 +1372,8 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 		}
 	}
 
-	&.res-filteReddit-filterline-pad-until-ready .listing-page .content[role=main] > .spacer:nth-of-type(2)::before,
+	&.res-filteReddit-filterline-pad-until-ready.listing-page #siteTable::before,
+	&.res-filteReddit-filterline-pad-until-ready.comments-page .nestedlisting::before,
 	.res-filterline {
 		background-color: rgba(38, 38, 38, .9);
 	}
@@ -1381,8 +1382,8 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 		&-filter {
 			border-bottom-color: #383838;
 
-			&-active,
-			&-active:hover {
+			&-hiding,
+			&-hiding:hover {
 				border-bottom-color: #e4e4e4;
 				color: #e4e4e4;
 			}

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -379,16 +379,17 @@ You can use the command line to manipulate Filterline. Enter it by pressing the 
 
 export type FilterStorageValues = {|
 	type: string,
-	state: boolean | null,
+	state: boolean,
 	criterion?: string,
 	name?: string,
 	conditions?: {},
-	sideEffects?: {},
+	effects?: {},
 |};
 
 type LineState = {
 	visible?: boolean,
 	filters?: { [id: string]: FilterStorageValues },
+	lastUsed?: number, // TODO Implement auto-pruning of unused storages (often from comment pages)
 };
 
 const pageID = fullLocation();
@@ -398,7 +399,7 @@ const customFilterVariant = thingType === 'post' ? 'customFiltersP' : 'customFil
 
 const createStateFromTypes = types => (
 	types.reduce((acc, v, i) => {
-		if (v) acc[`!${i}`] = { type: v, state: null };
+		if (v) acc[`!${i}`] = { type: v };
 		return acc;
 	}, {})
 );
@@ -445,7 +446,8 @@ async function getDefaultFilters() {
 }
 
 const initialFilterlineState = reifyPromise((async () => {
-	let { filters, visible } = await filterlineStorage.get(); // eslint-disable-line prefer-const
+	let { filters, visible, lastUsed } = await filterlineStorage.get(); // eslint-disable-line prefer-const
+	if (lastUsed) filterlineStorage.patch({ lastUsed: Date.now() });
 	if (!filters || !Object.values(filters).length) filters = await getDefaultFilters();
 	return { filters, visible };
 })());
@@ -477,7 +479,9 @@ module.beforeLoad = fastAsync(function*()	{
 	watchForThings([thingType], registerThing, { immediate: true });
 
 	// This must be done after `restoreState` and `populateFromOptions`
-	({ visible = module.options.showFilterline.value || filterline.hasActiveLineFilters() } = state);
+	({
+		visible = module.options.showFilterline.value || filterline.getActiveFilters().some(v => !(v instanceof ExternalFilter)),
+	} = state);
 	if (visible) BodyClasses.add('res-filteReddit-filterline-pad-until-ready');
 });
 
@@ -588,6 +592,10 @@ class ListFilter {
 		};
 
 		this.filter = addExternalFilter(this.externalKey, i18n(module.options[this.externalKey].title), getConditions, class extends ExternalFilter {
+			constructor(id: *, BaseCase: *, name: *, conditions: *, state: *, effects: *) {
+				super(id, BaseCase, name, conditions, state, { hide: true, ...effects });
+			}
+
 			async getMatchingEntry(thing) {
 				return sources.get(
 					await asyncFind(sources.keys(), v => Case.fromConditions(v).evaluate(thing))
@@ -654,7 +662,9 @@ function populateFromOptions() {
 		const conditions = Cases.resolveGroup(customFilter.body);
 		if (!Cases.isUseful(conditions.type)) continue;
 		addExternalFilter(customFilter.id, (customFilter.opts || {}).name, () => conditions, class extends ExternalFilter {
-			sideEffects = thingType === 'comment' ? { propagate: customFilter.opts.propagate } : {};
+			constructor(id: *, BaseCase: *, name: *, conditions: *, state: *, effects: *) {
+				super(id, BaseCase, name, conditions, state, { hide: true, propagate: !!customFilter.opts.propagate, ...effects });
+			}
 		});
 	}
 

--- a/lib/modules/filteReddit/Case.js
+++ b/lib/modules/filteReddit/Case.js
@@ -30,6 +30,8 @@ export class Case {
 
 		const state = await cased.evaluate(selected);
 
+		if (typeof state !== 'boolean') throw new Error('Could not evaluate case against selected thing');
+
 		return { conditions, state };
 	}
 

--- a/lib/modules/filteReddit/ExternalFilter.js
+++ b/lib/modules/filteReddit/ExternalFilter.js
@@ -21,7 +21,7 @@ export class ExternalFilter extends Filter {
 		}
 
 		if (Cases.isUseful(this.case.constructor.type)) {
-			const t = CreateElement.toggleButton(state => { this.update(state ? false : null); }, null, this.state === false, '', '');
+			const t = CreateElement.toggleButton(state => { this.update(undefined, undefined, { hide: state }); }, null, this.effects.hide, '', '');
 			this.element.appendChild(t);
 		}
 	}

--- a/lib/modules/filteReddit/Filter.js
+++ b/lib/modules/filteReddit/Filter.js
@@ -1,9 +1,10 @@
 /* @flow */
 
-import { $ } from '../../vendor';
+import _ from 'lodash';
 import type { Thing } from '../../utils';
 import {
 	fastAsync,
+	string,
 } from '../../utils';
 import type { FilterStorageValues } from '../filteReddit';
 import { Case } from './Case';
@@ -18,19 +19,20 @@ export class Filter {
 
 	BaseCase: Class<Case>;
 	case: Case;
-	state: boolean | null;
+	state: boolean;
 
 	element: HTMLElement;
 
-	sideEffects: { [key: string]: boolean } = {};
+	effects: { [key: string]: boolean } = {};
 
-	constructor(id: *, BaseCase: *, name: *, conditions: * = null, state: * = null, sideEffects: * = {}) {
+	constructor(id: *, BaseCase: *, name: *, conditions: * = null, state: * = true, effects: * = {}) {
 		this.id = id;
 		this.BaseCase = BaseCase;
 		this.name = name;
 		this.state = state;
 		this.setCase(BaseCase.fromConditions(conditions));
-		Object.assign(this.sideEffects, sideEffects);
+		// Add only active effects in order to minimize the number of effects to keep track of
+		Object.assign(this.effects, _.pickBy(effects, Boolean));
 	}
 
 	createElement() {}
@@ -39,14 +41,14 @@ export class Filter {
 		this.parent = parent;
 	}
 
-	getStateText(state: ?boolean, cased: Case = this.case): string {
+	getStateText(state: boolean = this.state, cased: Case = this.case): string {
 		return state !== false ?
 			this.name || cased.trueText || (this.BaseCase.text || this.BaseCase.type).toLowerCase() :
-			this.name && `¬ ${this.name}` || cased.falseText || `¬ ${this.getStateText(null, cased)}`;
+			this.name && `¬ ${this.name}` || cased.falseText || `¬ ${this.getStateText(true, cased)}`;
 	}
 
 	getSaveValues() {
-		const values: FilterStorageValues = { type: this.BaseCase.type, state: this.state, sideEffects: this.sideEffects };
+		const values: FilterStorageValues = { type: this.BaseCase.type, state: this.state, effects: this.effects };
 
 		if (this.BaseCase.variant === 'basic') {
 			values.conditions = this.case.conditions;
@@ -60,8 +62,12 @@ export class Filter {
 	}
 
 	remove() {
-		this.state = null;
+		for (const effect of Object.keys(this.effects)) this.effects[effect] = false;
 		if (this.parent) this.parent.removeFilter(this);
+	}
+
+	getEffects(): Array<string> {
+		return Object.keys(_.pickBy(this.effects, Boolean));
 	}
 
 	setCase(newCase: Case) {
@@ -69,7 +75,7 @@ export class Filter {
 		if (this.case.isEvaluatable()) this.case.observe(this);
 	}
 
-	update(state: ?*, conditions?: *, describeOnly: boolean = false) {
+	update(state: boolean = this.state, conditions?: *, effects: * = {}, describeOnly: boolean = false) {
 		const cased = conditions === undefined ? this.case : this.BaseCase.fromConditions(conditions, true);
 		if (!cased.isValid()) throw new Error('Invalid conditions');
 
@@ -77,8 +83,10 @@ export class Filter {
 			return `Show only posts which matches "${this.getStateText(state, cased)}"`;
 		}
 
-		if (state !== undefined) this.state = state;
+		this.state = state;
 		this.setCase(cased);
+		Object.assign(this.effects, effects);
+
 		this.refresh();
 	}
 
@@ -104,7 +112,7 @@ export class Filter {
 	}, describeOnly?: boolean = false): Promise<?string> {
 		if (disableFilter) {
 			if (describeOnly) return 'Disable filter';
-			return this.update(null);
+			return this.update(undefined, undefined, { hide: false });
 		}
 
 		let state, conditions;
@@ -116,10 +124,9 @@ export class Filter {
 			state = this.state;
 		}
 
-		state = reverseActive ? new Map([[false, true], [null, false], [true, false]]).get(state) :
-			new Map([[false, false], [null, true], [true, true]]).get(state);
+		if (reverseActive) state = !state;
 
-		return this.update(state, conditions, describeOnly);
+		return this.update(state, conditions, { hide: true }, describeOnly);
 	}
 
 	matches = fastAsync(function*(thing: Thing) {
@@ -138,24 +145,18 @@ export class Filter {
 		return this.case.conditions;
 	}
 
-	removeEntry(entry: *) { // eslint-disable-line no-unused-vars
-		this.update(null);
+	removeEntry(entry: *, effect: string) { // eslint-disable-line no-unused-vars
+		this.update(undefined, undefined, { [effect]: false });
 	}
 
-	async showThingFilterReason(thing: Thing) {
-		thing.element.setAttribute('filter-reason', this.getStateText(!this.state));
-
+	async buildReasonElement(thing: Thing, effect: string) {
 		const entry = await this.getMatchingEntry(thing);
-
-		$('<span>', {
-			class: 'res-filter-remove-entry',
-			title: JSON.stringify(entry, null, '  '),
-			click: () => { this.removeEntry(entry); },
-		}).prependTo(thing.element);
-	}
-
-	clearThingFilterReason(thing: Thing) {
-		thing.element.removeAttribute('filter-reason');
-		$(thing.element).find('> .res-filter-remove-entry').remove();
+		const element = string.html`
+			<div class="res-thing-filter-remove-matching-entry" title="${JSON.stringify(entry, null, '  ')}">
+				${effect}: ${this.getStateText(!this.state)} — click to remove matching filter entry
+			</div>
+		`;
+		element.addEventListener('click', () => { this.removeEntry(entry, effect); });
+		return element;
 	}
 }

--- a/lib/modules/filteReddit/Filterline.js
+++ b/lib/modules/filteReddit/Filterline.js
@@ -4,7 +4,6 @@ import _ from 'lodash';
 import { $ } from '../../vendor';
 import type { Thing } from '../../utils';
 import {
-	asyncFind,
 	fastAsync,
 	waitForEvent,
 	downcast,
@@ -45,24 +44,23 @@ export class Filterline {
 	filters: Filter[] = [];
 	sortedFilters: Filter[] = []; // Filters sorted by slowness
 
-	hiddenThings: Set<Thing> = new Set();
-	showFilterReason: boolean = false;
+	currentMatches: Map<Thing, { [string]: Filter | null }> = new Map();
+
+	permanentlyHiddenThings: Set<Thing> = new Set();
+	displayReasons: boolean = false;
 
 	element: HTMLElement;
 	dropdown: HTMLElement;
 	preamble: HTMLElement;
 	filterContainer: HTMLElement;
 	poweredElement: HTMLInputElement;
-	hideCheckbox: HTMLInputElement;
+	permanentlyHideCheckbox: HTMLInputElement;
+
+	initialized: boolean = false;
 
 	constructor(storage: *, thingType: *) {
 		this.storage = storage;
 		this.thingType = thingType;
-	}
-
-	isInitialized() {
-		// Auto-initialize when things are added
-		return !!this.things.size;
 	}
 
 	isPowered() { return !document.body.classList.contains('res-filters-disabled'); }
@@ -114,10 +112,10 @@ export class Filterline {
 			<div class="res-filterline-dropdown">
 				<div class="res-filterline-dropdown-other"></div>
 				<div class="res-filterline-dropdown-toggles">
-					<div class="res-filterline-show-reason">
+					<div class="res-filterline-display-match-reason">
 						<label>
 							<input type="checkbox">
-							<span>Show filter-reason</span>
+							<span>Show matching filters</span>
 						</label>
 					</div>
 				</div>
@@ -179,28 +177,28 @@ export class Filterline {
 			})()
 		);
 
-		const showFilterReasonCheckbox = downcast(element.querySelector('.res-filterline-show-reason input'), HTMLInputElement);
-		showFilterReasonCheckbox.addEventListener('change', () => {
-			this.toggleShowFilterReason(showFilterReasonCheckbox.checked);
+		const displayReasonsCheckbox = downcast(element.querySelector('.res-filterline-display-match-reason input'), HTMLInputElement);
+		displayReasonsCheckbox.addEventListener('change', () => {
+			this.toggleDisplayReasons(displayReasonsCheckbox.checked);
 		});
 
 		if (this.thingType === 'post' && loggedInUser()) {
-			const hideFiltered = string.html`
-				<div class="res-filterline-hide-filtered">
+			const permanentlyHide = string.html`
+				<div class="res-filterline-permanently-hide">
 					<label>
 						<input type="checkbox">
-						<span>Hide currently filtered</span>
+						<span>Permanently hide</span>
 					</label>
 				</div>
 			`;
-			const checkbox = this.hideCheckbox = downcast(hideFiltered.querySelector('input'), HTMLInputElement);
-			this.updateHideCheckbox();
-			hideFiltered.addEventListener('click', async () => {
+			const checkbox = this.permanentlyHideCheckbox = downcast(permanentlyHide.querySelector('input'), HTMLInputElement);
+			this.updatePermanentlyHideCheckbox();
+			permanentlyHide.addEventListener('click', async () => {
 				checkbox.disabled = true;
-				await (this.hiddenThings.size ? this.unhide() : this.hide());
+				await (this.permanentlyHiddenThings.size ? this.unhide() : this.hide());
 				checkbox.disabled = false;
 			});
-			element.querySelector('.res-filterline-dropdown-toggles').append(hideFiltered);
+			element.querySelector('.res-filterline-dropdown-toggles').append(permanentlyHide);
 		}
 
 		downcast(element.querySelector('.res-filterline-show-help'), HTMLElement).addEventListener('click', () => {
@@ -208,12 +206,12 @@ export class Filterline {
 		});
 	}
 
-	updateHideCheckbox() {
-		if (!this.hideCheckbox) return;
-		this.hideCheckbox.checked = this.hideCheckbox.indeterminate = false;
-		if (!this.hiddenThings.size) return;
-		if (this.getFiltered().length === this.hiddenThings.size) this.hideCheckbox.checked = true;
-		else this.hideCheckbox.indeterminate = true;
+	updatePermanentlyHideCheckbox() {
+		if (!this.permanentlyHideCheckbox) return;
+		this.permanentlyHideCheckbox.checked = this.permanentlyHideCheckbox.indeterminate = false;
+		if (!this.permanentlyHiddenThings.size) return;
+		if (this.getThings('hide').length === this.permanentlyHiddenThings.size) this.permanentlyHideCheckbox.checked = true;
+		else this.permanentlyHideCheckbox.indeterminate = true;
 	}
 
 	createNewFilterElement(CaseClass: Class<Case>, text: string = CaseClass.text, newOpts?: $Shape<NewFilterOpts>) {
@@ -246,14 +244,10 @@ export class Filterline {
 		return element;
 	}
 
-	getFiltered(byFilter?: Filter) {
-		return Array.from(this.things).filter(thing => byFilter ? thing.filter === byFilter : thing.filter);
-	}
-
-	async hide(things: Array<Thing> = this.getFiltered()) {
-		await things.map(thing => hide(thing));
-		for (const v of things) this.hiddenThings.add(v);
-		this.updateHideCheckbox();
+	async hide(things: Array<Thing> = this.getThings('hide')) {
+		await Promise.all(things.map(thing => hide(thing)));
+		for (const v of things) this.permanentlyHiddenThings.add(v);
+		this.updatePermanentlyHideCheckbox();
 
 		Notifications.showNotification({
 			moduleID: FilteReddit.module.moduleID,
@@ -262,10 +256,10 @@ export class Filterline {
 		});
 	}
 
-	async unhide(things: Array<Thing> = [...this.hiddenThings]) {
-		await things.map(thing => unhide(thing));
-		for (const v of things) this.hiddenThings.delete(v);
-		this.updateHideCheckbox();
+	async unhide(things: Array<Thing> = [...this.permanentlyHiddenThings]) {
+		await Promise.all(things.map(thing => unhide(thing)));
+		for (const v of things) this.permanentlyHiddenThings.delete(v);
+		this.updatePermanentlyHideCheckbox();
 
 		Notifications.showNotification({
 			moduleID: FilteReddit.module.moduleID,
@@ -274,8 +268,8 @@ export class Filterline {
 		});
 	}
 
-	getAsConditions(): * {
-		const extracted = filterMap(this.filters, v => typeof v.state === 'boolean' && v instanceof LineFilter && [v] || undefined);
+	getAsConditions(hasEffect: string = 'hide'): * {
+		const extracted = filterMap(this.filters, v => v.effects[hasEffect] && v instanceof LineFilter && [v] || undefined);
 		return Cases.resolveGroup(
 			Cases.getGroup(
 				'all',
@@ -330,7 +324,7 @@ export class Filterline {
 			return acc;
 		}, { ...this.deferredFilters });
 		await this.storage.deletePath('filters');
-		await this.storage.patch({ filters });
+		await this.storage.patch({ filters, lastUsed: Date.now() });
 	});
 
 	getCLI(): * {
@@ -427,9 +421,9 @@ export class Filterline {
 			save = true,
 			type,
 			criterion,
+			effects,
 			name,
 			state,
-			sideEffects,
 		} = opts;
 		let { conditions } = opts;
 
@@ -443,7 +437,7 @@ export class Filterline {
 			conditions = CaseClass.criterionToConditions(criterion);
 		}
 
-		const filter = new Filter(id, CaseClass, name, conditions, state, sideEffects);
+		const filter = new Filter(id, CaseClass, name, conditions, state, effects);
 
 		if (add) {
 			this.addFilter(filter);
@@ -458,19 +452,17 @@ export class Filterline {
 
 		this.filters.push(filter);
 
-		// It is possible to optimize the order of filters as long as no filter has yet matched
-		// if order is changed after first match, `getFiltersToTest` may return wrong results
-		if (this.isInitialized()) this.sortedFilters.push(filter);
-		else this.sortedFilters = _.sortBy(this.filters, ({ case: { constructor: { slow = false } } }) => slow);
-
-		if (this.isInitialized()) this.refreshAll(filter);
+		if (this.initialized) {
+			this.sortedFilters.push(filter);
+			this.refreshAll(filter);
+		}
 
 		if (this.filterContainer) this.addFilterElements([filter]);
 	}
 
 	async removeFilter(filter: Filter) {
 		if (filter.element) filter.element.remove();
-		if (this.isInitialized()) await Promise.all(this.refreshAll(filter));
+		if (this.initialized) await Promise.all(this.refreshAll(filter));
 		_.pull(this.filters, filter);
 		_.pull(this.sortedFilters, filter);
 		this.save();
@@ -481,100 +473,95 @@ export class Filterline {
 	}
 
 	getActiveFilters() {
-		return this.filters.filter(v => v.state !== null);
+		return this.filters.filter(v => v.case.isEvaluatable() && v.getEffects().length);
 	}
 
-	hasActiveLineFilters() {
-		return !!this.getActiveFilters().find(v => !(v instanceof ExternalFilter));
-	}
+	availableEffects: {
+		[key: string]: (Thing, Filter) => void,
+	} = {
+		propagate: (thing, match) => {
+			thing.element.classList.toggle('res-thing-hide-children', !!match);
+			this._refreshAfterChange(thing);
+		},
+		highlight: (thing, match) => {
+			thing.entry.style.backgroundColor = match ? 'rgba(255, 155, 155, .16)' : '';
+		},
+		hide: (thing, match) => {
+			thing.setHideFilter(match);
+			this._refreshAfterChange(thing);
+		},
+	};
 
-	getFilterPosition(filter: ?Filter) {
-		if (!filter) return -1;
-		return this.sortedFilters.indexOf(filter);
+	_refreshAfterChange(thing: Thing) {
+		if (
+			SelectedEntry.selectedThing &&
+			[SelectedEntry.selectedThing, ...SelectedEntry.selectedThing.getParents()].includes(thing) &&
+			!SelectedEntry.selectedThing.isVisible()
+		) {
+			SelectedEntry.frameThrottledMove('closestVisible', { scrollStyle: 'none' }, () => {});
+		}
+
+		ShowImages.refresh();
+		this.checkEmptyState();
 	}
 
 	getFiltersToTest(currentFilter?: Filter, invokedByFilter?: Filter): Filter[] {
 		if (!invokedByFilter) return this.sortedFilters;
 
-		const invokedByFilterIndex = this.getFilterPosition(invokedByFilter);
-		const currentFilterIndex = this.getFilterPosition(currentFilter);
+		const invokedByFilterIndex = this.sortedFilters.indexOf(invokedByFilter);
+		const currentFilterIndex = this.sortedFilters.indexOf(currentFilter);
 
-		if (currentFilterIndex === -1) {
+		if (!currentFilter) {
 			// No other filters did match last time; only retest this
 			return [invokedByFilter];
-		} else if (currentFilterIndex === invokedByFilterIndex) {
+		} else if (currentFilter === invokedByFilter) {
 			// The invokedBy filter matched last time; start testing from that one
 			return this.sortedFilters.slice(invokedByFilterIndex);
 		} else if (currentFilterIndex > invokedByFilterIndex) {
-			// thing.filter should always refers to the first matched filter
-			return _.compact([invokedByFilter, currentFilter]);
+			// Always store a reference to the first matched filter
+			return [invokedByFilter, currentFilter];
 		} else {
 			// Some earlier filter matched last time; ignore
 			return [];
 		}
 	}
 
-	availableSideEffects: {
-		[key: string]: (Thing, Array<boolean>) => void,
-	} = {
-		propagate: (thing, results) => {
-			thing.element.classList.toggle('res-thing-hide-children', results.includes(true));
-		},
-		highlight: (thing, results) => {
-			// XXX If a parent comment is hidden and that is propagated, then this comment won't be highlighted
-			thing.element.classList.toggle('res-filterline-highlight-match', results.includes(true));
-		},
-	};
-
-	async refreshThingSideEffects(thing: Thing, invokedByFilter?: Filter) {
-		const sideEffects = {};
-
-		await Promise.all(this.filters.map(async filter => {
-			// Ignore inactive filters
-			if (filter.state === null) return;
-
-			const active = Object.keys(_.pickBy(filter.sideEffects, Boolean));
-			if (active.length) {
-				const matches = await filter.matches(thing);
-				for (const s of active) sideEffects[s] = [...(sideEffects[s] || []), matches];
-			}
-		}));
-
-		if (invokedByFilter) {
-			// `invokedByFilter` may have side-effects that is being turned off, so always refresh those
-			for (const key of Object.keys(invokedByFilter.sideEffects)) {
-				if (!sideEffects[key]) sideEffects[key] = [false];
-			}
-		}
-
-		for (const [key, results] of Object.entries(sideEffects)) {
-			this.availableSideEffects[key](thing, results);
-		}
-	}
-
 	refreshThing = keyedMutex(fastAsync(function*(thing: Thing, invokedByFilter?: Filter) {
-		this.refreshThingSideEffects(thing, invokedByFilter);
+		if (!this.currentMatches.has(thing)) this.currentMatches.set(thing, {});
+		const currentMatches = this.currentMatches.get(thing);
 
-		const filtersToTest = this.getFiltersToTest(thing.filter, invokedByFilter);
-		if (!filtersToTest.length) return;
+		const effectsToRefresh = Object.keys(this.availableEffects);
 
-		const matchedFilter = yield asyncFind(
-			filtersToTest,
-			v => v.state !== null && v.matches(thing)
+		const filtersToTest = _.union(...effectsToRefresh.map(effect => this.getFiltersToTest(currentMatches[effect], invokedByFilter)))
+			// Keep order
+			.sort((a, b) => this.sortedFilters.indexOf(a) - this.sortedFilters.indexOf(b));
+
+		_.remove(effectsToRefresh, effect =>
+			// Only update effects that the current filter has touched
+			invokedByFilter && !invokedByFilter.effects.hasOwnProperty(effect) ||
+			// Don't update effects whose current matched filter will not be tested
+			currentMatches[effect] && !filtersToTest.includes(currentMatches[effect])
 		);
 
-		if (thing.filter !== matchedFilter) {
-			// XXX Show reason if hidden due to propagation?
-			if (this.showFilterReason) this.refreshThingFilterReason(thing, thing.filter, matchedFilter);
-			thing.setFilter(matchedFilter);
+		const updateEffect = (effect, filter) => {
+			const old = currentMatches[effect];
+			if (filter == old) return; // eslint-disable-line eqeqeq
+			currentMatches[effect] = filter;
+			this.availableEffects[effect](thing, filter);
 
-			// TODO The beneath may also have to refresh when the propagation side-effect is changed
-			if (matchedFilter && SelectedEntry.selectedThing === thing) {
-				SelectedEntry.frameThrottledMove('closestVisible', { scrollStyle: 'none' }, () => {});
+			if (this.displayReasons) this.refreshDisplayReasons(thing, old, filter);
+		};
+
+		for (const filter of filtersToTest) {
+			const effects = filter.getEffects().filter(v => effectsToRefresh.includes(v));
+			if (effects.length && (yield filter.matches(thing))) {
+				for (const effect of effects) updateEffect(effect, filter);
+				_.pull(effectsToRefresh, ...effects);
 			}
+		}
 
-			ShowImages.refresh();
-			this.checkEmptyState();
+		for (const effect of effectsToRefresh) {
+			updateEffect(effect, null);
 		}
 	}));
 
@@ -583,15 +570,29 @@ export class Filterline {
 	}
 
 	addThing(thing: Thing) {
+		if (!this.initialized) {
+			// Initialize once things are added
+			this.initialized = true;
+			// It is possible to optimize the order of filters until things are filtered
+			// if order is changed thereafter, `getFiltersToTest` may return invalid results
+			this.sortedFilters = _.sortBy(this.filters, ({ case: { constructor: { slow } } }) => slow);
+		}
+
 		this.things.add(thing);
 		return this.refreshThing(thing);
+	}
+
+	getThings(withEffect: string) {
+		return Array.from(this.currentMatches.entries())
+			.filter(([, effects]) => effects[withEffect])
+			.map(([thing]) => thing);
 	}
 
 	checkEmptyState = (() => {
 		const showNotification = _.debounce(_.once(() => {
 			const info = $('<p>').text(i18n('filteRedditEmptyNotificationInfo'));
 			const toggle = $('<button>').text(i18n('filteRedditEmptyNotificationToggleShowReason'))
-				.click(() => { this.toggleShowFilterReason(); });
+				.click(() => { this.toggleDisplayReasons(); });
 
 			Notifications.showNotification({
 				moduleID: FilteReddit.module.moduleID,
@@ -603,27 +604,27 @@ export class Filterline {
 		}), 4000);
 
 		return _.throttle(() => {
-			if (this.getFiltered().length !== this.things.size) {
+			if (Array.from(this.things).filter(v => v.isVisible()).length) {
 				showNotification.cancel();
-			} else if (!this.showFilterReason) {
+			} else if (!this.displayReasons) {
 				showNotification();
 			}
 		}, 100, { leading: false });
 	})();
 
-	toggleShowFilterReason(newState?: boolean = !this.showFilterReason) {
-		this.showFilterReason = newState;
-		this.refreshAllFilterReasons();
-		document.body.classList.toggle('res-show-filter-reason', this.showFilterReason);
+	toggleDisplayReasons(newState?: boolean = !this.displayReasons) {
+		this.displayReasons = newState;
+		for (const thing of this.things) this.refreshDisplayReasons(thing);
+		document.body.classList.toggle('res-display-match-reason', this.displayReasons);
 	}
 
-	refreshThingFilterReason(thing: Thing, previousMatch?: Filter, currentMatch?: Filter) {
-		if (previousMatch) previousMatch.clearThingFilterReason(thing);
-		if (currentMatch) currentMatch.clearThingFilterReason(thing);
-		if (currentMatch && this.showFilterReason) currentMatch.showThingFilterReason(thing);
-	}
+	async refreshDisplayReasons(thing: Thing) {
+		const reasons = this.displayReasons ? await Promise.all(
+			Object.entries(this.currentMatches.get(thing) || {})
+				.map(([effect, filter]) => filter && filter.buildReasonElement(thing, effect))
+				.filter(Boolean)
+		) : [];
 
-	refreshAllFilterReasons() {
-		for (const thing of this.things) this.refreshThingFilterReason(thing, undefined, thing.filter);
+		thing.setFilterReasons(reasons);
 	}
 }

--- a/lib/modules/filteReddit/LineFilter.js
+++ b/lib/modules/filteReddit/LineFilter.js
@@ -18,31 +18,30 @@ import { Filter } from './Filter';
 
 export class LineFilter extends Filter {
 	initialConditions: *;
-	inner: HTMLElement;
 
-	constructor(id: *, BaseCase: *, name: *, conditions: * = null, state: * = null, sideEffects: * = {}) {
+	constructor(id: *, BaseCase: *, name: *, conditions: * = null, state: * = true, effects: * = {}) {
 		if (BaseCase.variant === 'ondemand') {
-			// customFilters hides posts that don't match; keep on-demand consistent
-			if (state === undefined) state = false;
-
 			const externOpts = BaseCase._customFilter && BaseCase._customFilter.opts;
 			if (externOpts) {
 				if (!name) ({ name } = externOpts);
-				const { propagate } = externOpts;
-				if (!sideEffects.hasOwnProperty('propagate')) Object.assign(sideEffects, { propagate });
+
+				if (!effects.hasOwnProperty('propagate')) {
+					const { propagate } = externOpts;
+					Object.assign(effects, { propagate });
+				}
 			}
 		}
 
-		super(id, BaseCase, name, conditions, state, sideEffects);
+		super(id, BaseCase, name, conditions, state, effects);
 	}
 
-	update(state: * = this.state, conditions?: *, describeOnly: *) {
+	update(state: * = this.state, conditions?: *, effects: *, describeOnly: *) {
 		if (this.BaseCase.variant === 'ondemand' && conditions && !describeOnly) {
 			FilteReddit.updateCustomFilter(this.BaseCase.getCustomFilter(), { body: conditions });
 			conditions = null; // Force create new case
 		}
 
-		const message = super.update(state, conditions, describeOnly);
+		const message = super.update(state, conditions, effects, describeOnly);
 		if (this.element) this.refreshElement();
 		return message;
 	}
@@ -53,25 +52,22 @@ export class LineFilter extends Filter {
 	}
 
 	createElement() {
-		this.element = string.html`
-			<div class="res-filterline-filter" type="${this.BaseCase.type}">
-				<div class="res-filterline-filter-name"></div>
-			</div>
-		`;
-		this.inner = this.element.querySelector('.res-filterline-filter-name');
+		this.element = string.html`<div class="res-filterline-filter" type="${this.BaseCase.type}"></div>`;
 		this.refreshElement();
 
 		this.element.addEventListener('click', () => {
-			this.update(this.getNextState());
+			if (!this.effects.hide) this.update(undefined, undefined, { hide: true });
+			else if (this.state) this.update(false, undefined, { hide: true });
+			else this.update(true, undefined, { hide: false });
 		});
 
 		this.element.addEventListener('contextmenu', (e: Event) => { // Right click
-			if (this.state === null) this.remove();
-			else this.update(null);
+			if (this.effects.hide) this.update(undefined, undefined, { hide: false });
+			else this.remove();
 			e.preventDefault(); // Do not show context menu
 		});
 
-		this.element.addEventListener('mouseenter', () => this.showInfocard());
+		this.element.addEventListener('mouseenter', () => this.showInfocard()); // FIXME This causes the widget to be opened also when just scrolling through
 		this.element.addEventListener('click', () => this.showInfocard()); // Reset timout
 		this.element.addEventListener('contextmenu', () => this.showInfocard()); // Reset timeout
 	}
@@ -80,21 +76,15 @@ export class LineFilter extends Filter {
 		const card = Hover.infocard('filterline-filter');
 		card
 			.target(this.element)
-			.options({ width: 570, openDelay: (card.visible || immediately) ? 0 : 700, pin: Hover.pin.bottom })
+			.options({ width: 570, openDelay: (card.visible || immediately) ? 0 : 600, pin: Hover.pin.bottom })
 			.populateWith(this.populateHover.bind(this))
 			.begin();
 	}
 
 	refreshElement() {
-		this.inner.setAttribute('name', this.getStateText(this.state));
-		this.element.classList.toggle('res-filterline-filter-hidden', !this.BaseCase.variant === 'ondemand' && !this.case.isEvaluatable());
-		this.element.classList.toggle('res-filterline-filter-active', this.case.isEvaluatable() && this.state !== null);
-	}
-
-	getNextState() {
-		if (this.state === null) return true; // Active inverse -- hide those that match
-		if (this.state === true) return false; // Active -- hide those that  don't match
-		else return null; // Inactive -- disregard filter
+		this.element.setAttribute('text', this.getStateText());
+		this.element.classList.toggle('res-filterline-filter-disabled', !this.case.isEvaluatable());
+		this.element.classList.toggle('res-filterline-filter-hiding', this.case.isEvaluatable() && !!this.effects.hide);
 	}
 
 	// Memoize in order to preserve the builder when infocard closes
@@ -121,37 +111,31 @@ export class LineFilter extends Filter {
 			$builder.find('.builderControls, .addBuilderBlock').remove();
 		}
 
-		// Keep track of what is focused when redrawing
-		let lastFocus;
-
 		const $builderBlock = $builder.find('> .builderBlock');
 		$builderBlock.on('change input', frameThrottle(() => {
 			const conditions = SettingsConsole.readBuilderBlock($builderBlock, builderCases);
 			if (!_.isEqual(lastConditions, conditions)) {
 				lastConditions = conditions;
-				this.update(this.state, conditions);
-				lastFocus = $builder.get(0).contains(document.activeElement) && document.activeElement;
-				this.populateHover(card);
-				if (lastFocus) lastFocus.focus();
+				this.update(undefined, conditions);
+				// Keep track of what is focused when redrawing
+				const lastFocus = $builder.get(0).contains(document.activeElement) && document.activeElement;
+				if (lastFocus) card.refresh().then(() => lastFocus.focus());
 			}
 		}));
 
 		return {
-			getConditions: () => lastConditions,
-			get builder() {
-				return $builder.get(0);
-			},
+			get builder() { return $builder.get(0); },
 			isCaseChanged: () => !_.isEqual(this.initialConditions, lastConditions),
 		};
 	});
 
-	async populateHover(card: *) {
+	populateHover(card: *) {
 		const { parent: filterline } = this;
 		if (!filterline) throw new Error('Filter not attached');
 
 		const redraw = () => {
 			this.getBuilder.cache.clear();
-			this.populateHover(card);
+			card.refresh();
 		};
 
 		const head = string.html`
@@ -166,24 +150,25 @@ export class LineFilter extends Filter {
 		const body = string.html`
 			<div class="res-filterline-filter-hover">
 				<span class="res-filterline-filter-hover-options"></span>
-				<span>${this.state !== null ? `${this.state ? 'Showing' : 'Hiding'} posts where:` : 'Match posts where:'}</span>
+				<span>For posts (<span class="res-filterline-filter-hover-number-matches">…</span>) ${this.state ? 'not ' : ''}matching:</span>
 				<div class="builderItem"></div>
 				<div class="res-filterline-filter-hover-notice">${ // Keep element empty when no text due to :empty selector
 	this.BaseCase.variant === 'ondemand' && 'By adding browse context conditions such as "Date", "Logged in user", and "Custom toggle", you control where and when this filter is available.'}</div>
-				<div class="res-filterline-filter-hover-group" group="state-actions">
-					Modify state:
+				<div class="res-filterline-filter-hover-group" group="match-effects">
+					<div class="res-filterline-filter-hover-buttons"></div>
+				</div>
+				<div class="res-filterline-filter-hover-group" group="match-actions" hidden>
 					<div class="res-filterline-filter-hover-buttons"></div>
 				</div>
 		`;
 
-		card.populate([head, body]);
-
-		const { builder, getConditions, isCaseChanged } = this.getBuilder(filterline, card);
+		const { builder, isCaseChanged } = this.getBuilder(filterline, card);
 		body.querySelector('.builderItem').appendChild(builder);
 
 		// Focus first input in builder, since it's likely the user want to modify that condition
 		setTimeout(() => {
 			if (!builder.contains(document.activeElement)) {
+				// If an `input` element is not found, look for `select`
 				const e = [...builder.querySelectorAll('input'), ...builder.querySelectorAll('select')]
 					.find(e => e.offsetParent);
 				if (e) e.focus();
@@ -192,10 +177,10 @@ export class LineFilter extends Filter {
 
 		if (filterline.thingType === 'comment') {
 			const options = body.querySelector('.res-filterline-filter-hover-options');
-			const propagate = string.html`<label><input type="checkbox" ${this.sideEffects.propagate && 'checked'}>Also hide children</label>`;
+			const propagate = string.html`<label><input type="checkbox" ${this.effects.propagate && 'checked'}>Also hide children</label>`;
 			options.append(propagate);
 			waitForEvent(propagate, 'change').then(() => {
-				this.sideEffects.propagate = downcast(propagate.querySelector('input'), HTMLInputElement).checked;
+				this.effects.propagate = downcast(propagate.querySelector('input'), HTMLInputElement).checked;
 				this.refresh();
 			}).then(redraw);
 		}
@@ -228,7 +213,7 @@ export class LineFilter extends Filter {
 					})
 				);
 
-				this.update(this.state === null ? null : false, null);
+				this.update(false, null);
 			}).then(redraw);
 		}
 
@@ -253,52 +238,41 @@ export class LineFilter extends Filter {
 			}).then(redraw);
 		}
 
+		addButton(head, 'Invert', 'case-actions', 'invert')
+			.then(() => { this.update(!this.state); })
+			.then(redraw);
+
 		addButton(head, 'Remove', 'case-actions', 'remove')
 			.then(() => { this.remove(); })
 			.then(card.close.bind(card));
 
-		if (this.state !== null) addButton(body, 'Do nothing', 'state-actions', 'state-null').then(() => { this.update(null); }).then(redraw);
-		if (this.state !== false) addButton(body, 'Hide matching posts', 'state-actions', 'state-false').then(() => { this.update(false); }).then(redraw);
-		if (this.state !== true) addButton(body, 'Show only matching posts', 'state-actions', 'state-true').then(() => { this.update(true); }).then(redraw);
+		addButton(body, this.effects.hide ? 'Don\'t hide' : 'Hide', 'match-effects', `hide-${this.effects.hide ? 'false' : 'true'}`)
+			.then(() => { this.update(undefined, undefined, { hide: !this.effects.hide }); })
+			.then(redraw);
 
-		if (Modules.isRunning(CommentNavigator)) {
-			addButton(body, 'Navigate by', 'state-actions', 'navigate-by').then(() => {
-				this.update(null);
-				CommentNavigator.updateCustomConditions(getConditions());
+		addButton(body, this.effects.highlight ? 'Don\'t highlighting' : 'Highlight', 'match-effects', 'highlight').then(() => {
+			this.update(undefined, undefined, { highlight: !this.effects.highlight });
+		}).then(redraw);
+
+		if (Modules.isRunning(CommentNavigator) && !this.effects.hide) {
+			addButton(body, 'Navigate by', 'match-actions', 'navigate-by').then(() => {
+				CommentNavigator.updateCustomConditions(Cases.getGroup(this.state ? 'none' : 'all', [this.case.conditions]));
 				CommentNavigator.setCategory('custom');
 				card.close();
 			});
 		}
 
-		await this.updatePromise;
+		asyncFilter(Array.from(filterline.things), async thing => await this.matches(thing)) // eslint-disable-line no-return-await
+			.then(matches => {
+				const numberSpan = body.querySelector('.res-filterline-filter-hover-number-matches');
+				numberSpan.textContent = String(matches.length);
 
-		const uncertainMatches = filterline.getFiltered()
-			.filter(v => v.filter !== this)
-			.filter(v => filterline.getFiltersToTest(v.filter).includes(this));
+				if (filterline.thingType === 'post' && matches.length) {
+					addButton(body, 'Permanently hide', 'match-actions', 'native-hide')
+						.then(() => { filterline.hide(matches); });
+				}
+			});
 
-		const allMatching = filterline.getFiltered(this).concat(
-			this.state === null && [] ||
-				await asyncFilter(uncertainMatches, async thing => await this.matches(thing)) // eslint-disable-line no-return-await
-		);
-
-		if (allMatching.length) {
-			body.appendChild(string.html`
-				<div class="res-filterline-filter-hover-group" group="hidden-actions" hidden>
-					For posts (${allMatching.length}) hidden by filter:
-					<div class="res-filterline-filter-hover-buttons"></div>
-				</div>
-			`);
-
-			addButton(body, this.sideEffects.highlight ? 'Stop highlighting' : 'Highlight', 'hidden-actions', 'highlight').then(() => {
-				this.sideEffects.highlight = !this.sideEffects.highlight;
-				this.refresh();
-			}).then(redraw);
-
-			if (filterline.thingType === 'post') {
-				addButton(body, 'Permanently hide', 'hidden-actions', 'native-hide').then(() => { filterline.hide(allMatching); });
-			}
-		}
-
-		return []; // Don't register any changes
+		return [head, body];
 	}
 }

--- a/lib/modules/filteReddit/cases.js
+++ b/lib/modules/filteReddit/cases.js
@@ -40,7 +40,7 @@ export class Group extends Case {
 	];
 
 	static +defaultConditions = { op: 'all', of: [] };
-	static slow = 1;
+	static slow = 1; // May be considerably slower depending on children
 
 	_cases = _.sortBy(
 		this.conditions.of.map(v => Case.fromConditions(v)),
@@ -184,18 +184,16 @@ export function resolveGroup(initial: GroupConditions, precompute: boolean = tru
 		if (of.length === 1) {
 			const p = of[0];
 
-			if (op === 'none' && p.type === 'group') {
+			if (op !== 'none') {
+				return p;
+			} else if (p.type === 'group') {
 				if (p.op === 'none') {
 					p.op = 'any';
 					return p;
-				} else if (p.op === 'any') {
+				} else if (p.op === 'any' || p.op === 'all') {
 					p.op = 'none';
 					return p;
 				}
-			}
-
-			if (op !== 'none') {
-				return p;
 			}
 		}
 

--- a/lib/modules/hover.js
+++ b/lib/modules/hover.js
@@ -3,7 +3,7 @@
 import { $ } from '../vendor';
 import { Module } from '../core/module';
 import * as Options from '../core/options';
-import { getViewportSize } from '../utils';
+import { getViewportSize, waitForEvent } from '../utils';
 
 export const module: Module<*> = new Module('hover');
 
@@ -143,8 +143,8 @@ class Hover {
 	instanceID: string;
 
 	visible: boolean = false;
-	hideTimer: TimeoutID | void;
-	showTimer: TimeoutID | void;
+	hideTimer: TimeoutID | null = null;
+	showTimer: TimeoutID | null = null;
 	_target: HTMLElement | void;
 	_callback: HoverCallback | void;
 	_container: HTMLElement | void;
@@ -313,17 +313,19 @@ class Hover {
 	}
 
 	_startShowTimer() {
-		this._cancelShowTimer();
+		if (this.showTimer !== null) this._cancelShowTimer();
 		this.showTimer = setTimeout(() => this._afterShowTimer(), this._options.openDelay);
 	}
 
 	_cancelShowTimer() {
-		clearTimeout(this.showTimer);
+		if (this.showTimer !== null) clearTimeout(this.showTimer);
+		this.showTimer = null;
 	}
 
 	_afterShowTimer() {
 		this._cancelShowTimer();
 		this._clearShowListeners();
+
 		this.open();
 		this.visible = true;
 
@@ -332,21 +334,24 @@ class Hover {
 	}
 
 	_startHideTimer() {
-		clearTimeout(this.hideTimer);
+		if (this.hideTimer !== null) clearTimeout(this.hideTimer);
 		this.hideTimer = setTimeout(() => this._afterHideTimer(), this._options.fadeDelay);
 	}
 
 	_cancelHideTimer() {
-		clearTimeout(this.hideTimer);
+		if (this.hideTimer !== null) clearTimeout(this.hideTimer);
+		this.hideTimer = null;
 	}
 
-	_afterHideTimer() {
+	async _afterHideTimer() {
+		this._cancelHideTimer();
+
 		// Don't let the hover be hidden if it is active, e.g. a input field is focused
 		if (this.getContainer().contains(document.activeElement)) {
-			this._startHideTimer();
-			return;
+			await waitForEvent(this.getContainer(), 'blur');
+			if (this.hideTimer !== null) return; // Some other timer has started
 		}
-		this._cancelHideTimer();
+
 		this.close(true);
 		this.visible = false;
 	}

--- a/lib/modules/hover.js
+++ b/lib/modules/hover.js
@@ -252,6 +252,11 @@ class Hover {
 
 	_displayLoadIndicator() {}
 
+	async refresh() {
+		const callback = this._callback;
+		if (callback) this.populate(await callback(this));
+	}
+
 	populate(items: HoverContents[]) {
 		if (!this._enabled) return false;
 

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -304,7 +304,7 @@ const addScrollStyleListener = _.once(() => {
 	addListener((selected, unselected, { scrollStyle }) => {
 		if (
 			(['none', 'adopt']: Array<ScrollStyle>).includes(scrollStyle) &&
-			(selected.isFiltered() || unselected && unselected.isFiltered())
+			(selected.isHiddenByFilter(true) || unselected && unselected.isHiddenByFilter(true))
 		) {
 			anchor = {
 				to: selected.entry.getBoundingClientRect().top,

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -902,7 +902,7 @@ function shouldLinkBeDeferred(element) {
 	const thing = Thing.from(element);
 	return thing && !thing.isContentVisible() && // No need to complete building non-visible links
 		// Unless they are hidden because because of the expando filter
-		!(thing.filter && thing.filter.case.hasType('hasExpando'));
+		!(thing.hiddenByFilter && thing.hiddenByFilter.case.hasType('hasExpando'));
 }
 
 const inText = element => !!element.closest('.md, .search-result-footer');

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -64,7 +64,7 @@ export class Thing {
 	children = new Set();
 
 	// may be set by filters
-	filter: *;
+	hiddenByFilter: *;
 
 	static checkedFrom(element: HTMLElement | Thing): Thing {
 		const thing = Thing.from(element);
@@ -107,9 +107,9 @@ export class Thing {
 		}
 	}
 
-	setFilter(filter: ?*) {
-		this.filter = filter;
-		this.element.classList.toggle('RESFiltered', !!filter);
+	setHideFilter(match: *) {
+		this.element.classList.toggle('res-thing-filter-hide', !!match);
+		this.hiddenByFilter = match;
 
 		if (this.isComment()) {
 			if (this.children.size) this.refreshPartialVisibility();
@@ -117,10 +117,15 @@ export class Thing {
 		}
 	}
 
+	setFilterReasons(elements: Array<HTMLElement>) {
+		for (const old of this.element.querySelectorAll('.res-thing-filter-remove-matching-entry')) old.remove();
+		this.element.prepend(...elements);
+	}
+
 	// `frameThrottleQueuePositionReset` ensures that children will be evaluated first
 	// Class is applied when a thing is hidden by a filter, but has descendants that are not
 	refreshPartialVisibility = frameThrottleQueuePositionReset(() => {
-		this.element.classList.toggle('res-thing-partial', this.isFiltered() && Array.from(this.children).some(v => !v.isFiltered()));
+		this.element.classList.toggle('res-thing-partial', this.isHiddenByFilter() && Array.from(this.children).some(v => !v.isHiddenByFilter()));
 	});
 
 	getThreadTop(): Thing {
@@ -553,10 +558,10 @@ export class Thing {
 		return this.element.classList.contains('deleted');
 	}
 
-	isFiltered(partialAsFiltered: boolean = false): boolean {
+	isHiddenByFilter(partialAsFiltered: boolean = false): boolean {
 		// Keep in sync with the CSS rules
 		if (this.element.matches('body.hideOver18 .over18:not(.allowOver18)')) return true;
-		if (!this.element.classList.contains('RESFiltered')) return false;
+		if (!this.element.classList.contains('res-thing-filter-hide')) return false;
 		if (this.element.classList.contains('res-filterline-highlight-match')) return false;
 		if (!partialAsFiltered) {
 			if (this.element.classList.contains('res-thing-hide-children')) return true;
@@ -571,7 +576,7 @@ export class Thing {
 
 	// Should be equivalent to `this.element.offsetParent !== null`
 	isVisible(): boolean {
-		if (!document.body.classList.contains('res-filters-disabled') && this.isFiltered()) return false;
+		if (!document.body.classList.contains('res-filters-disabled') && this.isHiddenByFilter()) return false;
 		const { parent } = this;
 		if (parent) {
 			if (parent.isCollapsed()) return false;
@@ -584,7 +589,7 @@ export class Thing {
 
 	isContentVisible(): boolean {
 		return !(
-			(!document.body.classList.contains('res-filters-disabled') && this.isFiltered(true)) ||
+			(!document.body.classList.contains('res-filters-disabled') && this.isHiddenByFilter(true)) ||
 			this.isCollapsed() ||
 			!this.isVisible()
 		);

--- a/tests/Filterline.js
+++ b/tests/Filterline.js
@@ -20,7 +20,7 @@ function switchActiveState(browser, done) {
 		.execute(`
 			const element = document.querySelector('${filter}${tempAdditionalFilterSelector}');
 			element.click();
-			if (!element.classList.contains('res-filterline-filter-active')) element.click();
+			if (!element.classList.contains('res-filterline-filter-hiding')) element.click();
 		`);
 
 	done();
@@ -96,21 +96,21 @@ module.exports = {
 			.click('.res-filterline-external-filter[type="domains"] .toggleButton')
 			.waitForElementNotVisible(thing)
 
-			// show filter reason
-			.click('.res-filterline-show-reason')
-			.waitForElementVisible(`${thing} .res-filter-remove-entry`)
+			// show hide reason
+			.click('.res-filterline-display-match-reason')
+			.waitForElementVisible(`${thing} .res-thing-filter-remove-matching-entry`)
 			.assert.visible(thing)
-			.click('.res-filterline-show-reason')
-			.waitForElementNotPresent(`${thing} .res-filter-remove-entry`)
+			.click('.res-filterline-display-match-reason')
+			.waitForElementNotPresent(`${thing} .res-thing-filter-remove-matching-entry`)
 			.assert.hidden(thing)
-			.click('.res-filterline-show-reason')
-			.waitForElementVisible(`${thing} .res-filter-remove-entry`)
+			.click('.res-filterline-display-match-reason')
+			.waitForElementVisible(`${thing} .res-thing-filter-remove-matching-entry`)
 
 			// delete filter
 			.click('.res-toggle-filterline-visibility') // Hide the dropbox — Firefox evidently can't click when it partially obscures the element
-			.waitForElementNotVisible('.res-filterline-show-reason')
-			.click('.res-filter-remove-entry')
-			.waitForElementNotPresent(`${thing} .res-filter-remove-entry`)
+			.waitForElementNotVisible('.res-filterline-display-match-reason')
+			.click('.res-thing-filter-remove-matching-entry')
+			.waitForElementNotPresent(`${thing} .res-thing-filter-remove-matching-entry`)
 			.refresh()
 			.perform(initialize)
 			.waitForElementVisible(thing)
@@ -176,8 +176,8 @@ module.exports = {
 			.keys(['f'])
 			.waitForElementVisible('#keyCommandLineWidget')
 			.keys(['+=exp', browser.Keys.ENTER])
-			.waitForElementVisible(`${filter}[type="hasExpando"].res-filterline-filter-active:last-of-type`)
-			.assert.elementNotPresent(`${filter}[type="hasExpando"]:not(.res-filterline-filter-active):first-of-type`)
+			.waitForElementVisible(`${filter}[type="hasExpando"].res-filterline-filter-hiding:last-of-type`)
+			.assert.elementNotPresent(`${filter}[type="hasExpando"]:not(.res-filterline-filter-hiding):first-of-type`)
 			.assert.visible(thing)
 
 			// invert state
@@ -190,7 +190,7 @@ module.exports = {
 			.keys(['f'])
 			.waitForElementVisible('#keyCommandLineWidget')
 			.keys(['/exp', browser.Keys.ENTER])
-			.assert.elementPresent(`${filter}[type="hasExpando"]:not(.res-filterline-filter-active)`)
+			.assert.elementPresent(`${filter}[type="hasExpando"]:not(.res-filterline-filter-hiding)`)
 
 			.end();
 	},
@@ -208,7 +208,7 @@ module.exports = {
 		function testNextType(browser, done) {
 			const type = types.pop();
 			if (type) {
-				tempAdditionalFilterSelector = `.res-filterline-filter-active[type="${type}"]`;
+				tempAdditionalFilterSelector = `.res-filterline-filter-hiding[type="${type}"]`;
 
 				browser
 					.click('.res-filterline-preamble')
@@ -271,37 +271,35 @@ module.exports = {
 			.click('.addBuilderBlock [value="isNSFW"]')
 			.waitForElementVisible('.builderBlock[data-type="isNSFW"]')
 
-			// Hide matches
-			.waitForElementVisible(`${cardButton}[action="state-false"]`)
-			.click(`${cardButton}[action="state-false"]`)
-			.waitForElementVisible(normalPost)
-			.waitForElementNotVisible(nsfwPost)
-
-			// Show matches
-			.waitForElementVisible(`${cardButton}[action="state-true"]`)
-			.click(`${cardButton}[action="state-true"]`)
+			// Hide non-matches
+			.waitForElementVisible(`${cardButton}[action="hide-true"]`)
+			.click(`${cardButton}[action="hide-true"]`)
 			.waitForElementNotVisible(normalPost)
 			.waitForElementVisible(nsfwPost)
 
 			// Hide matches
-			.waitForElementVisible(`${cardButton}[action="state-false"]`)
-			.click(`${cardButton}[action="state-false"]`)
+			.waitForElementVisible(`${cardButton}[action="invert"]`)
+			.click(`${cardButton}[action="invert"]`)
 			.waitForElementVisible(normalPost)
 			.waitForElementNotVisible(nsfwPost)
 
 			// State persists on refresh
 			.refresh()
 			.perform(initialize)
-			.waitForElementNotVisible(nsfwPost)
 			.waitForElementVisible(normalPost)
+			.waitForElementNotVisible(nsfwPost)
 
-			// Remove
+			// Hide non-matches
 			.waitForElementVisible(`${filter}[type="group"]`)
 			.moveToElement(`${filter}[type="group"]`, 0, 0)
-			.pause(1000)
-			.waitForElementVisible(`${cardButton}[action="remove"]`)
+			.waitForElementVisible(`${cardButton}[action="invert"]`)
+			.click(`${cardButton}[action="invert"]`)
+			.waitForElementNotVisible(normalPost)
+			.waitForElementVisible(nsfwPost)
+
+			// Remove
 			.click(`${cardButton}[action="remove"]`)
-			.waitForElementNotVisible(`${cardButton}`)
+			.waitForElementVisible(normalPost)
 			.waitForElementVisible(nsfwPost)
 			.end();
 	},

--- a/tests/readComments.js
+++ b/tests/readComments.js
@@ -20,8 +20,8 @@ module.exports = {
 			.keys(['f'])
 			.waitForElementVisible('#keyCommandLineWidget')
 			.keys(['isRead', browser.Keys.ENTER])
-			.waitForElementPresent(`${b}.RESFiltered`)
-			.assert.elementNotPresent(`${a}.RESFiltered`)
+			.waitForElementPresent(`${b}.res-thing-filter-hide`)
+			.assert.elementNotPresent(`${a}.res-thing-filter-hide`)
 			.end();
 	},
 };


### PR DESCRIPTION
- Filterline sideEffects (highlight, propagate) are now generalized, and not dependent on whether a thing is hidden. Since Filterline now is not just about hiding things, a lot of class member are updated to reflect that.
- Adds a `lastUsed` value to the Filterline storage, for future pruning of unused filterlines.

Tested in browser: Firefox 64, Chrome 71
