### PR TITLE
Fixed "add subreddit" control overlay on top of expanded images

### DIFF
--- a/lib/css/modules/_subredditManager.scss
+++ b/lib/css/modules/_subredditManager.scss
@@ -437,6 +437,6 @@
 	#sr-header-area { text-transform: none; }
 }
 
-.side #sr-autocomplete-area { 
-	z-index: 1; 
+.side #sr-autocomplete-area {
+	z-index: 1;
 }

--- a/lib/css/modules/_subredditManager.scss
+++ b/lib/css/modules/_subredditManager.scss
@@ -436,3 +436,7 @@
 .res-subredditManager-allowLowercase {
 	#sr-header-area { text-transform: none; }
 }
+
+.side #sr-autocomplete-area { 
+	z-index: 1; 
+}


### PR DESCRIPTION
It's a simple fix to a bug that keeps annoying me.
z-index: 1 is chosen to match night mode

Relevant issue: #1740
Tested in browser: Chrome
