### PR TITLE
Filter list optimization

### DIFF
--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -780,7 +780,15 @@ export async function saveFilterlineStateAsDefault(type: string) {
 }
 
 function getStringMatchConditions(source, caseType, additionalCriteria) {
-	const [matchString = '', applyTo = 'everywhere', applyList = '', except = ''] = Array.isArray(source) ? source : [source];
+	const [matchString = '', applyTo = 'everywhere', applyList = '', except = ''] = source;
+
+	const mainFilter = {
+		type: caseType,
+		patt: matchString,
+		...additionalCriteria,
+	};
+
+	if (source.length === 1) return mainFilter;
 
 	let applyToConditions;
 	if (applyTo !== 'everywhere') {
@@ -815,11 +823,7 @@ function getStringMatchConditions(source, caseType, additionalCriteria) {
 		// applyTo filtering
 		applyToConditions || null,
 		// main filter
-		{
-			type: caseType,
-			patt: matchString,
-			...additionalCriteria,
-		},
+		mainFilter,
 		// filter exclusions
 		(except && except.length) && Cases.getGroup('none', [{
 			type: caseType,

--- a/lib/modules/filteReddit/Case.js
+++ b/lib/modules/filteReddit/Case.js
@@ -73,32 +73,21 @@ export class Case {
 		return cased;
 	}
 
-	static buildRegex(string: string, { allowEmptyString = false, fullMatch = true }: {| allowEmptyString?: boolean, fullMatch?: boolean |} = {}) {
+	static buildRegex(string: string, { fullMatch = true }: {| fullMatch?: boolean |} = {}) {
+		if (!string) throw new Error('String cannot be empty');
 		if (regexRegex.test(string)) {
 			const [, str, flags] = (regexRegex.exec(string): any); // guaranteed to match due to `.test()` above
 			return new RegExp(str, flags);
 		} else {
-			if (!allowEmptyString && !string) throw new Error('String cannot be empty');
 			const patt = _.escapeRegExp(string);
 			return new RegExp(fullMatch ? `^${patt}$` : patt, 'i');
 		}
 	}
 
-	static reconcileRegEx(values: *) {
-		const variants = {};
-		for (const value of values) {
-			const flags = process.env.BUILD_TARGET === 'edge' ? value.options : value.flags;
-			if (!variants[flags]) { variants[flags] = []; }
-			variants[flags].push(value.source);
-		}
-		return Object.entries(variants).map<*>(([flags, sources]) => new RegExp(sources.join('|'), flags));
-	}
-
-	static reconcile: ?() => Array<*>; // // `evaluate` supports 2nd argument `values` which is an array of same-class `value`
-
 	static +defaultConditions: ?$Shape<BuilderValue>;
 	static fields: *;
 	static slow: number = 0; // Estimated slowness of case; higher value → slower
+	static +reconcile: ?Array<*> => *;
 	static get disabled(): boolean {
 		return false;
 	}
@@ -152,4 +141,45 @@ export class Case {
 			o.refresh(false, thing);
 		}
 	}
+}
+
+export class PatternCase extends Case {
+	static build(_raw: string | Array<string>, { fullMatch = true }: {| fullMatch?: boolean |} = {}): Array<*> {
+		const raws = Array.isArray(_raw) ? _raw : [_raw];
+
+		const strings = new Set();
+		const variants = {};
+
+		for (const raw of raws) {
+			if (regexRegex.test(raw)) {
+				const [, str, flags = ''] = (regexRegex.exec(raw): any); // guaranteed to match due to `.test()` above
+				if (!variants[flags]) variants[flags] = [];
+				variants[flags].push(str);
+			} else {
+				const patt = _.escapeRegExp(raw);
+				strings.add(patt);
+			}
+		}
+
+		if (strings.size) {
+			const str = Array.from(strings).join('|');
+			if (!variants.i) variants.i = [];
+			variants.i.push(fullMatch ? `^(${str})$` : str);
+		}
+
+		return Object.entries(variants).map<*>(([flags, sources]) => new RegExp(sources.join('|'), flags));
+	}
+
+	static parseCriterion(input: *) { return { patt: input }; }
+	static defaultConditions = { patt: '' }; // Patt may also be an array of strings, and have `fullMatch` specified
+	static pattern = 'RegEx';
+
+	static reconcile(values: *) {
+		const a = values[0];
+		if (!a) throw new Error('No values');
+		const patt = values.map(v => v.patt);
+		return { type: a.type, patt };
+	}
+
+	value: Array<RegExp> = PatternCase.build(this.conditions.patt, { fullMatch: this.conditions.fullMatch });
 }

--- a/lib/modules/filteReddit/cases.js
+++ b/lib/modules/filteReddit/cases.js
@@ -42,12 +42,9 @@ export class Group extends Case {
 	static +defaultConditions = { op: 'all', of: [] };
 	static slow = 1; // May be considerably slower depending on children
 
-	_cases = _.sortBy(
-		this.conditions.of.map(v => Case.fromConditions(v)),
-		v => v.constructor.slow,
-		v => v.constructor.type
-	);
+	_cases = this.conditions.of.map(v => Case.fromConditions(v));
 
+	// TODO This is unnecessary for some external filters
 	trueText = this._cases.length && this.toCriterion(this.conditions.op, this._cases) || 'empty group';
 
 	toCriterion(op: *, cases: *) {
@@ -63,31 +60,9 @@ export class Group extends Case {
 		const op = this.conditions.op;
 		const [NONE, ANY, ONE, ALL] = [op === 'none', op === 'any', op === 'one', op === 'all'];
 
-		const evaluators = [];
-
-		const cases = this._cases;
-		const l = cases.length;
-		for (let i = 0; i < l; i++) { // eslint-disable-line no-restricted-syntax
-			const caseA = cases[i];
-			if (caseA instanceof Inert) throw new Error('Group can not contain inert case');
-
-			const evaluate = caseA.evaluate.bind(caseA);
-			const reconcile = (ANY || NONE) && caseA.constructor.reconcile;
-			if (reconcile) {
-				const values = [caseA.value];
-				let caseB;
-				// Look for more cases of same type
-				while ((caseB = cases[i + 1]) && caseA.constructor === caseB.constructor) {
-					i++;
-					values.push(caseB.value);
-				}
-
-				const reconciled = reconcile(values);
-				evaluators.push(thing => evaluate(thing, reconciled));
-			} else {
-				evaluators.push(evaluate);
-			}
-		}
+		const evaluators = this._cases
+			.sort((a, b) => a.constructor.slow - b.constructor.slow)
+			.map(cased => cased.evaluate.bind(cased));
 
 		return fastAsync(function*(thing) {
 			let seenTrue = false;
@@ -132,7 +107,7 @@ declare function resolveGroup(GroupConditions, ?boolean, ?boolean): BuilderValue
 export function resolveGroup(initial: GroupConditions, precompute: boolean = true, keepGroup: boolean = false) {
 	let seenTrue = false;
 
-	const of = [];
+	let of = [];
 	let op = initial.op;
 
 	for (let v of initial.of) {
@@ -189,6 +164,30 @@ export function resolveGroup(initial: GroupConditions, precompute: boolean = tru
 			if (op === 'any') return falseConditions;
 			if (op === 'one') return falseConditions;
 			if (op === 'all') return trueConditions;
+		}
+	}
+
+	if (precompute && (op === 'any' || op === 'all')) {
+		const l = of.length;
+		const typeSorted = of.sort((a, b) => a.type === b.type ? 0 : a.type > b.type ? 1 : -1);
+		of = [];
+		for (let i = 0; i < l; i++) { // eslint-disable-line no-restricted-syntax
+			const a = typeSorted[i];
+			const cls = available[a.type];
+			const reconcile = cls.reconcile;
+			if (reconcile) {
+				const values = [a];
+				let b;
+				// Look for more cases of same type
+				while ((b = typeSorted[i + 1]) && a.type === b.type) {
+					i++;
+					values.push(b);
+				}
+
+				of.push(reconcile(values));
+			} else {
+				of.push(a);
+			}
 		}
 	}
 

--- a/lib/modules/filteReddit/commentCases/CommentContent.js
+++ b/lib/modules/filteReddit/commentCases/CommentContent.js
@@ -1,25 +1,21 @@
 /* @flow */
 
-import { Case } from '../Case';
+import { PatternCase } from '../Case';
 
-export class CommentContent extends Case {
+export class CommentContent extends PatternCase {
 	static text = 'Comment content';
 
 	static parseCriterion(input: *) { return { patt: input }; }
 
-	static defaultConditions = { patt: '' };
 	static fields = ['comment contains ', { type: 'text', id: 'patt' }];
-	static reconcile = Case.reconcileRegEx;
-
-	static pattern = 'RegEx';
 
 	trueText = `comment contains ${this.conditions.patt}`;
 
-	value = Case.buildRegex(this.conditions.patt, { fullMatch: false });
+	value = PatternCase.build(this.conditions.patt, { fullMatch: false });
 
-	evaluate(thing: *, values: * = [this.value]) {
+	evaluate(thing: *) {
 		const body = thing.getTextBody();
 		if (!body) return null;
-		return values.some(v => v.test(body.textContent));
+		return this.value.some(v => v.test(body.textContent));
 	}
 }

--- a/lib/modules/filteReddit/postCases/Domain.js
+++ b/lib/modules/filteReddit/postCases/Domain.js
@@ -1,26 +1,19 @@
 /* @flow */
 
-import { Case } from '../Case';
+import { PatternCase } from '../Case';
 
-export class Domain extends Case {
+export class Domain extends PatternCase {
 	static text = 'Link domain name';
 
-	static parseCriterion(input: *) { return { patt: input }; }
 	static thingToCriterion(thing: *) { return thing.getPostDomain(); }
 
-	static defaultConditions = { patt: '' };
 	static fields = ['post links to the domain ', { type: 'text', id: 'patt' }];
-	static reconcile = Case.reconcileRegEx;
-
-	static pattern = 'RegEx';
 
 	trueText = `domain ${this.conditions.patt}`;
 
-	value = (({ patt, fullMatch = true }) => Case.buildRegex(patt, { fullMatch }))(this.conditions);
-
-	evaluate(thing: *, values: * = [this.value]) {
+	evaluate(thing: *) {
 		const domain = thing.getPostDomain();
 		if (!domain) return null;
-		return values.some(v => v.test(domain));
+		return this.value.some(v => v.test(domain));
 	}
 }

--- a/lib/modules/filteReddit/postCases/LinkFlair.js
+++ b/lib/modules/filteReddit/postCases/LinkFlair.js
@@ -1,25 +1,20 @@
 /* @flow */
 
-import { Case } from '../Case';
+import { PatternCase } from '../Case';
 
-export class LinkFlair extends Case {
+export class LinkFlair extends PatternCase {
 	static text = 'Link flair';
 
-	static parseCriterion(input: *) { return { patt: input }; }
 	static thingToCriterion(thing: *) { return thing.getPostFlairText(); }
 
-	static defaultConditions = { patt: '' };
 	static fields = ['post has link flair matching ', { type: 'text', id: 'patt' }];
-	static reconcile = Case.reconcileRegEx;
 
 	static pattern = '[RegEx]';
 
 	trueText = `link flair ${this.conditions.patt}`.trim();
 
-	value = (({ patt, fullMatch = true }) => Case.buildRegex(patt || '/./', { fullMatch, allowEmptyString: true }))(this.conditions);
-
-	evaluate(thing: *, values: * = [this.value]) {
+	evaluate(thing: *) {
 		const text = thing.getPostFlairText();
-		return values.some(v => v.test(text));
+		return this.value.some(v => v.test(text));
 	}
 }

--- a/lib/modules/filteReddit/postCases/PostTitle.js
+++ b/lib/modules/filteReddit/postCases/PostTitle.js
@@ -1,24 +1,18 @@
 /* @flow */
 
-import { Case } from '../Case';
+import { PatternCase } from '../Case';
 
-export class PostTitle extends Case {
+export class PostTitle extends PatternCase {
 	static text = 'Post title';
 
-	static parseCriterion(input: *) { return { patt: input }; }
-
-	static defaultConditions = { patt: '' };
 	static fields = ['post\'s title contains ', { type: 'text', id: 'patt' }];
-	static reconcile = Case.reconcileRegEx;
-
-	static pattern = 'RegEx';
 
 	trueText = `title contains ${this.conditions.patt}`;
 
-	value = Case.buildRegex(this.conditions.patt, { fullMatch: false });
+	value = PatternCase.build(this.conditions.patt, { fullMatch: false });
 
-	evaluate(thing: *, values: * = [this.value]) {
+	evaluate(thing: *) {
 		const title = thing.getTitle();
-		return values.some(v => v.test(title));
+		return this.value.some(v => v.test(title));
 	}
 }

--- a/lib/modules/filteReddit/postCases/Subreddit.js
+++ b/lib/modules/filteReddit/postCases/Subreddit.js
@@ -1,26 +1,19 @@
 /* @flow */
 
-import { Case } from '../Case';
+import { PatternCase } from '../Case';
 
-export class Subreddit extends Case {
+export class Subreddit extends PatternCase {
 	static text = 'Subreddit';
 
 	static thingToCriterion(thing: *) { return thing.getSubreddit(); }
-	static parseCriterion(input: string) { return { patt: input }; }
 
-	static defaultConditions = { patt: '' };
 	static fields = ['posted in /r/', { type: 'text', id: 'patt' }];
-	static reconcile = Case.reconcileRegEx;
-
-	static pattern = 'RegEx';
 
 	trueText = `in ${this.conditions.patt}`;
 
-	value = Case.buildRegex(this.conditions.patt);
-
-	evaluate(thing: *, values: * = [this.value]) {
+	evaluate(thing: *) {
 		const subreddit = thing.getSubreddit();
 		if (!subreddit) return null;
-		return values.some(v => v.test(subreddit));
+		return this.value.some(v => v.test(subreddit));
 	}
 }

--- a/lib/modules/filteReddit/postCases/UserFlair.js
+++ b/lib/modules/filteReddit/postCases/UserFlair.js
@@ -1,25 +1,22 @@
 /* @flow */
 
-import { Case } from '../Case';
+import { PatternCase } from '../Case';
 
-export class UserFlair extends Case {
+export class UserFlair extends PatternCase {
 	static text = 'User flair';
 
-	static parseCriterion(input: *) { return { patt: input }; }
 	static thingToCriterion(thing: *) { return thing.getUserFlairText(); }
 
-	static defaultConditions = { patt: '' };
 	static fields = ['author of this post has flair matching ', { type: 'text', id: 'patt' }];
-	static reconcile = Case.reconcileRegEx;
 
 	static pattern = '[RegEx]';
 
 	trueText = `user flair ${this.conditions.patt}`.trim();
 
-	value = Case.buildRegex(this.conditions.patt || '/./');
+	value = PatternCase.build(this.conditions.patt || '/./');
 
-	evaluate(thing: *, values: * = [this.value]) {
+	evaluate(thing: *) {
 		const text = thing.getUserFlairText();
-		return values.some(v => v.test(text));
+		return this.value.some(v => v.test(text));
 	}
 }

--- a/lib/modules/filteReddit/postCases/Username.js
+++ b/lib/modules/filteReddit/postCases/Username.js
@@ -1,26 +1,19 @@
 /* @flow */
 
-import { Case } from '../Case';
+import { PatternCase } from '../Case';
 
-export class Username extends Case {
+export class Username extends PatternCase {
 	static text = 'Username';
 
-	static parseCriterion(input: *) { return { patt: input }; }
 	static thingToCriterion(thing: *) { return thing.getAuthor(); }
 
-	static defaultConditions = { patt: '' };
 	static fields = ['posted by /u/', { type: 'text', id: 'patt' }];
-	static reconcile = Case.reconcileRegEx;
-
-	static pattern = 'RegEx';
 
 	trueText = `by ${this.conditions.patt}`;
 
-	value = Case.buildRegex(this.conditions.patt);
-
-	evaluate(thing: *, values: * = [this.value]) {
+	evaluate(thing: *) {
 		const user = thing.getAuthor();
 		if (!user) return null;
-		return values.some(v => v.test(user));
+		return this.value.some(v => v.test(user));
 	}
 }


### PR DESCRIPTION
The time spent creating and evaluating a list filter of 40000 users on 100 posts is reduced from multiple seconds to a few hundreds ms.

- Reconciles entries of same type at an earlier stage, to avoid creating a `Case` object for every entry
- Class `PatternCase` which extends `Case`, since many cases have a lot in common
- By deferring the string-to-regex build, it is easier to build more more performent regexes
  - The resulting `/^(a|b|c)$/` is must faster than the previous `/^a$|^b$|^c$/`

Tested in browser:  Chrome 71, Firefox 65