### PR TITLE
r2 watcher: Simplify interface and adjust callback aggregation

### DIFF
--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -7,7 +7,9 @@ import {
 	waitFor,
 	waitForChild,
 	waitForEvent,
-	newSitetable,
+	initR2Watcher,
+	initD2xWatcher,
+	isAppType,
 } from '../utils';
 import { _loadModuleOptions } from './options/options';
 import { _loadModulePrefs, _runModuleStage } from './modules/modules';
@@ -82,10 +84,13 @@ export const always: Promise<void> = loadOptions
 export const beforeLoad: Promise<void> = loadOptions
 	.then(() => _runModuleStage('beforeLoad'));
 
-export const go: Promise<*> = Promise.all([beforeLoad, bodyReady])
-	.then(() => Promise.all([newSitetable(document.body), _runModuleStage('go')]));
+export const watchers: Promise<*> = Promise.all([beforeLoad, bodyReady])
+	.then(() => isAppType('d2x') ? initD2xWatcher() : initR2Watcher());
 
-export const afterLoad: Promise<void> = Promise.all([go, loadComplete])
+export const go: Promise<*> = Promise.all([beforeLoad, bodyReady])
+	.then(() => _runModuleStage('go'));
+
+export const afterLoad: Promise<void> = Promise.all([go, watchers, loadComplete])
 	.then(() => _runModuleStage('afterLoad'));
 
 bodyStart.then(() => BodyClasses.add());

