### PR TITLE
orangered: Don't multicast outdated unread count

### DIFF
--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import Favico from 'favico.js';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
+import * as Modules from '../core/modules';
 import { loggedInUser } from '../utils';
 import { Session, multicast } from '../environment';
 import * as BetteReddit from './betteReddit';
@@ -150,6 +151,7 @@ module.go = () => {
 };
 
 export async function updateFromPage(doc: HTMLElement = document.body) {
+	if (!Modules.isRunning(module)) return;
 	if (!module.options.updateCurrentTab.value) return;
 	if (!loggedInUser()) return;
 


### PR DESCRIPTION
`updateFromPage` may process cached pages, e.g. when returning to the previous page after checking the inbox.

Tested in browser: Chrome 71
