### PR TITLE
menu: Clean-up, defer building items

### DIFF
--- a/lib/css/modules/_menu.scss
+++ b/lib/css/modules/_menu.scss
@@ -1,3 +1,0 @@
-#RESSettingsButton {
-	cursor: pointer;
-}

--- a/lib/css/modules/_nightMode.scss
+++ b/lib/css/modules/_nightMode.scss
@@ -98,14 +98,6 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 		color: rgb(117, 142, 168);
 	}
 
-	#RESMenu li {
-		background-color: #eee;
-
-		&.active {
-			background-color: #7f7f7f;
-		}
-	}
-
 	#DonateRES {
 		background: rgb(204, 204, 204);
 	}

--- a/lib/css/res.scss
+++ b/lib/css/res.scss
@@ -13,7 +13,6 @@
 @import 'modules/commentPreview';
 @import 'modules/commentTools';
 @import 'modules/dashboard';
-@import 'modules/menu';
 @import 'modules/newCommentCount';
 @import 'modules/noParticipation';
 @import 'modules/notifications';
@@ -60,12 +59,6 @@ body.res-console-open {
 	width: 100%;
 	height: 100%;
 	border: none;
-}
-
-#DashboardLink a {
-	display: block;
-	width: auto;
-	height: auto;
 }
 
 .res-logo {
@@ -120,11 +113,6 @@ body.res-console-open {
 @keyframes pop {
 	from { transform: scale(0, 0); }
 	to { transform: scale(1.5, 1.5); }
-}
-
-#RESSettingsButton,
-#openRESPrefs {
-	display: inline-block;
 }
 
 .RESDropdownList {
@@ -287,10 +275,6 @@ div.usertext-edit {
 	}
 }
 
-#RESMenu li h3:hover {
-	border-color: #000;
-}
-
 .res-icon-button {
 	cursor: pointer;
 	margin: 0 2px;
@@ -353,6 +337,7 @@ div.usertext-edit {
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
+		min-width: 3ex;
 
 		// Custom toggle labels
 		&[data-disabled-text]::before {

--- a/lib/modules/RESTips.js
+++ b/lib/modules/RESTips.js
@@ -13,6 +13,7 @@ import {
 	niceKeyCode,
 	positiveModulo,
 	DAY,
+	string,
 } from '../utils';
 import { Storage, i18n } from '../environment';
 import * as PenaltyBox from './penaltyBox';
@@ -55,12 +56,10 @@ const lastTooltipStorage = Storage.wrap('RESLastToolTip', 0);
 
 module.go = () => {
 	if (module.options.menuItem.value) {
-		const $menuItem = $('<div>', {
-			id: 'RESTipsMenuItem',
-			text: i18n('tipsAndTricks'),
-		});
-
-		Menu.addMenuItem($menuItem, () => { showOrdinaryTip('random'); });
+		Menu.addMenuItem(
+			() => string.html`<span>${i18n('tipsAndTricks')}</span>`,
+			() => { showOrdinaryTip('random'); }
+		);
 	}
 };
 
@@ -230,7 +229,7 @@ const tips: Array<Tip> = [{
 		<p>For feature requests, or just help getting a question answered, be sure to subscribe to <a href="/r/Enhancement">/r/Enhancement</a>.</p>
 		<p>If RES has enhanced your reddit experience, please show your appreciation by <a href="${RES_SETTINGS_HASH}/contribute">donating or contributing!</a></p>
 		`,
-	attachTo: '#openRESPrefs',
+	attachTo: '#RESSettingsButton',
 	position: 5,
 }, {
 	message: 'Click the tag icon next to a user to tag that user with any name you like - you can also color code the tag.',

--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -201,7 +201,7 @@ async function createAccountMenu() {
 		accountMenu.append(element);
 	}
 
-	return [(accountMenu: any)]; // The JQuery Flow declaration doesn't allow for `DocumentFragment`
+	return [accountMenu];
 }
 
 function findMatchingAccount(username, partialMatch) {

--- a/lib/modules/announcements.js
+++ b/lib/modules/announcements.js
@@ -88,7 +88,11 @@ const notify = _.once(async post => {
 	const hasSeenNotification = await lastUnreadDate.has();
 	if (hasSeenNotification) {
 		// showNotification(post, url); // TODO: Make this slightly less obnoxious
-		addMenuItem(post, url, title);
+		Menu.addMenuItem(
+			() => createMenuItem(post, url, title),
+			() => { openNewTab(url); },
+			-8
+		);
 	}
 });
 
@@ -115,11 +119,11 @@ function showNotification(post, url) {
 }
 */
 
-function addMenuItem(post, url, title = '') {
-	const $menuItem = $('<div>', { id: 'RESAnnouncementMenuItem' });
+function createMenuItem(post, url, title = '') {
+	const menuItem = document.createElement('span');
 	$('<span class="RESMenuItemButton"></span>')
 		.append(CreateElement.icon(0xF076, 'span', '', i18n('announcementsMarkAsRead')))
-		.appendTo($menuItem)
+		.appendTo(menuItem)
 		.on('click', (e: Event) => {
 			e.preventDefault();
 			e.stopPropagation();
@@ -133,8 +137,8 @@ function addMenuItem(post, url, title = '') {
 			e.stopPropagation();
 			setMarkedRead();
 		})
-		.appendTo($menuItem);
-	Menu.addMenuItem($menuItem, () => { openNewTab(url); });
+		.appendTo(menuItem);
+	return menuItem;
 }
 
 function addAnnouncementBiff(post, url, title, withPizzazz) {

--- a/lib/modules/commandLine.js
+++ b/lib/modules/commandLine.js
@@ -44,16 +44,13 @@ module.go = () => {
 };
 
 function addMenuItem() {
-	const $menuItem = $('<div>', { text: 'command line' })
-		.append($('<span>', {
-			class: 'RESMenuItemButton res-icon',
-			text: '\uF060',
-		}));
-
-	Menu.addMenuItem($menuItem, () => {
-		Menu.hidePrefsDropdown();
-		open();
-	});
+	Menu.addMenuItem(
+		() => string.html`<div>command line <span class="RESMenuItemButton res-icon">\uF060</span></div>`,
+		() => {
+			Menu.hidePrefsDropdown();
+			open();
+		}
+	);
 }
 
 const commandLine = _.once(() => {

--- a/lib/modules/contribute.js
+++ b/lib/modules/contribute.js
@@ -2,6 +2,7 @@
 
 import { Module } from '../core/module';
 import { i18n, openNewTab } from '../environment';
+import { string } from '../utils';
 import * as Menu from './menu';
 
 export const module: Module<*> = new Module('contribute');
@@ -14,7 +15,7 @@ module.description = 'contributeDesc';
 
 module.go = () => {
 	Menu.addMenuItem(
-		`<div class="RES-donate">${i18n('donateToRES')} &#8679;</div>`,
+		() => string.html`<span>${i18n('donateToRES')} &#8679;</span>`,
 		() => { openNewTab('https://redditenhancementsuite.com/contribute/'); }
 	);
 };

--- a/lib/modules/customToggles.js
+++ b/lib/modules/customToggles.js
@@ -1,9 +1,10 @@
 /* @flow */
 
+import _ from 'lodash';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
 import * as Options from '../core/options';
-import { CreateElement } from '../utils';
+import { CreateElement, string } from '../utils';
 import { multicast } from '../environment';
 import * as CommandLine from './commandLine';
 import * as Menu from './menu';
@@ -60,15 +61,13 @@ module.beforeLoad = () => {
 		toggle.onToggle(() => {
 			Options.set(module, 'toggle', module.options.toggle.value);
 		});
+
+		toggle.addMenuItem();
 	}
 };
 
 module.go = () => {
 	registerCommandLine();
-
-	for (const toggle of customToggles) {
-		toggle.addMenuItem();
-	}
 };
 
 export class Toggle {
@@ -114,11 +113,15 @@ export class Toggle {
 		this.toggleCallbacks.push(callback);
 	}
 
-	addMenuItem(title: string = `Toggle ${this.text}`, on?: string, off?: string) {
-		const $toggle = $('<div>', { text: this.text || '\u00A0' /* nbsp */, title })
-			.append(CreateElement.toggleButton(undefined, this.text, this.enabled, on, off));
-		this.onStateChange(() => { $toggle.find('.toggleButton').toggleClass('enabled', this.enabled); });
-		Menu.addMenuItem($toggle, () => { this.toggle(); });
+	addMenuItem(title: string = `Toggle ${this.text}`, order: number = 9, on?: string, off?: string) {
+		const createItem = _.once(() => {
+			const item = string.html`<div title="${title}">${this.text || '\u00A0'}</div>`;
+			const toggle = CreateElement.toggleButton(undefined, this.text, this.enabled, on, off);
+			item.append(toggle);
+			this.onStateChange(() => { toggle.classList.toggle('enabled', this.enabled); });
+			return item;
+		});
+		Menu.addMenuItem(createItem, () => { this.toggle(); }, order);
 	}
 
 	addCLI(commandPredicate: string) {

--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -80,7 +80,14 @@ module.shouldRun = () => isCurrentSubreddit('dashboard');
 
 module.always = () => {
 	if (Modules.isEnabled(module)) {
-		if (module.options.menuItem.value) Menu.addMenuItem(`<div id="DashboardLink"><a href="/r/Dashboard">${i18n('myDashboard')}</a></div>`, undefined, true);
+		if (module.options.menuItem.value) {
+			Menu.addMenuItem(
+				() => string.html`<a href="/r/Dashboard">${i18n('myDashboard')}</a>`,
+				undefined,
+				-7
+			);
+		}
+
 		const subreddit = currentSubreddit();
 		if (module.options.dashboardShortcut.value && subreddit) {
 			Init.bodyReady.then(() => requestAnimationFrame(() => addDashboardShortcuts(subreddit)));

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -486,7 +486,7 @@ module.beforeLoad = fastAsync(function*()	{
 
 module.go = () => {
 	if (module.options.NSFWQuickToggle.value) {
-		nsfwToggle.addMenuItem(i18n('nsfwSwitchToggleTitle'));
+		nsfwToggle.addMenuItem(i18n('nsfwSwitchToggleTitle'), 8);
 	}
 
 	makeFilterlineInteractable();

--- a/lib/modules/hover.js
+++ b/lib/modules/hover.js
@@ -123,7 +123,7 @@ export const pin = {
 	right: 'right',
 };
 
-type HoverContents = JQuery | HTMLElement | string | null;
+type HoverContents = JQuery | HTMLElement | DocumentFragment | string | null;
 type HoverCallback = (self: Hover) => Promise<HoverContents[]> | HoverContents[];
 
 class Hover {
@@ -266,7 +266,7 @@ class Hover {
 			if (!item) return;
 			const $element = $(container).find(`[data-hover-element="${i}"]`);
 			$element.children().detach(); // allow re-use of elements with jQuery event handlers
-			$element.empty().append(item);
+			$element.empty().append((item: any)); // The JQuery Flow declaration doesn't allow for `DocumentFragment`
 		});
 
 		const fixedParent = getFixedParent(this.getCheckedTarget());

--- a/lib/modules/menu.js
+++ b/lib/modules/menu.js
@@ -1,10 +1,9 @@
 /* @flow */
 
-import { $ } from '../vendor';
 import { Module } from '../core/module';
 import * as Modules from '../core/modules';
 import { i18n } from '../environment';
-import { isAppType } from '../utils';
+import { string } from '../utils';
 import * as Floater from './floater';
 import * as Hover from './hover';
 import * as SettingsNavigation from './settingsNavigation';
@@ -41,47 +40,37 @@ module.options = {
 	},
 };
 
-module.beforeLoad = () => {
-	renderConsoleLink();
-};
+const items: Array<{| getElement: () => HTMLElement, onClick: (e: Event) => void, order: number |}> = [];
+let RESPrefsLink;
 
 module.go = () => {
-	addConsoleLink();
+	RESPrefsLink = string.html`<span id="RESSettingsButton" style="cursor: pointer" title="${i18n('RESSettings')}" class="gearIcon"></span>`;
+
+	if (module.options.gearIconClickAction.value !== 'toggleMenuNoHover') {
+		RESPrefsLink.addEventListener('mouseenter', () => { showPrefsDropdown(200); });
+	}
+
+	RESPrefsLink.addEventListener('click', () => {
+		if (module.options.gearIconClickAction.value === 'openCommandLine' && Modules.isRunning(CommandLine)) {
+			CommandLine.toggle();
+		} else if (module.options.gearIconClickAction.value === 'openSettings') {
+			SettingsNavigation.open();
+		} else {
+			showPrefsDropdown(0);
+		}
+	});
+
+	const r2MenuPosition = document.body.querySelector('#header-bottom-right ul');
+	if (r2MenuPosition) {
+		r2MenuPosition.after(string.html`<span class="separator">|</span>`, RESPrefsLink);
+	} else {
+		Floater.addElement(RESPrefsLink, { order: 5 });
+	}
 };
 
 module.afterLoad = () => {
 	addLegacyStyling();
 };
-
-let RESPrefsLink;
-let $menuItems = $();
-
-function renderConsoleLink() {
-	RESPrefsLink = $(`<span id="openRESPrefs"><span id="RESSettingsButton" title="${i18n('RESSettings')}" class="gearIcon"></span>`)
-		.mouseenter(() => {
-			if (module.options.gearIconClickAction.value !== 'toggleMenuNoHover') {
-				showPrefsDropdown(200);
-			}
-		})
-		.find('.gearIcon').click(() => {
-			if (module.options.gearIconClickAction.value === 'openCommandLine' && Modules.isRunning(CommandLine)) {
-				CommandLine.toggle();
-			} else if (module.options.gearIconClickAction.value === 'openSettings') {
-				SettingsNavigation.open();
-			} else {
-				showPrefsDropdown(0);
-			}
-		}).end()
-		.get(0);
-}
-
-function addConsoleLink() {
-	$('#header-bottom-right')
-		.find('ul')
-		.after(RESPrefsLink)
-		.after('<span class="separator">|</span>');
-	if (isAppType('d2x')) Floater.addElement(RESPrefsLink, { order: 5 });
-}
 
 function showPrefsDropdown(openDelay: number) {
 	Hover.dropdownList(module.moduleID, Hover.HIDDEN_FROM_SETTINGS)
@@ -90,8 +79,12 @@ function showPrefsDropdown(openDelay: number) {
 			fadeDelay: 200,
 			fadeSpeed: 0.2,
 		})
-		.populateWith(() => [$menuItems])
-		.target(RESPrefsLink.querySelector('#RESSettingsButton')) // workaround subreddit stylings where the container ends up super tall
+		.populateWith(() => {
+			const f = document.createDocumentFragment();
+			f.append(...items.sort(({ order: a }, { order: b }) => a - b).map(buildItem));
+			return [f];
+		})
+		.target(RESPrefsLink) // workaround subreddit stylings where the container ends up super tall
 		.begin();
 }
 
@@ -99,25 +92,20 @@ export function hidePrefsDropdown() {
 	Hover.dropdownList(module.moduleID).close(true);
 }
 
-export function addMenuItem(ele: JQuery | HTMLElement | string, onClick?: (e: Event) => void, prepend?: boolean = false) {
-	let $menuItem = $(ele);
-	if (!$menuItem.is('li')) {
-		$menuItem = $('<li />').append(ele);
-	}
+export function addMenuItem(getElement: *, onClick: * = () => {}, order: * = 0) {
+	items.push({ getElement, onClick, order });
+}
 
-	if (onClick) $menuItem[0].addEventListener('click', onClick);
-
-	if (prepend) {
-		$menuItems = $menuItem.add($menuItems);
-	} else {
-		$menuItems = $menuItems.add($menuItem);
-	}
+function buildItem({ getElement, onClick }) {
+	const li = document.createElement('li');
+	li.addEventListener('click', onClick);
+	li.append(getElement());
+	return li;
 }
 
 function addLegacyStyling() {
-	const gearIcon = RESPrefsLink.querySelector('.gearIcon');
-	const backgroundImage = window.getComputedStyle(gearIcon).backgroundImage;
+	const { backgroundImage } = window.getComputedStyle(RESPrefsLink);
 	if (backgroundImage && backgroundImage !== 'none') {
-		gearIcon.classList.add('res-gearIcon-legacy');
+		RESPrefsLink.classList.add('res-gearIcon-legacy');
 	}
 }

--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -132,6 +132,7 @@ module.beforeLoad = () => {
 		StyleTweaks.toggleSubredditStyleIfNecessary();
 	});
 	toggle.addCLI('ns');
+	if (module.options.nightSwitch.value) toggle.addMenuItem(i18n('nightModeToggleTitle'), 7, '☽', '☀');
 };
 
 module.always = () => {
@@ -143,10 +144,6 @@ module.always = () => {
 
 module.go = () => {
 	handleAutomaticNightMode();
-
-	if (module.options.nightSwitch.value) {
-		toggle.addMenuItem(i18n('nightModeToggleTitle'), '☽', '☀');
-	}
 };
 
 export function isNightModeOn(): boolean {

--- a/lib/modules/search.js
+++ b/lib/modules/search.js
@@ -7,8 +7,6 @@ import { Module } from '../core/module';
 import * as Modules from '../core/modules';
 import { Alert, CreateElement, downcast, empty, string } from '../utils';
 import { i18n } from '../environment';
-import * as CommandLine from './commandLine';
-import * as Menu from './menu';
 import * as SettingsNavigation from './settingsNavigation';
 
 export const module: Module<*> = new Module('search');
@@ -33,33 +31,6 @@ module.description = `
 	</div>
 `;
 module.descriptionRaw = true;
-
-module.go = () => {
-	const $menuItem = $('<span>', {
-		id: 'RESSearchMenuItem',
-		class: 'RESMenuItemButton res-icon',
-		text: '\uF094',
-		title: 'search settings',
-		click: e => {
-			e.preventDefault();
-			e.stopPropagation();
-			Menu.hidePrefsDropdown();
-			SettingsNavigation.open(module.moduleID);
-		},
-	});
-	$menuItem.appendTo(SettingsNavigation.$menuItem());
-
-	CommandLine.registerCommand(/^set(?:t?ings?)?$/, 'settings [words to search for]- search RES settings console',
-		(command, val) => {
-			let str = 'Search RES settings';
-			if (val && val.length) {
-				str += ` for: ${val}`;
-			}
-			return str;
-		},
-		(command, val) => SettingsNavigation.open(module.moduleID, val)
-	);
-};
 
 const PRESERVE_SPACES = true;
 

--- a/lib/modules/settingsNavigation.js
+++ b/lib/modules/settingsNavigation.js
@@ -1,9 +1,9 @@
 /* @flow */
 
-import _ from 'lodash';
 import { $ } from '../vendor';
 import { RES_SETTINGS_HASH } from '../constants/urlHashes';
 import { context, isOptionsPage, getOptionsURL, i18n } from '../environment';
+import { string } from '../utils';
 import { Module } from '../core/module';
 import * as Modules from '../core/modules';
 import * as Menu from '../modules/menu';
@@ -33,13 +33,31 @@ module.options = {
 	},
 };
 
-export const $menuItem = _.once(() => $('<div>', { id: 'SettingsConsole', text: i18n('RESSettingsConsole') }));
-
 module.beforeLoad = () => {
-	Menu.addMenuItem($menuItem(), () => {
-		Menu.hidePrefsDropdown();
-		open();
-	}, true);
+	const createItem = () => {
+		const ele = string.html`<div id="SettingsConsole">${i18n('RESSettingsConsole')}</div>`;
+		$('<span>', {
+			class: 'RESMenuItemButton res-icon',
+			text: '\uF094',
+			title: 'search settings',
+			click: () => { open('search'); },
+		}).appendTo(ele);
+		return ele;
+	};
+
+	Menu.addMenuItem(
+		createItem,
+		() => {
+			Menu.hidePrefsDropdown();
+			open();
+		},
+		-10
+	);
+
+	CommandLine.registerCommand(/^set(?:t?ings?)?$/, 'settings [words to search for]- search RES settings console',
+		(command, val) => `Search RES settings ${val && val.length ? ` for: ${val}` : ''}`,
+		(command, val) => open('search', val)
+	);
 };
 
 module.go = () => {


### PR DESCRIPTION
- Defers building the menu items till menu is displayed in order to improve performance
- Adds `order` parameter to menu interface in order to ensure stability
- The menu cog is now added to the floater when the r2-header is not available

Tested in browser: Chrome 71, Firefox 65