--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -194,7 +194,10 @@ module.exclude = [
 
 module.beforeLoad = () => {
 	if (module.options.commentsLinksNewTabs.value) {
-		watchForElements(['newComments', 'siteTable'], '.thing div.md a', commentsLinksNewTabs);
+		watchForThings(['comment'], comment => {
+			const body = comment.getTextBody();
+			if (body) for (const link of body.querySelectorAll('a')) commentsLinksNewTabs((link: any));
+		});
 	}
 
 	if (module.options.fixHideLinks.value) {

--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -205,7 +205,10 @@ module.beforeLoad = () => {
 	}
 
 	if (module.options.doNoCtrlF.value) {
-		watchForElements(['newComments', 'siteTable'], 'ul.flat-list.buttons li a, .side a.reddit-comment-link', applyNoCtrlF);
+		watchForElements(['page'], '.side a.reddit-comment-link', applyNoCtrlF);
+		watchForThings(null, thing => {
+			for (const link of thing.entry.querySelectorAll('ul.flat-list.buttons li a')) applyNoCtrlF(link);
+		});
 	}
 
 	if (module.options.videoTimes.value || module.options.videoUploaded.value || module.options.videoViewed.value) {

--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -10,7 +10,7 @@ import {
 	isCurrentSubreddit,
 	loggedInUser,
 	string,
-	newSitetable,
+	registerPage,
 } from '../utils';
 import { i18n, Storage, ajax } from '../environment';
 import * as Init from '../core/init';
@@ -780,7 +780,7 @@ function WidgetObject(widgetOptions: WidgetOptions) {
 
 		// now run watcher functions from other modules on this content...
 		if ($widgetContent[0]) {
-			newSitetable($widgetContent[0]);
+			registerPage($widgetContent[0]);
 		}
 	};
 	this.error = e => {

--- a/lib/modules/filteReddit/commentCases/CommentContent.js
+++ b/lib/modules/filteReddit/commentCases/CommentContent.js
@@ -18,8 +18,8 @@ export class CommentContent extends Case {
 	value = Case.buildRegex(this.conditions.patt, { fullMatch: false });
 
 	evaluate(thing: *, values: * = [this.value]) {
-		const md = thing.entry.querySelector('.md');
-		if (!md) return null;
-		return values.some(v => v.test(md.textContent));
+		const body = thing.getTextBody();
+		if (!body) return null;
+		return values.some(v => v.test(body.textContent));
 	}
 }

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -236,16 +236,16 @@ function setReturnToPage(selected: ?Thing) {
 
 	let number = 1;
 
-	const $marker = $(selected.element).closest('.sitetable, .search-result-listing').prev('.NERPageMarker');
-	const marker = $marker.get(0);
-	if (marker) ({ number } = $marker.data());
+	const $earlierMarkers = $(selected.element).prevAll('.NERPageMarker');
+	const marker = $earlierMarkers.get(0);
+	if (marker) number = parseInt(marker.dataset.number, 10);
 
 	// replaceState is expensive, so avoid it when possible
 	const { ner: saved } = history.state || {};
 	if (saved && saved.number === number) return;
 
 	// After appended page number two, the browser will auto-scroll too far
-	const allowAutoScroll = $(selected.element).closest('.sitetable, .search-result-listing').prevAll('.NERPageMarker').length < 2;
+	const allowAutoScroll = $earlierMarkers.length < 2;
 	history.scrollRestoration = allowAutoScroll ? 'auto' : 'manual';
 
 	try {
@@ -469,7 +469,7 @@ const appendPage = fastAsync(function*(newSiteTable) {
 		addCSS(`body.res > .content .link .rank { width: ${(lastLen * 1.1).toFixed(1)}ex; }`);
 	}
 
-	siteTable().append(pageMarker, newSiteTable);
+	siteTable().append(pageMarker, ...newSiteTable.children);
 
 	if (!nextPageUrl) endNER('No more pages');
 

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -12,7 +12,7 @@ import {
 	addCSS,
 	scrollToElement,
 	fastAsync,
-	newSitetable,
+	registerPage,
 	watchForThings,
 	documentLoggedInUser,
 	loggedInUser,
@@ -444,7 +444,7 @@ const loadPage = mutex(async (url: string) => {
 
 		pages[currentPageNumber] = { url, nextPageUrl, html: newSiteTable.outerHTML };
 
-		await newSitetable(newSiteTable);
+		await registerPage(newSiteTable);
 		await appendPage(newSiteTable);
 	} catch (e) {
 		endNER(`Could not load the next page: ${e.message}`);

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -444,7 +444,7 @@ const loadPage = mutex(async (url: string) => {
 
 		pages[currentPageNumber] = { url, nextPageUrl, html: newSiteTable.outerHTML };
 
-		await registerPage(newSiteTable);
+		registerPage(newSiteTable);
 		await appendPage(newSiteTable);
 	} catch (e) {
 		endNER(`Could not load the next page: ${e.message}`);

--- a/lib/modules/pageNavigator.js
+++ b/lib/modules/pageNavigator.js
@@ -89,13 +89,18 @@ const showLinkTitleTemplate = ({ thumbnailSrc, linkId, settingsHash, linkHref, l
 
 function backToNewCommentArea() {
 	const commentArea = document.querySelector('.commentarea > form.usertext textarea');
-	if (!commentArea || !commentArea.offsetParent) return;
+	if (!commentArea) return;
+
 	const $backToNewCommentArea = $(`<a class="pageNavigator res-icon" data-id="addComment" href="#comments" title="${i18n('pageNavToCommentTitle')}">&#xF003;</a>`);
 	$backToNewCommentArea.on('click', (e: Event) => {
 		e.preventDefault();
 		commentArea.focus();
 	});
 	Floater.addElement($backToNewCommentArea);
+
+	requestAnimationFrame(() => {
+		if (!commentArea.offsetParent) $backToNewCommentArea.get(0).hidden = true;
+	});
 }
 
 const showLinkTitle = _.once(submissionThing => {

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -232,7 +232,7 @@ const lastSelectedId = sessionStorage[lastSelectedKey];
 
 function selectInitial(thing) {
 	if (selectedThing) return;
-	if (thing.getFullname() !== lastSelectedId) return;
+	if (lastSelectedId && thing.getFullname() !== lastSelectedId) return;
 	if (!thing.isVisible()) return;
 
 	if (module.options.scrollToSelectedThingOnLoad.value) history.scrollRestoration = 'manual';
@@ -249,7 +249,7 @@ const addLastSelectedListener = _.once(() => {
 });
 
 const movers = {
-	closestVisible: (thing: Thing) => thing.getClosestVisible(false),
+	closestVisible: (thing: Thing) => thing.getClosestVisible(),
 	up: (thing: Thing) => thing.getNext({ direction: 'up' }),
 	down: (thing: Thing) => thing.getNext({ direction: 'down' }),
 	top: (/*:: thing: Thing */) => Thing.visibleThings()[0],
@@ -331,7 +331,6 @@ const installUpdateSelectedElementClassListener = _.once(() =>
 		}
 	}, 'beforePaint')
 );
-
 
 // why !important on .entry.res-selected?  Because some subreddits are unfortunately using !important for no good reason on .entry divs...
 

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -101,7 +101,7 @@ module.options = {
 
 module.beforeLoad = () => {
 	if (module.options.selectLastThingOnLoad.value) {
-		watchForThings(['post', 'comment', 'message'], selectInitial, { immediate: true });
+		watchForThings(null, selectInitial, { immediate: true });
 	}
 
 	addScrollStyleListener();
@@ -233,14 +233,13 @@ const lastSelectedId = sessionStorage[lastSelectedKey];
 function selectInitial(thing) {
 	if (selectedThing) return;
 	if (thing.getFullname() !== lastSelectedId) return;
-	const target = thing.getClosestVisible();
-	if (!target) return;
+	if (!thing.isVisible()) return;
 
 	if (module.options.scrollToSelectedThingOnLoad.value) history.scrollRestoration = 'manual';
 	// `scrollRestoration` may also be set in neverEndingReddit
 	const scrollToSelected = history.scrollRestoration === 'manual';
 
-	select(target, { scrollStyle: scrollToSelected ? 'legacy' : 'none' });
+	select(thing, { scrollStyle: scrollToSelected ? 'legacy' : 'none' });
 }
 
 const addLastSelectedListener = _.once(() => {

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -34,6 +34,7 @@ import {
 	string,
 	waitForEvent,
 	watchForElements,
+	watchForThings,
 	getPercentageVisibleYAxis,
 	getViewportSize,
 } from '../utils';
@@ -480,30 +481,15 @@ module.beforeLoad = () => {
 		`);
 	}
 
-	watchForElements(['siteTable'], getSelector(), checkElementForMedia);
-	watchForElements(['selfText', 'newComments'], getSelector(true), checkElementForMedia);
+	watchForElements(['selfText'], null, scanBody);
+	watchForThings(['comment', 'message'], thing => scanBody(thing.getTextBody()));
+	watchForThings(['post'], thing => checkElementForMedia(downcast(thing.getTitleElement(), HTMLAnchorElement)));
 };
 
-function getSelector(isSelfText) {
-	// get elements common across all pages first...
-	// if we're on a comments page, get those elements too...
-	if (isPageType('comments', 'commentsLinklist', 'profile')) {
-		return '#siteTable a.title, .expando .usertext-body > div.md a, .content .usertext-body > div.md a';
-	} else if (isSelfText) {
-		// We're scanning newly opened (from an expando) selftext...
-		return '.usertext-body > div.md a';
-	} else if (isPageType('wiki')) {
-		return '.wiki-page-content a';
-	} else if (isPageType('inbox')) {
-		return '#siteTable div.entry .md a';
-	} else if (isPageType('search')) {
-		return '#siteTable a.title, .contents a.search-link';
-	} else {
-		return '#siteTable a.title, #siteTable_organic a.title';
-	}
-}
-
 module.go = () => {
+	if (isPageType('wiki')) scanBody(document.querySelector('.wiki-page-content'));
+	if (isPageType('comments')) scanBody(document.querySelector('.usertext-body'));
+
 	createImageButtons();
 
 	if (module.options.mediaBrowse.value) {
@@ -885,6 +871,13 @@ function getMediaInfo(mediaUrl, thing) {
 	}
 }
 
+function scanBody(element: ?Element) {
+	if (!element) return;
+	for (const link of element.querySelectorAll('a')) {
+		checkElementForMedia(downcast(link, HTMLAnchorElement));
+	}
+}
+
 const linksMap: WeakMap<HTMLAnchorElement, Expando> = new WeakMap();
 export function getLinkExpando(link: HTMLAnchorElement): ?Expando {
 	return linksMap.get(link);
@@ -899,7 +892,7 @@ function shouldLinkBeDeferred(element) {
 
 const inText = element => !!element.closest('.md, .search-result-footer');
 
-async function checkElementForMedia(element) {
+async function checkElementForMedia(element: HTMLAnchorElement) {
 	if (shouldLinkBeDeferred(element)) {
 		await new Promise(resolve => deferredLinks.set(element, resolve));
 		deferredLinks.delete(element);
@@ -972,7 +965,7 @@ async function checkElementForMedia(element) {
 
 function placeExpando(expando, element, thing) {
 	if (!inText(element) && thing && thing.getTitleElement()) {
-		element.parentElement.after(expando.button);
+		if (element.parentElement) element.parentElement.after(expando.button);
 		thing.entry.appendChild(expando.box);
 	} else {
 		$(element).add($(element).next('.keyNavAnnotation')).last()

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -488,7 +488,6 @@ module.beforeLoad = () => {
 
 module.go = () => {
 	if (isPageType('wiki')) scanBody(document.querySelector('.wiki-page-content'));
-	if (isPageType('comments')) scanBody(document.querySelector('.usertext-body'));
 
 	createImageButtons();
 

--- a/lib/modules/showImages/expando.js
+++ b/lib/modules/showImages/expando.js
@@ -49,10 +49,13 @@ export class Expando {
 					buttonPlaceholder.replaceWith(button);
 					boxPlaceholder.replaceWith(box);
 				},
-				types: [
+				types: _.flatten([
 					'native',
-					button.classList.contains('selftext') ? 'selftext' : null,
-				].filter(v => v),
+					button.classList.contains('selftext') ? 'selftext' : // This may be muted, depending on its content (not possible to know before expanding)
+					(box.dataset.cachedhtml || '').match(/\bvideo-player\b/) ? ['video', 'non-muted'] :
+					(box.dataset.cachedhtml || '').match(/\<iframe\b/) ? ['iframe', 'non-muted'] :
+					['image', 'muted'],
+				]).filter(Boolean),
 				ready: true,
 			}: any /* TODO: this is kinda dangerous, there should be a subclass instead */);
 

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -14,10 +14,9 @@ import {
 	isPageType,
 	loggedInUser,
 	string,
-	watchForElements,
+	watchForThings,
 	empty,
 	watchForRedditEvents,
-	usernameSelector,
 	getUsernameFromLink,
 	isAppType,
 } from '../utils';
@@ -141,7 +140,17 @@ const getTagBatched = batch(async users => {
 }, { size: Infinity, delay: 0 });
 
 module.beforeLoad = () => {
-	watchForElements(['siteTable', 'newComments', 'selfText'], usernameSelector, applyToUser);
+	// Fetch immediately so data is ready when adding tag
+	watchForThings(null, thing => {
+		const user = thing.getAuthor();
+		if (user) Tag.get(user);
+	}, { immediate: true });
+
+	watchForThings(null, thing => {
+		const element = thing.getAuthorElement();
+		if (element) applyToUser(element);
+	});
+
 	watchForRedditEvents('postAuthor', (element, { author, _: { update } }) => {
 		if (update) return;
 		applyToUser(element, { username: author });
@@ -169,7 +178,7 @@ module.go = () => {
 	registerCommandLine();
 };
 
-export async function applyToUser(element: HTMLAnchorElement | HTMLElement, {
+export function applyToUser(element: HTMLAnchorElement | HTMLElement, {
 	username = getUsernameFromLink(element) || '',
 	renderTaggingIcon = module.options.showTaggingIcon.value && username !== loggedInUser(),
 	renderVoteWeight = module.options.trackVoteWeight.value && username !== loggedInUser(),
@@ -187,7 +196,7 @@ export async function applyToUser(element: HTMLAnchorElement | HTMLElement, {
 	// since in most cases there's no applied tag
 	const tag = Tag.getUnfilled(username);
 	tag.add(element, { renderVoteWeight, renderTaggingIcon });
-	await tag.fill();
+	tag.fill();
 }
 
 export const tags: Map<string, Tag> = new Map();

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -258,6 +258,10 @@ export class Thing {
 		return this.element.dataset.url || this.getPostLink().href;
 	}
 
+	getTextBody(): HTMLElement {
+		return this.entry.querySelector('.md');
+	}
+
 	getCommentsLink(): HTMLAnchorElement {
 		return downcast(this.entry.querySelector('a.comments, a.search-comments'), HTMLAnchorElement);
 	}

--- a/lib/utils/async.js
+++ b/lib/utils/async.js
@@ -235,6 +235,23 @@ export function mutex<V, T:(...args: any) => Promise<V> | V>(callback: T): T {
 	}: any);
 }
 
+// `callback` is invoked when the event queue is empty, or on the next animation frame
+// returns a promise that resolves when callback resolves
+export function throttle(callback: *) {
+	let promise: ?Promise<*>;
+
+	return () => {
+		promise = promise || Promise.race([
+			new Promise(res => { requestAnimationFrame(res); }),
+			new Promise(res => { setTimeout(res); }),
+		]).then(() => {
+			promise = null;
+			return callback();
+		});
+		return promise;
+	};
+}
+
 /* eslint-disable no-redeclare */
 // rest params can't be placed before non-rest params, so this is unfortunately necessary
 // add another case if you need more params

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -168,7 +168,7 @@ export {
 } from './value';
 
 export {
-	newSitetable,
+	registerPage,
 	initR2Watcher,
 	watchForElements,
 	watchForThings,

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -169,10 +169,15 @@ export {
 
 export {
 	newSitetable,
+	initR2Watcher,
 	watchForElements,
 	watchForThings,
-	watchForRedditEvents,
 } from './watchers';
+
+export {
+	initD2xWatcher,
+	watchForRedditEvents,
+} from './watchers_d2x';
 
 export * as BodyClasses from './bodyClasses';
 

--- a/lib/utils/watchers.js
+++ b/lib/utils/watchers.js
@@ -1,15 +1,14 @@
 /* @flow */
 
 import _ from 'lodash';
-import { sortBy, map, flow } from 'lodash/fp';
 import { Thing } from './Thing';
-import { isAppType, isPageType } from './location';
-import { forEachChunked } from './async';
-import { waitForChild, watchForFutureChildren, getViewportSize } from './dom';
+import { isPageType } from './location';
+import { getPercentageVisibleYAxis, getViewportSize, waitForChild, watchForFutureDescendants, watchForFutureChildren } from './dom';
+import { forEachChunked, throttle } from './async';
 
 type WatcherOptions = {| immediate?: boolean |};
 
-type ElementWatcherType = 'siteTable' | 'selfText' | 'newComments';
+type ElementWatcherType = 'page' | 'selfText';
 type ElementWatcherCallback = (e: any) => void | Promise<void>;
 
 const elementWatchers: {
@@ -17,11 +16,11 @@ const elementWatchers: {
 		selector: ?string,
 		callback: ElementWatcherCallback,
 		options?: WatcherOptions,
+		registered: WeakSet<*>,
 	}>,
 } = {
-	siteTable: [],
+	page: [],
 	selfText: [],
-	newComments: [],
 };
 
 type ThingWatcherType = 'comment' | 'message' | 'post' | 'subreddit';
@@ -31,6 +30,7 @@ const thingWatchers: {
 	[ThingWatcherType]: Array<{
 		callback: ThingWatcherCallback,
 		options?: WatcherOptions,
+		registered: WeakSet<*>,
 	}>,
 } = {
 	comment: [],
@@ -39,114 +39,138 @@ const thingWatchers: {
 	subreddit: [],
 };
 
-function registerElement(type, element, sorter = callbacks => callbacks) {
-	const elementCallbacks: Map<HTMLElement, Array<() => mixed>> = new Map();
+const runCallback = fn => { try { fn(); } catch (e) { console.error(e); } };
 
-	function addCallback(callback, actingOnElement, options) {
-		if (options && options.immediate) {
-			try { callback(); } catch (e) { console.error(e); }
-		} else {
-			const callbacks = elementCallbacks.get(actingOnElement);
-			if (callbacks) callbacks.push(callback);
-			else elementCallbacks.set(actingOnElement, [callback]);
-		}
-	}
+type Chunks = Array<[Thing, Array<() => void>]>;
+const executeChunk = ([, callbacks]) => { for (const callback of callbacks) runCallback(callback); };
+const executeChunks = chunks => { for (const chunk of chunks) executeChunk(chunk); };
 
-	for (const thing of Thing.findThings(element)) {
-		const thingWatcherCallbacks =
-			thing.isPost() && thingWatchers.post ||
-			thing.isComment() && thingWatchers.comment ||
-			thing.isMessage() && thingWatchers.message ||
-			thing.isSubreddit() && thingWatchers.subreddit ||
-			[];
+const chunkedCallbacks = new Map();
+const immediateCallbacks = [];
 
-		for (const { callback, options } of thingWatcherCallbacks) {
-			addCallback(() => callback(thing), thing.element, options);
-		}
-	}
+const runCallbacks = throttle(async () => {
+	for (const fn of immediateCallbacks) runCallback(fn);
+	immediateCallbacks.length = 0;
 
-	for (const { selector, callback, options } of elementWatchers[type]) {
-		const elements = selector ? Array.from(element.querySelectorAll(selector)) : [element];
-		for (const e of elements) {
-			// Avoid excessive number of chunked callbacks by tying the callback to an existing Thing
-			const closest = e.closest && (e.parentElement: any).closest('.thing') || e;
-			addCallback(() => callback(e), closest, options);
-		}
-	}
+	const chunks = Array.from(chunkedCallbacks);
+	chunkedCallbacks.clear();
+	const { immediate = [], normal = [], background = [] } = partitionChunks(chunks);
+	executeChunks(immediate);
+	await forEachChunked(normal, executeChunk);
+	// Don't await hidden chunks as their progress is not important
+	forEachChunked(background, executeChunk);
+});
 
-	return flow(
-		sorter,
-		map(v => v[1]),
-		forEachChunked(c => { for (const callback of c) try { callback(); } catch (e) { console.error(e); } })
-	)(Array.from(elementCallbacks));
+function partitionChunks(chunks: Chunks): { immediate?: Chunks, normal?: Chunks, background?: Chunks } {
+	// If the document is opened in the background, this may casue an expensive reflow and would likely be unnecessary
+	if (document.hidden) return { background: chunks };
+
+	// Prioritize visible things
+	const { visible = [], hidden = [] } = _.groupBy(chunks, ([thing]) => thing.isVisible() ? 'visible' : 'hidden');
+
+	if (!visible.length) return { background: hidden };
+
+	// When there's few chunks, there's likely too much overhead for the reflow to be worthwhile
+	if (visible.length <= 55) return { immediate: visible, background: hidden };
+
+	// Things in the viewport should be executed immediately
+	const inViewport = [];
+
+	// Prioritize things closest to the viewport
+	// This causes a reflow
+	const viewportHeight = getViewportSize().height;
+	const sorted = _.sortBy(visible, chunk => {
+		const [thing] = chunk;
+		if (getPercentageVisibleYAxis(thing.element)) inViewport.push(chunk);
+		const fromTop = thing.element.getBoundingClientRect().top;
+		return fromTop >= 0 ? fromTop : -fromTop + viewportHeight;
+	});
+	_.pull(sorted, ...inViewport);
+
+	return { immediate: inViewport, normal: sorted, background: hidden };
 }
 
-export function watchForThings(types: Array<ThingWatcherType>, callback: ThingWatcherCallback, options?: WatcherOptions) {
-	for (const type of types) thingWatchers[type].push({ callback, options });
+function addCallback(callback, actingOnElement, options) {
+	let chunk;
+	if (document.contains(actingOnElement) && !(options && options.immediate)) {
+		// Avoid excessive number of chunked callbacks by tying the callback to a Thing
+		// By grouping callbacks acting on a common thing, the number of elements having to be reflowed is reduced
+		chunk = Thing.from(actingOnElement);
+	}
+
+	if (chunk) {
+		const callbacks = chunkedCallbacks.get(chunk);
+		if (callbacks) callbacks.push(callback);
+		else chunkedCallbacks.set(chunk, [callback]);
+	} else {
+		immediateCallbacks.push(callback);
+	}
+}
+
+function registerElement(type, element) {
+	for (const { selector, callback, options, registered } of elementWatchers[type]) {
+		const elements = selector ? Array.from(element.querySelectorAll(selector)) : [element];
+		for (const e of elements) {
+			if (registered.has(e)) continue;
+			registered.add(e);
+			const fn = () => { callback(e); };
+			addCallback(fn, e, options);
+		}
+	}
+
+	return runCallbacks();
+}
+
+function registerThing(element: HTMLElement) {
+	const thing = Thing.checkedFrom(element);
+
+	const thingWatcherCallbacks =
+		thing.isPost() && thingWatchers.post ||
+		thing.isComment() && thingWatchers.comment ||
+		thing.isMessage() && thingWatchers.message ||
+		thing.isSubreddit() && thingWatchers.subreddit ||
+		[];
+
+	for (const { callback, options, registered } of thingWatcherCallbacks) {
+		if (registered.has(thing)) continue;
+		registered.add(thing);
+		const fn = () => { callback(thing); };
+		addCallback(fn, thing.element, options);
+	}
+
+	return runCallbacks();
+}
+
+export function watchForThings(types: ?Array<ThingWatcherType>, callback: ThingWatcherCallback, options?: WatcherOptions) {
+	if (!types) types = Object.keys(thingWatchers);
+	for (const type of types) thingWatchers[type].push({ callback, options, registered: new WeakSet() });
 }
 
 export function watchForElements(types: Array<ElementWatcherType>, selector: ?string, callback: ElementWatcherCallback, options?: WatcherOptions) {
-	for (const type of types) elementWatchers[type].push({ selector, callback, options });
+	for (const type of types) elementWatchers[type].push({ selector, callback, options, registered: new WeakSet() });
+}
+
+export function registerPage(page: HTMLElement) {
+	return registerElement('page', page);
 }
 
 export function initR2Watcher() {
-	watchForElements(['siteTable'], '.entry div.expando', addSelfTextObserver);
+	watchForThings(['post'], thing => {
+		const container = thing.entry.querySelector('div.expando');
+		if (!container) return;
+		waitForChild(container, 'form').then(form => { registerElement('selfText', form.querySelector('.md')); });
+	});
+
+	const sitetable = document.body.querySelector('#siteTable');
+	if (sitetable) watchForFutureChildren(sitetable, Thing.thingSelector, registerThing);
 
 	if (isPageType('comments')) {
-		addCommentsObserver(document.querySelector('.commentarea .sitetable'));
-
-		watchForThings(['comment'], thing => {
-			const sitetable: ?HTMLElement = thing.element.querySelector('.sitetable');
-
-			// Comments without replies does not have `.sitetable`
-			if (sitetable) {
-				addCommentsObserver(sitetable);
-			} else {
-				waitForChild(thing.element.querySelector('.child'), '.sitetable').then(sitetable => {
-					addCommentsObserver(sitetable);
-
-					const comment = sitetable.querySelector('.thing');
-					if (comment) registerElement('newComments', comment);
-				});
-			}
-		});
+		watchForFutureDescendants(document.body.querySelector('.commentarea'), '.thing', registerThing);
 	}
 
-	newSitetable(document.body);
-}
+	watchForElements(['page'], Thing.thingSelector, element => {
+		registerThing(element);
+	}, { immediate: true });
 
-let documentLoaded = false;
-
-export function newSitetable(siteTable: HTMLElement) {
-	if (siteTable === document.body) {
-		documentLoaded = true;
-	} else if (!documentLoaded) {
-		// The sitetable will be processed when the document is loaded
-		return;
-	}
-
-	let sorter;
-	if (document.contains(siteTable)) {
-		const { height: viewportHeight } = getViewportSize();
-		sorter = sortBy(([element]) => {
-			const fromTop = element.getBoundingClientRect().top;
-			return element.offsetParent ?
-				(fromTop >= 0 ? fromTop : -fromTop + viewportHeight) :
-				Infinity;
-		});
-	}
-
-	return registerElement('siteTable', siteTable, sorter);
-}
-
-function addCommentsObserver(ele) {
-	watchForFutureChildren(ele, '.thing', comment => {
-		registerElement('newComments', comment);
-	});
-}
-
-function addSelfTextObserver(ele) {
-	watchForFutureChildren(ele, 'form', form => {
-		registerElement('selfText', form);
-	});
+	return registerPage(document.body);
 }

--- a/lib/utils/watchers.js
+++ b/lib/utils/watchers.js
@@ -2,15 +2,6 @@
 
 import _ from 'lodash';
 import { sortBy, map, flow } from 'lodash/fp';
-import { JSAPI_CONSUMER_NAME } from '../constants/jsapi';
-import type {
-	CommentAuthorEventData, // eslint-disable-line no-unused-vars
-	PostAuthorEventData, // eslint-disable-line no-unused-vars
-	PostEventData, // eslint-disable-line no-unused-vars
-	SubredditEventData, // eslint-disable-line no-unused-vars
-	UserHovercardEventData, // eslint-disable-line no-unused-vars
-	PostModToolsEventData, // eslint-disable-line no-unused-vars
-} from '../types/events';
 import { Thing } from './Thing';
 import { isAppType, isPageType } from './location';
 import { forEachChunked } from './async';
@@ -98,114 +89,31 @@ export function watchForElements(types: Array<ElementWatcherType>, selector: ?st
 	for (const type of types) elementWatchers[type].push({ selector, callback, options });
 }
 
-const callbacks = {
-	subreddit: [],
-	postAuthor: [],
-	post: [],
-};
+export function initR2Watcher() {
+	watchForElements(['siteTable'], '.entry div.expando', addSelfTextObserver);
 
-/* eslint-disable no-redeclare, no-unused-vars */
-declare function watchForRedditEvents(type: 'subreddit', callback: (HTMLElement, SubredditEventData) => void | Promise<void>): void;
-declare function watchForRedditEvents(type: 'postAuthor', callback: (HTMLElement, PostAuthorEventData) => void | Promise<void>): void;
-declare function watchForRedditEvents(type: 'post', callback: (HTMLElement, PostEventData) => void | Promise<void>): void;
-declare function watchForRedditEvents(type: 'userHovercard', callback: (HTMLElement, UserHovercardEventData) => void | Promise<void>): void;
-declare function watchForRedditEvents(type: 'commentAuthor', callback: (HTMLElement, CommentAuthorEventData) => void | Promise<void>): void;
-declare function watchForRedditEvents(type: 'postModTools', callback: (HTMLElement, PostModToolsEventData) => void | Promise<void>): void;
+	if (isPageType('comments')) {
+		addCommentsObserver(document.querySelector('.commentarea .sitetable'));
 
-export function watchForRedditEvents(type: $Keys<typeof callbacks>, callback) {
-	if (!callbacks[type]) {
-		callbacks[type] = [];
-	}
-	callbacks[type].push(callback);
-}
-/* eslint-enable no-redeclare */
+		watchForThings(['comment'], thing => {
+			const sitetable: ?HTMLElement = thing.element.querySelector('.sitetable');
 
-function handleRedditEvent(event) {
-	const { target, detail: { type, data } } = event;
-	const fns = callbacks[type];
-	if (!fns) {
-		if (process.env.NODE_ENV === 'development') {
-			console.warn('Unhandled reddit event type:', type);
-		}
-		return;
-	}
-
-	let expandoId = `${type}|`;
-	switch (type) {
-		case 'postAuthor':
-			expandoId += data.post.id;
-			break;
-		case 'commentAuthor':
-			expandoId += data.comment.id;
-			break;
-		case 'userHovercard':
-			expandoId += `${data.contextId}|${data.user.id}`;
-			break;
-		case 'subreddit':
-		case 'post':
-		case 'postModTools':
-		default:
-			expandoId += data.id;
-			break;
-	}
-
-	const update = target.expando && target.expando._.id === expandoId ?
-		(target.expando._.update || 0) + 1 :
-		0;
-
-	const expando = {
-		...data,
-		_: {
-			id: expandoId,
-			type,
-			update,
-		},
-	};
-
-	target.expando = expando;
-
-	const ownedTarget = target.querySelector(`[data-name="${JSAPI_CONSUMER_NAME}"]`);
-	for (const fn of fns) {
-		try {
-			fn(ownedTarget, expando);
-		} catch (e) {
-			console.log(e);
-		}
-	}
-}
-
-const initObservers = _.once(() => {
-	if (isAppType('d2x')) {
-		document.addEventListener('reddit', (handleRedditEvent: any), true);
-		const meta = document.createElement('meta');
-		meta.name = 'jsapi.consumer';
-		meta.content = JSAPI_CONSUMER_NAME;
-		document.head.appendChild(meta);
-		meta.dispatchEvent(new CustomEvent('reddit.ready'));
-	} else {
-		watchForElements(['siteTable'], '.entry div.expando', addSelfTextObserver);
-
-		if (isPageType('comments')) {
-			addCommentsObserver(document.querySelector('.commentarea .sitetable'));
-
-			watchForThings(['comment'], thing => {
-				const sitetable: ?HTMLElement = thing.element.querySelector('.sitetable');
-
-				// Comments without replies does not have `.sitetable`
-				if (sitetable) {
+			// Comments without replies does not have `.sitetable`
+			if (sitetable) {
+				addCommentsObserver(sitetable);
+			} else {
+				waitForChild(thing.element.querySelector('.child'), '.sitetable').then(sitetable => {
 					addCommentsObserver(sitetable);
-				} else {
-					waitForChild(thing.element.querySelector('.child'), '.sitetable').then(sitetable => {
-						addCommentsObserver(sitetable);
 
-						const comment = sitetable.querySelector('.thing');
-						if (comment) registerElement('newComments', comment);
-					});
-				}
-			});
-		}
+					const comment = sitetable.querySelector('.thing');
+					if (comment) registerElement('newComments', comment);
+				});
+			}
+		});
 	}
-});
+
+	newSitetable(document.body);
+}
 
 let documentLoaded = false;
 
@@ -216,8 +124,6 @@ export function newSitetable(siteTable: HTMLElement) {
 		// The sitetable will be processed when the document is loaded
 		return;
 	}
-
-	initObservers();
 
 	let sorter;
 	if (document.contains(siteTable)) {

--- a/lib/utils/watchers.js
+++ b/lib/utils/watchers.js
@@ -3,7 +3,7 @@
 import _ from 'lodash';
 import { Thing } from './Thing';
 import { isPageType } from './location';
-import { getPercentageVisibleYAxis, getViewportSize, waitForChild, watchForFutureDescendants, watchForFutureChildren } from './dom';
+import { watchForChildren, watchForFutureDescendants } from './dom';
 import { forEachChunked, throttle } from './async';
 
 type WatcherOptions = {| immediate?: boolean |};
@@ -41,58 +41,31 @@ const thingWatchers: {
 
 const runCallback = fn => { try { fn(); } catch (e) { console.error(e); } };
 
+let createChunks = true;
 type Chunks = Array<[Thing, Array<() => void>]>;
 const executeChunk = ([, callbacks]) => { for (const callback of callbacks) runCallback(callback); };
-const executeChunks = chunks => { for (const chunk of chunks) executeChunk(chunk); };
+const executeChunks = (chunks: Chunks) => { for (const chunk of chunks) executeChunk(chunk); };
 
 const chunkedCallbacks = new Map();
-const immediateCallbacks = [];
 
-const runCallbacks = throttle(async () => {
-	for (const fn of immediateCallbacks) runCallback(fn);
-	immediateCallbacks.length = 0;
-
+const runChunkedCallbacks = throttle(() => {
 	const chunks = Array.from(chunkedCallbacks);
 	chunkedCallbacks.clear();
-	const { immediate = [], normal = [], background = [] } = partitionChunks(chunks);
-	executeChunks(immediate);
-	await forEachChunked(normal, executeChunk);
-	// Don't await hidden chunks as their progress is not important
-	forEachChunked(background, executeChunk);
+
+	const [visible, hidden]: any = _.partition(chunks, ([thing]) => thing.isVisible());
+	// Execute a few callbacks on the first frame, in an attempt to minimize the delay in mutation elements in the user's viewport
+	executeChunks(visible.splice(0, isPageType('comments') ? 1 : 10));
+	// Run callbacks on visible things before hidden ones
+	return forEachChunked([...visible, ...hidden], executeChunk);
 });
-
-function partitionChunks(chunks: Chunks): { immediate?: Chunks, normal?: Chunks, background?: Chunks } {
-	// If the document is opened in the background, this may casue an expensive reflow and would likely be unnecessary
-	if (document.hidden) return { background: chunks };
-
-	// Prioritize visible things
-	const { visible = [], hidden = [] } = _.groupBy(chunks, ([thing]) => thing.isVisible() ? 'visible' : 'hidden');
-
-	if (!visible.length) return { background: hidden };
-
-	// When there's few chunks, there's likely too much overhead for the reflow to be worthwhile
-	if (visible.length <= 55) return { immediate: visible, background: hidden };
-
-	// Things in the viewport should be executed immediately
-	const inViewport = [];
-
-	// Prioritize things closest to the viewport
-	// This causes a reflow
-	const viewportHeight = getViewportSize().height;
-	const sorted = _.sortBy(visible, chunk => {
-		const [thing] = chunk;
-		if (getPercentageVisibleYAxis(thing.element)) inViewport.push(chunk);
-		const fromTop = thing.element.getBoundingClientRect().top;
-		return fromTop >= 0 ? fromTop : -fromTop + viewportHeight;
-	});
-	_.pull(sorted, ...inViewport);
-
-	return { immediate: inViewport, normal: sorted, background: hidden };
-}
 
 function addCallback(callback, actingOnElement, options) {
 	let chunk;
-	if (document.contains(actingOnElement) && !(options && options.immediate)) {
+	if (
+		createChunks &&
+		!(options && options.immediate) &&
+		document.contains(actingOnElement)
+	) {
 		// Avoid excessive number of chunked callbacks by tying the callback to a Thing
 		// By grouping callbacks acting on a common thing, the number of elements having to be reflowed is reduced
 		chunk = Thing.from(actingOnElement);
@@ -102,8 +75,9 @@ function addCallback(callback, actingOnElement, options) {
 		const callbacks = chunkedCallbacks.get(chunk);
 		if (callbacks) callbacks.push(callback);
 		else chunkedCallbacks.set(chunk, [callback]);
+		runChunkedCallbacks();
 	} else {
-		immediateCallbacks.push(callback);
+		callback();
 	}
 }
 
@@ -117,8 +91,6 @@ function registerElement(type, element) {
 			addCallback(fn, e, options);
 		}
 	}
-
-	return runCallbacks();
 }
 
 function registerThing(element: HTMLElement) {
@@ -137,8 +109,6 @@ function registerThing(element: HTMLElement) {
 		const fn = () => { callback(thing); };
 		addCallback(fn, thing.element, options);
 	}
-
-	return runCallbacks();
 }
 
 export function watchForThings(types: ?Array<ThingWatcherType>, callback: ThingWatcherCallback, options?: WatcherOptions) {
@@ -151,26 +121,31 @@ export function watchForElements(types: Array<ElementWatcherType>, selector: ?st
 }
 
 export function registerPage(page: HTMLElement) {
-	return registerElement('page', page);
+	registerElement('page', page);
 }
 
 export function initR2Watcher() {
 	watchForThings(['post'], thing => {
 		const container = thing.entry.querySelector('div.expando');
 		if (!container) return;
-		waitForChild(container, 'form').then(form => { registerElement('selfText', form.querySelector('.md')); });
+		watchForChildren(container, 'form', () => {
+			const body = thing.getTextBody();
+			if (body) registerElement('selfText', body);
+		});
 	});
 
-	const sitetable = document.body.querySelector('#siteTable');
-	if (sitetable) watchForFutureChildren(sitetable, Thing.thingSelector, registerThing);
-
 	if (isPageType('comments')) {
-		watchForFutureDescendants(document.body.querySelector('.commentarea'), '.thing', registerThing);
+		const commentarea = document.body.querySelector('.commentarea');
+		if (commentarea) watchForFutureDescendants(commentarea, '.thing', registerThing);
 	}
 
-	watchForElements(['page'], Thing.thingSelector, element => {
-		registerThing(element);
-	}, { immediate: true });
+	watchForElements(['page'], Thing.thingSelector, registerThing, { immediate: true });
 
-	return registerPage(document.body);
+	registerPage(document.body);
+
+	// Run chunks only on the initial load
+	createChunks = false;
+
+	// Resolve when chunks are completed
+	return runChunkedCallbacks();
 }

--- a/lib/utils/watchers_d2x.js
+++ b/lib/utils/watchers_d2x.js
@@ -1,0 +1,95 @@
+// @flow
+import { JSAPI_CONSUMER_NAME } from '../constants/jsapi';
+import type {
+	CommentAuthorEventData, // eslint-disable-line no-unused-vars
+	PostAuthorEventData, // eslint-disable-line no-unused-vars
+	PostEventData, // eslint-disable-line no-unused-vars
+	SubredditEventData, // eslint-disable-line no-unused-vars
+	UserHovercardEventData, // eslint-disable-line no-unused-vars
+	PostModToolsEventData, // eslint-disable-line no-unused-vars
+} from '../types/events';
+
+const callbacks = {
+	subreddit: [],
+	postAuthor: [],
+	post: [],
+};
+
+/* eslint-disable no-redeclare, no-unused-vars */
+declare function watchForRedditEvents(type: 'subreddit', callback: (HTMLElement, SubredditEventData) => void | Promise<void>): void;
+declare function watchForRedditEvents(type: 'postAuthor', callback: (HTMLElement, PostAuthorEventData) => void | Promise<void>): void;
+declare function watchForRedditEvents(type: 'post', callback: (HTMLElement, PostEventData) => void | Promise<void>): void;
+declare function watchForRedditEvents(type: 'userHovercard', callback: (HTMLElement, UserHovercardEventData) => void | Promise<void>): void;
+declare function watchForRedditEvents(type: 'commentAuthor', callback: (HTMLElement, CommentAuthorEventData) => void | Promise<void>): void;
+declare function watchForRedditEvents(type: 'postModTools', callback: (HTMLElement, PostModToolsEventData) => void | Promise<void>): void;
+
+export function watchForRedditEvents(type: $Keys<typeof callbacks>, callback) {
+	if (!callbacks[type]) {
+		callbacks[type] = [];
+	}
+	callbacks[type].push(callback);
+}
+/* eslint-enable no-redeclare */
+
+function handleRedditEvent(event) {
+	const { target, detail: { type, data } } = event;
+	const fns = callbacks[type];
+	if (!fns) {
+		if (process.env.NODE_ENV === 'development') {
+			console.warn('Unhandled reddit event type:', type);
+		}
+		return;
+	}
+
+	let expandoId = `${type}|`;
+	switch (type) {
+		case 'postAuthor':
+			expandoId += data.post.id;
+			break;
+		case 'commentAuthor':
+			expandoId += data.comment.id;
+			break;
+		case 'userHovercard':
+			expandoId += `${data.contextId}|${data.user.id}`;
+			break;
+		case 'subreddit':
+		case 'post':
+		case 'postModTools':
+		default:
+			expandoId += data.id;
+			break;
+	}
+
+	const update = target.expando && target.expando._.id === expandoId ?
+		(target.expando._.update || 0) + 1 :
+		0;
+
+	const expando = {
+		...data,
+		_: {
+			id: expandoId,
+			type,
+			update,
+		},
+	};
+
+	target.expando = expando;
+
+	const ownedTarget = target.querySelector(`[data-name="${JSAPI_CONSUMER_NAME}"]`);
+	for (const fn of fns) {
+		try {
+			fn(ownedTarget, expando);
+		} catch (e) {
+			console.log(e);
+		}
+	}
+}
+
+export function initD2xWatcher() {
+	document.addEventListener('reddit', (handleRedditEvent: any), true);
+	const meta = document.createElement('meta');
+	meta.name = 'jsapi.consumer';
+	meta.content = JSAPI_CONSUMER_NAME;
+	document.head.appendChild(meta);
+	meta.dispatchEvent(new CustomEvent('reddit.ready'));
+}


### PR DESCRIPTION
 - Reduces the amount of callbacks in the first chunk, so that the first draw after `go` is performed earlier
 - Removes forced reflow on init, since sorting callbacks by distance from viewport in most cases isn't worthwhile
 - `siteTable` is renamed `page` (scans whole page on initial load, and later sitetables provided by dashboard and ner)
 - `newComments` is removed (use Thing watcher instead)
 - `selfText` is now invoked on comment pages (when applicable)
 - Thing callbacks can be invoked for all Thing types by using `null` as the first argument

Tested in browser: Firefox 64, Chrome 70
