### PR TITLE
Optimize Filterline

### DIFF
--- a/lib/modules/filteReddit/ExternalFilter.js
+++ b/lib/modules/filteReddit/ExternalFilter.js
@@ -7,6 +7,11 @@ import * as Cases from './cases';
 import { Filter } from './Filter';
 
 export class ExternalFilter extends Filter {
+	isActive() {
+		// If the case will always evaluate false, prevent this filter from making Filterline believe it's being useful
+		return this.case.constructor.type !== 'false' && super.isActive();
+	}
+
 	createElement() {
 		this.element = string.html`
 			<div class="res-filterline-external-filter" type="${this.BaseCase.type}">

--- a/lib/modules/filteReddit/Filter.js
+++ b/lib/modules/filteReddit/Filter.js
@@ -21,6 +21,8 @@ export class Filter {
 	case: Case;
 	state: boolean;
 
+	active: boolean = false;
+
 	element: HTMLElement;
 
 	effects: { [key: string]: boolean } = {};
@@ -30,9 +32,13 @@ export class Filter {
 		this.BaseCase = BaseCase;
 		this.name = name;
 		this.state = state;
-		this.setCase(BaseCase.fromConditions(conditions));
 		// Add only active effects in order to minimize the number of effects to keep track of
 		Object.assign(this.effects, _.pickBy(effects, Boolean));
+		this.setCase(BaseCase.fromConditions(conditions));
+	}
+
+	isActive() {
+		return !!this.getEffects().length && this.case.isEvaluatable();
 	}
 
 	createElement() {}
@@ -67,12 +73,13 @@ export class Filter {
 	}
 
 	getEffects(): Array<string> {
-		return Object.keys(_.pickBy(this.effects, Boolean));
+		return Object.entries(this.effects).filter(([, enabled]) => enabled).map(([name]) => name);
 	}
 
 	setCase(newCase: Case) {
 		this.case = newCase;
-		if (this.case.isEvaluatable()) this.case.observe(this);
+		this.active = this.isActive(); // XXX Make sure to update this anytime effects or case changes
+		if (this.active) this.case.observe(this);
 	}
 
 	update(state: boolean = this.state, conditions?: *, effects: * = {}, describeOnly: boolean = false) {
@@ -84,8 +91,8 @@ export class Filter {
 		}
 
 		this.state = state;
-		this.setCase(cased);
 		Object.assign(this.effects, effects);
+		this.setCase(cased);
 
 		this.refresh();
 	}
@@ -130,8 +137,6 @@ export class Filter {
 	}
 
 	matches = fastAsync(function*(thing: Thing) {
-		if (!this.case.isEvaluatable()) return false;
-
 		try {
 			const result = yield this.case.evaluate(thing);
 			return result === null ? false : this.state === !result;

--- a/lib/modules/filteReddit/Filterline.js
+++ b/lib/modules/filteReddit/Filterline.js
@@ -63,6 +63,20 @@ export class Filterline {
 		this.thingType = thingType;
 	}
 
+	// Initialize once things are being processed
+	isInitialized(): boolean {
+		if (this.initialized) return true;
+
+		if (!this.getActiveFilters().length) return false;
+
+		this.initialized = true;
+		// It is possible to optimize the order of filters until things are filtered
+		// if order is changed thereafter, `getFiltersToTest` may return invalid results
+		this.sortedFilters = _.sortBy(this.filters, ({ case: { constructor: { slow } } }) => slow);
+
+		return true;
+	}
+
 	isPowered() { return !document.body.classList.contains('res-filters-disabled'); }
 
 	togglePowered = (powered: boolean = !this.isPowered()) => {
@@ -452,7 +466,7 @@ export class Filterline {
 
 		this.filters.push(filter);
 
-		if (this.initialized) {
+		if (this.isInitialized()) {
 			this.sortedFilters.push(filter);
 			this.refreshAll(filter);
 		}
@@ -462,7 +476,7 @@ export class Filterline {
 
 	async removeFilter(filter: Filter) {
 		if (filter.element) filter.element.remove();
-		if (this.initialized) await Promise.all(this.refreshAll(filter));
+		if (this.isInitialized()) await Promise.all(this.refreshAll(filter));
 		_.pull(this.filters, filter);
 		_.pull(this.sortedFilters, filter);
 		this.save();
@@ -473,7 +487,7 @@ export class Filterline {
 	}
 
 	getActiveFilters() {
-		return this.filters.filter(v => v.case.isEvaluatable() && v.getEffects().length);
+		return this.filters.filter(v => v.active);
 	}
 
 	availableEffects: {
@@ -552,7 +566,7 @@ export class Filterline {
 			if (this.displayReasons) this.refreshDisplayReasons(thing, old, filter);
 		};
 
-		for (const filter of filtersToTest) {
+		for (const filter of this.getActiveFilters().filter(v => filtersToTest.includes(v))) {
 			const effects = filter.getEffects().filter(v => effectsToRefresh.includes(v));
 			if (effects.length && (yield filter.matches(thing))) {
 				for (const effect of effects) updateEffect(effect, filter);
@@ -570,16 +584,8 @@ export class Filterline {
 	}
 
 	addThing(thing: Thing) {
-		if (!this.initialized) {
-			// Initialize once things are added
-			this.initialized = true;
-			// It is possible to optimize the order of filters until things are filtered
-			// if order is changed thereafter, `getFiltersToTest` may return invalid results
-			this.sortedFilters = _.sortBy(this.filters, ({ case: { constructor: { slow } } }) => slow);
-		}
-
 		this.things.add(thing);
-		return this.refreshThing(thing);
+		if (this.isInitialized()) return this.refreshThing(thing);
 	}
 
 	getThings(withEffect: string) {


### PR DESCRIPTION
- Don't run filter engine when there's no active filters
- Prevent cases from observing when they're not active

Tested in browser: Chrome 70, Firefox 64
