### PR TITLE
username clean-up: Move selector and getUsernameFromLink to utils

### DIFF
--- a/lib/modules/userHighlight.js
+++ b/lib/modules/userHighlight.js
@@ -291,6 +291,7 @@ function highlightMentionedUsers(element, color, hoverColor) {
 	Array.from(element.querySelectorAll('a'))
 		.map(getUsername)
 		.filter(Boolean)
+		.filter(user => user !== loggedInUser())
 		.forEach(user => highlight(`author[href$="/${user}" i]`, color, hoverColor));
 }
 

--- a/lib/modules/userHighlight.js
+++ b/lib/modules/userHighlight.js
@@ -7,12 +7,12 @@ import {
 	hashCode,
 	isPageType,
 	loggedInUser,
+	getUsernameFromLink,
 	watchForThings,
 } from '../utils';
 import { i18n } from '../environment';
 import * as SettingsConsole from './settingsConsole';
 import * as UserInfo from './userInfo';
-import { getUsername } from './userTagger';
 
 export const module: Module<*> = new Module('userHighlight');
 
@@ -289,7 +289,7 @@ module.go = () => {
 
 function highlightMentionedUsers(element, color, hoverColor) {
 	Array.from(element.querySelectorAll('a'))
-		.map(getUsername)
+		.map(getUsernameFromLink)
 		.filter(Boolean)
 		.filter(user => user !== loggedInUser())
 		.forEach(user => highlight(`author[href$="/${user}" i]`, color, hoverColor));

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -11,6 +11,8 @@ import {
 	formatDateDiff,
 	formatNumber,
 	getUserInfo,
+	usernameSelector,
+	getUsernameFromLink,
 	loggedInUser,
 	string,
 	Thing,
@@ -102,16 +104,18 @@ export const highlightedUsers = {};
 
 module.go = () => {
 	if (module.options.hoverInfo.value) {
-		$(document.body).on('mouseover', UserTagger.usernameSelector, handleMouseOver);
+		$(document.body).on('mouseover', usernameSelector, handleMouseOver);
 	}
 };
 
 function handleMouseOver(e: Event) {
-	const authorLink = downcast(e.target, HTMLAnchorElement);
-	if (!UserTagger.usernameRE.test(authorLink.href)) return;
-	const [, username] = UserTagger.usernameRE.exec(authorLink.href) || [];
-	if (!username) console.error(i18n('userInfoInvalidUsernameLink'));
-	const thing = Thing.from(authorLink);
+	const username = getUsernameFromLink(e.target);
+	if (!username) {
+		console.error(i18n('userInfoInvalidUsernameLink'));
+		return;
+	}
+
+	const thing = Thing.from(e.target);
 
 	Hover.infocard(module.moduleID)
 		.target(e.target)

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -17,6 +17,8 @@ import {
 	watchForElements,
 	empty,
 	watchForRedditEvents,
+	usernameSelector,
+	getUsernameFromLink,
 	isAppType,
 } from '../utils';
 import { Storage, openNewTabs, i18n } from '../environment';
@@ -125,20 +127,6 @@ module.options = {
 	},
 };
 
-export const usernameRE = /(?:u|user)\/([\w\-]{3,20}(?![\w\-]))/;
-
-export function getUsername(element: HTMLElement): ?string {
-	if (!(element instanceof HTMLAnchorElement)) return;
-
-	const { href, origin } = element;
-
-	// The link should refer to this site
-	if (!location.origin.endsWith(origin.split('.').slice(-2).join('.'))) return;
-
-	const [, username] = href.match(usernameRE) || [];
-	if (username) return username;
-}
-
 export const tagStorage = Storage.wrapPrefix('tag.', () => (({}: any): {|
 	text?: string,
 	link?: string,
@@ -181,30 +169,15 @@ module.go = () => {
 	registerCommandLine();
 };
 
-export const usernameSelector = '.contents .author, .noncollapsed a.author, p.tagline a.author, #friend-table span.user a, .sidecontentbox .author, div.md a[href^="/u/"]:not([href*="/m/"]), div.md a[href*="reddit.com/u/"]:not([href*="/m/"]), .usertable a.author, .usertable span.user a, div.wiki-page-content .author';
-
-type WatcherOptions = {|
+export async function applyToUser(element: HTMLAnchorElement | HTMLElement, {
+	username = getUsernameFromLink(element) || '',
+	renderTaggingIcon = module.options.showTaggingIcon.value && username !== loggedInUser(),
+	renderVoteWeight = module.options.trackVoteWeight.value && username !== loggedInUser(),
+}: {|
 	username?: string,
 	renderTaggingIcon?: boolean,
 	renderVoteWeight?: boolean,
-|};
-
-export async function applyToUser(element: HTMLAnchorElement | HTMLElement, options?: WatcherOptions) {
-	let {
-		username,
-		renderTaggingIcon,
-		renderVoteWeight,
-	} = options || {};
-	if (!username && element instanceof HTMLAnchorElement) {
-		username = getUsername(element);
-	}
-	if (typeof renderTaggingIcon === 'undefined') {
-		renderTaggingIcon = module.options.showTaggingIcon.value && username !== loggedInUser();
-	}
-	if (typeof renderVoteWeight === 'undefined') {
-		renderVoteWeight = module.options.trackVoteWeight.value && username !== loggedInUser();
-	}
-
+|} = {}) {
 	if (!username) {
 		console.warn('Could not find username', element);
 		return;

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -159,6 +159,8 @@ export {
 	loggedInUser,
 	documentLoggedInUser,
 	loggedInUserHash,
+	usernameSelector,
+	getUsernameFromLink,
 } from './user';
 
 export {

--- a/lib/utils/user.js
+++ b/lib/utils/user.js
@@ -42,6 +42,32 @@ export const loggedInUserInfo = _.once((): Promise<CurrentRedditUser | void> =>
 	!isLoggedIn() ? Promise.resolve() : ajax({ url: '/api/me.json', type: 'json' })
 		.then(data => data.data && data.data.modhash ? data : undefined));
 
+const usernameRE = /(?:u|user)\/([\w\-]{3,20}(?![\w\-]))/;
+
+export const usernameSelector = [
+	'.contents .author',
+	'p.tagline a.author',
+	'#friend-table span.user a',
+	'.sidecontentbox .author',
+	'div.md a[href^="/u/"]:not([href*="/m/"])',
+	'div.md a[href*="reddit.com/u/"]:not([href*="/m/"])',
+	'.usertable a.author',
+	'.usertable span.user a',
+	'div.wiki-page-content .author',
+].join(', ');
+
+export function getUsernameFromLink(element: HTMLElement): ?string {
+	if (!(element instanceof HTMLAnchorElement)) return;
+
+	const { href, origin } = element;
+
+	// The link should refer to this site
+	if (!location.origin.endsWith(origin.split('.').slice(-2).join('.'))) return;
+
+	const [, username] = href.match(usernameRE) || [];
+	if (username) return username;
+}
+
 export function getUserInfo(username: ?string = loggedInUser()): Promise<RedditAccount> {
 	if (!username) {
 		return Promise.reject(new Error('getUserInfo: null/undefined username'));


### PR DESCRIPTION
Tested in browser: Chrome 70
