### PR TITLE
firefox: Fix backup providers requesting unneed browser permissions

### DIFF
--- a/lib/environment/foreground/auth.js
+++ b/lib/environment/foreground/auth.js
@@ -3,19 +3,34 @@
 import { sendMessage } from './messaging';
 import * as Permissions from './permissions';
 
-export async function launchAuthFlow(
-	{ domain, clientId, scope = '' }: {| domain: string, clientId: string, scope?: string |},
-	warnUserInteraction: (message: string) => Promise<void>,
-): Promise<string> {
+export async function launchAuthFlow({
+	domain,
+	clientId,
+	scope = '',
+	permissions,
+}: {|
+	domain: string,
+	clientId: string,
+	scope?: string,
+	permissions: Array<string>,
+|}, warnUserInteraction: (message: string) => Promise<void>): Promise<string> {
 	let responseUrl;
 	try {
 		responseUrl = await sendMessage('authFlow', { domain, clientId, scope, interactive: false });
 	} catch (e) {
 		console.error('Noninteractive auth failed:', e);
 
-		await warnUserInteraction('You may be redirected to redditenhancementsuite.com to complete the login process.');
+		if (permissions.length && !await Permissions.has(permissions)) {
+			const resAuth = 'https://redditenhancementsuite.com/oauth';
+			// Firefox can use `launchWebAuthFlow` and doesn't need to redirect to our domain
+			if (process.env.BUILD_TARGET !== 'firefox' && !await Permissions.has([resAuth])) {
+				permissions.push(resAuth);
+			}
 
-		await Permissions.request(['https://redditenhancementsuite.com/oauth']);
+			await warnUserInteraction(permissions.includes(resAuth) ? 'You may be redirected to redditenhancementsuite.com to complete the login process.' : '');
+
+			await Permissions.request(permissions);
+		}
 
 		responseUrl = await sendMessage('authFlow', { domain, clientId, scope, interactive: true });
 	}

--- a/lib/modules/backupAndRestore/providers/Dropbox.js
+++ b/lib/modules/backupAndRestore/providers/Dropbox.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { ajax, launchAuthFlow, Permissions } from '../../../environment';
+import { ajax, launchAuthFlow } from '../../../environment';
 import { Alert } from '../../../utils';
 import { Provider } from './Provider';
 
@@ -17,12 +17,12 @@ export class Dropbox extends Provider {
 		this.accessToken = await launchAuthFlow({
 			domain: 'https://www.dropbox.com/oauth2/authorize',
 			clientId: 'tdevom9o5xn0hnt',
+			permissions: process.env.BUILD_TARGET === 'firefox' ? [] : ['https://www.dropbox.com/oauth2/authorize'],
 		}, async message => {
 			await Alert.open(`
 				<p><b>RES needs your permission to backup to Dropbox.</b></p>
 				<p>${message}</p>
 			`, { cancelable: true });
-			await Permissions.request(['https://www.dropbox.com/oauth2/authorize']);
 		});
 
 		return this;

--- a/lib/modules/backupAndRestore/providers/GoogleDrive.js
+++ b/lib/modules/backupAndRestore/providers/GoogleDrive.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { Base64 } from 'js-base64';
-import { ajax, launchAuthFlow, Permissions } from '../../../environment';
+import { ajax, launchAuthFlow } from '../../../environment';
 import { Alert } from '../../../utils';
 import { Provider } from './Provider';
 
@@ -20,12 +20,12 @@ export class GoogleDrive extends Provider {
 			domain: `https://accounts.google.com/o/oauth2/v2/auth?login_hint=${googleLoginHint}`,
 			clientId: '568759524377-nv0o2u4afuuulkfcjd7f6guf27qkevpt.apps.googleusercontent.com',
 			scope: 'https://www.googleapis.com/auth/drive.appdata',
+			permissions: process.env.BUILD_TARGET === 'firefox' ? ['https://content.googleapis.com/drive/v3/*'] : ['https://accounts.google.com/o/oauth2/v2/auth'],
 		}, async message => {
 			await Alert.open(`
 				<p><b>RES needs your permission to backup to Google Drive.</b></p>
 				<p>${message}</p>
 			`, { cancelable: true });
-			await Permissions.request(['https://accounts.google.com/o/oauth2/v2/auth', 'https://content.googleapis.com/drive/v3/*']);
 		});
 
 		return this;

--- a/lib/modules/backupAndRestore/providers/OneDrive.js
+++ b/lib/modules/backupAndRestore/providers/OneDrive.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { ajax, launchAuthFlow, Permissions } from '../../../environment';
+import { ajax, launchAuthFlow } from '../../../environment';
 import { Alert } from '../../../utils';
 import { Provider } from './Provider';
 
@@ -18,12 +18,12 @@ export class OneDrive extends Provider {
 			domain: 'https://login.live.com/oauth20_authorize.srf',
 			clientId: 'a1f95f80-0129-475b-9894-dfbb94f5ff1c',
 			scope: 'onedrive.appfolder',
+			permissions: process.env.BUILD_TARGET === 'firefox' ? [] : ['https://login.live.com/oauth20_authorize.srf'],
 		}, async message => {
 			await Alert.open(`
 				<p><b>RES needs your permission to backup to OneDrive.</b></p>
 				<p>${message}</p>
 			`, { cancelable: true });
-			await Permissions.request(['https://login.live.com/oauth20_authorize.srf']);
 		});
 
 		return this;


### PR DESCRIPTION
This fix also removes the browser permission prompt when the providers just requires user login (and not browser permissions).

Tested in browser: Firefox 66, Chrome 71
