### PR TITLE
settingsConsole: Redirect to standalone page when embedding fails

### DIFF
--- a/lib/constants/sessionStorage.js
+++ b/lib/constants/sessionStorage.js
@@ -1,4 +1,3 @@
 /* @flow */
 
-export const ALLOWED_MODULES_KEY = 'RES.allowedModules';
 export const LAST_SELECTED_ENTRY_KEY = 'RES.lastSelectedEntry';

--- a/lib/core/modules/index.js
+++ b/lib/core/modules/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 export {
+	allowedModules,
 	all,
 	get,
 	getByCategory,

--- a/lib/core/modules/modules.js
+++ b/lib/core/modules/modules.js
@@ -1,7 +1,6 @@
 /* @flow */
 
 import { flow, keyBy, map } from 'lodash/fp';
-import { ALLOWED_MODULES_KEY } from '../../constants/sessionStorage';
 import { Storage, i18n } from '../../environment';
 import {
 	downcast,
@@ -30,13 +29,11 @@ if (process.env.NODE_ENV === 'development') {
 	window.modules = modules;
 }
 
-// When specified, no other modules should run
+// When containing modules, no other modules other than those specified should run
 // Stages `beforeLoad`, `go`, `afterLoad` may only be executed on these modules
-let allowedModules: ?Array<string>;
+export const allowedModules: Array<string> = [];
 
 export async function _loadModulePrefs() {
-	allowedModules = JSON.parse(sessionStorage.getItem(ALLOWED_MODULES_KEY) || 'null');
-
 	const storedPrefs = await modulePrefsStorage.getAll();
 
 	for (const [id, module] of Object.entries(modules)) {
@@ -93,7 +90,7 @@ export function isEnabled(opaqueId: OpaqueModuleId): boolean {
 export function isRunning(opaqueId: OpaqueModuleId): boolean {
 	const module = get(opaqueId);
 	return (
-		(!allowedModules || allowedModules.includes(module.moduleID)) &&
+		(!allowedModules.length || allowedModules.includes(module.moduleID)) &&
 		isEnabled(module) &&
 		matchesPageLocation(module.include, module.exclude) &&
 		module.shouldRun()

--- a/lib/modules/settingsNavigation.js
+++ b/lib/modules/settingsNavigation.js
@@ -168,11 +168,13 @@ export function update(url: { href: string, hash: string } = location) {
 
 function listener({ origin, data }: MessageEvent) {
 	if (origin !== getOptionsURL().origin) return;
-	const { hash, closing } = (data: any);
+	const { hash, closing, redirectToOptions } = (data: any);
 	if (closing) {
 		close();
 	} else if (hash) {
 		setHash(hash);
+	} else if (redirectToOptions) {
+		location.href = getOptionsURL().href;
 	}
 }
 

--- a/lib/options/options.entry.js
+++ b/lib/options/options.entry.js
@@ -1,12 +1,9 @@
 /* @flow */
 
-import { ALLOWED_MODULES_KEY } from '../constants/sessionStorage';
-
 import * as Context from '../environment/foreground/context';
 import { init, loadOptions } from '../core/init';
+import { allowedModules } from '../core/modules';
 import { start } from './settingsConsole';
-
-sessionStorage.setItem(ALLOWED_MODULES_KEY, JSON.stringify(['nightMode', 'notifications']));
 
 // The options page depends on the context object in order to generate correct links and perform requests against Reddit
 new Promise(res => {
@@ -14,6 +11,16 @@ new Promise(res => {
 		// Use default context if the option page is not embedded
 		res();
 	} else {
+		let sessionStorageBlocked = true;
+		try {
+			// Chrome throws a exception sessionStorage cannot be accessed
+			// This happens when "3rd party cookies" are blocked
+			sessionStorageBlocked = !JSON.stringify(sessionStorage);
+		} catch (e) {
+			if (sessionStorageBlocked) window.parent.postMessage({ redirectToOptions: true }, '*');
+			return;
+		}
+
 		window.addEventListener('message', function waitForContext({ data: { context } }) {
 			Object.assign(Context.data, context);
 			window.removeEventListener('message', waitForContext, true);
@@ -21,6 +28,7 @@ new Promise(res => {
 		}, true);
 	}
 }).then(() => {
+	allowedModules.push('nightMode', 'notifications');
 	init();
 	loadOptions.then(start);
 });


### PR DESCRIPTION
Chrome's "block 3rd party cookies" blocks localStorage and sessionStorage from being accessed on embedded pages, which RES requires to work properly

Relevant issue: https://www.reddit.com/r/RESissues/comments/ah1j0u/res_settings_wont_open_after_update_to_latest/
Tested in browser: Chrome 71
