### PR TITLE
showImages: Option for muting videos by default

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -408,6 +408,12 @@ module.options = {
 		}],
 		description: 'showImagesExpandoCommentRedirectsDesc',
 	},
+	startVideosMuted: {
+		title: 'showImagesStartVideosMutedTitle',
+		type: 'boolean',
+		value: false,
+		description: 'showImagesStartVideosMutedDesc',
+	},
 	onlyPlayMutedWhenVisible: {
 		title: 'showImagesOnlyPlayMutedWhenVisibleTitle',
 		type: 'boolean',
@@ -1933,15 +1939,14 @@ const mutedVideoManager = _.once(() => {
 	};
 });
 
-const volumeStorage = Storage.wrap('showImages.video.volume', (1: number));
-
 class Video extends Media {
+	static volumeStorage = Storage.wrap('showImages.video.volume', (1: number));
+
 	video: HTMLVideoElement;
 	autoplay: boolean;
 	time: number;
 	frameRate: number;
 	useVideoManager: boolean;
-	muted: boolean;
 
 	constructor({
 		title,
@@ -1967,7 +1972,6 @@ class Video extends Media {
 		this.autoplay = muted || module.options.autoplayVideo.value;
 		this.time = time;
 		this.frameRate = frameRate;
-		this.muted = muted;
 
 		this.element = videoTemplate({
 			title,
@@ -1977,7 +1981,7 @@ class Video extends Media {
 			source,
 			// Prevent poster from flashing before the video is ready when autoplaying
 			poster: !this.autoplay && poster || '',
-			muted,
+			hasAudio: !muted,
 			loop,
 			reversable,
 			openInNewWindow: module.options.openInNewWindow.value,
@@ -2061,7 +2065,8 @@ class Video extends Media {
 		}
 
 		if (!muted) {
-			Promise.all([waitForEvent(this.video, 'canplay'), volumeStorage.get()]).then(([, volume]) => {
+			if (module.options.startVideosMuted.value) this.video.muted = true;
+			Promise.all([waitForEvent(this.video, 'canplay'), Video.volumeStorage.get()]).then(([, volume]) => {
 				this.video.volume = volume;
 			});
 		}
@@ -2146,18 +2151,21 @@ class Video extends Media {
 			const ctrlVolumeLevel = ctrlVolume.querySelector('.res-video-volume-level');
 			const volumePercentage = ctrlVolume.querySelector('.res-video-volume-percentage');
 
-			let previousLevel = 0;
 			const updateVolume = e => {
 				const base = ctrlVolumeLevel.clientHeight;
 				const click = base - e.offsetY;
-				this.video.volume = previousLevel = Math.min(click / base, 1);
-				volumeStorage.set(this.video.volume);
+				const level = Math.min(click / base, 1);
+				if (level > 0.05) {
+					this.video.volume = level;
+					this.video.muted = false;
+					Video.volumeStorage.set(level);
+				} else {
+					this.video.muted = true;
+				}
 			};
 
 			ctrlVolume.addEventListener('click', () => {
-				// $FlowIssue
-				if (this.video.volume) [previousLevel, this.video.volume] = [this.video.volume, 0];
-				else this.video.volume = previousLevel;
+				this.video.muted = !this.video.muted;
 			});
 			ctrlVolumeLevel.addEventListener('mousemove', (e: MouseEvent) => {
 				if (e.buttons === 1 /* left mouse button */) updateVolume(e);
@@ -2168,7 +2176,7 @@ class Video extends Media {
 			});
 
 			const refresh = () => {
-				ctrlVolume.setAttribute('level', String(Math.ceil(this.video.volume * 3)));
+				ctrlVolume.setAttribute('level', (this.video.muted || !this.video.volume) ? '0' : String(Math.ceil(this.video.volume * 3)));
 				volumePercentage.style.height = `${this.video.volume * 100}%`;
 			};
 

--- a/lib/modules/showImages/templates.js
+++ b/lib/modules/showImages/templates.js
@@ -90,7 +90,7 @@ export const videoTemplate = ({
 	href,
 	source,
 	poster,
-	muted,
+	hasAudio,
 	loop,
 	reversable,
 	formattedPlaybackRate,
@@ -102,7 +102,7 @@ export const videoTemplate = ({
 	href: string,
 	source?: string,
 	poster?: string,
-	muted: boolean,
+	hasAudio: boolean,
 	loop: boolean,
 	reversable: boolean,
 	formattedPlaybackRate: string,
@@ -120,7 +120,7 @@ export const videoTemplate = ({
 		`}
 		<div class="res-video-container">
 			<a class="noKeyNav" href="${href}" ${openInNewWindow && string._html`target="_blank" rel="noopener noreferrer"`}>
-				<video ${muted && 'muted'} ${loop && 'loop'} poster="${poster}"></video>
+				<video ${!hasAudio && 'muted'} ${loop && 'loop'} poster="${poster}"></video>
 			</a>
 			<div class="res-video-interface">
 				<div class="res-video-progress">
@@ -133,7 +133,7 @@ export const videoTemplate = ({
 						${reversable && string._html`
 						<div title="Reverse video" class="res-icon res-video-button res-video-reverse"></div>
 						`}
-						${!muted && string._html`
+						${hasAudio && string._html`
 							<div title="Adjust volume" class="res-icon res-video-button res-video-volume">
 								<div class="res-video-volume-level">
 									<div class="res-video-volume-percentage"></div>

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -4294,6 +4294,12 @@
 	"showImagesExpandoCommentRedirectsDesc": {
 		"message": "How should RES handle posts where the link is redirected to the comments page with preview expanded?"
 	},
+	"showImagesStartVideosMutedTitle": {
+		"message": "Videos Start Muted"
+	},
+	"showImagesStartVideosMutedDesc": {
+		"message": "Don't auto-play audio on videos."
+	},
 	"showImagesOnlyPlayMutedWhenVisibleTitle": {
 		"message": "Only Play Muted When Visible"
 	},


### PR DESCRIPTION
It might not be as granular as might be desired, but nevertheless fulfills a frequent request for v5.14.

Tested in browser: Chrome 72, Firefox 65