### PR TITLE
showImages: Remove option 'showVideoControls'

### DIFF
--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -528,14 +528,14 @@ img {
 		width: 100%;
 	}
 
-	// Push below and remove hide progress bar if native controls are visible
+	// Push below and remove progress bar and redundant button if native browser controls are visible
 	&-has-native-controls &-interface {
 		display: block;
 		background: rgba(52, 47, 38, 1);
+		border-top: 1px solid #e4e4e4;
 
 		#{$va}-toggle-pause,
-		#{$va}-position-thumb,
-		#{$va}-position {
+		#{$va}-progress {
 			display: none !important;
 		}
 	}

--- a/lib/css/modules/_showImages.scss
+++ b/lib/css/modules/_showImages.scss
@@ -355,7 +355,7 @@ img {
 	}
 }
 
-.video-advanced {
+.res-video {
 	$va: &;
 
 	display: inline-block;
@@ -577,7 +577,7 @@ body:not(.res-showImages-displayImageCaptions) {
 .res-showImages-captionsPosition {
 	@at-root {
 		.res-image,
-		.video-advanced,
+		.res-video,
 		.res-gallery {
 			display: inline-flex;
 			flex-direction: column;

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -2004,8 +2004,12 @@ class Video extends Media {
 
 		this.ready = Promise.race([waitForEvent(this.video, 'suspend'), waitForEvent(lastSource, 'error')]);
 
-		// $FlowIssue `toggleAttribute` not typed
-		this.video.addEventListener('pause', () => { this.element.toggleAttribute('playing', !this.video.paused); });
+		this.video.addEventListener('pause', () => {
+			// $FlowIssue `toggleAttribute` not typed
+			this.element.toggleAttribute('playing', !this.video.paused);
+			// If browser controls are shown, stop auto mananging since that could cause conflicts (e.g. force play when paused by user)
+			if (this.video.controls && this.useVideoManager) mutedVideoManager().unobserve(this.video);
+		});
 		// $FlowIssue `toggleAttribute` not typed
 		this.video.addEventListener('play', () => { this.element.toggleAttribute('playing', !this.video.paused); });
 

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -60,7 +60,7 @@ import {
 	mediaControlsTemplate,
 	siteAttributionTemplate,
 	textTemplate,
-	videoAdvancedTemplate,
+	videoTemplate,
 } from './showImages/templates';
 import {
 	Expando,
@@ -406,22 +406,14 @@ module.options = {
 		}],
 		description: 'showImagesExpandoCommentRedirectsDesc',
 	},
-	showVideoControls: {
-		title: 'showImagesShowVideoControlsTitle',
-		type: 'boolean',
-		value: true,
-		description: 'showImagesShowVideoControlsDesc',
-	},
 	onlyPlayMutedWhenVisible: {
 		title: 'showImagesOnlyPlayMutedWhenVisibleTitle',
-		dependsOn: options => options.showVideoControls.value,
 		type: 'boolean',
 		value: true,
 		description: 'showImagesOnlyPlayMutedWhenVisibleDesc',
 	},
 	maxSimultaneousPlaying: {
 		title: 'showImagesMaxSimultaneousPlayingTitle',
-		dependsOn: options => options.showVideoControls.value,
 		type: 'text',
 		value: '0',
 		description: 'showImagesMaxSimultaneousPlayingDesc',
@@ -1950,15 +1942,14 @@ class Video extends Media {
 	}: VideoMedia, context) {
 		super();
 
-		const advancedControls = module.options.showVideoControls.value;
-		this.useVideoManager = advancedControls && module.options.onlyPlayMutedWhenVisible.value && muted;
+		this.useVideoManager = module.options.onlyPlayMutedWhenVisible.value && muted;
 
 		this.autoplay = muted || module.options.autoplayVideo.value;
 		this.time = time;
 		this.frameRate = frameRate;
 		this.muted = muted;
 
-		this.element = videoAdvancedTemplate({
+		this.element = videoTemplate({
 			title,
 			caption,
 			credits,
@@ -1969,15 +1960,13 @@ class Video extends Media {
 			muted,
 			loop,
 			reversable,
-			controls: !advancedControls,
-			advancedControls,
 			openInNewWindow: module.options.openInNewWindow.value,
 			formattedPlaybackRate: this.formatMultilineNumber(playbackRate, 'x'),
 		});
 		this.video = downcast(this.element.querySelector('video'), HTMLVideoElement);
-		const container = this.element.querySelector('.video-advanced-container');
+		const container = this.element.querySelector('.res-video-container');
 
-		const msgError = this.element.querySelector('.video-advanced-error');
+		const msgError = this.element.querySelector('.res-video-error');
 		const displayError = (error: Error | ProgressEvent) => {
 			if (msgError.hidden) {
 				msgError.hidden = false;
@@ -2036,14 +2025,12 @@ class Video extends Media {
 			}
 		});
 
-		if (advancedControls) {
-			Promise.all([waitForEvent(this.element, 'mouseenter'), waitForEvent(this.video, 'loadedmetadata')])
-				.then(() => this.addAdvancedControls());
+		Promise.all([waitForEvent(this.element, 'mouseenter'), waitForEvent(this.video, 'loadedmetadata')])
+			.then(() => this.addControls());
 
-			new MutationObserver(() =>
-				this.element.classList.toggle('video-advanced-has-native-controls', this.video.hasAttribute('controls'))
-			).observe(this.video, { attributes: true });
-		}
+		new MutationObserver(() =>
+			this.element.classList.toggle('res-video-has-native-controls', this.video.hasAttribute('controls'))
+		).observe(this.video, { attributes: true });
 
 		if (!loop && this.autoplay) {
 			waitForEvent(this.video, 'ended').then(() => this.stopAutoplay());
@@ -2083,21 +2070,21 @@ class Video extends Media {
 		return `${value.toFixed(2).replace('.', '.\u200B'/* zwsp */)}${suffix}`;
 	}
 
-	addAdvancedControls() {
-		const ctrlContainer = this.element.querySelector('.video-advanced-controls');
-		const ctrlReverse = ctrlContainer.querySelector('.video-advanced-reverse');
-		const ctrlTogglePause = ctrlContainer.querySelector('.video-advanced-toggle-pause');
-		const ctrlSpeedDecrease = ctrlContainer.querySelector('.video-advanced-speed-decrease');
-		const ctrlSpeedIncrease = ctrlContainer.querySelector('.video-advanced-speed-increase');
-		const ctrlTimeDecrease = ctrlContainer.querySelector('.video-advanced-time-decrease');
-		const ctrlTimeIncrease = ctrlContainer.querySelector('.video-advanced-time-increase');
+	addControls() {
+		const ctrlContainer = this.element.querySelector('.res-video-controls');
+		const ctrlReverse = ctrlContainer.querySelector('.res-video-reverse');
+		const ctrlTogglePause = ctrlContainer.querySelector('.res-video-toggle-pause');
+		const ctrlSpeedDecrease = ctrlContainer.querySelector('.res-video-speed-decrease');
+		const ctrlSpeedIncrease = ctrlContainer.querySelector('.res-video-speed-increase');
+		const ctrlTimeDecrease = ctrlContainer.querySelector('.res-video-time-decrease');
+		const ctrlTimeIncrease = ctrlContainer.querySelector('.res-video-time-increase');
 
-		const progress = this.element.querySelector('.video-advanced-progress');
-		const indicatorPosition = progress.querySelector('.video-advanced-position');
-		const ctrlPosition = progress.querySelector('.video-advanced-position-thumb');
+		const progress = this.element.querySelector('.res-video-progress');
+		const indicatorPosition = progress.querySelector('.res-video-position');
+		const ctrlPosition = progress.querySelector('.res-video-position-thumb');
 
-		const msgSpeed = ctrlContainer.querySelector('.video-advanced-speed');
-		const msgTime = ctrlContainer.querySelector('.video-advanced-time');
+		const msgSpeed = ctrlContainer.querySelector('.res-video-speed');
+		const msgTime = ctrlContainer.querySelector('.res-video-time');
 
 		ctrlTogglePause.addEventListener('click', () => {
 			if (this.video.paused) this.video.play(); else this.video.pause();
@@ -2130,10 +2117,10 @@ class Video extends Media {
 			this.video.currentTime = this.video.duration * percentage;
 		});
 
-		const ctrlVolume = ctrlContainer.querySelector('.video-advanced-volume');
+		const ctrlVolume = ctrlContainer.querySelector('.res-video-volume');
 		if (ctrlVolume) {
-			const ctrlVolumeLevel = ctrlVolume.querySelector('.video-advanced-volume-level');
-			const volumePercentage = ctrlVolume.querySelector('.video-advanced-volume-percentage');
+			const ctrlVolumeLevel = ctrlVolume.querySelector('.res-video-volume-level');
+			const volumePercentage = ctrlVolume.querySelector('.res-video-volume-percentage');
 
 			let previousLevel = 0;
 			const updateVolume = e => {

--- a/lib/modules/showImages/templates.js
+++ b/lib/modules/showImages/templates.js
@@ -83,7 +83,7 @@ export const textTemplate = ({ title, credits, src }: {| title?: string, credits
 	</div>
 `;
 
-export const videoAdvancedTemplate = ({
+export const videoTemplate = ({
 	title,
 	caption,
 	credits,
@@ -93,8 +93,6 @@ export const videoAdvancedTemplate = ({
 	muted,
 	loop,
 	reversable,
-	controls,
-	advancedControls,
 	formattedPlaybackRate,
 	openInNewWindow,
 }: {|
@@ -107,12 +105,10 @@ export const videoAdvancedTemplate = ({
 	muted: boolean,
 	loop: boolean,
 	reversable: boolean,
-	controls: boolean,
-	advancedControls: boolean,
 	formattedPlaybackRate: string,
 	openInNewWindow: boolean,
 |}) => string.html`
-	<div class="video-advanced">
+	<div class="res-video">
 		${title && string._html`
 		<h4 class="res-title">${title}</h4>
 		`}
@@ -122,60 +118,50 @@ export const videoAdvancedTemplate = ({
 		${credits && string._html`
 		<div class="res-credits">${string.safe(credits)}</div>
 		`}
-		<div class="video-advanced-container">
-			${controls ? string._html`
-			<video controls ${muted && 'muted'} ${loop && 'loop'} poster="${poster}"></video>
-			` : string._html`
+		<div class="res-video-container">
 			<a class="noKeyNav" href="${href}" ${openInNewWindow && string._html`target="_blank" rel="noopener noreferrer"`}>
 				<video ${muted && 'muted'} ${loop && 'loop'} poster="${poster}"></video>
 			</a>
-			`}
-			${advancedControls ? string._html`
-			<div class="video-advanced-interface">
-				<div class="video-advanced-progress">
-					<div class="video-advanced-position"></div>
-					<div class="video-advanced-position-thumb"></div>
+			<div class="res-video-interface">
+				<div class="res-video-progress">
+					<div class="res-video-position"></div>
+					<div class="res-video-position-thumb"></div>
 				</div>
-				<div class="video-advanced-main">
-					<div class="video-advanced-controls">
-						<div title="Toggle pause" class="res-icon video-advanced-button video-advanced-toggle-pause"></div>
+				<div class="res-video-main">
+					<div class="res-video-controls">
+						<div title="Toggle pause" class="res-icon res-video-button res-video-toggle-pause"></div>
 						${reversable && string._html`
-						<div title="Reverse video" class="res-icon video-advanced-button video-advanced-reverse"></div>
+						<div title="Reverse video" class="res-icon res-video-button res-video-reverse"></div>
 						`}
 						${!muted && string._html`
-							<div title="Adjust volume" class="res-icon video-advanced-button video-advanced-volume">
-								<div class="video-advanced-volume-level">
-									<div class="video-advanced-volume-percentage"></div>
+							<div title="Adjust volume" class="res-icon res-video-button res-video-volume">
+								<div class="res-video-volume-level">
+									<div class="res-video-volume-percentage"></div>
 								</div>
 							</div>
 						`}
-						<div class="video-advanced-controls-group video-advanced-current-time">
-							<div title="Select previous frame" class="res-icon video-advanced-button video-advanced-time-decrease"></div>
-							<div class="video-advanced-time">1.00s</div>
-							<div title="Select next frame" class="res-icon video-advanced-button video-advanced-time-increase"></div>
+						<div class="res-video-controls-group res-video-current-time">
+							<div title="Select previous frame" class="res-icon res-video-button res-video-time-decrease"></div>
+							<div class="res-video-time">1.00s</div>
+							<div title="Select next frame" class="res-icon res-video-button res-video-time-increase"></div>
 						</div>
-						<div class="video-advanced-controls-group video-advanced-playback-rate">
-							<div title="Decrease speed by 10%" class="res-icon video-advanced-button video-advanced-speed-decrease"></div>
-							<div class="video-advanced-speed">${string.safe(formattedPlaybackRate)}</div>
-							<div title="Increase speed by 10%" class="res-icon video-advanced-button video-advanced-speed-increase"></div>
+						<div class="res-video-controls-group res-video-playback-rate">
+							<div title="Decrease speed by 10%" class="res-icon res-video-button res-video-speed-decrease"></div>
+							<div class="res-video-speed">${string.safe(formattedPlaybackRate)}</div>
+							<div title="Increase speed by 10%" class="res-icon res-video-button res-video-speed-increase"></div>
 						</div>
 					</div>
-					<div hidden class="video-advanced-error">
+					<div hidden class="res-video-error">
 						<div class="res-icon">&#xf15b</div>
 					</div>
-					<div class="video-advanced-info">
+					<div class="res-video-info">
 						${source && string._html`
-						<a class="video-advanced-link video-advanced-source" href="${source}">source</a>
+						<a class="res-video-link res-video-source" href="${source}">source</a>
 						`}
 						<div class="res-expando-siteAttribution"></div>
 					</div>
 				</div>
 			</div>
-			` : string._html`
-			<div hidden class="video-advanced-error">
-				<div class="res-icon">&#xf15b</div>
-			</div>
-			`}
 		</div>
 	</div>
 `;

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -4269,12 +4269,6 @@
 	"showImagesExpandoCommentRedirectsDesc": {
 		"message": "How should RES handle posts where the link is redirected to the comments page with preview expanded?"
 	},
-	"showImagesShowVideoControlsTitle": {
-		"message": "Show Video Controls"
-	},
-	"showImagesShowVideoControlsDesc": {
-		"message": "Show controls such as pause/play, step and playback rate."
-	},
 	"showImagesOnlyPlayMutedWhenVisibleTitle": {
 		"message": "Only Play Muted When Visible"
 	},


### PR DESCRIPTION
The option is confusing (disabling it removes RES' controls, but adds the browser's controls), and probably little used. 

Tested in browser: Firefox 64, Chrome 70