### PR TITLE
Optional permissions in Firefox

### DIFF
--- a/firefox/beta/manifest.json
+++ b/firefox/beta/manifest.json
@@ -69,7 +69,9 @@
 		"tabs",
 		"history",
 		"storage",
-		"unlimitedStorage",
+		"unlimitedStorage"
+	],
+	"optional_permissions": [
 		"downloads",
 
 		"https://api.twitter.com/*",
@@ -83,6 +85,8 @@
 	],
 	"web_accessible_resources": [
 		"{{../../lib/fonts/batch-icons-webfont.woff}}",
+		"{{../../lib/environment/background/permissions/prompt.html}}",
+		"{{../../lib/environment/background/permissions/prompt.entry.js}}",
 		"{{../../lib/options/options.html}}"
 	]
 }

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -69,7 +69,9 @@
 		"tabs",
 		"history",
 		"storage",
-		"unlimitedStorage",
+		"unlimitedStorage"
+	],
+	"optional_permissions": [
 		"downloads",
 
 		"https://api.twitter.com/*",
@@ -83,6 +85,8 @@
 	],
 	"web_accessible_resources": [
 		"{{../lib/fonts/batch-icons-webfont.woff}}",
+		"{{../lib/environment/background/permissions/prompt.html}}",
+		"{{../lib/environment/background/permissions/prompt.entry.js}}",
 		"{{../lib/options/options.html}}"
 	]
 }

--- a/lib/css/modules/_nightMode.scss
+++ b/lib/css/modules/_nightMode.scss
@@ -1212,7 +1212,7 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 
 	// Affects RES console header img.
 	// Subreddit stylesheets can't override filter, so we only use when it won't affect them.
-	#RESLogo {
+	.res-logo {
 		filter: invert(79%) grayscale(100%);
 	}
 

--- a/lib/environment/background/permissions.js
+++ b/lib/environment/background/permissions.js
@@ -4,16 +4,69 @@ import { apiToPromise } from '../utils/api';
 import { addListener } from './messaging';
 
 addListener('permissions', ({ operation, permissions, origins }) => {
-	if (process.env.BUILD_TARGET === 'chrome') {
+	if (process.env.BUILD_TARGET === 'chrome' || process.env.BUILD_TARGET === 'firefox') {
 		switch (operation) {
 			case 'contains':
 				return apiToPromise(chrome.permissions.contains)({ permissions, origins });
 			case 'request':
-				return apiToPromise(chrome.permissions.request)({ permissions, origins });
+				return request({ permissions, origins })
+					.catch(e => {
+						if (process.env.BUILD_TARGET === 'firefox') {
+							return makePromptWindow({ permissions, origins });
+						} else {
+							console.error(e);
+							return false;
+						}
+					});
 			default:
 				throw new Error(`Invalid permissions operation: ${operation}`);
 		}
-	} else if (process.env.BUILD_TARGET === 'firefox' || process.env.BUILD_TARGET === 'edge') {
+	} else if (process.env.BUILD_TARGET === 'edge') {
 		return true;
 	}
 });
+
+export const request = apiToPromise(chrome.permissions.request);
+
+async function makePromptWindow({ permissions, origins }) {
+	const url = new URL('prompt.html', location.origin);
+	url.searchParams.set('permissions', JSON.stringify(permissions));
+	url.searchParams.set('origins', JSON.stringify(origins));
+
+	const width = 630;
+	const height = 255;
+	// Display popup on middle of screen
+	const left = Math.floor(screen.width / 2 - width / 2);
+	const top = Math.floor(screen.height / 2 - height / 2);
+
+	const { tabs: [{ id }] } = await apiToPromise(chrome.windows.create)({ url: url.href, type: 'popup', width, height, left, top });
+
+	return new Promise(resolve => {
+		function updateListener(tabId, updates) {
+			if (tabId !== id) return;
+
+			const url = updates.url && new URL(updates.url);
+			if (url && url.searchParams.has('result')) {
+				stopListening();
+				const result = url.searchParams.get('result');
+				if (!result) return;
+				resolve(JSON.parse(result));
+				apiToPromise(chrome.tabs.remove)(id);
+			}
+		}
+
+		function removeListener(tabId) {
+			if (tabId !== id) return;
+			stopListening();
+			resolve(false);
+		}
+
+		function stopListening() {
+			chrome.tabs.onUpdated.removeListener(updateListener);
+			chrome.tabs.onRemoved.removeListener(removeListener);
+		}
+
+		chrome.tabs.onUpdated.addListener(updateListener);
+		chrome.tabs.onRemoved.addListener(removeListener);
+	});
+}

--- a/lib/environment/background/permissions/prompt.entry.js
+++ b/lib/environment/background/permissions/prompt.entry.js
@@ -1,0 +1,19 @@
+/* @flow */
+
+import { request } from '../permissions';
+
+const url = new URL(location.href);
+const requested = {
+	permissions: JSON.parse(url.searchParams.get('permissions') || '[]'),
+	origins: JSON.parse(url.searchParams.get('origins') || '[]'),
+};
+
+const button = document.body.querySelector('#request');
+button.addEventListener('click', async () => {
+	const result = await request(requested);
+	url.searchParams.set('result', JSON.stringify(result));
+	location.href = url.href;
+});
+
+// Focus, so pressing space / enter can be used as an alternative to clicking the button
+button.focus();

--- a/lib/environment/background/permissions/prompt.html
+++ b/lib/environment/background/permissions/prompt.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html class="res-nightmode">
+	<head>
+		<title>Reddit Enhancement Suite: Permissions needed</title>
+		<link rel="stylesheet" href="../../../css/res.scss"></link>
+	</head>
+	<body style="font-family: verdana,arial,helvetica,sans-serif;">
+		<div class="res-logo"></div>
+		<div style="border-top: 1px solid #3c3c3c;">
+			<p>
+				To execute this action, you must first request and grant permissions.
+			</p>
+			<button id="request">Request permissions</button>
+			<p>
+				Reddit Enhancement Suite has opened this window due to security restrictions in Firefox. In order to request the required permissions, <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/User_actions">user interaction must be performed on an included extension page</a>. For more information, see the <a href="https://www.reddit.com/r/Enhancement/wiki/permissions">wiki</a>.
+			</p>
+		</div>
+	</body>
+	<script src="./prompt.entry.js"></script>
+</html>


### PR DESCRIPTION
Firefox requires that optional permissions requests are initiated from an included page (among a small set of other options). This provides such a page.

![peek 2018-12-02 12-41](https://user-images.githubusercontent.com/1748521/49339261-9ba55680-f62f-11e8-9287-20b7b2bc843d.gif)

Tested in browser: Firefox 63, Chrome 71

Closes #4471
