### PR TITLE
ner: Separate load logic from UI, simplify

### DIFF
--- a/lib/css/modules/_neverEndingReddit.scss
+++ b/lib/css/modules/_neverEndingReddit.scss
@@ -1,5 +1,3 @@
-@import '../zindex';
-
 .NERPageMarker {
 	text-align: center;
 	color: #7f7f7f;
@@ -12,7 +10,6 @@
 	border: 1px solid #c7c7c7;
 	border-radius: 3px;
 	padding: 3px 0;
-
 
 	&.NERPageMarkerLast {
 		min-height: 30px;
@@ -31,16 +28,6 @@
 		a + a {
 			margin-left: 2em;
 		}
-	}
-}
-
-// hide next/prev page and random subreddit indicators
-.res-ner-listing {
-	// for /about/log
-	~ .nextprev,
-	div.nav-buttons,
-	.nav-buttons .nextprev {
-		display: none;
 	}
 }
 
@@ -90,16 +77,11 @@
 		height: 10px;
 		border: 1px solid #888;
 		border-radius: 50%;
-	}
-
-	&::after,
-	&.paused.reversePause::after {
 		content: '\F16C';
 		padding: 2px;
 	}
 
-	&.paused::after,
-	&.reversePause::after {
+	&.paused::after {
 		content: '\F16B';
 		padding: 2px 1px 2px 3px;
 	}

--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -7,7 +7,6 @@ import * as CommandLine from './commandLine';
 import * as Hover from './hover';
 import * as Floater from './floater';
 import * as Notifications from './notifications';
-import * as NeverEndingReddit from './neverEndingReddit';
 import * as SettingsNavigation from './settingsNavigation';
 
 export const module: Module<*> = new Module('accountSwitcher');
@@ -341,6 +340,6 @@ function manageAccounts() {
 }
 
 function reloadPage() {
-	NeverEndingReddit.resetReturnToPage();
-	location.reload();
+	// Don't use `location.reload` since we want to create a new history entry, in case the current one contains state data
+	location.href = location.href; // eslint-disable-line no-self-assign
 }

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -1286,13 +1286,13 @@ function moveDownFallback() {
 			!SelectedEntry.selectedThing ||
 			[SelectedEntry.selectedThing, undefined].includes(_.last(Thing.visibleThings()))
 		);
-	if (bump) return NeverEndingReddit.loadNextPage(true);
+	if (bump) NeverEndingReddit.loadNextPage({ scrollToLoadWidget: true });
 }
 
 function nextPage() {
 	// if Never Ending Reddit is enabled, just scroll to the bottom.  Otherwise, click the 'next' link.
 	if (Modules.isRunning(NeverEndingReddit)) {
-		NeverEndingReddit.loadNextPage(true);
+		NeverEndingReddit.loadNextPage({ scrollToLoadWidget: true });
 	} else {
 		// get the first link to the next page of reddit...
 		const nextPrevLinks = NeverEndingReddit.getNextPrevLinks();

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -4,7 +4,6 @@ import _ from 'lodash';
 import { $ } from '../vendor';
 import { RES_NER_PAGE_HASH } from '../constants/urlHashes';
 import { Module } from '../core/module';
-import * as Modules from '../core/modules';
 import * as Init from '../core/init';
 import { Storage, ajax } from '../environment';
 import {
@@ -12,18 +11,17 @@ import {
 	Thing,
 	addCSS,
 	scrollToElement,
+	empty,
 	fastAsync,
 	registerPage,
 	watchForThings,
 	documentLoggedInUser,
 	loggedInUser,
 	isCurrentSubreddit,
-	mutex,
 	string,
 } from '../utils';
 import * as Floater from './floater';
 import * as Notifications from './notifications';
-import * as Orangered from './orangered';
 import * as SelectedEntry from './selectedEntry';
 import * as SettingsNavigation from './settingsNavigation';
 
@@ -60,7 +58,7 @@ module.options = {
 		title: 'nerShowPauseButtonTitle',
 	},
 	reversePauseIcon: {
-		dependsOn: options => options.autoLoad.value,
+		dependsOn: options => options.autoLoad.value && options.showPauseButton.value,
 		type: 'boolean',
 		value: false,
 		description: 'nerReversePauseIconDesc',
@@ -101,17 +99,9 @@ module.exclude = [
 module.shouldRun = () => !isCurrentSubreddit('dashboard');
 
 const dupeSet = new Set();
-const siteTable = _.once(() => Thing.thingsContainer());
-let currentPageNumber = 1;
-let nextPageUrl;
-let $NREPause, isPaused, pauseReason, pauseAfterPages, nextPausePage;
-
-let initAutoNextPage: ?() => void;
-let loaderWidget;
-export let loadPromise;
-
 const isPausedStorage = Storage.wrap('RESmodules.neverEndingReddit.isPaused', false);
 const pauseReasonStorage = Storage.wrap('RESmodules.neverEndingReddit.pauseReason', (null: void | null | 'manual' | 'pauseAfterEvery'));
+let pauseButton, isPaused, pauseReason;
 
 module.beforeLoad = async () => {
 	[isPaused, pauseReason] = await Promise.all([
@@ -128,63 +118,78 @@ module.beforeLoad = async () => {
 	}
 
 	if (module.options.returnToPrevPage.value) initiateReturnToPrevPage();
+
+	// This may be dangerus since it make `beforeLoad` await `bodyReady`, which could mess up the dependant init phases
+	// but is necessary in order to retrieve the next page URL from the first page instead of potential `returnToPrev` page
+	await registerFirstPage();
 };
 
 module.go = () => {
-	// code inspired by River of Reddit, but rewritten from scratch to work across multiple browsers...
-	// Original River of Reddit author: reddy kapil
-	// Original link to Chrome extension: https://chrome.google.com/extensions/detail/bjiggjllfebckflfdjbimogjieeghcpp
+	if (!getNextPageUrl()) return;
 
-	if (!siteTable()) return;
-
-	if (!nextPageUrl) { // May be restored from returnToPrevPage
-		try {
-			const nextLink = getNextPrevLinks(siteTable()).next;
-			nextPageUrl = nextLink && nextLink.getAttribute('href');
-		} catch (e) { /* empty */ }
-	}
-
-	if (nextPageUrl) initiate();
-};
-
-function initiate() {
-	siteTable().classList.add('res-ner-listing');
-
-	if (!loaderWidget) attachLoaderWidget(buildLoaderWidget());
+	prepareNextPageLoad();
 
 	if (module.options.autoLoad.value) {
 		if (module.options.showPauseButton.value) {
-			addPauseControls();
+			pauseButton = $('<div>', {
+				id: 'NREPause',
+				title: 'Pause / Restart Never Ending Reddit',
+				click: () => togglePause(!isPaused, 'manual', 'Never-Ending Reddit has been paused. Click the play/pause button to unpause it.'),
+			}).get(0);
+			Floater.addElement(pauseButton);
+			togglePause(isPaused, pauseReason);
 		}
 
 		SelectedEntry.addListener(selected => {
-			if (!selected || isPaused) return;
-
+			if (isPaused) return;
 			const things = Thing.visibleThingElements();
 			const distanceFromBottom = things.length - (things.indexOf(selected.element) + 1);
 			if (distanceFromBottom === 1) prefetchNextPage();
 			else if (distanceFromBottom < 1) loadNextPage();
 		});
 	}
-}
+};
 
-function addPauseControls() {
-	$NREPause = $('<div>', {
-		id: 'NREPause',
-		title: 'Pause / Restart Never Ending Reddit',
-		click: () => togglePause(!isPaused, 'manual', 'Never-Ending Reddit has been paused. Click the play/pause button to unpause it.'),
-	});
+const container = _.once(() => getLastSiteTable());
+const pages: Array<{|
+	url: string,
+	nextPageUrl: ?string,
+	html: ?string,
+|}> = [];
 
-	if (module.options.reversePauseIcon.value) $NREPause.addClass('reversePause');
+export let loadNextPage: (opts?: { scrollToLoadWidget: boolean }) => void = () => {};
+let refreshAutoLoad: ?() => void;
 
-	Floater.addElement($NREPause);
+const getNextPageUrl = (): ?string => pages.slice(-1)[0].nextPageUrl;
+const registerFirstPage = _.once(async () => {
+	await Init.bodyReady;
+	pages[0] = { url: location.pathname, nextPageUrl: retrieveNextPageUrl(document.body), html: null };
+});
 
-	pauseAfterPages = parseInt(module.options.pauseAfterEvery.value, 10) || Infinity;
-	// set up initial state of NER bar
-	togglePause(isPaused, pauseReason);
+function prepareNextPageLoad() {
+	const last = pages.slice(-1)[0];
+	const { nextPageUrl } = last;
+	if (!nextPageUrl) {
+		endNER('No more pages');
+		return;
+	}
+
+	const startPromise = new Promise(res => { loadNextPage = res; });
+	const donePromise = startPromise
+		.then(() => loadPage(nextPageUrl, pages.indexOf(last) + 1))
+		.then(() => prepareNextPageLoad())
+		.catch(e => {
+			endNER(`Could not load the next page: ${e.message}`);
+			console.error(e);
+		});
+
+	createLoaderWidget(startPromise, donePromise);
 }
 
 function togglePause(pause, source, pauseMessage) {
+	if (pauseButton) pauseButton.classList.toggle('paused', module.options.reversePauseIcon.value !== pause);
+	if (isPaused === pause) return;
+
 	isPaused = pause;
 	pauseReason = source;
 
@@ -196,48 +201,24 @@ function togglePause(pause, source, pauseMessage) {
 		pauseReasonStorage.delete();
 	}
 
-	setLoaderWidgetActionText(loaderWidget);
-
-	if (isPaused) {
-		if ($NREPause) $NREPause.addClass('paused');
-		if (pauseMessage) {
-			Notifications.showNotification({
-				moduleID: module.moduleID,
-				notificationID: source || undefined,
-				message: pauseMessage,
-			});
-		}
-	} else {
-		nextPausePage = currentPageNumber + pauseAfterPages;
-
-		if ($NREPause) $NREPause.removeClass('paused');
-		if (initAutoNextPage) initAutoNextPage();
+	if (isPaused && pauseMessage) {
+		Notifications.showNotification({
+			moduleID: module.moduleID,
+			notificationID: source || undefined,
+			message: pauseMessage,
+		});
 	}
+
+	if (refreshAutoLoad) refreshAutoLoad();
 }
 
 const isNerUrl = () => location.hash.startsWith(RES_NER_PAGE_HASH);
-
-export function resetReturnToPage() {
-	if (!Modules.isRunning(module)) return;
-	if (!module.options.returnToPrevPage.value) return;
-	setReturnToPage(null);
-}
-
-const pages: {
-	[number: number]: {
-		url: string,
-		nextPageUrl: ?string,
-		html: string,
-	},
-} = {};
 let storeHtml = true;
 
-function setReturnToPage(selected: ?Thing) {
-	if (!selected) return;
+function setReturnToPage(selected: Thing) {
+	let number = 0;
 
-	let number = 1;
-
-	const $earlierMarkers = $(selected.element).prevAll('.NERPageMarker');
+	const $earlierMarkers = $(selected.element).parent().prev('.NERPageMarker');
 	const marker = $earlierMarkers.get(0);
 	if (marker) number = parseInt(marker.dataset.number, 10);
 
@@ -252,8 +233,8 @@ function setReturnToPage(selected: ?Thing) {
 	try {
 		history.replaceState(
 			{ ...history.state, ner: { number, ...pages[number], ...(storeHtml ? {} : { html: null }) } },
-			`${document.title}${number > 1 ? `- page ${number}` : ''}`,
-			number > 1 ? `${RES_NER_PAGE_HASH}=${number}` : `${location.pathname}${location.search}${isNerUrl() ? '' : location.hash}`
+			`${document.title}${number ? `- page ${number + 1}` : ''}`,
+			number ? `${RES_NER_PAGE_HASH}=${number + 1}` : `${location.pathname}${location.search}${isNerUrl() ? '' : location.hash}`
 		);
 	} catch (e) {
 		const firefoxFix = process.env.BUILD_TARGET === 'firefox' && e.name === 'NS_ERROR_ILLEGAL_VALUE' && 'To fix this, go to about:config and increase browser.history.maxStateObjectSize' || '';
@@ -269,27 +250,14 @@ function initiateReturnToPrevPage() {
 		const { ner } = history.state || {};
 		if (!ner) return;
 
-		const { url, html } = ner;
-		({ number: currentPageNumber, nextPageUrl } = ner);
+		const { number, url, nextPageUrl, html } = ner;
+		pages[number] = { url, nextPageUrl, html };
 
 		if (html) {
-			pages[currentPageNumber] = { url, nextPageUrl, html };
-			appendPage($(html).get(0));
+			appendPage($(html).get(0), number);
 		} else {
-			loadPage(url);
+			loadPage(url, number);
 		}
-	}
-}
-
-function pauseAfterPage() {
-	if (currentPageNumber + 1 === nextPausePage) {
-		const message = `
-			    <p>Time for a break!</p>
-			    <p>Never-Ending Reddit has been paused because you've passed ${pauseAfterPages} pages.</p>
-			`;
-
-		togglePause(true, 'pauseAfterEvery', message);
-		return true;
 	}
 }
 
@@ -307,174 +275,164 @@ function handleDupes(thing: *) {
 	}
 }
 
-export function getNextPrevLinks(ele: HTMLElement = document.body): { next?: HTMLAnchorElement, prev?: HTMLAnchorElement } {
-	const $ele = $(ele);
-	// `~ .nextprev a[rel~=next]` for /about/log, because they aren't in the siteTable.
-	// It wouldn't be reddit if it were consistent, would it?
+function getLastSiteTable(body: HTMLElement = document.body): HTMLElement {
+	return Array.from(body.querySelectorAll('.sitetable, .search-result-listing .contents')).pop();
+}
+
+export function getNextPrevLinks(ele: HTMLElement = document.body, hideNavigation: boolean = false): { next?: HTMLAnchorElement, prev?: HTMLAnchorElement } {
+	const buttons = Array.from(ele.querySelectorAll([
+		'.nav-buttons',
+		'#siteTable + .nextprev', // /about/log differs from other pages
+	].join(', '))).pop();
+	if (hideNavigation && buttons) buttons.hidden = true;
 	const links = {
-		next: ($ele.find('.nextprev a[rel~=next], ~ .nextprev a[rel~=next]')[0]: any),
-		prev: ($ele.find('.nextprev a[rel~=prev], ~ .nextprev a[rel~=prev]')[0]: any),
+		next: buttons && (buttons.querySelector('a[rel~=next]'): any),
+		prev: buttons && (buttons.querySelector('a[rel~=prev]'): any),
 	};
 
 	if (!links.next && !links.prev) throw new Error('Could not find any .nextprev links');
 	return links;
 }
 
-function buildLoaderWidget() {
-	// add a widget at the bottom that will be used to detect that we've scrolled to the bottom, and will also serve as a "loading" bar...
-	const widget = document.createElement('div');
-	setLoaderWidgetActionText(widget);
-	widget.id = 'progressIndicator';
-	widget.className = 'neverEndingReddit';
-
-	widget.addEventListener('click', (e: Event) => { if (e.target.tagName !== 'A') loadNextPage(); });
-
-	return widget;
+// This also hides the original navigation
+function retrieveNextPageUrl(body: HTMLElement): ?string {
+	try {
+		const nextLink = getNextPrevLinks(body, true).next;
+		return nextLink ? nextLink.getAttribute('href') : null;
+	} catch (e) {
+		console.error('Could not find a link to the next page', e);
+		return null;
+	}
 }
 
 function setLoaderWidgetActionText(widget) {
-	$(widget).empty();
-	$('<h2>Never Ending Reddit</h2>')
-		.appendTo(widget)
-		.append(SettingsNavigation.makeUrlHashLink(module.moduleID, undefined, ' ', 'gearIcon'));
+	const text = module.options.autoLoad.value && isPaused ?
+		'Click to load the next page; or click the "pause" button in the top right corner' :
+		'Click to load the next page';
 
-	let text = 'Click to load the next page';
-	if (module.options.autoLoad.value && !isPaused) {
-		text = 'scroll or click to load the next page';
-	} else if (module.options.autoLoad.value && isPaused) {
-		text = 'click to load the next page; or click the "pause" button in the top right corner';
-	}
-
-	$('<p class="NERWidgetText" />')
-		.text(text)
-		.appendTo(widget);
-
-	const nextpage = $('<a id="NERStaticLink">or open next page</a>')
-		.attr('href', nextPageUrl || '')
-		.click(() => {
-			loadPromise = true; // avoid trying to load a new page before we navigate
-			if (pauseReason === 'pauseAfterEvery') togglePause(false);
-		});
-
-	$('<p class="NERWidgetText" />').append(nextpage)
-		.append('&nbsp;(and clear Never-Ending stream)')
-		.appendTo(widget);
+	empty(widget);
+	widget.append(...string.html`<span>
+		<h2>
+			Never Ending Reddit
+			${string.safe(SettingsNavigation.makeUrlHashLink(module.moduleID, undefined, ' ', 'gearIcon'))}
+		</h2>
+		<p class="NERWidgetText">${text}</p>
+		<p class="NERWidgetText">
+			<a id="NERStaticLink" href="${getNextPageUrl() || ''}">or open next page</a> (and clear Never-Ending stream)
+		</p>
+	</span>`.children);
 }
 
-function attachLoaderWidget(widget) {
-	loaderWidget = widget;
-	siteTable().after(widget);
+function createLoaderWidget(startPromise, donePromise) {
+	const widget = document.createElement('div');
+	widget.id = 'progressIndicator';
+	widget.className = 'neverEndingReddit';
+
+	widget.addEventListener('click', (e: Event) => {
+		if (e.target.tagName === 'A') return;
+		loadNextPage();
+		if (pauseReason === 'pauseAfterEvery') togglePause(false);
+	});
+
+	startPromise.then(({ scrollToLoadWidget = false } = {}) => {
+		empty(widget);
+		widget.append(string.html`<span class="RESLoadingSpinner"></span>`);
+		if (scrollToLoadWidget) scrollToElement(widget, null, { scrollStyle: 'middle', direction: 'down' });
+	});
+
+	donePromise.finally(() => {
+		widget.remove();
+	});
 
 	const prefetchIo = new IntersectionObserver(([{ isIntersecting }]) => {
 		if (!isIntersecting) return;
 		prefetchNextPage();
-		prefetchIo.disconnect();
 	}, { rootMargin: '100%' });
 	prefetchIo.observe(widget);
 
-	initAutoNextPage = _.once(() => {
-		const loadNextPageIo = new IntersectionObserver(([{ isIntersecting }]) => {
+	const pauseAfterPages = parseInt(module.options.pauseAfterEvery.value, 10);
+	if (Number.isFinite(pauseAfterPages) && pages.length % pauseAfterPages === 0) {
+		(new IntersectionObserver(([{ isIntersecting }]) => {
 			if (!isIntersecting) return;
-			loadNextPage();
-			prefetchIo.disconnect();
-			loadNextPageIo.disconnect();
-		}, { threshold: [1] });
-		loadNextPageIo.observe(widget);
+			togglePause(true, 'pauseAfterEvery', `
+				<p>Time for a break!</p>
+				<p>Never-Ending Reddit has been paused because you've passed ${pauseAfterPages} pages.</p>
+			`);
+		}, {})).observe(widget);
+	}
+
+	const loadNextPageIo = new IntersectionObserver(([{ isIntersecting }]) => {
+		if (!isIntersecting) return;
+		loadNextPage();
+	}, { threshold: [1] });
+
+	refreshAutoLoad = () => {
+		const enabled = module.options.autoLoad.value && !isPaused;
+		if (enabled) loadNextPageIo.observe(widget);
+		else loadNextPageIo.disconnect();
+		setLoaderWidgetActionText(widget);
+	};
+
+	refreshAutoLoad();
+
+	startPromise.then(() => {
+		prefetchIo.disconnect();
+		loadNextPageIo.disconnect();
+		refreshAutoLoad = null;
 	});
 
-	if (module.options.autoLoad.value && !isPaused && !pauseAfterPage()) initAutoNextPage();
+	container().append(widget);
 }
 
 const fetchPage = url => ajax({ url, cacheFor: HOUR });
-const prefetchNextPage = () => { if (nextPageUrl) fetchPage(nextPageUrl); };
+const prefetchNextPage = () => { const url = getNextPageUrl(); if (url) fetchPage(url); };
 
-export function loadNextPage(scrollToLoadWidget: boolean = false): Promise<void> | boolean | void {
-	if (!nextPageUrl) return;
+async function loadPage(url: string, number: number) {
+	const html = (await fetchPage(url))
+		// remove some elements which may have side-effects when parsed
+		.replace(/<style(.|\s)*?>|<link(.|\s)*?>|<script(.|\s)*?\/script>/g, '');
 
-	if (!loadPromise) {
-		currentPageNumber++;
-		loadPromise = loadPage(nextPageUrl).then(() => { loadPromise = null; });
+	const tempDiv = $('<div>').html(html).get(0);
+
+	if (loggedInUser() !== documentLoggedInUser(tempDiv)) {
+		throw new Error('Page loaded was not for current user');
 	}
 
-	if (scrollToLoadWidget) scrollToElement(loaderWidget, null, { scrollStyle: 'middle', direction: 'down' });
+	// grab the siteTable out of there...
+	const newSiteTable = getLastSiteTable(tempDiv);
+	if (!newSiteTable) throw Error('Could not find any siteTable');
 
-	return loadPromise;
+	const noresults = newSiteTable.querySelector('#noresults');
+	if (noresults) throw new Error(noresults.textContent);
+
+	// Avoid attributes (class, id etc) which have impact on styling
+	for (const { name } of newSiteTable.attributes) newSiteTable.removeAttribute(name);
+
+	pages[number] = { url, nextPageUrl: retrieveNextPageUrl(tempDiv), html: newSiteTable.outerHTML };
+
+	// Invoke watcher callbacks etc on page
+	registerPage(newSiteTable);
+
+	await appendPage(newSiteTable, number);
+
+	window.dispatchEvent(new Event('neverEndingLoad', { bubbles: true, cancelable: true }));
 }
 
-const loadPage = mutex(async (url: string) => {
-	const page = fetchPage(url);
-
-	if (loaderWidget) {
-		$(loaderWidget).html('<span class="RESLoadingSpinner"></span>');
-	}
-
-	const newLoaderWidget = buildLoaderWidget();
-
-	try {
-		const html = (await page)
-			// remove some elements which may have side-effects when parsed
-			.replace(/<style(.|\s)*?>|<link(.|\s)*?>|<script(.|\s)*?\/script>/g, '');
-
-		const tempDiv = $('<div>').html(html).get(0);
-		const username = loggedInUser();
-		const tempUsername = documentLoggedInUser(tempDiv);
-		if (tempUsername !== username) {
-			throw new Error('page loaded was not for current user');
-		}
-
-		// check for new mail
-		Orangered.updateFromPage(tempDiv);
-
-		try {
-			const nextLink = getNextPrevLinks(tempDiv).next;
-			nextPageUrl = nextLink && nextLink.getAttribute('href');
-		} catch (e) {
-			const noresults = tempDiv.querySelector('#noresults');
-			if (noresults) {
-				return endNER(noresults.textContent);
-			} else {
-				throw Error('Could not find a link to the next page');
-			}
-		}
-
-		// grab the siteTable out of there...
-		const newSiteTable = Thing.thingsContainer(tempDiv);
-		if (!newSiteTable) {
-			throw Error('Could not find any siteTable');
-		}
-
-		pages[currentPageNumber] = { url, nextPageUrl, html: newSiteTable.outerHTML };
-
-		registerPage(newSiteTable);
-		await appendPage(newSiteTable);
-	} catch (e) {
-		endNER(`Could not load the next page: ${e.message}`);
-		console.error(e);
-	}
-
-	if (loaderWidget) loaderWidget.remove();
-	if (nextPageUrl) attachLoaderWidget(newLoaderWidget);
-});
-
-const appendPage = fastAsync(function*(newSiteTable) {
-	const pageMarker = string.html`<div class="NERPageMarker" data-number="${currentPageNumber}">
-		Page ${currentPageNumber}
+const appendPage = fastAsync(function*(newSiteTable, number) {
+	const pageMarker = string.html`<div class="NERPageMarker" data-number="${number}">
+		Page ${number + 1}
 		${string.safe(SettingsNavigation.makeUrlHashLink(module.moduleID, undefined, ' ', 'gearIcon'))}
 	</div>`;
 
-	yield Init.bodyReady;
+	yield registerFirstPage();
 
-	const firstLen = $(siteTable()).find('.link:last .rank').text().length;
+	const firstLen = $(container()).find('.link:last .rank').text().length;
 	const lastLen = $(newSiteTable).find('.link:last .rank').text().length;
 	if (lastLen > firstLen) {
 		addCSS(`body.res > .content .link .rank { width: ${(lastLen * 1.1).toFixed(1)}ex; }`);
 	}
 
-	siteTable().append(pageMarker, ...newSiteTable.children);
-
-	if (!nextPageUrl) endNER('No more pages');
-
-	window.dispatchEvent(new Event('neverEndingLoad', { bubbles: true, cancelable: true }));
+	container().append(pageMarker, newSiteTable);
 });
 
 function endNER(text) {
@@ -486,12 +444,10 @@ function endNER(text) {
 		.append(`
 			<p class="nextprev">
 				<a href="${location.href.split('#')[0]}">start over</a>
-				<a href="${nextPageUrl || ''}">try again</a>
+				<a href="${getNextPageUrl() || ''}">try again</a>
 				<a target="_blank" rel="noopener noreferer" href="/r/Enhancement/wiki/faq/never_ending_reddit">learn more</a>
 				<a href="/r/random">random subreddit</a>
 			</p>
 		`)
-		.appendTo(siteTable());
-
-	nextPageUrl = null;
+		.appendTo(container());
 }

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -48,7 +48,6 @@ import {
 	Storage,
 } from '../environment';
 import * as Options from '../core/options';
-import * as NeverEndingReddit from './neverEndingReddit';
 import * as Notifications from './notifications';
 import * as SelectedEntry from './selectedEntry';
 import * as SettingsNavigation from './settingsNavigation';
@@ -604,10 +603,6 @@ function enableConserveMemory() {
 	}, { rootMargin });
 
 	window.addEventListener('scroll', _.debounce(idleThrottle(() => {
-		// Running this can conflict with partially-ready expandos, as is the case
-		// while NER is ready-ing a new page
-		if (NeverEndingReddit.loadPromise) return;
-
 		const activeExpandos = Array.from(primaryExpandos.values());
 
 		for (const expando of activeExpandos) {

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -20,24 +20,6 @@ export class Thing {
 	static thingSelector = '.thing, .search-result-link';
 	static entrySelector = '.entry, .search-result-link > :not(.thumbnail)';
 
-	static thingsContainer(body: HTMLElement = document.body): HTMLElement {
-		return (
-			body.querySelector('.sitetable') ||
-			_.last(Array.from(body.querySelectorAll('.search-result-listing')))
-		);
-	}
-
-	static findThings(container?: HTMLElement = Thing.thingsContainer()): Thing[] {
-		const potentialThings = [
-			...(container.matches(Thing.thingSelector) ? [container] : []),
-			...container.querySelectorAll(Thing.thingSelector),
-		];
-		return filterMap(potentialThings, ele => {
-			const thing = Thing.from(ele);
-			if (thing) return [thing];
-		});
-	}
-
 	static thingElements(): HTMLElement[] {
 		return Array.from(document.querySelectorAll(Thing.bodyThingSelector));
 	}


### PR DESCRIPTION
- Cleans up code by segregate UI logic from page load logic
- Fixes UI bug where widget and endNER appears simultaneously
- Fixes next/prev disappearing from subreddit section on search pages
- Improves performance on initial load

Tested in browser: Chrome 71, Firefox 65
