### PR TITLE
username autocompletion: Improve performance, restrict selection to upvoted / tagged / on page

### DIFF
--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -1171,19 +1171,18 @@ async function getSubredditCompletions(query) {
 	return names.map(name => `/r/${name}`);
 }
 
+// Auto-complete users on this page in addition to previously tagged or upvoted users, but not ignored ones
+const users = _.once(async () => _.uniq([
+	...(await UserTagger.Tag.getStored()).filter(({ text, votesUp }) => text || votesUp),
+	...UserTagger.tags.values(),
+])
+	.map(({ id }) => id)
+	.sort()
+);
+
 async function getUserCompletions(query) {
-	const tagNames = Object.keys(await UserTagger.tagStorage.getAll());
-	const pageNames = Array.from(UserTagger.tags.keys());
-	return [...tagNames, ...pageNames]
+	return (await users())
 		.filter(e => e.toLowerCase().startsWith(query.toLowerCase()))
-		.sort()
-		.reduce((prev, current) => {
-			// Removing duplicates
-			if (prev[prev.length - 1] !== current) {
-				prev.push(current);
-			}
-			return prev;
-		}, [])
 		.map(user => `/u/${user}`);
 }
 

--- a/lib/modules/troubleshooter.js
+++ b/lib/modules/troubleshooter.js
@@ -81,15 +81,10 @@ function clearCache() {
 async function clearTags() {
 	const confirm = window.confirm(i18n('troubleshooterAreYouPositive'));
 	if (confirm) {
-		const tags = await UserTagger.tagStorage.getAll();
-		const keysToDelete = [];
-		for (const [key, { text, votesUp = 0, votesDown = 0 }] of Object.entries(tags)) {
-			if (!text && votesUp <= 1 && votesDown <= 1) {
-				keysToDelete.push(key);
-			}
-		}
-		UserTagger.tagStorage.deleteMultiple(keysToDelete);
-		Notifications.showNotification(i18n('troubleshooterEntriesRemoved', keysToDelete.length), 2500);
+		const toDelete = (await UserTagger.Tag.getStored())
+			.filter(({ text, votesUp = 0, votesDown = 0 }) => !text && votesUp <= 1 && votesDown <= 1);
+		for (const tag of toDelete) tag.delete();
+		Notifications.showNotification(i18n('troubleshooterEntriesRemoved', toDelete.length), 2500);
 	} else {
 		Notifications.showNotification(i18n('troubleshooterNoActionTaken'), 2500);
 	}

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -127,7 +127,7 @@ module.options = {
 	},
 };
 
-export const tagStorage = Storage.wrapPrefix('tag.', () => (({}: any): {|
+const tagStorage = Storage.wrapPrefix('tag.', () => (({}: any): {|
 	text?: string,
 	link?: string,
 	color?: string,

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -217,10 +217,10 @@ export class Tag {
 	}
 
 	static getUnfilled(id: string): Tag {
-		let tag = tags.get(id);
+		let tag = tags.get(id.toLowerCase());
 		if (!tag) {
 			tag = new Tag(id);
-			tags.set(id, tag);
+			tags.set(id.toLowerCase(), tag);
 		}
 
 		return tag;
@@ -283,6 +283,10 @@ export class Tag {
 		const base = (new Tag()).extract();
 		const data = this.extract();
 		tagStorage.set(this.id, _.pickBy(data, (v, k) => base[k] !== v));
+	}
+
+	delete() {
+		tagStorage.delete(this.id);
 	}
 
 	add(element: HTMLAnchorElement | HTMLElement, { renderTaggingIcon = false, renderVoteWeight = false }: {| renderTaggingIcon?: boolean, renderVoteWeight?: boolean |} = {}) {
@@ -825,13 +829,12 @@ async function drawUserTagTable(sortMethod, descending) {
 
 			$('#userTaggerTable tbody').append(d);
 		});
-	$('#userTaggerTable tbody .deleteIcon').click(function() {
-		const thisUser = $(this).attr('user').toLowerCase();
-		const $button = $(this);
-		Alert.open(i18n('userTaggerAreYouSureYouWantToDeleteTag', thisUser), { cancelable: true })
+	$('#userTaggerTable tbody .deleteIcon').click(async function() {
+		const tag = await Tag.get(this.getAttribute('user'));
+		Alert.open(i18n('userTaggerAreYouSureYouWantToDeleteTag', tag.id), { cancelable: true })
 			.then(() => {
-				tagStorage.delete(thisUser);
-				$button.closest('tr').remove();
+				tag.delete();
+				this.closest('tr').remove();
 			});
 	});
 }


### PR DESCRIPTION
- Only display users on the current page, in addition to those whom have been tagged or upvoted earlier, because otherwise the list gradually becomes very noisy
- Retrieve users only once, since loading the tag storage is slow, especially on Firefox

Tested in browser: Chrome 70
