### PR TITLE
Replace jquery-sortable with sortablejs

### DIFF
--- a/lib/css/res.scss
+++ b/lib/css/res.scss
@@ -511,22 +511,8 @@ span.multi-count {
 	background-color: lightblue;
 }
 
-.handle,
-.dragging {
+.handle {
 	cursor: grab !important;
-}
-
-.dragging {
-	pointer-events:	none;
-}
-
-.RESSortPlaceholder::after {
-	border: medium dashed grey;
-	color: grey;
-	content: 'drop here';
-	text-align: center;
-	border-radius: 3px;
-	display: block;
 }
 
 .builderItem {

--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -1,14 +1,13 @@
 /* @flow */
 
 import _ from 'lodash';
-import { $ } from '../vendor';
+import { $, Sortable } from '../vendor';
 import { Module } from '../core/module';
 import {
 	Alert,
 	CreateElement,
 	BodyClasses,
 	currentSubreddit,
-	EdgeScroll,
 	formatDateTime,
 	isCurrentSubreddit,
 	loggedInUser,
@@ -189,27 +188,10 @@ function initUpdateQueue() {
 		if (widget) addWidget(widget);
 	}
 
-	const $dashboard = $('#RESDashboard');
-	const edgeScroll = new EdgeScroll($dashboard.get(0));
-
-	setTimeout(() => {
-		$dashboard.sortable({
-			delay: 200,
-			nested: false,
-			handle: 'div.RESDashboardComponentHeader',
-			itemSelector: '.RESDashboardComponent',
-			placeholderClass: 'RESSortPlaceholder',
-			placeholder: '<li class="RESSortPlaceholder"></li>',
-			onDrop($item, container, _super, event) {
-				_super($item, container, _super, event);
-				edgeScroll.stop();
-				saveOrder();
-			},
-			onDragStart() {
-				edgeScroll.start();
-			},
-		});
-	}, 300);
+	Sortable.create(document.querySelector('#RESDashboard'), {
+		handle: 'div.RESDashboardComponentHeader',
+		onChange: () => saveOrder(),
+	});
 }
 
 const updateQueue = [];

--- a/lib/modules/filteReddit/LineFilter.js
+++ b/lib/modules/filteReddit/LineFilter.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import _ from 'lodash';
+import { Sortable } from '../../vendor';
 import {
 	asyncFilter,
 	caseBuilder,
@@ -121,6 +122,8 @@ export class LineFilter extends Filter {
 				if (lastFocus) card.refresh().then(() => lastFocus.focus());
 			}
 		}));
+
+		Sortable.create($builderBlock.get(0), { handle: '.handle' });
 
 		return {
 			get builder() { return $builderBlock.get(0); },

--- a/lib/options/settingsConsole.js
+++ b/lib/options/settingsConsole.js
@@ -2,6 +2,7 @@
 
 import _ from 'lodash';
 import { markdown } from 'snudown-js';
+import Sortable from 'sortablejs';
 import { flow, filter, groupBy, sortBy } from 'lodash/fp';
 import * as Metadata from '../core/metadata';
 import * as Modules from '../core/modules';
@@ -13,7 +14,6 @@ import {
 	NAMED_KEYS,
 	caseBuilder,
 	downcast,
-	EdgeScroll,
 	escapeHTML,
 	frameThrottle,
 	frameDebounce,
@@ -707,7 +707,7 @@ function drawConfigOptions(mod) {
 
 				$(addRowButton).insertAfter($thisOptionSetting);
 
-				makeOptionTableSortable(thisTbody);
+				Sortable.create(thisTbody, { handle: '.handle' });
 			}
 		} else if (option.type === 'builder') {
 			$thisOptionContainer.addClass('specialOptionType');
@@ -960,28 +960,6 @@ function updateAdvancedOptionsVisibility() {
 	} else {
 		document.getElementById('RESConsoleContent').classList.add('advanced-options-disabled');
 	}
-}
-
-function makeOptionTableSortable(tableBody) {
-	const edgeScroll = new EdgeScroll(tableBody);
-
-	$(tableBody).sortable({
-		nested: false,
-		handle: '.handle',
-		placeholderClass: 'RESSortPlaceholder',
-		placeholder: '<tr class="RESSortPlaceholder"><td></td></tr>',
-		containerSelector: 'tbody',
-		itemSelector: 'tr',
-		onDrop($item, container, _super, event) {
-			_super($item, container, _super, event);
-			edgeScroll.stop();
-			$item.trigger('change');
-		},
-		onDragStart($item, container, _super, event) {
-			_super($item, container, _super, event);
-			edgeScroll.start();
-		},
-	});
 }
 
 function getOptions(mod) {

--- a/lib/utils/caseBuilder.js
+++ b/lib/utils/caseBuilder.js
@@ -1,13 +1,9 @@
 /* @flow */
 
 import _ from 'lodash';
-import { $ } from '../vendor';
+import { $, Sortable } from '../vendor';
 import { i18n } from '../environment';
-import {
-	downcast,
-	EdgeScroll,
-	string,
-} from './';
+import { downcast, string } from './';
 
 export function drawOptionBuilder(options: *, mod: *, optionName: *) {
 	const option = options[optionName];
@@ -29,7 +25,8 @@ export function drawOptionBuilder(options: *, mod: *, optionName: *) {
 			}
 		});
 	option.value.forEach(item => drawBuilderItem(item, option.customOptionsFields, option.cases).appendTo($itemContainer));
-	makeBuilderItemsSortable($itemContainer);
+
+	Sortable.create($itemContainer.get(0), { handle: '.handle' });
 
 	return $('<div>').append($itemContainer, $addRowButton)[0];
 }
