### PR TITLE
storage: Remove PrefixWrapper#getMultiple(Nullable)

### DIFF
--- a/lib/core/options/options.js
+++ b/lib/core/options/options.js
@@ -9,23 +9,22 @@ import { filterMap, shouldPrune } from '../../utils';
 
 const moduleOptionsStorage = Storage.wrapPrefix('RESoptions.', (): { [string]: any } => ({}));
 
-export async function _loadModuleOptions() {
-	const allOptions = await moduleOptionsStorage.getMultipleNullable(Modules.all().map(mod => mod.moduleID));
-
-	for (const mod of Modules.all()) {
-		_initOptions(mod, allOptions[mod.moduleID]);
-	}
-
+export function _loadModuleOptions() {
 	shouldPrune('RESoptions').then(should => { if (should) prune(); });
+
+	return loadOptions();
+}
+
+function loadOptions() {
+	return Promise.all(Modules.all().map(async module => {
+		if (_.isEmpty(module.options)) return;
+		const stored = await moduleOptionsStorage.get(module.moduleID);
+		_initOptions(module, stored);
+	}));
 }
 
 // copy in stored options and assign default values
-const _initOptions = _.memoize((module, storedOptions) => {
-	if (_.isEmpty(module.options)) {
-		// module has no options, don't attempt to load them
-		return;
-	}
-
+function _initOptions(module, storedOptions) {
 	// copy over default values
 	for (const opt of Object.values(module.options)) {
 		opt.default = opt.value;
@@ -46,7 +45,7 @@ const _initOptions = _.memoize((module, storedOptions) => {
 		// normal option, copy in the value from storage
 		module.options[key].value = storedValue.value;
 	}
-}, module => module.moduleID);
+}
 
 export const loadRaw = flow(
 	(opaqueId: OpaqueModuleId) => Modules.get(opaqueId),

--- a/lib/environment/foreground/storage.js
+++ b/lib/environment/foreground/storage.js
@@ -23,14 +23,6 @@ export function getAll(): Promise<{ [string]: mixed }> {
 	return __get(null);
 }
 
-export function getMultiple<T: string>(keys: T[]): Promise<{ [T]: any | null }> {
-	const defaults = {};
-	for (const k of keys) {
-		defaults[k] = null;
-	}
-	return __get(defaults);
-}
-
 export function set(key: string, value: mixed): Promise<void> {
 	return withLockOn(key, () => _set(key, value));
 }
@@ -180,20 +172,6 @@ class PrefixWrapper<T> {
 			if (k.startsWith(this._prefix)) {
 				acc[k.slice(this._prefix.length)] = v;
 			}
-		}, {});
-	}
-
-	async getMultiple(keys: string[]): Promise<{ [string]: T }> {
-		const rawValues = await getMultiple(keys.map(k => this._keyGen(k)));
-		return _.transform(rawValues, (acc, v, k) => {
-			acc[k.slice(this._prefix.length)] = (v === null ? this._default() : v);
-		}, {});
-	}
-
-	async getMultipleNullable(keys: string[]): Promise<{ [string]: T | null }> {
-		const rawValues = await getMultiple(keys.map(k => this._keyGen(k)));
-		return _.transform(rawValues, (acc, v, k) => {
-			acc[k.slice(this._prefix.length)] = v;
 		}, {});
 	}
 

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -22,7 +22,6 @@ import {
 	watchForThings,
 	mutex,
 	waitForEvent,
-	batch,
 } from '../utils';
 import { Storage, isPrivateBrowsing } from '../environment';
 import * as Dashboard from './dashboard';
@@ -108,8 +107,7 @@ module.beforeLoad = () => {
 		refreshSubscriptionButton();
 	}
 
-	// Immediate in order to avoid many entry lookups
-	watchForThings(['post'], displayNewCommentCount, { immediate: true });
+	watchForThings(['post'], displayNewCommentCount);
 };
 
 module.go = () => {
@@ -150,11 +148,6 @@ module.afterLoad = () => {
 
 const getId = thing => thing.getFullname().split('_').slice(-1)[0];
 
-const getEntryBatched = batch(async ids => {
-	const entries = await entryStorage.getMultipleNullable(ids);
-	return ids.map(id => entries[id]);
-}, { size: Infinity, delay: 0 });
-
 function setEntry(id: string, newCommentCount: number) {
 	if (!module.options.monitorPostsVisited.value) return false;
 	if (!module.options.monitorPostsVisitedIncognito.value && isPrivateBrowsing()) return false;
@@ -166,13 +159,13 @@ function setEntry(id: string, newCommentCount: number) {
 }
 
 export async function hasEntry(thing: Thing): Promise<boolean> {
-	return !!(await getEntryBatched(getId(thing)));
+	return !!await entryStorage.getNullable((getId(thing)));
 }
 
 export async function getNewCount(thing: Thing): Promise<?number> {
 	const currentCount = thing.getCommentCount();
 
-	const countObj = await getEntryBatched(getId(thing));
+	const countObj = await entryStorage.getNullable(getId(thing));
 	const lastOpenedCount = countObj && countObj.count;
 
 	if (typeof currentCount !== 'number' || typeof lastOpenedCount !== 'number') return;

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -8,7 +8,6 @@ import {
 	Alert,
 	CreateElement,
 	Thing,
-	batch,
 	downcast,
 	isCurrentSubreddit,
 	isPageType,
@@ -135,11 +134,6 @@ const tagStorage = Storage.wrapPrefix('tag.', () => (({}: any): {|
 	votesDown?: number,
 	votesUp?: number,
 |}), user => user.toLowerCase());
-
-const getTagBatched = batch(async users => {
-	const tags = await tagStorage.getMultipleNullable(users);
-	return users.map(user => tags[user.toLowerCase()]);
-}, { size: Infinity, delay: 0 });
 
 module.beforeLoad = () => {
 	// Fetch immediately so data is ready when adding tag
@@ -269,7 +263,7 @@ export class Tag {
 	}
 
 	fill = _.once(async () => {
-		const data = await getTagBatched(this.id);
+		const data = await tagStorage.getNullable(this.id);
 		if (data) this.load(data);
 	});
 


### PR DESCRIPTION
Loading multiple items together can be so slow that RES doesn't initialize (adding option body classes, custom styles etc) before Firefox decides to paint the first frame, causing a FOUC. Benchmarking this, the total time spent loading from storage is a little (about one third) larger, but the removal of complexity and said Firefox issue makes this worth it.

Tested in browser: Firefox 66, Chrome 74
