### PR TITLE
Fix 3rd party cookie blocking issue on Firefox [Externally blocked]

### DIFF
--- a/lib/environment/background/ajax.js
+++ b/lib/environment/background/ajax.js
@@ -3,18 +3,16 @@
 import _ from 'lodash';
 import { addListener } from './messaging';
 
-addListener('ajax', async ({ method, url, headers, data, credentials }) => {
-	const rawResponse = await fetch(url, {
+addListener('ajax', ({ method, url, headers, body, credentials }) => (
+	fetch(url, {
 		method,
 		headers,
 		credentials,
-		body: data,
-	});
-
-	return {
-		ok: rawResponse.ok,
-		status: rawResponse.status,
-		headers: _.fromPairs(Array.from(rawResponse.headers.entries())),
-		text: await rawResponse.text(),
-	};
-});
+		body,
+	}).then(async r => ({
+		ok: r.ok,
+		status: r.status,
+		headers: _.fromPairs(Array.from(r.headers.entries())),
+		text: await r.text(),
+	}))
+));

--- a/lib/environment/foreground/ajax.js
+++ b/lib/environment/foreground/ajax.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-import _ from 'lodash';
 import { context } from '../../environment';
 import { sendMessage } from './messaging';
 import * as XhrCache from './xhrCache';
@@ -50,7 +49,7 @@ declare function ajax(opt: AjaxOptions<'raw'>): Promise<{
  * `cacheFor` is a TTL, in milliseconds.
  */
 export async function ajax(options: AjaxOptions<*>) {
-	const { method, url, headers, data, type, cacheFor, sameOrigin, credentials } = buildRequestParams(options);
+	const { method, url, headers, data: body, type, cacheFor, credentials } = buildRequestParams(options);
 
 	if (cacheFor) {
 		const cached = await XhrCache.check(url, cacheFor);
@@ -59,20 +58,7 @@ export async function ajax(options: AjaxOptions<*>) {
 		}
 	}
 
-	const response = await (sameOrigin ?
-		fetch(url, {
-			method,
-			headers,
-			credentials,
-			body: data,
-		}).then(async r => ({
-			ok: r.ok,
-			status: r.status,
-			headers: _.fromPairs(Array.from(r.headers.entries())),
-			text: await r.text(),
-		})) :
-		sendMessage('ajax', { method, url, headers, data, credentials })
-	);
+	const response = await sendMessage('ajax', { method, url, headers, body, credentials });
 
 	if (!response.ok) {
 		throw new FetchError(url, response.status);
@@ -96,20 +82,19 @@ function buildRequestParams({ method = 'GET', url, query = {}, headers = {}, dat
 	data: string | void,
 	type: ResponseType,
 	cacheFor: number,
-	sameOrigin: boolean,
 	credentials: 'omit' | 'include',
 |} {
-	const siteOrigin = new URL(context.origin);
+	const siteURL = new URL(context.origin);
 
 	// Expand relative URLs
-	const requestURL = new URL(url, siteOrigin);
+	const requestURL = new URL(url, siteURL);
 
 	// Append query string to URL
 	for (const [key, val] of Object.entries(query)) {
 		requestURL.searchParams.set(key, String(val));
 	}
 
-	const sameSite = requestURL.hostname.split('.').slice(-2).join('.') === siteOrigin.hostname.split('.').slice(-2).join('.');
+	const sameSite = requestURL.hostname.split('.').slice(-2).join('.') === siteURL.hostname.split('.').slice(-2).join('.');
 	if (sameSite) {
 		// Add `app=res` to same-origin request URLs
 		requestURL.searchParams.set('app', 'res');
@@ -128,8 +113,6 @@ function buildRequestParams({ method = 'GET', url, query = {}, headers = {}, dat
 		requestURL.hostname = requestURL.hostname.replace(/new\./, 'www.');
 	}
 
-	const sameOrigin = siteOrigin.origin === requestURL.origin;
-
 	// Convert plain data objects to application/x-www-form-urlencoded
 	if (typeof data === 'object') {
 		headers['Content-Type'] = 'application/x-www-form-urlencoded';
@@ -146,7 +129,6 @@ function buildRequestParams({ method = 'GET', url, query = {}, headers = {}, dat
 		type,
 		cacheFor,
 		credentials: credentials || 'omit',
-		sameOrigin,
 	};
 }
 


### PR DESCRIPTION
Firefox 66 (nightly) [includes a fix](https://bugzilla.mozilla.org/show_bug.cgi?id=1509112) which allows users who have "Block all third-party cookies" enabled, to make requests to (manifest) permitted URLs from the background. Those requests includes cookies, and as such makes it unnecessary for the user to whitelist third-party domains to be able to use neverEndingReddit etc.

- [ ] Since the fix won't be LTS before in July, requests must still, by default, be sent in foreground.  A way to check whether cookies have been blocked, and only then try the background, is necessary.
- [ ] A fallback method may also be used to work around uMatrix etc blocking requests

Tested in browser: Firefox 66 (works), Firefox 65 (doesn't work)
