### PR TITLE
Replace momentjs with (much leaner) dayjs

### DIFF
--- a/lib/modules/filteReddit/browseCases/Date.js
+++ b/lib/modules/filteReddit/browseCases/Date.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import moment from 'moment';
+import { dayjs } from '../../../utils/localization';
 import { Case } from '../Case';
 
 const options = [
@@ -11,21 +11,14 @@ const options = [
 export class Date extends Case {
 	static text = 'Date';
 
-	static defaultConditions = { op: '<', date: moment().add(1, 'M').format('Y-M-D') };
+	static defaultConditions = { op: '<', date: '2020-12-30' };
 	static fields = ['today is ', { type: 'select', options, id: 'op' }, ' ', { type: 'text', id: 'date' }];
 
-	value = { op: this.conditions.op, date: moment(this.conditions.date) };
+	value = { op: this.conditions.op, date: dayjs(this.conditions.date) };
 
 	isValid() { return this.value.date.isValid(); }
 
 	evaluate() {
-		const now = moment();
-		if (this.value.op === '<') {
-			return now.isBefore(this.value.date);
-		} else if (this.value.op === '>=') {
-			return now.isSameOrAfter(this.value.date);
-		} else {
-			throw new Error('Invalid option');
-		}
+		return (this.value.op === '<') === dayjs().isBefore(this.value.date);
 	}
 }

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -10,7 +10,7 @@ import {
 	escapeHTML,
 	execRegexes,
 	filterMap,
-	formatDateDiff,
+	formatRelativeTime,
 	formatDateTime,
 	getPostMetadata,
 	isCurrentSubreddit,
@@ -445,7 +445,6 @@ async function drawSubscriptionsTable(sortMethod, descending) {
 	for (const { subscriptionDate, updateTime, id, url, title, subreddit } of thisCounts) {
 		if (subscriptionDate) {
 			const thisUpdateTime = new Date(updateTime);
-			const now = new Date();
 
 			// set up buttons.
 			const { button: thisTrashButton, promise: thisTrashPromise } = createButton(id, 'delete');
@@ -456,13 +455,13 @@ async function drawSubscriptionsTable(sortMethod, descending) {
 			thisUnsubPromise.then(drawSubscriptionsTable);
 
 			const thisExpires = new Date(subscriptionDate + (DAY * parseInt(module.options.subscriptionLength.value, 10)));
-			const thisExpiresContent = `<abbr title="${formatDateTime(thisExpires)}">${formatDateDiff(now, thisExpires)}</abbr>`;
+			const thisExpiresContent = `<abbr title="${formatDateTime(thisExpires)}">${formatRelativeTime(thisExpires)}</abbr>`;
 
 			// populate table row.
 			const thisROW = `
 				<tr data-id="${id}"><td><a href="${url}">${escapeHTML(title)}</a></td>
 				<td><a href="/r/${subreddit}">/r/${subreddit}</a></td>
-				<td><abbr title="${formatDateTime(thisUpdateTime)}">${formatDateDiff(thisUpdateTime)} ago</abbr></td>
+				<td><abbr title="${formatDateTime(thisUpdateTime)}">${formatRelativeTime(thisUpdateTime)}</abbr></td>
 				<td>${thisExpiresContent}</td><td></td></tr>
 			`;
 

--- a/lib/utils/localization.js
+++ b/lib/utils/localization.js
@@ -1,24 +1,44 @@
 /* @flow */
 
-import moment from 'moment';
+import _ from 'lodash';
 import { locale } from '../environment';
+
+// Avoid initializing dayjs before it's necessary
+const Dayjs = _.once(() => {
+	require('dayjs/locale/de'); // eslint-disable-line global-require
+	require('dayjs/locale/el'); // eslint-disable-line global-require
+	require('dayjs/locale/es'); // eslint-disable-line global-require
+	require('dayjs/locale/he'); // eslint-disable-line global-require
+	require('dayjs/locale/it'); // eslint-disable-line global-require
+	require('dayjs/locale/nl'); // eslint-disable-line global-require
+	require('dayjs/locale/pl'); // eslint-disable-line global-require
+	require('dayjs/locale/pt-br'); // eslint-disable-line global-require
+	require('dayjs/locale/pt'); // eslint-disable-line global-require
+	const dayjs = require('dayjs'); // eslint-disable-line global-require
+	dayjs.extend(require('dayjs/plugin/relativeTime')); // eslint-disable-line global-require
+	dayjs.extend(require('dayjs/plugin/localizedFormat')); // eslint-disable-line global-require
+	dayjs.locale(locale);
+	return dayjs;
+});
+
+export const dayjs = (...args: any) => new Dayjs()(...args);
 
 export function formatNumber(number: number): string {
 	return number.toLocaleString(locale);
 }
 
 export function formatDate(date?: Date /* = now */): string {
-	return moment(date).locale(locale).format('L');
+	return dayjs(date).format('L');
 }
 
 export function formatDateTime(date?: Date /* = now */): string {
-	return moment(date).locale(locale).format('L LTS');
+	return dayjs(date).format('L LTS');
 }
 
 export function formatDateDiff(from: Date, to?: Date /* = now */): string {
-	return moment(to).locale(locale).from(from, true);
+	return dayjs(to).from(from, true);
 }
 
 export function formatRelativeTime(from: Date): string {
-	return moment(from).locale(locale).fromNow();
+	return dayjs(from).fromNow();
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     ]
   },
   "dependencies": {
+    "dayjs": "1.8.8",
     "dompurify": "1.0.8",
     "fast-levenshtein": "2.0.6",
     "favico.js": "0.3.10",
@@ -70,7 +71,6 @@
     "jquery-sortable": "0.9.13",
     "jquery.tokeninput": "Reddit-Enhancement-Suite/jquery-tokeninput#v2.0.1",
     "lodash": "4.17.11",
-    "moment": "2.22.2",
     "numeral": "2.0.6",
     "resize-observer-lite": "Reddit-Enhancement-Suite/resize-observer-lite#59af4a859cb7da7859fec1f6bceecf26dd278916",
     "snudown-js": "3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2613,6 +2613,11 @@ date-time@^2.1.0:
   dependencies:
     time-zone "^1.0.0"
 
+dayjs@1.8.8:
+  version "1.8.8"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.8.tgz#81c81a8bb2488ef859f6c9bead9b62d649072bfd"
+  integrity sha512-qBY3kVAVJMxzS4e7DAwZZ/SSiO/DBXbvc/qqbyf1FbsZrxBq81QPdUEWhiPu8Fragf5RfHsLwtH8kCGwKL4qLQ==
+
 debug-log@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
@@ -5838,11 +5843,6 @@ mocha-nightwatch@3.2.2:
     lodash.create "3.1.1"
     mkdirp "0.5.1"
     supports-color "3.1.2"
-
-moment@2.22.2:
-  version "2.22.2"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
-  integrity sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Dayjs is modular and extendable. By being selective with what methods and locales are imported, we get a dependency that is less than 20 kB (in contrast to momentjs' 300 kB)

Tested in browser: Chrome 73