### PR TITLE
Mixer Mediahost - Muted as default

### DIFF
--- a/lib/modules/hosts/mixer.js
+++ b/lib/modules/hosts/mixer.js
@@ -12,6 +12,7 @@ export default new Host('mixer', {
 
 		return {
 			type: 'IFRAME',
+			muted: true,
 			embed,
 			fixedRatio: true,
 		};


### PR DESCRIPTION
API now supports muted on embed.

Relevant issue:  N/A
Tested in browser: Chrome 70
