### PR TITLE
Fix logoLink on redesign

### DIFF
--- a/lib/modules/logoLink.js
+++ b/lib/modules/logoLink.js
@@ -50,7 +50,7 @@ module.options = {
 };
 
 module.go = () => {
-	const redditLogoNode: ?HTMLAnchorElement = (document.getElementById('header-img-a') || document.getElementById('header-img'): any);
+	const redditLogoNode: ?HTMLAnchorElement = (document.getElementById('header-img-a') || document.getElementById('header-img') || document.querySelector('header a[href="/"]'): any);
 	if (redditLogoNode) {
 		const url = getLogoLinkUrl();
 		if (url) {


### PR DESCRIPTION
Fixes #4968 
Tested in browser: firefox

![image](https://user-images.githubusercontent.com/4805872/51503651-cc894880-1da1-11e9-98e8-5b16a6be87c9.png)
Cursor isn't shown in snip but hovering on the logo.