### PR TITLE
filteReddit: Optimize list filters

### DIFF
--- a/lib/modules/filteReddit/Case.js
+++ b/lib/modules/filteReddit/Case.js
@@ -84,10 +84,21 @@ export class Case {
 		}
 	}
 
+	static reconcileRegEx(values: *) {
+		const variants = {};
+		for (const value of values) {
+			const flags = value.flags;
+			if (!variants[flags]) { variants[flags] = []; }
+			variants[flags].push(value.source);
+		}
+		return Object.entries(variants).map<*>(([flags, sources]) => new RegExp(sources.join('|'), flags));
+	}
+
+	static reconcile: ?() => Array<*>; // // `evaluate` supports 2nd argument `values` which is an array of same-class `value`
+
 	static +defaultConditions: ?$Shape<BuilderValue>;
 	static fields: *;
 	static slow: number = 0; // Estimated slowness of case; higher value → slower
-	static reconcilable: boolean = false; // `evaluate` supports 2nd argument `values` which is an array of same-class `value`
 	static get disabled(): boolean {
 		return false;
 	}

--- a/lib/modules/filteReddit/cases.js
+++ b/lib/modules/filteReddit/cases.js
@@ -71,7 +71,9 @@ export class Group extends Case {
 			const caseA = cases[i];
 			if (caseA instanceof Inert) throw new Error('Group can not contain inert case');
 
-			if ((ANY || NONE) && caseA.constructor.reconcilable) {
+			const evaluate = caseA.evaluate.bind(caseA);
+			const reconcile = (ANY || NONE) && caseA.constructor.reconcile;
+			if (reconcile) {
 				const values = [caseA.value];
 				let caseB;
 				// Look for more cases of same type
@@ -80,9 +82,10 @@ export class Group extends Case {
 					values.push(caseB.value);
 				}
 
-				evaluators.push(thing => caseA.evaluate(thing, values));
+				const reconciled = reconcile(values);
+				evaluators.push(thing => evaluate(thing, reconciled));
 			} else {
-				evaluators.push(caseA.evaluate.bind(caseA));
+				evaluators.push(evaluate);
 			}
 		}
 

--- a/lib/modules/filteReddit/commentCases/CommentContent.js
+++ b/lib/modules/filteReddit/commentCases/CommentContent.js
@@ -9,7 +9,7 @@ export class CommentContent extends Case {
 
 	static defaultConditions = { patt: '' };
 	static fields = ['comment contains ', { type: 'text', id: 'patt' }];
-	static reconcilable = true;
+	static reconcile = Case.reconcileRegEx;
 
 	static pattern = 'RegEx';
 

--- a/lib/modules/filteReddit/postCases/Domain.js
+++ b/lib/modules/filteReddit/postCases/Domain.js
@@ -10,7 +10,7 @@ export class Domain extends Case {
 
 	static defaultConditions = { patt: '' };
 	static fields = ['post links to the domain ', { type: 'text', id: 'patt' }];
-	static reconcilable = true;
+	static reconcile = Case.reconcileRegEx;
 
 	static pattern = 'RegEx';
 

--- a/lib/modules/filteReddit/postCases/LinkFlair.js
+++ b/lib/modules/filteReddit/postCases/LinkFlair.js
@@ -10,7 +10,7 @@ export class LinkFlair extends Case {
 
 	static defaultConditions = { patt: '' };
 	static fields = ['post has link flair matching ', { type: 'text', id: 'patt' }];
-	static reconcilable = true;
+	static reconcile = Case.reconcileRegEx;
 
 	static pattern = '[RegEx]';
 

--- a/lib/modules/filteReddit/postCases/PostTitle.js
+++ b/lib/modules/filteReddit/postCases/PostTitle.js
@@ -9,7 +9,7 @@ export class PostTitle extends Case {
 
 	static defaultConditions = { patt: '' };
 	static fields = ['post\'s title contains ', { type: 'text', id: 'patt' }];
-	static reconcilable = true;
+	static reconcile = Case.reconcileRegEx;
 
 	static pattern = 'RegEx';
 

--- a/lib/modules/filteReddit/postCases/Subreddit.js
+++ b/lib/modules/filteReddit/postCases/Subreddit.js
@@ -10,7 +10,7 @@ export class Subreddit extends Case {
 
 	static defaultConditions = { patt: '' };
 	static fields = ['posted in /r/', { type: 'text', id: 'patt' }];
-	static reconcilable = true;
+	static reconcile = Case.reconcileRegEx;
 
 	static pattern = 'RegEx';
 

--- a/lib/modules/filteReddit/postCases/UserFlair.js
+++ b/lib/modules/filteReddit/postCases/UserFlair.js
@@ -10,7 +10,7 @@ export class UserFlair extends Case {
 
 	static defaultConditions = { patt: '' };
 	static fields = ['author of this post has flair matching ', { type: 'text', id: 'patt' }];
-	static reconcilable = true;
+	static reconcile = Case.reconcileRegEx;
 
 	static pattern = '[RegEx]';
 

--- a/lib/modules/filteReddit/postCases/Username.js
+++ b/lib/modules/filteReddit/postCases/Username.js
@@ -10,7 +10,7 @@ export class Username extends Case {
 
 	static defaultConditions = { patt: '' };
 	static fields = ['posted by /u/', { type: 'text', id: 'patt' }];
-	static reconcilable = true;
+	static reconcile = Case.reconcileRegEx;
 
 	static pattern = 'RegEx';
 


### PR DESCRIPTION
When reconcilable RegEx cases are found, sources with same flags are joined with `|`. Testing one big RegEx is considerably cheaper than testing many small. This was especially noticeable when having 40000 filtered users.

Tested in browser: Chrome 72, Firefox 65
