### PR TITLE
new module: Request all optional permissions

### DIFF
--- a/lib/modules/requestPermissions.js
+++ b/lib/modules/requestPermissions.js
@@ -1,0 +1,44 @@
+/* @flow */
+
+import { Module } from '../core/module';
+
+export const module: Module<*> = new Module('requestPermissions');
+
+module.moduleName = 'requestPermissionsName';
+module.description = 'requestPermissionsDesc';
+module.category = 'aboutCategory';
+module.disabledByDefault = true;
+module.permissions = {
+	// TODO Find some way to keep in sync with manifests
+	requiredPermissions: process.env.BUILD_TARGET === 'firefox' ? [
+		'downloads',
+
+		'https://api.twitter.com/*',
+		'https://backend.deviantart.com/oembed',
+		'https://api.gyazo.com/api/oembed',
+		'https://codepen.io/api/oembed',
+		'https://api.tumblr.com/v2/blog/*/posts',
+		'https://xkcd.com/*/info.0.json',
+		'https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*',
+		'https://*.googleusercontent.com/download/drive/v3/*',
+		'https://content.googleapis.com/drive/v3/*',
+	] : [
+		'downloads',
+
+		'https://api.twitter.com/*',
+		'https://backend.deviantart.com/oembed',
+		'https://api.gyazo.com/api/oembed',
+		'https://codepen.io/api/oembed',
+		'https://api.tumblr.com/v2/blog/*/posts',
+		'https://xkcd.com/*/info.0.json',
+		'https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*',
+		'https://*.googleusercontent.com/download/drive/v3/*',
+		'https://content.googleapis.com/drive/v3/*',
+
+		'https://redditenhancementsuite.com/oauth',
+		'https://accounts.google.com/o/oauth2/v2/auth',
+		'https://www.dropbox.com/oauth2/authorize',
+		'https://login.live.com/oauth20_authorize.srf',
+	],
+	message: 'This will open a prompt for all remaining optional permissionss',
+};

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -2876,6 +2876,12 @@
 	"quickMessageLinkToCurrentPageDesc": {
 		"message": "Automatically start with a link to the current page in the message body (or, if opened from the user info popup, a link to the current post or comment)."
 	},
+	"requestPermissionsName": {
+		"message": "Request Permissions"
+	},
+	"requestPermissionsDesc": {
+		"message": "Grant optional permissions now so that prompts won't appear later.\n\nIf no prompt appears when enabling this, permissions are already granted."
+	},
 	"RESTipsDailyTipDesc": {
 		"message": "Show a random tip once every 24 hours."
 	},


### PR DESCRIPTION
Useful for doing it once and for all, and for testing the optional permissions system.

Must be manually kept in sync with the browers' manifests.

Tested in browser: Firefox 65, Chrome 71
