### PR TITLE
 menu: Close dropdown by default on action

### DIFF
--- a/lib/modules/commandLine.js
+++ b/lib/modules/commandLine.js
@@ -46,10 +46,7 @@ module.go = () => {
 function addMenuItem() {
 	Menu.addMenuItem(
 		() => string.html`<div>command line <span class="RESMenuItemButton res-icon">\uF060</span></div>`,
-		() => {
-			Menu.hidePrefsDropdown();
-			open();
-		}
+		() => open(),
 	);
 }
 

--- a/lib/modules/customToggles.js
+++ b/lib/modules/customToggles.js
@@ -114,14 +114,20 @@ export class Toggle {
 	}
 
 	addMenuItem(title: string = `Toggle ${this.text}`, order: number = 9, on?: string, off?: string) {
-		const createItem = _.once(() => {
-			const item = string.html`<div title="${title}">${this.text || '\u00A0'}</div>`;
-			const toggle = CreateElement.toggleButton(undefined, this.text, this.enabled, on, off);
-			item.append(toggle);
-			this.onStateChange(() => { toggle.classList.toggle('enabled', this.enabled); });
-			return item;
-		});
-		Menu.addMenuItem(createItem, () => { this.toggle(); }, order);
+		Menu.addMenuItem(
+			_.once(() => {
+				const item = string.html`<div title="${title}">${this.text || '\u00A0'}</div>`;
+				const toggle = CreateElement.toggleButton(undefined, this.text, this.enabled, on, off);
+				item.append(toggle);
+				this.onStateChange(() => { toggle.classList.toggle('enabled', this.enabled); });
+				return item;
+			}),
+			e => {
+				this.toggle();
+				e.stopPropagation();
+			},
+			order
+		);
 	}
 
 	addCLI(commandPredicate: string) {

--- a/lib/modules/menu.js
+++ b/lib/modules/menu.js
@@ -40,7 +40,7 @@ module.options = {
 	},
 };
 
-const items: Array<{| getElement: () => HTMLElement, onClick: (e: Event) => void, order: number |}> = [];
+const items = [];
 let RESPrefsLink;
 
 module.go = () => {
@@ -53,8 +53,10 @@ module.go = () => {
 	RESPrefsLink.addEventListener('click', () => {
 		if (module.options.gearIconClickAction.value === 'openCommandLine' && Modules.isRunning(CommandLine)) {
 			CommandLine.toggle();
+			hidePrefsDropdown();
 		} else if (module.options.gearIconClickAction.value === 'openSettings') {
 			SettingsNavigation.open();
+			hidePrefsDropdown();
 		} else {
 			showPrefsDropdown(0);
 		}
@@ -88,17 +90,19 @@ function showPrefsDropdown(openDelay: number) {
 		.begin();
 }
 
-export function hidePrefsDropdown() {
+function hidePrefsDropdown() {
 	Hover.dropdownList(module.moduleID).close(true);
 }
 
-export function addMenuItem(getElement: *, onClick: * = () => {}, order: * = 0) {
+export function addMenuItem(getElement: () => HTMLElement, onClick: (e: Event) => void = () => {}, order: number = 0) {
 	items.push({ getElement, onClick, order });
 }
 
 function buildItem({ getElement, onClick }) {
 	const li = document.createElement('li');
-	li.addEventListener('click', onClick);
+	li.addEventListener('click', onClick, true);
+	// Dropdown will be closed on click unless event propagation is stopped
+	li.addEventListener('click', hidePrefsDropdown);
 	li.append(getElement());
 	return li;
 }

--- a/lib/modules/menu.js
+++ b/lib/modules/menu.js
@@ -41,32 +41,32 @@ module.options = {
 };
 
 const items = [];
-let RESPrefsLink;
+let gear;
 
 module.go = () => {
-	RESPrefsLink = string.html`<span id="RESSettingsButton" style="cursor: pointer" title="${i18n('RESSettings')}" class="gearIcon"></span>`;
+	gear = string.html`<span id="RESSettingsButton" style="cursor: pointer" title="${i18n('RESSettings')}" class="gearIcon"></span>`;
 
 	if (module.options.gearIconClickAction.value !== 'toggleMenuNoHover') {
-		RESPrefsLink.addEventListener('mouseenter', () => { showPrefsDropdown(200); });
+		gear.addEventListener('mouseenter', () => { showDropdown(200); });
 	}
 
-	RESPrefsLink.addEventListener('click', () => {
+	gear.addEventListener('click', () => {
 		if (module.options.gearIconClickAction.value === 'openCommandLine' && Modules.isRunning(CommandLine)) {
 			CommandLine.toggle();
-			hidePrefsDropdown();
+			hideDropdown();
 		} else if (module.options.gearIconClickAction.value === 'openSettings') {
 			SettingsNavigation.open();
-			hidePrefsDropdown();
+			hideDropdown();
 		} else {
-			showPrefsDropdown(0);
+			showDropdown(0);
 		}
 	});
 
 	const r2MenuPosition = document.body.querySelector('#header-bottom-right ul');
 	if (r2MenuPosition) {
-		r2MenuPosition.after(string.html`<span class="separator">|</span>`, RESPrefsLink);
+		r2MenuPosition.after(string.html`<span class="separator">|</span>`, gear);
 	} else {
-		Floater.addElement(RESPrefsLink, { order: 5 });
+		Floater.addElement(gear, { order: 5 });
 	}
 };
 
@@ -74,7 +74,7 @@ module.afterLoad = () => {
 	addLegacyStyling();
 };
 
-function showPrefsDropdown(openDelay: number) {
+function showDropdown(openDelay: number) {
 	Hover.dropdownList(module.moduleID, Hover.HIDDEN_FROM_SETTINGS)
 		.options({
 			openDelay,
@@ -86,11 +86,11 @@ function showPrefsDropdown(openDelay: number) {
 			f.append(...items.sort(({ order: a }, { order: b }) => a - b).map(buildItem));
 			return [f];
 		})
-		.target(RESPrefsLink) // workaround subreddit stylings where the container ends up super tall
+		.target(gear) // workaround subreddit stylings where the container ends up super tall
 		.begin();
 }
 
-function hidePrefsDropdown() {
+function hideDropdown() {
 	Hover.dropdownList(module.moduleID).close(true);
 }
 
@@ -102,14 +102,14 @@ function buildItem({ getElement, onClick }) {
 	const li = document.createElement('li');
 	li.addEventListener('click', onClick, true);
 	// Dropdown will be closed on click unless event propagation is stopped
-	li.addEventListener('click', hidePrefsDropdown);
+	li.addEventListener('click', hideDropdown);
 	li.append(getElement());
 	return li;
 }
 
 function addLegacyStyling() {
-	const { backgroundImage } = window.getComputedStyle(RESPrefsLink);
+	const { backgroundImage } = window.getComputedStyle(gear);
 	if (backgroundImage && backgroundImage !== 'none') {
-		RESPrefsLink.classList.add('res-gearIcon-legacy');
+		gear.classList.add('res-gearIcon-legacy');
 	}
 }

--- a/lib/modules/settingsNavigation.js
+++ b/lib/modules/settingsNavigation.js
@@ -34,23 +34,18 @@ module.options = {
 };
 
 module.beforeLoad = () => {
-	const createItem = () => {
-		const ele = string.html`<div id="SettingsConsole">${i18n('RESSettingsConsole')}</div>`;
-		$('<span>', {
-			class: 'RESMenuItemButton res-icon',
-			text: '\uF094',
-			title: 'search settings',
-			click: () => { open('search'); },
-		}).appendTo(ele);
-		return ele;
-	};
-
 	Menu.addMenuItem(
-		createItem,
 		() => {
-			Menu.hidePrefsDropdown();
-			open();
+			const ele = string.html`<div id="SettingsConsole">${i18n('RESSettingsConsole')}</div>`;
+			$('<span>', {
+				class: 'RESMenuItemButton res-icon',
+				text: '\uF094',
+				title: 'search settings',
+				click: () => { open('search'); },
+			}).appendTo(ele);
+			return ele;
 		},
+		() => open(),
 		-10
 	);
 

--- a/tests/accountSwitcher.js
+++ b/tests/accountSwitcher.js
@@ -18,7 +18,7 @@ module.exports = {
 			.url('https://en.reddit.com/r/RESIntegrationTests/wiki/pages')
 			.waitForElementVisible('#RESAccountSwitcherIcon')
 			.click('#RESAccountSwitcherIcon')
-			.assert.visible('.RESAccountSwitcherDropdown')
+			.waitForElementVisible('.RESAccountSwitcherDropdown')
 			.assert.containsText('.RESAccountSwitcherDropdown', username)
 			.assert.containsText('.RESAccountSwitcherDropdown', 'add account')
 			.end();
@@ -44,6 +44,7 @@ module.exports = {
 			.url('https://en.reddit.com/r/RESIntegrationTests/wiki/pages')
 			.waitForElementVisible('#RESAccountSwitcherIcon')
 			.click('#RESAccountSwitcherIcon')
+			.waitForElementVisible('.RESAccountSwitcherDropdown')
 			.click('.RESAccountSwitcherDropdown .accountName')
 			.waitForElementVisible('#alert_message')
 			.assert.containsText('#alert_message', `Could not log in as ${username}`)


### PR DESCRIPTION
Fixes some instances where the dropdown doesn't close when it makes sense that it should.

Tested in browser: Chrome 71
