### PR TITLE
Fix Google Drive causing CORS issues for some Firefox users

### DIFF
--- a/edge/manifest.json
+++ b/edge/manifest.json
@@ -72,6 +72,7 @@
 		"https://api.tumblr.com/v2/blog/*/posts",
 		"https://xkcd.com/*/info.0.json",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
+		"https://*.googleusercontent.com/download/drive/v3/*",
 		"https://content.googleapis.com/drive/v3/*",
 
 		"https://api.photobucket.com/v2/media/fromurl",

--- a/firefox/beta/manifest.json
+++ b/firefox/beta/manifest.json
@@ -81,6 +81,7 @@
 		"https://api.tumblr.com/v2/blog/*/posts",
 		"https://xkcd.com/*/info.0.json",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
+		"https://*.googleusercontent.com/download/drive/v3/*",
 		"https://content.googleapis.com/drive/v3/*"
 	],
 	"web_accessible_resources": [

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -81,6 +81,7 @@
 		"https://api.tumblr.com/v2/blog/*/posts",
 		"https://xkcd.com/*/info.0.json",
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
+		"https://*.googleusercontent.com/download/drive/v3/*",
 		"https://content.googleapis.com/drive/v3/*"
 	],
 	"web_accessible_resources": [

--- a/lib/modules/backupAndRestore/providers/GoogleDrive.js
+++ b/lib/modules/backupAndRestore/providers/GoogleDrive.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-import { Base64 } from 'js-base64';
 import { ajax, launchAuthFlow } from '../../../environment';
 import { Alert } from '../../../utils';
 import { Provider } from './Provider';
@@ -20,7 +19,7 @@ export class GoogleDrive extends Provider {
 			domain: `https://accounts.google.com/o/oauth2/v2/auth?login_hint=${googleLoginHint}`,
 			clientId: '568759524377-nv0o2u4afuuulkfcjd7f6guf27qkevpt.apps.googleusercontent.com',
 			scope: 'https://www.googleapis.com/auth/drive.appdata',
-			permissions: process.env.BUILD_TARGET === 'firefox' ? ['https://content.googleapis.com/drive/v3/*'] : ['https://accounts.google.com/o/oauth2/v2/auth'],
+			permissions: process.env.BUILD_TARGET === 'firefox' ? ['https://*.googleusercontent.com/download/drive/v3/*', 'https://content.googleapis.com/drive/v3/*'] : ['https://content.googleapis.com/drive/v3/*', 'https://accounts.google.com/o/oauth2/v2/auth'],
 		}, async message => {
 			await Alert.open(`
 				<p><b>RES needs your permission to backup to Google Drive.</b></p>
@@ -60,16 +59,12 @@ export class GoogleDrive extends Provider {
 	async read() {
 		const file = await this.getExistingFile();
 		if (!file) throw new Error('Could not find backup.');
-		const data = await ajax({
+		return ajax({
 			method: 'GET',
 			url: `https://content.googleapis.com/drive/v3/files/${file.id}`,
 			query: { alt: 'media' },
-			headers: {
-				'x-goog-encode-response-if-executable': 'base64', // Download immediately (Edge 15 appears to not handle the 307s properly)
-				Authorization: `Bearer ${this.accessToken}`,
-			},
+			headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${this.accessToken}` },
 		});
-		return Base64.decode(data);
 	}
 
 	async write(data: string) {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "jquery": "3.3.1",
     "jquery-sortable": "0.9.13",
     "jquery.tokeninput": "Reddit-Enhancement-Suite/jquery-tokeninput#v2.0.1",
-    "js-base64": "2.4.9",
     "lodash": "4.17.11",
     "moment": "2.22.2",
     "numeral": "2.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4904,11 +4904,6 @@ jquery@^2.1.2:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
   integrity sha1-LInWiJterFIqfuoywUUhVZxsvwI=
 
-js-base64@2.4.9:
-  version "2.4.9"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.9.tgz#748911fb04f48a60c4771b375cac45a80df11c03"
-  integrity sha512-xcinL3AuDJk7VSzsHgb9DvvIXayBbadtMZ4HFPx8rUszbW1MuNMlwYVC4zzCZ6e1sqZpnNS5ZFYOhXqA39T7LQ==
-
 js-levenshtein@^1.1.3:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.4.tgz#3a56e3cbf589ca0081eb22cd9ba0b1290a16d26e"


### PR DESCRIPTION
Additional permissions are seemingly necessary. This is also removes workaround for earlier Edge versions.

Tested in browser:  Chrome 71, Firefox 65