### PR TITLE
keyboardNavigation: Fix toggling expandos causing undesired scrolling

### DIFF
--- a/lib/modules/pageNavigator.js
+++ b/lib/modules/pageNavigator.js
@@ -3,7 +3,7 @@
 import _ from 'lodash';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
-import { getHeaderOffset, isPageType, scrollTo, frameThrottle, string, watchForThings } from '../utils';
+import { getHeaderOffset, isPageType, frameThrottle, scrollToElement, string, watchForThings } from '../utils';
 import { i18n } from '../environment';
 import * as Floater from './floater';
 import * as SettingsNavigation from './settingsNavigation';
@@ -61,7 +61,7 @@ function backToTop() {
 	const $backToTop = $(`<a class="pageNavigator res-icon" data-id="top" href="#header" title="${i18n('pageNavToTopTitle')}">&#xF148;</a>`);
 	$backToTop.on('click', (e: Event) => {
 		e.preventDefault();
-		scrollTo(0, 0);
+		window.scrollTo(0, 0);
 		SelectedEntry.move('top');
 	});
 	Floater.addElement($backToTop);
@@ -158,7 +158,7 @@ const showLinkTitle = _.once(submissionThing => {
 			if (!belowSubmission) hideWidget();
 		}, { rootMargin: '100px 0px 0px 0px' }).observe(submissionThing.element);
 
-		window.addEventListener('scroll', () => { if (scrollTo.isProgrammaticEvent()) hideWidget(); });
+		window.addEventListener('scroll', () => { if (scrollToElement.isProgrammaticEvent()) hideWidget(); });
 	});
 
 	window.addEventListener('wheel', updateWidget, { passive: true });

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -723,7 +723,10 @@ export function toggleThingExpandos(thing: Thing, { scrollOnToggle }: {| scrollO
 	if (openExpandos.length) {
 		for (const expando of openExpandos) expando.collapse();
 
-		if (scrollOnToggle) scrollToElement(thing.entry, null, { scrollStyle: 'directional' });
+		if (scrollOnToggle) {
+			// Only scroll downwards to the top of the entry, to make more space for the expandos
+			scrollToElement(thing.entry, null, { scrollStyle: 'directional', restrictDirectionTo: 'up' });
+		}
 	} else {
 		for (const expando of expandos) {
 			if (
@@ -734,7 +737,10 @@ export function toggleThingExpandos(thing: Thing, { scrollOnToggle }: {| scrollO
 			}
 		}
 
-		if (scrollOnToggle) scrollToElement(thing.entry, null, { scrollStyle: 'top' });
+		if (scrollOnToggle) {
+			// Only scroll downwards to the top of the entry, to make more space for the expandos
+			scrollToElement(thing.entry, null, { scrollStyle: 'top', restrictDirectionTo: 'down' });
+		}
 	}
 }
 

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -220,11 +220,13 @@ function padBottom(scrollTop, viewportHeight) {
 	}
 }
 
+let recentScroll = false;
+
 export type ScrollStyle = 'none' | 'top' | 'adopt' | 'middle' | 'page' | 'legacy' | 'directional';
 type Direction = 'up' | 'down';
 type Anchor = {| to: number, from: ?number |};
 
-export function scrollToElement(to: HTMLElement, from: ?HTMLElement, { scrollStyle, direction: selectedDirection, anchor }: {| scrollStyle: ScrollStyle, direction?: Direction, anchor?: Anchor |}): void {
+export function scrollToElement(to: HTMLElement, from: ?HTMLElement, { scrollStyle, restrictDirectionTo, direction: selectedDirection, anchor }: {| scrollStyle: ScrollStyle, restrictDirectionTo?: Direction, direction?: Direction, anchor?: Anchor |}): void {
 	if (scrollStyle === 'none') {
 		if (anchor && typeof anchor.to === 'number') {
 			const diff = to.getBoundingClientRect().top - anchor.to;
@@ -245,10 +247,13 @@ export function scrollToElement(to: HTMLElement, from: ?HTMLElement, { scrollSty
 		scrollStyle = 'top';
 	}
 
+	let compensateHeader = true;
+	let scrollY;
+
 	if (scrollStyle === 'top') {
 		// Always scroll element to top of page; pad bottom if necessary
 		padBottom(top, viewport.height);
-		scrollTo(0, top);
+		scrollY = top;
 	} else if (from && scrollStyle === 'adopt') {
 		// Replace the viewport position of `from` with `element`
 		const fromTop = anchor && typeof anchor.from === 'number' ?
@@ -264,7 +269,8 @@ export function scrollToElement(to: HTMLElement, from: ?HTMLElement, { scrollSty
 			diff += fromTop - viewport.height + 60;
 		}
 
-		scrollTo(0, window.scrollY + diff, false);
+		scrollY = window.scrollY + diff;
+		compensateHeader = false;
 	} else if (scrollStyle === 'middle') {
 		const buffer = (viewport.height - target.height) / 2;
 		const newScrollY = top - buffer;
@@ -275,45 +281,44 @@ export function scrollToElement(to: HTMLElement, from: ?HTMLElement, { scrollSty
 			if (viewportDirection !== selectedDirection) return;
 		}
 
-		scrollTo(0, newScrollY);
+		scrollY = newScrollY;
 	} else if (target.top >= 0 && target.bottom <= viewport.height) {
 		// Element is already completely inside viewport
 		// (remember, top and bottom are relative to viewport)
 		// do nothing
 	} else if (scrollStyle === 'legacy') {
 		// Element not completely in viewport, so scroll to top
-		scrollTo(0, top);
+		scrollY = top;
 	} else if (target.top < viewport.yOffset) {
 		// Element starts above viewport
 		// So, align top of element to top of viewport
-		scrollTo(0, top);
+		scrollY = top;
 	} else if (viewport.height < target.bottom &&
 		target.height < viewport.height) {
 		// Visible part of element starts or extends below viewport
 		if (scrollStyle === 'page') {
-			scrollTo(0, top);
+			scrollY = top;
 		} else {
 			// So, align bottom of target to bottom of viewport
-			scrollTo(0, viewport.top + target.bottom - viewport.height);
+			scrollY = viewport.top + target.bottom - viewport.height;
 		}
 	} else {
 		// Visible part of element below the viewport but it'll fill the viewport, or fallback
 		// So, align top of element to top of viewport
-		scrollTo(0, top);
+		scrollY = top;
+	}
+
+	if (scrollY !== undefined) {
+		if (compensateHeader) scrollY -= getHeaderOffset();
+		const scollDirection = scrollY > viewport.top ? 'down' : 'up';
+		if (viewport.top === scrollY || (restrictDirectionTo && restrictDirectionTo !== scollDirection)) return;
+		window.scrollTo(0, scrollY);
+		recentScroll = true;
+		waitForEvent(window, 'scroll').then(() => { recentScroll = false; });
 	}
 }
 
-let recentScroll = false;
-
-export function scrollTo(x: number, y: number, compensateHeader: boolean = true): void {
-	recentScroll = true;
-	waitForEvent(window, 'scroll').then(() => { recentScroll = false; });
-
-	const headerOffset = compensateHeader ? getHeaderOffset() : 0;
-	window.scrollTo(x, y - headerOffset);
-}
-
-scrollTo.isProgrammaticEvent = (): boolean => recentScroll;
+scrollToElement.isProgrammaticEvent = (): boolean => recentScroll;
 
 // Automatically scroll elements vertically when the cursor is close to its edge
 export class EdgeScroll {

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -51,7 +51,6 @@ export {
 	getHeaderOffset,
 	getD2xBodyOffset,
 	getPercentageVisibleYAxis,
-	scrollTo,
 	scrollToElement,
 	waitForChild,
 	waitForDescendant,


### PR DESCRIPTION
Only scroll downwards if that makes it possible to see more of the post.

Tested in browser: Chrome 71, Firefox 65