@@ -80,7 +77,6 @@ function drawBuilderItem(data: *, customOptionsFields: * = [], cases: *) {
 		);
 
 	const $body = drawBuilderBlock(data.body, cases, false);
-	makeBuilderBlockSortable($body);
 
 	return $('<div class="builderItem">').append($header, $body);
 }
@@ -193,51 +189,6 @@ function drawFields(fields, data, cases) {
 	});
 }
 
-function makeBuilderItemsSortable($builder) {
-	const edgeScroll = new EdgeScroll($builder.get(0));
-
-	$builder.sortable({
-		nested: false,
-		handle: '.builderItem > .builderItemControls .handle',
-		placeholderClass: 'RESSortPlaceholder',
-		placeholder: '<div class="RESSortPlaceholder"></div>',
-		containerSelector: '.optionBuilder',
-		itemSelector: '.builderItem',
-		onDrop($item, container, _super, event) {
-			_super($item, container, _super, event);
-			edgeScroll.stop();
-			$item.trigger('change');
-		},
-		onDragStart($item, container, _super, event) {
-			_super($item, container, _super, event);
-			edgeScroll.start();
-		},
-	});
-}
-
-export function makeBuilderBlockSortable($builderBlock: *) {
-	const edgeScroll = new EdgeScroll($builderBlock.get(0));
-
-	$builderBlock.sortable({
-		nested: true,
-		handle: '.handle',
-		placeholderClass: 'RESSortPlaceholder',
-		placeholder: '<li class="RESSortPlaceholder"></li>',
-		containerSelector: '.builderWrap',
-		itemPath: '> .builderBlock > .builderMulti',
-		itemSelector: 'li',
-		onDrop($item, container, _super, event) {
-			_super($item, container, _super, event);
-			edgeScroll.stop();
-			$item.trigger('change');
-		},
-		onDragStart($item, container, _super, event) {
-			_super($item, container, _super, event);
-			edgeScroll.start();
-		},
-	});
-}
-
 const builderFields = {
 	multi: {
 		draw(data, field, cases = {}) {
@@ -264,6 +215,8 @@ const builderFields = {
 
 				addCaseSelect.selectedIndex = 0;
 			});
+
+			Sortable.create($rowWrapper.get(0), { group: 'block', handle: '.handle' });
 
 			return $rowWrapper.add(addCaseSelect);
 		},

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -1,7 +1,6 @@
 /* @flow */
 
 import _ from 'lodash';
-import { frameThrottle } from './async';
 import { downcast } from './flow';
 
 export function waitForEvent(ele: EventTarget, ...events: string[]): Promise<Event> {
@@ -387,58 +386,6 @@ export function scrollToElement(to: HTMLElement, from: ?HTMLElement, {
 }
 
 scrollToElement.isProgrammaticEvent = (): boolean => recentScroll;
-
-// Automatically scroll elements vertically when the cursor is close to its edge
-export class EdgeScroll {
-	distanceStartScrolling: number = 40; // scroll when within this distance (px) from a edge
-	element: HTMLElement; // layer which should be kept visible
-
-	constructor(element: HTMLElement) {
-		this.element = element;
-	}
-
-	// Find the element which prevents `b` from being fully displayed
-	findBlocker(b: HTMLElement) {
-		const _e = b.getBoundingClientRect();
-
-		let p = b;
-		while ((p = p.parentElement)) {
-			const _p = p.getBoundingClientRect();
-			if (
-				p.scrollHeight - 1 > _p.height && // The element is scrollable
-				(_p.top > _e.top || _e.bottom > _p.bottom) // The element covers the child
-			) return p;
-		}
-	}
-
-	update = frameThrottle((e: MouseEvent) => {
-		let scrollElement = this.element;
-		while ((scrollElement = this.findBlocker(scrollElement))) {
-			const distances = {
-				top: Math.ceil(e.clientY - Math.max(0, scrollElement.getBoundingClientRect().top)),
-				bottom: Math.ceil(Math.min(
-					getViewportSize().height,
-					// 'document.documentElement''s scrollbar ends at the bottom of the viewport even if its rect height is less
-					scrollElement === document.documentElement ? getViewportSize().height : scrollElement.getBoundingClientRect().bottom
-				) - e.clientY),
-			};
-
-			if (distances.top < this.distanceStartScrolling) {
-				scrollElement.scrollTop -= this.distanceStartScrolling - distances.top;
-			} else if (distances.bottom < this.distanceStartScrolling) {
-				scrollElement.scrollTop += this.distanceStartScrolling - distances.bottom;
-			} else {
-				continue;
-			}
-
-			// keep scrolling as long as the cursor is close to the edge
-			this.update(e); // e will only be updated on mousemove
-		}
-	});
-
-	start() { window.addEventListener('mousemove', this.update); }
-	stop() { window.removeEventListener('mousemove', this.update); }
-}
 
 const headerIds = { fullWidth: [], partialWidth: [] };
 

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -44,7 +44,6 @@ export {
 } from './color';
 
 export {
-	EdgeScroll,
 	addCSS,
 	click,
 	elementInViewport,

--- a/lib/vendor/index.js
+++ b/lib/vendor/index.js
@@ -1,7 +1,13 @@
 /* @flow */
 
+// Import only the functionality of sortablejs which is needed
+import Sortable, { AutoScroll } from 'sortablejs/modular/sortable.core.esm';
+
+Sortable.mount(new AutoScroll());
+export { Sortable };
+
 /**
- * This file re-exports global libraries, which technically could be accessed via the global object,
+ * Re-export global libraries, which technically could be accessed via the global object,
  * to ease the future pain of migrating them to proper libraries (imported from npm).
  */
 

--- a/lib/vendor/jqueryPlugins.js
+++ b/lib/vendor/jqueryPlugins.js
@@ -9,10 +9,8 @@ import { $ } from './jquery';
 
 /**
  * jQuery plugins
- * vendor/jquery.edgescroll-0.1.js
  */
 
-import 'jquery-sortable';
 import 'jquery.tokeninput';
 
 /**

--- a/package.json
+++ b/package.json
@@ -65,11 +65,11 @@
     "fast-levenshtein": "2.0.6",
     "favico.js": "0.3.10",
     "jquery": "3.4.1",
-    "jquery-sortable": "0.9.13",
     "jquery.tokeninput": "Reddit-Enhancement-Suite/jquery-tokeninput#v2.0.1",
     "lodash": "4.17.15",
     "numeral": "2.0.6",
     "snudown-js": "3.1.5",
+    "sortablejs": "1.10.0-rc3",
     "suncalc": "1.8.0",
     "tinycolor2": "1.4.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4977,13 +4977,6 @@ istanbul-reports@^2.2.4:
   dependencies:
     handlebars "^4.1.2"
 
-jquery-sortable@0.9.13:
-  version "0.9.13"
-  resolved "https://registry.yarnpkg.com/jquery-sortable/-/jquery-sortable-0.9.13.tgz#1cbfb655013a0747370571f06e22f524a00ffba2"
-  integrity sha1-HL+2VQE6B0c3BXHwbiL1JKAP+6I=
-  dependencies:
-    jquery "^2.1.2"
-
 jquery.tokeninput@Reddit-Enhancement-Suite/jquery-tokeninput#v2.0.1:
   version "2.0.1"
   resolved "https://codeload.github.com/Reddit-Enhancement-Suite/jquery-tokeninput/tar.gz/63d22f6799d464fb2c0e737f98b9c0597d5206fa"
@@ -4992,11 +4985,6 @@ jquery@3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
   integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
-
-jquery@^2.1.2:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
-  integrity sha1-LInWiJterFIqfuoywUUhVZxsvwI=
 
 js-levenshtein@^1.1.3:
   version "1.1.6"
@@ -7737,6 +7725,11 @@ socks@~2.3.2:
   dependencies:
     ip "^1.1.5"
     smart-buffer "4.0.2"
+
+sortablejs@1.10.0-rc3:
+  version "1.10.0-rc3"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.10.0-rc3.tgz#2fe63463a38b5cd12ec914fc3e03583048496f42"
+  integrity sha512-uw8vZqwI3nkIeAqdrP6N/GDxFW3dY7yz3/rK0GLLoe8aJ2RZALmo6mAwOi+uA7RYuqfz2lm7AACr4ms6gXcb6w==
 
 source-list-map@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
jquery-sortable is broken in the settings console, and is no longer maintained. Sortablejs appear to work fine with minimal configuration.

- [x] Fix issue in Firefox where it does not initialize

Tested in browser: Chrome 73, Firefox 65
