### PR TITLE
redesign: Don't display (broken) RESTips

### DIFF
--- a/lib/modules/RESTips.js
+++ b/lib/modules/RESTips.js
@@ -46,6 +46,10 @@ module.options = {
 	},
 };
 
+// Many of the tips refers to modules that are disabled in the redesign
+// so avoid confusing users
+module.include = ['r2'];
+
 const featureTipsStorage = Storage.wrapPrefix('RESTips.featureTips.', () => ({ enabled: true }));
 const lastTooltipStorage = Storage.wrap('RESLastToolTip', 0);
 


### PR DESCRIPTION
Most tips are for features not ported to the redesign.

Tested in browser: Firefox 65, Chrome 71
