### PR TITLE
New module: Disable chat

### DIFF
--- a/lib/modules/disableChat.js
+++ b/lib/modules/disableChat.js
@@ -1,0 +1,22 @@
+/* @flow */
+
+import { Module } from '../core/module';
+import * as Init from '../core/init';
+import { downcast, watchForChildren } from '../utils';
+
+export const module: Module<*> = new Module('disableChat');
+
+module.moduleName = 'disableChatName';
+module.category = 'productivityCategory';
+module.description = 'disableChatDesc';
+module.disabledByDefault = true;
+
+module.beforeLoad = () => {
+	Init.bodyStart.then(() => {
+		watchForChildren(document.body, 'script', ele => {
+			const script = downcast(ele, HTMLScriptElement);
+			if (typeof script.src !== 'string') return;
+			if ((/^\/_chat/).test(new URL(script.src).pathname)) ele.remove();
+		});
+	});
+};

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -405,6 +405,12 @@
 	"keyboardNavDesc": {
 		"message": "Keyboard navigation for reddit!"
 	},
+	"disableChatName": {
+		"message": "Disable Chat"
+	},
+	"disableChatDesc": {
+		"message": "Prevent Reddit's chat from running and improve page load speed."
+	},
 	"showImagesMediaBrowseTitle": {
 		"message": "Media Browse"
 	},


### PR DESCRIPTION
Reddit's chat is quite resource heavy, so it's nice with an option to prevent it from loading.

On my laptop it takes more than 200 ms only just to evaluate the main bundle:
![image](https://user-images.githubusercontent.com/1748521/51087671-87886500-1756-11e9-969b-c954077f5b5d.png)

Tested in browser:  Chrome 71, Firefox 65