### PR TITLE
Don't reload RES on active pages after upgrade

### DIFF
--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -21,6 +21,13 @@ let start;
 export function init() {
 	if (location.hash === RES_DISABLED_HASH) return;
 
+	if (document.documentElement && document.documentElement.classList.contains('res')) {
+		// Firefox reloads the extension on all active pages when upgrading
+		// RES doeesn't handle that well
+		document.documentElement.classList.add('res-page-requires-reload');
+		throw new Error('RES has already been loaded on this page.');
+	}
+
 	// Testing requires access to the options page,
 	// and I couldn't figure out a way to find the extension URL in Nightwatch
 	if (location.hash.startsWith(RES_SETTINGS_REDIRECT_TO_STANDALONE_HASH)) {

--- a/lib/css/res.scss
+++ b/lib/css/res.scss
@@ -1118,3 +1118,17 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 		display: none;
 	}
 }
+
+.res-page-requires-reload::before {
+	position: fixed;
+	content: 'This page must be reloaded for Reddit Extension Suite to function correctly';
+	right: 20px;
+	bottom: 20px;
+	z-index: 99999999;
+	color: red;
+	font-size: 1em;
+	background-color: wheat;
+	padding: 3px;
+	border-radius: 3px;
+	opacity: 0.5;
+}


### PR DESCRIPTION
Firefox reloads the extension on all active pages when upgrading the it, which causes issues because they all starts loading at the same time, and adds elements to Reddit without removing the old ones.

This change makes the load stop if it is noticed that the document already has the `res` class, and instead a prompt to reload the page is added:
![image](https://user-images.githubusercontent.com/1748521/51625649-01ca9d80-1f3e-11e9-823d-d5cebf917647.png)


Tested in browser: Firefox 65, Chrome 71
