### PR TITLE
gfycat: Add support for "ifr" URLs

### DIFF
--- a/lib/modules/hosts/gfycat.js
+++ b/lib/modules/hosts/gfycat.js
@@ -16,7 +16,7 @@ export default new Host('gfycat', {
 			type: 'boolean',
 		},
 	},
-	detect: ({ pathname }) => (/^\/(?:gifs\/detail\/)?(\w+)(?:\.gif)?/i).exec(pathname),
+	detect: ({ pathname }) => (/^\/(?:(?:ifr|gifs\/detail)\/)?(\w+)(?:\.gif)?/i).exec(pathname),
 	async handleLink(href, [, id], info = null) {
 		const isMobileResolution = this.options.useMobileGfycat.value;
 


### PR DESCRIPTION
Example URL: https://www.reddit.com/r/HighQualityGifs/comments/a309fe/the_ultimate_siege_engine/

Tested in browser: Chrome 70
