### PR TITLE
Faster initialization: New init phase 'contentStart' and JIT watcher callbacks

### DIFF
--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -6,10 +6,13 @@ import {
 	BodyClasses,
 	waitFor,
 	waitForChild,
+	waitForDescendant,
 	waitForEvent,
-	initR2Watcher,
+	r2WatcherBodyReady,
+	r2WatcherSitetableStart,
 	initD2xWatcher,
 	isAppType,
+	isPageType,
 } from '../utils';
 import { _loadModuleOptions } from './options/options';
 import { _loadModulePrefs, _runModuleStage } from './modules/modules';
@@ -50,6 +53,12 @@ export const bodyStart: Promise<*> = sourceLoaded
 		waitForChild(document.documentElement, 'body'),
 		waitFor(() => document.body, 100),
 		contentLoaded,
+	]));
+
+export const sitetableStarted: Promise<*> = bodyStart
+	.then(() => Promise.race([
+		waitForDescendant(document.body, isPageType('comments') ? '.sitetable.nestedlisting' : '#siteTable'),
+		bodyReady,
 	]));
 
 export const bodyReady: Promise<*> = bodyStart
@@ -99,13 +108,19 @@ export const always: Promise<void> = loadOptions
 export const beforeLoad: Promise<void> = loadOptions
 	.then(() => _runModuleStage('beforeLoad'));
 
-export const watchers: Promise<*> = Promise.all([beforeLoad, bodyReady])
-	.then(() => isAppType('d2x') ? initD2xWatcher() : initR2Watcher());
+export const contentStart: Promise<*> = Promise.all([beforeLoad, sitetableStarted])
+	.then(() => Promise.all([
+		_runModuleStage('contentStart'),
+		isAppType('r2') ? r2WatcherSitetableStart() : undefined,
+	]));
 
 export const go: Promise<*> = Promise.all([beforeLoad, bodyReady])
-	.then(() => _runModuleStage('go'));
+	.then(() => Promise.all([
+		isAppType('d2x') ? initD2xWatcher() : r2WatcherBodyReady(),
+		_runModuleStage('go'),
+	]));
 
-export const afterLoad: Promise<void> = Promise.all([go, watchers, loadComplete])
+export const afterLoad: Promise<void> = Promise.all([contentStart, go, loadComplete])
 	.then(() => _runModuleStage('afterLoad'));
 
 // BodyClasses may have been added before document.body was ready

--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -32,6 +32,7 @@ export class Module<RawOpt: { [string]: any }, Opt: { [string]: ModuleOption<Raw
 	// no default value for cleaner profiling (modules without a stage defined won't be timed)
 	onInit: (() => Promise<void> | void) | void = undefined;
 	beforeLoad: (() => Promise<void> | void) | void = undefined;
+	contentStart: (() => Promise<void> | void) | void = undefined;
 	go: (() => Promise<void> | void) | void = undefined;
 	afterLoad: (() => Promise<void> | void) | void = undefined;
 	always: (() => Promise<void> | void) | void = undefined;

--- a/lib/css/modules/_filteReddit.scss
+++ b/lib/css/modules/_filteReddit.scss
@@ -4,6 +4,16 @@ body.hideOver18 {
 	}
 }
 
+.res-hideUntilProcessed-post .thing.link,
+.res-hideUntilProcessed-comment .thing.comment {
+	&:not([res-initial-filtering-done]) {
+		&,
+		& ~ * {
+			display: none !important;
+		}
+	}
+}
+
 html:not(.res-filters-disabled):not(.res-display-match-reason) {
 	.res-thing-filter-hide {
 		&:not(.res-thing-partial),

--- a/lib/css/modules/_filteReddit.scss
+++ b/lib/css/modules/_filteReddit.scss
@@ -102,14 +102,6 @@ html:not(.res-filters-disabled):not(.res-display-match-reason) {
 	}
 }
 
-body.res-filteReddit-filterline-pad-until-ready {
-	&.comments-page .nestedlisting::before,
-	&.listing-page #siteTable::before {
-		@include filterline-basic-layout;
-		content: ' ';
-	}
-}
-
 %res-filterline-icon {
 	display: inline-block;
 	transform: rotate(180deg);

--- a/lib/css/modules/_nightMode.scss
+++ b/lib/css/modules/_nightMode.scss
@@ -1368,13 +1368,9 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 		}
 	}
 
-	&.res-filteReddit-filterline-pad-until-ready.listing-page #siteTable::before,
-	&.res-filteReddit-filterline-pad-until-ready.comments-page .nestedlisting::before,
 	.res-filterline {
 		background-color: rgba(38, 38, 38, .9);
-	}
 
-	.res-filterline {
 		&-filter {
 			border-bottom-color: #383838;
 

--- a/lib/foreground.entry.js
+++ b/lib/foreground.entry.js
@@ -7,10 +7,10 @@ import 'file-loader?name=LICENSE!../LICENSE';
 // load environment listeners
 import 'sibling-loader!./environment/foreground/messaging';
 
-import * as Context from './environment/foreground/context';
-
 import { init, bodyReady } from './core/init';
 
-Context.establish(bodyReady);
+import * as Context from './environment/foreground/context';
 
 init();
+
+Context.establish(bodyReady);

--- a/lib/modules/RESTips.js
+++ b/lib/modules/RESTips.js
@@ -54,7 +54,7 @@ module.include = ['r2'];
 const featureTipsStorage = Storage.wrapPrefix('RESTips.featureTips.', () => ({ enabled: true }));
 const lastTooltipStorage = Storage.wrap('RESLastToolTip', 0);
 
-module.go = () => {
+module.contentStart = () => {
 	if (module.options.menuItem.value) {
 		Menu.addMenuItem(
 			() => string.html`<span>${i18n('tipsAndTricks')}</span>`,

--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -115,7 +115,7 @@ module.options = {
 
 let hover;
 
-module.go = () => {
+module.contentStart = () => {
 	const downArrow = module.options.dropDownStyle.value === 'alien' ?
 		string.html`<span id="RESAccountSwitcherIcon"></span>` :
 		string.html`<span id="RESAccountSwitcherIcon"><span class="downArrow"></span></span>`;

--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -183,6 +183,13 @@ module.options = {
 		title: 'betteRedditCommentCollapseInInboxTitle',
 		bodyClass: true,
 	},
+	restrictScrollEvents: {
+		type: 'boolean',
+		value: false,
+		description: 'betteRedditRestrictScrollEventsDesc',
+		title: 'betteRedditRestrictScrollEventsTitle',
+		advanced: true,
+	},
 };
 
 module.exclude = [
@@ -231,6 +238,22 @@ module.beforeLoad = () => {
 		case 'none':
 		default:
 			break;
+	}
+
+	if (module.options.restrictScrollEvents.value) {
+		const scr = document.createElement('script');
+		scr.innerHTML = `{
+			// Prevents overzealous Reddit scroll listeners from constantly mutating the DOM while scrolling
+			let debounce, lastEvent;
+			window.addEventListener('scroll', e => {
+				if (!debounce)  debounce = _.debounce(e => window.dispatchEvent(e), 300);
+				if (e === lastEvent) return;
+				lastEvent = e;
+				debounce(e);
+				e.stopImmediatePropagation();
+			}, true);
+		}`;
+		document.documentElement.append(scr);
 	}
 };
 

--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -257,7 +257,7 @@ module.beforeLoad = () => {
 	}
 };
 
-module.go = () => {
+module.contentStart = () => {
 	if (module.options.scoreHiddenTimeLeft.value && isPageType('comments', 'commentsLinklist')) {
 		$('.sitetable').on('mouseenter', '.score-hidden', function() {
 			const timeNode = $(this).siblings('time').get(0);

--- a/lib/modules/commandLine.js
+++ b/lib/modules/commandLine.js
@@ -37,7 +37,7 @@ module.options = {
 	},
 };
 
-module.go = () => {
+module.contentStart = () => {
 	if (module.options.menuItem.value) {
 		addMenuItem();
 	}

--- a/lib/modules/commentDepth.js
+++ b/lib/modules/commentDepth.js
@@ -62,7 +62,7 @@ module.options = {
 	},
 };
 
-module.go = () => {
+module.contentStart = () => {
 	$(document.body).on('mousedown', 'a[href*="/comments"]', (e: Event) => {
 		const target: HTMLAnchorElement = (e.target: any);
 		const url = new URL(target.href, location.href);

--- a/lib/modules/commentHidePersistor.js
+++ b/lib/modules/commentHidePersistor.js
@@ -16,6 +16,7 @@ module.include = [
 	'inbox',
 ];
 
+const COLLAPSE_REASON = 'commentHidePersistor';
 const currentId: string = (execRegexes.comments(location.pathname) || [])[2];
 const entryStorage = Storage.wrapPrefix('commentHidePersistor.', (): {
 	updateTime: number,
@@ -23,29 +24,22 @@ const entryStorage = Storage.wrapPrefix('commentHidePersistor.', (): {
 } => ({
 	updateTime: Date.now(),
 }));
+const initial = currentId && entryStorage.get(currentId);
 
 module.beforeLoad = async () => {
-	if (!currentId) throw new Error('Could not find comment page id');
+	const { collapsedThings } = await initial || {};
+	if (!collapsedThings) return;
 
-	await restoreCommentCollapse();
+	watchForThings(['comment'], thing => {
+		if (collapsedThings.hasOwnProperty(thing.getFullname())) thing.setCommentCollapse(true, COLLAPSE_REASON);
+	}, { immediate: true });
 };
 
-module.go = () => {
+module.contentStart = () => {
 	listenToCommentCollapse();
 
 	maybePruneOldEntries('commentHidePersistor', entryStorage);
 };
-
-const COLLAPSE_REASON = 'commentHidePersistor';
-
-async function restoreCommentCollapse() {
-	const { collapsedThings } = await entryStorage.get(currentId);
-	if (collapsedThings) {
-		watchForThings(['comment'], thing => {
-			if (collapsedThings.hasOwnProperty(thing.getFullname())) thing.setCommentCollapse(true, COLLAPSE_REASON);
-		}, { immediate: true });
-	}
-}
 
 function listenToCommentCollapse() {
 	$(document.body).on('click', 'a.expand', (e: MouseEvent) => {

--- a/lib/modules/commentNavigator.js
+++ b/lib/modules/commentNavigator.js
@@ -43,7 +43,7 @@ module.include = [
 	'comments',
 ];
 
-module.go = () => {
+module.contentStart = () => {
 	installEntryElement();
 
 	if (module.options.showByDefault.value) {
@@ -78,7 +78,7 @@ const initialize = _.once(() => {
 	watchForThings(['comment'], () => { _memoized.cache.clear(); });
 
 	SelectedEntry.addListener(updateFromSelected, 'beforePaint');
-	if (SelectedEntry.selectedThing) updateFromSelected(SelectedEntry.selectedThing);
+	if (Thing.selected) updateFromSelected(Thing.selected);
 });
 
 const sortTypes: {
@@ -348,7 +348,7 @@ export async function move(change: 'up' | 'down' | 'top') {
 		// Return to the last navigated post if currently moved beyond it in the opposite direction
 		const all = Thing.things();
 		const lastNavigatedToIndex = all.indexOf(lastNavigatedTo);
-		const selectedIndex = all.indexOf(SelectedEntry.selectedThing);
+		const selectedIndex = all.indexOf(Thing.selected);
 
 		if (
 			change === 'down' && selectedIndex < lastNavigatedToIndex ||

--- a/lib/modules/commentPreview.js
+++ b/lib/modules/commentPreview.js
@@ -122,7 +122,7 @@ module.beforeLoad = () => {
 	if (isWiki && subreddit) initWikiImages(subreddit);
 };
 
-module.go = () => {
+module.contentStart = () => {
 	if (module.options.enableBigEditor.value) {
 		$(document.body).on('click', '.RESBigEditorPop', showBigEditor);
 

--- a/lib/modules/commentQuickCollapse.js
+++ b/lib/modules/commentQuickCollapse.js
@@ -84,7 +84,7 @@ module.beforeLoad = () => {
 	}
 };
 
-module.go = () => {
+module.contentStart = () => {
 	if (module.options.hideCommentsOnHeaderDoubleClick.value) {
 		hideCommentsOnHeaderDoubleClick();
 	}

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -240,7 +240,7 @@ const SUBMIT_LIMITS = {
 const macroCallbackTable: Array<(box: HTMLTextAreaElement) => void> = [];
 const macroKeyTable: Array<[KeyArray, number]> = [];
 
-module.go = () => {
+module.contentStart = () => {
 	$(document.body).on('focus', commentTextareaSelector, attachEditorToUsertext);
 
 	initializeCtrlEnterToSubmit();

--- a/lib/modules/contribute.js
+++ b/lib/modules/contribute.js
@@ -13,7 +13,7 @@ module.sort = -9;
 module.alwaysEnabled = true;
 module.description = 'contributeDesc';
 
-module.go = () => {
+module.contentStart = () => {
 	Menu.addMenuItem(
 		() => string.html`<span>${i18n('donateToRES')} &#8679;</span>`,
 		() => { openNewTab('https://redditenhancementsuite.com/contribute/'); }

--- a/lib/modules/customToggles.js
+++ b/lib/modules/customToggles.js
@@ -69,7 +69,7 @@ module.beforeLoad = () => {
 	}
 };
 
-module.go = () => {
+module.contentStart = () => {
 	registerCommandLine();
 };
 

--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import _ from 'lodash';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
 import {
@@ -98,6 +99,9 @@ module.options = {
 };
 module.shouldRun = () => isCurrentSubreddit('dashboard');
 
+// depends on loggedInUser; must be called after the username is available
+const initialWidgetLoad = _.once(getLatestWidgets);
+
 module.always = () => {
 	if (Modules.isEnabled(module)) {
 		if (module.options.menuItem.value) {
@@ -111,13 +115,16 @@ module.always = () => {
 
 		const subreddit = currentSubreddit();
 		if (module.options.dashboardShortcut.value && subreddit) {
-			Init.bodyReady.then(() => requestAnimationFrame(() => addDashboardShortcuts(subreddit)));
+			Init.sitetableStarted.then(async () => {
+				await initialWidgetLoad();
+				addDashboardShortcuts(subreddit);
+			});
 		}
 	}
 };
 
 module.go = async () => {
-	await getLatestWidgets();
+	await initialWidgetLoad();
 
 	drawDashboard();
 

--- a/lib/modules/disableChat.js
+++ b/lib/modules/disableChat.js
@@ -25,7 +25,7 @@ module.beforeLoad = () => {
 	});
 };
 
-module.go = () => {
+module.contentStart = () => {
 	const icon = document.body.querySelector('#chat');
 	if (icon) {
 		if (icon.nextElementSibling) icon.nextElementSibling.remove(); // Remove seperator

--- a/lib/modules/easterEgg.js
+++ b/lib/modules/easterEgg.js
@@ -13,7 +13,7 @@ module.hidden = true;
 
 let konami;
 
-module.go = () => {
+module.contentStart = () => {
 	konami = createKonami(() => {
 		const $baconBit = $('<div>', { id: 'baconBit' }).appendTo(document.body);
 		Notifications.showNotification({

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -7,6 +7,7 @@ import { Module } from '../core/module';
 import * as Options from '../core/options';
 import {
 	BodyClasses,
+	Thing,
 	asyncFlow,
 	batch,
 	currentDomain,
@@ -15,13 +16,11 @@ import {
 	fullLocation,
 	CreateElement,
 	extendDeep,
-	fastAsync,
 	indexOptionTable,
 	isCurrentMultireddit,
 	isCurrentSubreddit,
 	isPageType,
 	mutex,
-	reifyPromise,
 	watchForThings,
 	scrollToElement,
 	string,
@@ -33,7 +32,6 @@ import * as CommandLine from './commandLine';
 import * as CustomToggles from './customToggles';
 import * as Notifications from './notifications';
 import * as RESTips from './RESTips';
-import * as SelectedEntry from './selectedEntry';
 import * as Cases from './filteReddit/cases';
 import { Case } from './filteReddit/Case';
 import { Filterline } from './filteReddit/Filterline';
@@ -96,7 +94,6 @@ module.options = {
 		value: false,
 		description: 'filteRedditShowFilterlineDesc',
 		title: 'filteRedditShowFilterlineTitle',
-		bodyClass: true,
 	},
 	excludeOwnPosts: {
 		type: 'boolean',
@@ -480,18 +477,17 @@ async function getDefaultFilters() {
 	}
 }
 
-const initialFilterlineState = reifyPromise((async () => {
-	let { filters, visible, lastUsed } = await filterlineStorage.get(); // eslint-disable-line prefer-const
-	if (lastUsed) filterlineStorage.patch({ lastUsed: Date.now() });
-	if (!filters || !Object.values(filters).length) filters = await getDefaultFilters();
-	return { filters, visible };
-})());
-
 let nsfwToggle;
 let filterline: Filterline;
 let visible: boolean;
 
-module.beforeLoad = fastAsync(function*()	{
+const initial = (async () => {
+	let { filters, visible, lastUsed } = await filterlineStorage.get(); // eslint-disable-line prefer-const
+	if (!filters || !Object.values(filters).length) filters = await getDefaultFilters();
+	return { filters, visible, lastUsed };
+})();
+
+module.beforeLoad = async () => {
 	updateNsfwBodyClass(module.options.NSFWfilter.value);
 	nsfwToggle = new CustomToggles.Toggle('nsfwMode', i18n('nsfwSwitchToggleText'), module.options.NSFWfilter.value);
 	nsfwToggle.onToggle(() => { Options.set(module, 'NSFWfilter', nsfwToggle.enabled); });
@@ -506,8 +502,19 @@ module.beforeLoad = fastAsync(function*()	{
 	Cases.populatePrimitives(['browse', thingType]);
 	filterline = new Filterline(filterlineStorage, thingType);
 
-	const state = yield initialFilterlineState.get();
-	filterline.restoreState(state.filters);
+	watchForThings([thingType], async thing => {
+		if (shouldFilter(thing)) {
+			await filterline.addThing(thing);
+		}
+
+		// $FlowIssue toggleAttribute
+		thing.element.toggleAttribute('res-initial-filtering-done', true);
+	}, { immediate: true });
+
+	let filters, lastUsed;
+	({ filters, visible = false, lastUsed } = await initial); // eslint-disable-line prefer-const
+
+	filterline.restoreState(filters);
 	populateFromOptions();
 
 	if (
@@ -515,35 +522,29 @@ module.beforeLoad = fastAsync(function*()	{
 		module.options.excludeUserPages.value && isPageType('profile')
 	) filterline.togglePowered(false);
 
-	watchForThings([thingType], registerThing, { immediate: true });
+	// Visibility must be updated after `restoreState` and `populateFromOptions`
+	if (!visible) visible = module.options.showFilterline.value || filterline.getActiveFilters().some(v => !(v instanceof ExternalFilter));
 
-	// This must be done after `restoreState` and `populateFromOptions`
-	({
-		visible = module.options.showFilterline.value || filterline.getActiveFilters().some(v => !(v instanceof ExternalFilter)),
-	} = state);
-	if (visible) BodyClasses.add('res-filteReddit-filterline-pad-until-ready');
-});
+	if (lastUsed) requestIdleCallback(() => { filterlineStorage.patch({ lastUsed: Date.now() }); });
+};
 
-module.go = () => {
+module.contentStart = () => {
+	makeFilterlineInteractable();
+
 	if (module.options.NSFWQuickToggle.value) {
 		nsfwToggle.addMenuItem(i18n('nsfwSwitchToggleTitle'), 8);
 	}
 
-	makeFilterlineInteractable();
-
 	registerSubredditFilterCommand();
 };
 
-function registerThing(thing) {
-	if (
+const shouldFilter = thing => (
+	!(
 		module.options.excludeOwnPosts.value && context.username &&
 		currentUserProfile() !== context.username &&
 		context.username === thing.getAuthor()
-	) return;
-
-	// Returns a promise which resolves when initial filtering is done
-	return filterline.addThing(thing);
-}
+	)
+);
 
 function makeFilterlineInteractable() {
 	const insertFilterline = _.once(() => {
@@ -554,8 +555,6 @@ function makeFilterlineInteractable() {
 		} else {
 			document.querySelector('#siteTable, .search-result-listing').before(filterline.element);
 		}
-
-		BodyClasses.remove('res-filteReddit-filterline-pad-until-ready');
 
 		RESTips.addFeatureTip('filterlineVisible', { ...featureTips.filterlineVisible, attachTo: filterline.element });
 	});
@@ -670,7 +669,7 @@ class ListFilter {
 	}
 
 	async toggleString(matchString: string, newState?: boolean = !this.includesString(matchString)) {
-		SelectedEntry.anchor(); // Toggling the filter may move the viewport. Try to keep the selected post in place.
+		if (Thing.selected) Thing.selected.anchor(); // Toggling the filter may move the viewport. Try to keep the selected post in place.
 		await this.toggleEntry(newState, this.findEntry(matchString) || [matchString]);
 	}
 }
@@ -1016,7 +1015,7 @@ function updateNsfwBodyClass(filterOn) {
 function registerSubredditFilterCommand() {
 	const getSubreddit = val => (
 		val ||
-		SelectedEntry.selectedThing && SelectedEntry.selectedThing.getSubreddit() ||
+		Thing.selected && Thing.selected.getSubreddit() ||
 		currentSubreddit() ||
 		''
 	);

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -46,6 +46,13 @@ module.category = 'subredditsCategory';
 module.description = 'filteRedditDesc';
 module.keywords = ['filterreddit'];
 module.options = {
+	hideUntilProcessed: {
+		type: 'boolean',
+		value: true,
+		description: 'filteRedditHideUntilProcessedDesc',
+		title: 'filteRedditHideUntilProcessedTitle',
+		advanced: true,
+	},
 	NSFWfilter: {
 		type: 'boolean',
 		value: false,
@@ -491,6 +498,10 @@ module.beforeLoad = fastAsync(function*()	{
 	nsfwToggle.onStateChange(() => { updateNsfwBodyClass(nsfwToggle.enabled); });
 	nsfwToggle.addCLI('nsfw');
 	watchForThings(['post'], updateNsfwThingClass, { immediate: true });
+
+	if (module.options.hideUntilProcessed.value) {
+		BodyClasses.add(`res-hideUntilProcessed-${thingType}`);
+	}
 
 	Cases.populatePrimitives(['browse', thingType]);
 	filterline = new Filterline(filterlineStorage, thingType);

--- a/lib/modules/filteReddit/Case.js
+++ b/lib/modules/filteReddit/Case.js
@@ -3,7 +3,6 @@
 import _ from 'lodash';
 import { Thing, string } from '../../utils';
 import type { BuilderValue, BuilderRootValue } from '../../core/module';
-import * as SelectedEntry from '../selectedEntry';
 import * as Cases from './cases';
 
 export class Case {
@@ -14,7 +13,7 @@ export class Case {
 	static +parseCriterion: ?(input: string) => *;
 
 	static async getSelectedEntryValue() {
-		const selected = SelectedEntry.selectedThing;
+		const selected = Thing.selected;
 		if (!selected) throw new Error('No entry is currently selected.');
 
 		let conditions;

--- a/lib/modules/filteReddit/Filterline.js
+++ b/lib/modules/filteReddit/Filterline.js
@@ -22,7 +22,6 @@ import { i18n } from '../../environment';
 import * as Hover from '../hover';
 import * as Notifications from '../notifications';
 import * as SelectedEntry from '../selectedEntry';
-import * as ShowImages from '../showImages';
 import * as FilteReddit from '../filteReddit';
 import * as RESTips from '../RESTips';
 import * as Cases from './cases';
@@ -547,7 +546,6 @@ export class Filterline {
 
 	_refreshAfterChange = frameThrottle(() => {
 		SelectedEntry.refreshSelect();
-		ShowImages.refresh();
 		this.checkEmptyState();
 	});
 

--- a/lib/modules/filteReddit/postCases/Expando.js
+++ b/lib/modules/filteReddit/postCases/Expando.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import _ from 'lodash';
 import * as ShowImages from '../../showImages';
 import { Expando as E /* avoids name conflict */ } from '../../showImages/expando';
 import { Case } from '../Case';
@@ -15,7 +16,7 @@ export class Expando extends Case {
 
 	static defaultConditions = { types: [] };
 	static fields = ['post has expando, and (if specified) expando types intersects with ', { type: 'checkset', items: ShowImages.types, id: 'types' }];
-	static slow = 9; // If this filter causes a thing to be hidden, the expando won't be deferred and mediainfo will be fetched, which in some instances causes extra bandwidth usage
+	static slow = 9; // In order to evaluate whether an expando matches, the expando must be built first (which is slow due to API requests)
 
 	static pattern = `[(${ShowImages.types.join('|')})]`;
 	static criterionOperators = true;
@@ -25,23 +26,42 @@ export class Expando extends Case {
 	isValid() { return ShowImages.matchesTypes(this.value.types); }
 
 	_matches(e: ?E) {
-		// Treat non-ready expando as non-existing
-		if (!e || !e.ready) return false;
+		if (!e) return false;
+		if (!e.ready) return null;
 		return ShowImages.matchesTypes(this.value.types, e.types);
 	}
 
-	evaluate(thing: *) {
+	// Memoized in order to add only one observer to each promise
+	_waitTillReady = _.memoize(thing => {
+		const completeTask = thing.tasks.byId.get(ShowImages.module);
+		if (completeTask) {
+			const promise = completeTask();
+			// Wait at most 1 s for the task; if it takes longer, refresh this filter when it's done
+			return Promise.race([
+				promise,
+				new Promise(rej => setTimeout(rej, 1000)),
+			]).catch(() => {
+				promise.finally(() => { this.refresh(); });
+			});
+		}
+	});
+
+	async evaluate(thing: *) {
+		await this._waitTillReady(thing);
+
 		if (thing.isPost()) {
 			const expando = E.getEntryExpandoFrom(thing);
 			return this._matches(expando);
 		} else {
 			const expandos = E.getTextExpandosFrom(thing);
-			return expandos.some(this._matches.bind(this));
+			const res = expandos.map(this._matches.bind(this));
+			if (res.some(Boolean)) return true;
+			if (res.some(v => v === null)) return null;
+			return false;
 		}
 	}
 
 	onObserve() {
-		ShowImages.thingExpandoBuildListeners.add(this.refresh.bind(this));
 		return true;
 	}
 }

--- a/lib/modules/filteReddit/postCases/NewCommentCount.js
+++ b/lib/modules/filteReddit/postCases/NewCommentCount.js
@@ -27,8 +27,8 @@ export class NewCommentCount extends Case {
 	isValid() { return parseInt(this.value.val, 10) >= 0; }
 
 	async evaluate(thing: *) {
-		const count = await N.hasEntry(thing) ? await N.getNewCount(thing) : thing.getCommentCount();
-		if (typeof count !== 'number') return null;
+		const newCount = await N.getNewCount(thing);
+		const count = typeof newCount === 'number' ? newCount : thing.getCommentCount();
 		return numericalCompare(this.value.op, count, this.value.val);
 	}
 }

--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -853,12 +853,12 @@ module.beforeLoad = () => {
 		SelectedEntry.addListener(updateLinkAnnotations, 'beforePaint');
 		watchForElements(['selfText'], null, element => {
 			const thing = Thing.from(element);
-			if (SelectedEntry.selectedThing === thing) updateLinkAnnotations(thing);
+			if (Thing.selected === thing) updateLinkAnnotations(thing);
 		});
 	}
 };
 
-module.go = () => {
+module.contentStart = () => {
 	window.addEventListener('keydown', handleKeyPress, true);
 };
 
@@ -1082,7 +1082,7 @@ const promptUniqueShortcut = _.memoize(async (shortcut, options: any) => {
 });
 
 function getSelected(): Thing {
-	const selected = SelectedEntry.selectedThing;
+	const selected = Thing.selected;
 	if (!selected) throw new Error('A entry must be selected');
 	if (!selected.isVisible()) throw new Error('Entry must be visible');
 	return selected;
@@ -1283,8 +1283,8 @@ function handleGoModeEscapeKey(event: KeyboardEvent) {
 function moveDownFallback() {
 	const bump = Modules.isRunning(NeverEndingReddit) &&
 		(
-			!SelectedEntry.selectedThing ||
-			[SelectedEntry.selectedThing, undefined].includes(_.last(Thing.visibleThings()))
+			!Thing.selected ||
+			[Thing.selected, undefined].includes(_.last(Thing.visibleThings()))
 		);
 	if (bump) NeverEndingReddit.loadNextPage({ scrollToLoadWidget: true });
 }

--- a/lib/modules/localDate.js
+++ b/lib/modules/localDate.js
@@ -9,7 +9,7 @@ module.moduleName = 'localDateName';
 module.category = 'myAccountCategory';
 module.description = 'localDateDesc';
 
-module.go = () => {
+module.contentStart = () => {
 	$(document.body)
 		.on('mouseenter', 'time', function() {
 			const $this = $(this);

--- a/lib/modules/logoLink.js
+++ b/lib/modules/logoLink.js
@@ -49,7 +49,7 @@ module.options = {
 	},
 };
 
-module.go = () => {
+module.contentStart = () => {
 	const redditLogoNode: ?HTMLAnchorElement = (document.getElementById('header-img-a') || document.getElementById('header-img') || document.querySelector('header a[href="/"]'): any);
 	if (redditLogoNode) {
 		const url = getLogoLinkUrl();

--- a/lib/modules/menu.js
+++ b/lib/modules/menu.js
@@ -43,7 +43,7 @@ module.options = {
 const items = [];
 let gear;
 
-module.go = () => {
+module.contentStart = () => {
 	gear = string.html`<span id="RESSettingsButton" style="cursor: pointer" title="${i18n('RESSettings')}" class="gearIcon"></span>`;
 
 	if (module.options.gearIconClickAction.value !== 'toggleMenuNoHover') {
@@ -71,7 +71,7 @@ module.go = () => {
 };
 
 module.afterLoad = () => {
-	addLegacyStyling();
+	requestAnimationFrame(addLegacyStyling);
 };
 
 function showDropdown(openDelay: number) {

--- a/lib/modules/messageMenu.js
+++ b/lib/modules/messageMenu.js
@@ -68,7 +68,7 @@ module.options = {
 	},
 };
 
-module.go = () => {
+module.contentStart = () => {
 	$('#mail, .mail-count, #NREMail, #NREMailCount').on('mouseenter', onMouseEnter);
 };
 

--- a/lib/modules/modhelper.js
+++ b/lib/modules/modhelper.js
@@ -3,7 +3,6 @@
 import { markdown } from 'snudown-js';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
-import { isPageType } from '../utils';
 import * as SettingsNavigation from './settingsNavigation';
 
 export const module: Module<*> = new Module('modHelper');
@@ -13,10 +12,9 @@ module.category = 'coreCategory';
 module.description = 'modhelperDesc';
 module.hidden = true;
 module.alwaysEnabled = true;
+module.include = ['stylesheet'];
 module.go = () => {
-	if (isPageType('stylesheet')) {
-		doStyleSheetCheck();
-	}
+	doStyleSheetCheck();
 };
 
 const tips = {

--- a/lib/modules/multiredditNavbar.js
+++ b/lib/modules/multiredditNavbar.js
@@ -78,7 +78,7 @@ module.options = {
 	},
 };
 
-module.go = () => {
+module.contentStart = () => {
 	if (module.options.sectionMenu.value) {
 		$('.listing-chooser .multis').on('mouseenter', 'li', onMouseEnterMultiLink);
 	}

--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import { $ } from '../vendor';
 import { RES_NER_PAGE_HASH } from '../constants/urlHashes';
 import { Module } from '../core/module';
+import * as Init from '../core/init';
 import { Storage, ajax, context } from '../environment';
 import {
 	HOUR,
@@ -107,8 +108,6 @@ module.beforeLoad = () => {
 			handleDupes(thing);
 		}, { immediate: true });
 	}
-
-	initiateReturnToPrevPage();
 };
 
 module.go = async () => {
@@ -139,7 +138,7 @@ const pages: Array<{|
 |}> = [];
 
 export let loadNextPage: (opts?: { scrollToLoadWidget: boolean }) => void = () => {};
-let refreshAutoLoad: ?() => void;
+let refreshAutoLoad;
 
 const getNextPageUrl = (): ?string => pages.slice(-1)[0].nextPageUrl;
 
@@ -167,6 +166,9 @@ function prepareNextPageLoad(displayEndBanner = true) {
 		});
 
 	createLoaderWidget(startPromise, donePromise);
+
+	// It is not desirable to enable auto load instantly after creating the widget, to let misc async tasks complete
+	Promise.all([Init.afterLoad, new Promise((requestIdleCallback: any))]).then(() => { if (refreshAutoLoad) refreshAutoLoad(false); });
 }
 
 const pauseButton = _.once(() => {
@@ -204,10 +206,6 @@ function setReturnToPage(selected: Thing) {
 	const { ner: saved } = history.state || {};
 	if (saved && saved.number === number) return;
 
-	// After appended page number two, the browser will auto-scroll too far
-	const allowAutoScroll = $earlierMarkers.length < 2;
-	history.scrollRestoration = allowAutoScroll ? 'auto' : 'manual';
-
 	history.replaceState(
 		{ ...history.state, ner: { number, ...pages[number] } },
 		`${document.title}${number ? `- page ${number + 1}` : ''}`,
@@ -218,19 +216,15 @@ function setReturnToPage(selected: Thing) {
 const initiateReturnToPrevPage = _.once(() => {
 	if (!module.options.returnToPrevPage.value) return;
 
-	const { ner } = history.state || {};
-	if (!ner || !isNerUrl()) return;
-
-	const { number, url } = ner;
-
-	if (url) {
-		// Cached & memoized, so it loads quickly
-		fetchPage(url);
+	const { ner: { number, url } = {} } = history.state || {};
+	let append;
+	if (number && url && isNerUrl()) {
+		const loadPromise = loadPage(url, number, new Promise(res => { append = () => { res(); return loadPromise; }; }));
 	}
 
-	return () => {
-		if (url) loadPage(url, number);
-		SelectedEntry.addListener(setReturnToPage, 'beforeScroll');
+	return async () => {
+		if (append) await append();
+		SelectedEntry.addListener(setReturnToPage, 'instantly');
 	};
 });
 
@@ -343,21 +337,21 @@ function createLoaderWidget(startPromise, donePromise) {
 	const pauseReasonIo = new IntersectionObserver(([{ isIntersecting }]) => {
 		if (isIntersecting && pauseReason) displayPauseReason(pauseReason);
 	}, { threshold: [1] });
-	pauseReasonIo.observe(widget);
 
 	const loadNextPageIo = new IntersectionObserver(([{ isIntersecting }]) => {
 		if (!isIntersecting) return;
 		loadNextPage();
 	}, { threshold: [1] });
 
-	refreshAutoLoad = () => {
+	refreshAutoLoad = (updateWidget = true) => {
 		const enabled = !pauseReason;
 		if (enabled) loadNextPageIo.observe(widget);
 		else loadNextPageIo.disconnect();
-		setLoaderWidgetActionText(widget);
+		if (updateWidget) setLoaderWidgetActionText(widget);
+		pauseReasonIo.observe(widget);
 	};
 
-	refreshAutoLoad();
+	setLoaderWidgetActionText(widget);
 
 	startPromise.then(() => {
 		prefetchIo.disconnect();
@@ -370,7 +364,7 @@ function createLoaderWidget(startPromise, donePromise) {
 const fetchPage = _.memoize(url => ajax({ url, cacheFor: HOUR }));
 const prefetchNextPage = () => { const url = getNextPageUrl(); if (url) fetchPage(url); };
 
-async function loadPage(url: string, number: number) {
+async function loadPage(url: string, number: number, attachPromise: ?Promise<*>) {
 	const html = (await fetchPage(url))
 		// remove some elements which may have side-effects when parsed
 		.replace(/<style(.|\s)*?>|<link(.|\s)*?>|<script(.|\s)*?\/script>/g, '');
@@ -400,6 +394,8 @@ async function loadPage(url: string, number: number) {
 		<a href="${pages[number].url}">Page ${number + 1}</a>
 		${string.safe(SettingsNavigation.makeUrlHashLink(module.moduleID, undefined, ' ', 'gearIcon'))}
 	</div>`;
+
+	await attachPromise;
 
 	const firstLen = $(container()).find('.link:last .rank').text().length;
 	const lastLen = $(newSiteTable).find('.link:last .rank').text().length;

--- a/lib/modules/newCommentCount.js
+++ b/lib/modules/newCommentCount.js
@@ -114,7 +114,7 @@ module.beforeLoad = () => {
 	watchForThings(['post'], displayNewCommentCount);
 };
 
-module.go = () => {
+module.contentStart = () => {
 	if (subscriptionButton) {
 		$('.commentarea .panestack-title').append(subscriptionButton);
 	}

--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -134,6 +134,8 @@ module.beforeLoad = () => {
 	});
 	toggle.addCLI('ns');
 	if (module.options.nightSwitch.value) toggle.addMenuItem(i18n('nightModeToggleTitle'), 7, '☽', '☀');
+
+	handleAutomaticNightMode();
 };
 
 module.always = () => {
@@ -141,10 +143,6 @@ module.always = () => {
 		// Nightmode might have been erronously applied in `onInit`
 		removeNightMode();
 	}
-};
-
-module.go = () => {
-	handleAutomaticNightMode();
 };
 
 export function isNightModeOn(): boolean {

--- a/lib/modules/noParticipation.js
+++ b/lib/modules/noParticipation.js
@@ -69,7 +69,7 @@ const boilerplateNotificationText = `
 
 let noParticipationActive;
 
-module.go = () => {
+module.contentStart = () => {
 	if (module.options.escapeNP.value) {
 		$(document.body).on('mousedown', 'a', removeNpFromLink);
 	}

--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -137,7 +137,7 @@ module.options = {
 	},
 };
 
-module.go = () => {
+module.contentStart = () => {
 	if (module.options.faviconUseLegacy.value) setupFavicon();
 
 	if (!loggedInUser()) {

--- a/lib/modules/pageNavigator.js
+++ b/lib/modules/pageNavigator.js
@@ -48,7 +48,7 @@ module.beforeLoad = () => {
 	}
 };
 
-module.go = () => {
+module.contentStart = () => {
 	if (module.options.toComment.value && isPageType('comments')) {
 		backToNewCommentArea();
 	}
@@ -64,7 +64,7 @@ function backToTop() {
 		window.scrollTo(0, 0);
 		SelectedEntry.move('top');
 	});
-	Floater.addElement($backToTop);
+	Floater.addElement($backToTop, { order: 9 });
 }
 
 const showLinkTitleTemplate = ({ thumbnailSrc, linkId, settingsHash, linkHref, linkNewTab, title, domainHref, domain, time, author, authorHref }) => string.html`
@@ -88,7 +88,8 @@ const showLinkTitleTemplate = ({ thumbnailSrc, linkId, settingsHash, linkHref, l
 `;
 
 function backToNewCommentArea() {
-	const commentArea = document.querySelector('.commentarea > form.usertext textarea');
+	// TODO Find a way to determine whether the comment area is visible which does not cause a reflow
+	const commentArea = document.querySelector('.commentarea > form.usertext textarea:not([disabled])');
 	if (!commentArea) return;
 
 	const $backToNewCommentArea = $(`<a class="pageNavigator res-icon" data-id="addComment" href="#comments" title="${i18n('pageNavToCommentTitle')}">&#xF003;</a>`);
@@ -97,10 +98,6 @@ function backToNewCommentArea() {
 		commentArea.focus();
 	});
 	Floater.addElement($backToNewCommentArea);
-
-	requestAnimationFrame(() => {
-		if (!commentArea.offsetParent) $backToNewCommentArea.get(0).hidden = true;
-	});
 }
 
 const showLinkTitle = _.once(submissionThing => {

--- a/lib/modules/profileNavigator.js
+++ b/lib/modules/profileNavigator.js
@@ -71,7 +71,7 @@ module.options = {
 	},
 };
 
-module.go = () => {
+module.contentStart = () => {
 	const username = loggedInUser();
 	if (module.options.sectionMenu.value && username) {
 		$('#header .user a').on('mouseenter', (e: Event) => onMouseEnterProfileLink(username, e));

--- a/lib/modules/quarantineHide.js
+++ b/lib/modules/quarantineHide.js
@@ -2,7 +2,7 @@
 
 import { Module } from '../core/module';
 import { $ } from '../vendor';
-import { BodyClasses } from '../utils';
+import { BodyClasses, frameThrottle, watchForThings } from '../utils';
 import { inQuarantinedSubreddit } from '../utils/location';
 
 export const module: Module<*> = new Module('quarantineHide');
@@ -27,17 +27,12 @@ module.options = {
 
 module.include = ['linklist', 'comments', 'wiki'];
 
-module.go = () => {
+module.contentStart = () => {
 	if (module.options.hideFlair.value) {
-		removeStamp();
-		window.addEventListener('neverEndingLoad', removeStamp);
+		watchForThings(['post'], frameThrottle(() => { $('.quarantine-stamp').parent().remove(); }));
 	}
 	if (inQuarantinedSubreddit() && module.options.hideQuarantinedInSub.value) {
 		BodyClasses.remove('quarantine');
 		$('.quarantine-notice').hide();
 	}
 };
-
-function removeStamp() {
-	$('.quarantine-stamp').parent().remove();
-}

--- a/lib/modules/quickMessage.js
+++ b/lib/modules/quickMessage.js
@@ -82,7 +82,7 @@ module.options = {
 
 const lastSentAsStorage = Storage.wrapPrefix('RESmodules.quickMessage.lastSentAs.', () => (null: null | string));
 
-module.go = () => {
+module.contentStart = () => {
 	CommandLine.registerCommand(
 		(cmd, val) => cmd === 'qm' && (/^(?:([^\s]+)(?:\s(.*))?)?$/).exec(val),
 		'qm [recipient [message]] - open quick message dialog',

--- a/lib/modules/readComments.js
+++ b/lib/modules/readComments.js
@@ -4,8 +4,6 @@ import { Module } from '../core/module';
 import { Storage, isPrivateBrowsing } from '../environment';
 import {
 	execRegexes,
-	reifyPromise,
-	fastAsync,
 	maybePruneOldEntries,
 } from '../utils';
 import * as SelectedEntry from './selectedEntry';
@@ -42,14 +40,14 @@ const entryStorage = Storage.wrapPrefix('readComments.', (): {|
 	updateTime: Date.now(),
 	ids: {},
 }));
-const initialStorage = reifyPromise(
-	entryStorage.get(currentId).then(({ ids }) => new Set(Object.keys(ids)))
-);
+
+const initial = entryStorage.get(currentId);
+let ids;
 
 module.beforeLoad = async () => {
-	if (!module.options.monitorWhenIncognito.value && isPrivateBrowsing()) return;
+	ids = await (initial.then(({ ids }) => new Set(Object.keys(ids))));
 
-	const ids = await initialStorage.get();
+	if (!module.options.monitorWhenIncognito.value && isPrivateBrowsing()) return;
 
 	SelectedEntry.addListener(selected => {
 		if (selected.isComment() && selected.isContentVisible()) {
@@ -62,8 +60,7 @@ module.beforeLoad = async () => {
 	maybePruneOldEntries('readComments', entryStorage, parseInt(module.options.cleanComments.value, 10));
 };
 
-export const isRead = fastAsync(function*(thing: *): * {
-	if (!initialStorage) return false;
-	const ids = yield initialStorage.get();
+export const isRead = (thing: *) => {
+	if (!ids) throw new Error();
 	return ids.has(thing.getFullname());
-});
+};

--- a/lib/modules/saveComments.js
+++ b/lib/modules/saveComments.js
@@ -46,7 +46,7 @@ module.beforeLoad = async () => {
 	watchForThings(['comment'], addSaveLinkToComment);
 };
 
-module.go = async () => {
+module.contentStart = async () => {
 	if (savedRe.test(location.pathname)) {
 		await drawSavedComments();
 		switchTab(location.hash);

--- a/lib/modules/searchHelper.js
+++ b/lib/modules/searchHelper.js
@@ -168,7 +168,7 @@ module.options = {
 	},
 };
 
-module.go = () => {
+module.contentStart = () => {
 	if (module.options.addSearchOptions.value) {
 		const searchExpando = document.getElementById('searchexpando');
 		if (searchExpando) {

--- a/lib/modules/selectedEntry.js
+++ b/lib/modules/selectedEntry.js
@@ -32,13 +32,6 @@ module.options = {
 		value: false,
 		description: 'selectedEntryAutoSelectOnScrollDesc',
 	},
-	scrollToSelectedThingOnLoad: {
-		title: 'selectedEntryScrollToSelectedThingOnLoadTitle',
-		type: 'boolean',
-		value: false,
-		advanced: true,
-		description: 'selectedEntryScrollToSelectedThingOnLoadDesc',
-	},
 	addLine: {
 		title: 'selectedEntryAddLineTitle',
 		type: 'boolean',
@@ -92,7 +85,7 @@ module.options = {
 };
 
 const lastSelectedKey = `${LAST_SELECTED_ENTRY_KEY}-${location.pathname}`;
-export let selectedThing: ?Thing;
+export const getLastSelectedId = () => sessionStorage[lastSelectedKey];
 let selectedContainer: ?Element;
 let oldSelected;
 
@@ -103,64 +96,47 @@ module.beforeLoad = () => {
 	if (module.options.setColors.value) styleColor();
 	styleOutline();
 
-	if (!sessionStorage[lastSelectedKey]) {
-		watchForThings(null, _.once(select));
-	}
+	// Auto select the previous selected thing this session, or the first thing
+	const lastSelectedId = getLastSelectedId();
+	watchForThings(null, thing => {
+		if (Thing.selected) return;
+		if (!lastSelectedId) return select(thing);
+		if (thing.getFullname() !== lastSelectedId) return;
+		history.scrollRestoration = 'manual';
+		select(thing, { scrollStyle: 'legacy' });
+	}, { immediate: true });
 };
 
-module.go = () => {
+module.contentStart = () => {
 	// Select Thing on manual click
 	$(document.body).on('mouseup', Thing.thingSelector, (e: MouseEvent) => {
 		if (click.isProgrammaticEvent(e)) return;
 		const thing = Thing.from(e.target);
-		if (thing) select(thing, { scrollStyle: 'none' });
+		if (thing) select(thing);
+		return false; // In comment threads `thingSelector` may match parents of `target`; returning `false` prevents the event bubbling to them
 	});
-
-	// When loading additonal comments, select the first newly loaded comment
-	watchForThings(['comment'], _.throttle(thing => {
-		if (selectedThing && document.contains(selectedThing.element)) return;
-		if (selectedContainer && selectedContainer !== thing.element.closest('.sitetable')) return;
-		select(thing);
-		// The comment may be hidden by filters, so check that it's actually visible
-		autoSelect();
-	}, 100, { leading: true, trailing: false }), { immediate: true });
 
 	if (module.options.autoSelectOnScroll.value) {
 		window.addEventListener('scroll', () => { autoSelect(); });
 	}
-
-	addListener(selected => {
-		sessionStorage[lastSelectedKey] = selected.getFullname();
-	}, 'beforeScroll');
-
-	const lastSelectedId = sessionStorage[lastSelectedKey];
-	if (lastSelectedId) {
-		requestAnimationFrame(() => {
-			const thing = Thing.from(document.querySelector(`.thing[data-fullname=${lastSelectedId}]`));
-			if (!thing || !thing.isVisible()) {
-				autoSelect();
-				return;
-			}
-
-			if (module.options.scrollToSelectedThingOnLoad.value) history.scrollRestoration = 'manual';
-			// `scrollRestoration` may also be set in neverEndingReddit
-			const scrollToSelected = history.scrollRestoration === 'manual';
-			select(thing, { scrollStyle: scrollToSelected ? 'legacy' : 'none' });
-		});
-	}
 };
 
-export function anchor() {
-	// Keep the selected thing anchored if it is in the viewport
-	const thing = selectedThing;
-	if (!thing) return;
-	const anchor = getPercentageVisibleYAxis(thing.entry) && { to: thing.entry.getBoundingClientRect().top };
-	if (!anchor) return;
-	requestAnimationFrame(() => {
-		if (thing !== selectedThing || !thing.entry.offsetParent) return;
-		scrollToElement(thing.entry, undefined, { scrollStyle: 'none', anchor });
-	});
-}
+module.afterLoad = () => {
+	if (!Thing.selected || !Thing.selected.isVisible()) autoSelect();
+
+	// When loading additonal comments, select the first newly loaded comment
+	watchForThings(['comment'], _.throttle(thing => {
+		if (Thing.selected && document.contains(Thing.selected.element)) return;
+		if (selectedContainer && selectedContainer !== thing.element.closest('.sitetable')) return;
+		select(thing);
+	}, 100, { leading: true, trailing: false }), { immediate: true });
+
+	addListener(selected => {
+		const id = selected.getFullname();
+		if (!id) return;
+		sessionStorage[lastSelectedKey] = id;
+	}, 'beforePaint');
+};
 
 type SelectOptions = {
 	allowMediaBrowse?: boolean,
@@ -169,7 +145,7 @@ type SelectOptions = {
 
 type SelectOptionsWithDirection = SelectOptions & { direction?: 'down' | 'up' };
 
-const listeners = { beforeScroll: [], beforePaint: [], idle: [] };
+const listeners = { instantly: [], beforePaint: [], idle: [] };
 
 export function addListener(
 	callback: (new_: Thing, old: ?Thing, opt: SelectOptionsWithDirection) => mixed,
@@ -200,52 +176,45 @@ const runCallbacks = (() => {
 		};
 	}
 
+	const runBeforePaint = throttle(frameThrottle, listeners.beforePaint);
 	const runIdle = throttle(idleThrottle, listeners.idle);
-	const runPaint = throttle(frameThrottle, listeners.beforePaint);
 
 	return (new_, old, opt) => {
-		if (listeners.beforeScroll.length) runListeners(listeners.beforeScroll, new_, old, opt);
-		if (listeners.beforePaint.length) runPaint(new_, old, opt);
+		if (listeners.instantly.length) runListeners(listeners.instantly, new_, old, opt);
+		if (listeners.beforePaint.length) runBeforePaint(new_, old, opt);
 		if (listeners.idle.length) runIdle(new_, old, opt);
 	};
 })();
 
 export function select(newSelected: Thing, options: SelectOptions = { scrollStyle: 'none' }, force: boolean = false) {
-	if (!force && newSelected === selectedThing) return;
+	if (!force && newSelected === Thing.selected) return;
 
-	oldSelected = selectedThing;
+	oldSelected = Thing.selected;
+	Thing.selected = newSelected;
+	selectedContainer = newSelected.element.closest('.sitetable');
 
-	options = {
-		...options,
-		direction: newSelected && newSelected.isVisible() && oldSelected && oldSelected.isVisible() ?
-			(newSelected.entry.getBoundingClientRect().top > oldSelected.entry.getBoundingClientRect().top ? 'down' : 'up') :
-			undefined,
-	};
-
-	runCallbacks(newSelected, oldSelected, options);
-
-	selectedThing = newSelected;
-	selectedContainer = newSelected && newSelected.element.closest('.sitetable');
+	const direction = oldSelected && oldSelected.getDirectionOf(newSelected);
+	runCallbacks(newSelected, oldSelected, { ...options, ...(direction ? { direction } : undefined) });
 }
 
 const autoSelect = frameDebounce(() => {
-	if (selectedThing && getPercentageVisibleYAxis(selectedThing.entry)) return;
+	if (Thing.selected && getPercentageVisibleYAxis(Thing.selected.entry)) return;
 
-	const closestToCurrent = selectedThing && selectedThing.getClosestVisible();
+	const closestToCurrent = Thing.selected && Thing.selected.getClosestVisible();
 	if (closestToCurrent && getPercentageVisibleYAxis(closestToCurrent.entry)) {
 		select(closestToCurrent);
 		return;
 	}
 
 	const things = Thing.visibleThings();
-	const currentIndex = things.indexOf(selectedThing);
+	const currentIndex = things.indexOf(Thing.selected);
 	const closestThings = _.sortBy(things.filter(thing => thing.isVisible()), thing => Math.abs(things.indexOf(thing) - currentIndex));
 	const closestVisible = _.maxBy(closestThings, ({ entry }) => getPercentageVisibleYAxis(entry));
 	if (closestVisible) select(closestVisible);
 });
 
 export function refreshSelect() {
-	if (!selectedThing || selectedThing.isVisible()) return;
+	if (!Thing.selected || Thing.selected.isVisible()) return;
 	autoSelect();
 }
 
@@ -266,26 +235,26 @@ const movers = {
 };
 
 export function move(direction: $Keys<typeof movers>, options?: SelectOptionsWithDirection, fallback?: () => ?*) {
-	if (!selectedThing || !selectedThing.element.offsetParent) {
+	if (!Thing.selected || !Thing.selected.element.offsetParent) {
 		autoSelect();
 		return;
 	}
 
 	const targetFn = movers[direction];
 
-	if (!selectedThing && targetFn.length) {
+	if (!Thing.selected && targetFn.length) {
 		if (!fallback || !fallback()) throw new Error('Function only works when an entry is selected');
 	}
 
-	const target = targetFn((selectedThing: any));
+	const target = targetFn((Thing.selected: any));
 
 	if (!target) {
 		if (fallback && fallback()) return;
 
-		if (selectedThing) return select(selectedThing, { scrollStyle: 'middle' });
+		if (Thing.selected) return select(Thing.selected, { scrollStyle: 'middle' });
 		throw new Error('Could not find a target');
-	} else if (selectedThing === target) {
-		if (selectedThing) return select(selectedThing, { scrollStyle: 'middle' });
+	} else if (Thing.selected === target) {
+		if (Thing.selected) return select(Thing.selected, { scrollStyle: 'middle' });
 		throw new Error('Target already selected');
 	}
 
@@ -293,13 +262,15 @@ export function move(direction: $Keys<typeof movers>, options?: SelectOptionsWit
 }
 
 const addScrollStyleListener = _.once(() => {
-	// Filtered comments may be collapsed or expanded (causing height change) depending on whether they are selected
 	let anchor;
+	// Partially visible comments may change height change depending on whether they are selected,
+	// so it is necessary to anchor them to avoid having viewport move relative to the selected thing
+	// XXX Can the native browser scroll anchoring achieve this?
 	addListener((selected, unselected, { scrollStyle }) => {
 		if (
 			unselected && selected !== unselected &&
 			(['none', 'adopt']: Array<ScrollStyle>).includes(scrollStyle) &&
-			(selected.matchingHideFilter || unselected.matchingHideFilter)
+			(selected.element.classList.contains('res-thing-partial') || unselected.element.classList.contains('res-thing-partial'))
 		) {
 			anchor = {
 				to: selected.entry.getBoundingClientRect().top,
@@ -308,11 +279,13 @@ const addScrollStyleListener = _.once(() => {
 		} else {
 			anchor = undefined;
 		}
-	}, 'beforeScroll', -Infinity);
+	}, 'instantly', -Infinity);
 
-	// Scroll may force reflow when determining new position
-	// Run it last so that another listener won't invalidate it
-	addListener((selected, unselected, { scrollStyle, direction }) => scrollToElement(selected.entry, unselected && unselected.entry, { scrollStyle, direction, anchor }), 'beforePaint', Infinity);
+	addListener(async (selected, unselected, { direction, scrollStyle }) => {
+		selected.runTasks();
+		// If this has to wait for the thing to be visible, a promise is returned
+		await scrollToElement(selected.entry, unselected && unselected.entry, { scrollStyle, direction, anchor, waitTillVisible: true });
+	}, 'beforePaint', 9);
 });
 
 const installUpdateSelectedElementClassListener = _.once(() =>

--- a/lib/modules/settingsNavigation.js
+++ b/lib/modules/settingsNavigation.js
@@ -48,7 +48,7 @@ module.beforeLoad = () => {
 	);
 };
 
-module.go = () => {
+module.contentStart = () => {
 	function findModules(val) {
 		return Modules.all()
 			.filter(v => !v.hidden)

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -30,7 +30,6 @@ import {
 	forEachSeq,
 	idleThrottle,
 	frameThrottle,
-	frameDebounce,
 	isPageType,
 	string,
 	waitForEvent,
@@ -489,8 +488,9 @@ module.beforeLoad = () => {
 	}
 
 	watchForElements(['selfText'], null, scanBody);
-	watchForThings(['comment', 'message'], thing => scanBody(thing.getTextBody()));
-	watchForThings(['post'], thing => checkElementForMedia(thing.getPostLink()));
+	// TODO Restore filter case Expando interaction
+	watchForThings(['comment', 'message'], thing => scanBody(thing.getTextBody()), { id: module });
+	watchForThings(['post'], thing => checkElementForMedia(thing.getPostLink()), { id: module });
 
 	watchForRedditEvents('comment', (placeholder, { _: { update } }) => {
 		if (update) return;
@@ -510,14 +510,16 @@ module.beforeLoad = () => {
 	});
 };
 
-module.go = () => {
-	if (isPageType('wiki')) scanBody(document.querySelector('.wiki-page-content'));
-
+module.contentStart = () => {
 	createImageButtons();
 
 	if (module.options.mediaBrowse.value) {
-		SelectedEntry.addListener(mediaBrowse, 'beforeScroll');
+		SelectedEntry.addListener(mediaBrowse, 'instantly');
 	}
+};
+
+module.go = () => {
+	if (isPageType('wiki')) scanBody(document.querySelector('.wiki-page-content'));
 
 	// Handle spotlight next/prev hiding open expando's
 	const spotlight = document.querySelector('#siteTable_organic');
@@ -536,8 +538,6 @@ module.afterLoad = () => {
 	if (module.options.conserveMemory.value) {
 		enableConserveMemory();
 	}
-
-	window.addEventListener('scroll', refresh);
 };
 
 function siteModuleOptionKey(siteModule) {
@@ -571,16 +571,6 @@ function* modulesForHostname(hostname) {
 
 	for (const m of genericHosts) yield m;
 }
-
-const deferredLinks: Map<HTMLElement, () => void> = new Map();
-
-function checkDeferredLinks() {
-	for (const [link, complete] of deferredLinks) {
-		if (!shouldLinkBeDeferred(link)) complete();
-	}
-}
-
-export const thingExpandoBuildListeners: * = $.Callbacks('unique'); // eslint-disable-line new-cap
 
 /**
  * enableConserveMemory
@@ -619,6 +609,8 @@ function enableConserveMemory() {
 			}
 		}
 	}, { rootMargin });
+
+	// TODO Also handle native expandos
 
 	window.addEventListener('scroll', idleThrottle(() => {
 		const activeExpandos = Array.from(primaryExpandos.values());
@@ -680,11 +672,6 @@ function createImageButtons() {
 		});
 	}
 }
-
-export const refresh = frameDebounce(() => {
-	checkDeferredLinks();
-	updateAutoExpandCount();
-});
 
 const updateAutoExpandCount = idleThrottle(() => {
 	if (!viewImagesButton) return;
@@ -903,21 +890,9 @@ export function getLinkExpando(link: HTMLAnchorElement): ?Expando {
 	return linksMap.get(link);
 }
 
-function shouldLinkBeDeferred(element) {
-	const thing = Thing.from(element);
-	return thing && !thing.isContentVisible() && // No need to complete building non-visible links
-		// Unless they are hidden because because of the expando filter
-		!(thing.matchingHideFilter && thing.matchingHideFilter.case.hasType('hasExpando'));
-}
-
 const inText = element => !!element.closest('.md, .search-result-footer');
 
 async function checkElementForMedia(element: HTMLAnchorElement) {
-	if (shouldLinkBeDeferred(element)) {
-		await new Promise(resolve => deferredLinks.set(element, resolve));
-		deferredLinks.delete(element);
-	}
-
 	const thing = Thing.from(element);
 	const entryExpando = !inText(element) && Expando.getEntryExpandoFrom(thing);
 	const nativeExpando = entryExpando instanceof Expando ? null : entryExpando;
@@ -977,8 +952,6 @@ async function checkElementForMedia(element: HTMLAnchorElement) {
 		expando.destroy();
 		linksMap.delete(element);
 	}
-
-	if (thing) thingExpandoBuildListeners.fire(thing);
 }
 
 function placeExpando(expando, element, thing) {

--- a/lib/modules/showKarma.js
+++ b/lib/modules/showKarma.js
@@ -37,7 +37,7 @@ module.options = {
 	},
 };
 
-module.go = async () => {
+module.contentStart = async () => {
 	const username = loggedInUser();
 	if (username) {
 		if (module.options.showCommentKarma.value) {

--- a/lib/modules/showParent.js
+++ b/lib/modules/showParent.js
@@ -53,7 +53,7 @@ module.include = [
 	'comments',
 ];
 
-module.go = () => {
+module.contentStart = () => {
 	$(document.body).on('mouseenter', '.comment .buttons :not(:first-child) .bylink', function() {
 		startHover(this, {
 			openDelay: parseFloat(module.options.hoverDelay.value),

--- a/lib/modules/singleClick.js
+++ b/lib/modules/singleClick.js
@@ -55,7 +55,7 @@ module.beforeLoad = () => {
 	watchForThings(['post'], applyLinks);
 };
 
-module.go = () => {
+module.contentStart = () => {
 	// mousedown because Firefox doesn't fire click events on middle click...
 	$(document.body).on('mousedown', '.redditSingleClick', (e: MouseEvent) => {
 		if (e.button !== 2) {

--- a/lib/modules/stylesheet.js
+++ b/lib/modules/stylesheet.js
@@ -197,7 +197,7 @@ module.beforeLoad = () => {
 	}
 };
 
-module.go = () => {
+module.contentStart = () => {
 	if (module.options.loggedInUserClass.value) {
 		applyLoggedInUserClass();
 	}

--- a/lib/modules/subredditInfo.js
+++ b/lib/modules/subredditInfo.js
@@ -56,7 +56,7 @@ module.options = {
 	},
 };
 
-module.go = () => {
+module.contentStart = () => {
 	const linkSelector = [
 		'a.subreddit',
 		'a.search-subreddit-link',

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -17,6 +17,7 @@ import {
 	loggedInUser,
 	regexes,
 	string,
+	waitForDescendant,
 	watchForThings,
 } from '../utils';
 import { Session, Storage, ajax, isPrivateBrowsing, i18n } from '../environment';
@@ -220,13 +221,17 @@ const subredditShortcutsStorage = Storage.wrap(() => {
 	addedDate: number,
 |}>));
 
-module.go = async () => {
-	if (module.options.lastUpdate.value && document.getElementsByClassName('listing-chooser').length) {
-		lastUpdate();
-	}
+// depends on loggedInUser; must be called after the username is available
+const initialShortcutsLoad = _.once(getLatestShortcuts);
 
-	// depends on loggedInUser; must be called after body is ready
-	await getLatestShortcuts();
+module.beforeLoad = () => {
+	waitForDescendant(document.documentElement, '#sr-header-area').then(createSubredditBar);
+};
+
+module.contentStart = async () => {
+	await initialShortcutsLoad();
+
+	createSidebarShortcutToggle();
 
 	watchForThings(['subreddit'], thing => {
 		const titleElement = thing.getTitleElement();
@@ -236,19 +241,22 @@ module.go = async () => {
 		if (!subreddit) return;
 		container.append(createShortcutToggleButton(subreddit));
 	});
+};
 
-	manageSubreddits();
+module.afterLoad = () => {
+	redrawShortcuts();
+
+	if (module.options.lastUpdate.value && document.getElementsByClassName('listing-chooser').length) {
+		lastUpdate();
+	}
 
 	const subreddit = currentSubreddit();
 	if (subreddit) {
-		setLastViewtime(subreddit);
+		requestAnimationFrame(() => { setLastViewtime(subreddit); });
 	}
 };
 
-function manageSubreddits() {
-	// This is the init function for Manage Subreddits - it'll get your preferences and redraw the top bar.
-	redrawSubredditBar();
-	// Listen for subscriptions / unsubscriptions from reddits so we know to reload the JSON string...
+function createSidebarShortcutToggle() {
 	// also, add a +/- shortcut button...
 	const subreddit = currentSubreddit();
 	if (subreddit && module.options.subredditShortcut.value) {
@@ -775,7 +783,7 @@ function subredditDragEnd() {
 	return false;
 }
 
-function redrawSubredditBar() {
+function createSubredditBar(headerContents) {
 	const originalShortcuts: HTMLAnchorElement[] = (Array.from(document.querySelectorAll('.sr-list a.choice')): any[]);
 	let myRandomEnabled, myRandomGold;
 	if (module.options.linkMyRandom.value) {
@@ -798,7 +806,6 @@ function redrawSubredditBar() {
 	const originalPopular = originalShortcuts.find(({ pathname }) => pathname === '/r/popular/');
 	const originalProfilePosts = originalShortcuts.find(({ pathname }) => pathname === '/r/profileposts/');
 
-	const headerContents = document.querySelector('#sr-header-area');
 	if (headerContents) {
 		// Clear out the existing stuff in the top bar first, we'll replace it with our own stuff.
 		$(headerContents).html('');
@@ -1004,8 +1011,6 @@ function redrawSubredditBar() {
 			}
 		});
 		shortCutsEditContainer.appendChild(shortCutsLeft);
-
-		redrawShortcuts();
 	}
 }
 

--- a/lib/modules/subredditStyleToggle.js
+++ b/lib/modules/subredditStyleToggle.js
@@ -97,25 +97,15 @@ function createToggle(initialState) {
 
 	toggle.toggle('auto', initialState);
 
-	Init.bodyReady.then(makeInteractable);
+	makeInteractable();
 }
 
 function makeInteractable() {
 	if (module.options.checkbox.value) {
-		const sidebarHeader = document.querySelector('.titlebox h1.redditname');
-		if (sidebarHeader) {
-			const container = string.html`
-				<form class="toggle res-sr-style-toggle">
-					<label for="res-style-checkbox">${i18n('subredditStyleToggleUse')}</label>
-				</form>
-			`;
-
-			const checkbox = toggle.buildCheckbox();
-			checkbox.setAttribute('id', 'res-style-checkbox');
-			checkbox.setAttribute('name', 'res-style-checkbox');
-			container.prepend(checkbox);
-			sidebarHeader.after(container);
-		}
+		Init.sitetableStarted.then(() => {
+			const place = document.body.querySelector('.titlebox h1.redditname');
+			if (place) insertCheckbox(place);
+		});
 	}
 
 	if (module.options.browserToolbarButton.value) {
@@ -129,6 +119,20 @@ function makeInteractable() {
 	if ($('#show_stylesheets').length) {
 		$('label[for=show_stylesheets]').after(string.escape` <span class="little gray">(${i18n('subredditStyleToggleRedditPrefsMessage')} <a href="/r/Enhancement/wiki/srstyle">${i18n('subredditStyleToggleClickToLearnMore')}</a>)</span>`);
 	}
+}
+
+function insertCheckbox(place) {
+	const container = string.html`
+		<form class="toggle res-sr-style-toggle">
+			<label for="res-style-checkbox">${i18n('subredditStyleToggleUse')}</label>
+		</form>
+	`;
+
+	const checkbox = toggle.buildCheckbox();
+	checkbox.setAttribute('id', 'res-style-checkbox');
+	checkbox.setAttribute('name', 'res-style-checkbox');
+	container.prepend(checkbox);
+	place.after(container);
 }
 
 const shouldDisable = (nightmodeCompatible: boolean | Promise<boolean> = NightMode.isNightmodeCompatible(true)) => asyncSome([
@@ -169,7 +173,7 @@ const getHeaderImg = _.once(async () => {
 	const imgWrapper = (
 		await Init.bodyStart.then(query) ||
 		await waitForChild(document.body, '#header').then(query) ||
-		await Init.bodyReady.then(query)
+		await Init.contentStart.then(query)
 	);
 
 	return { imgWrapper, headerImg: imgWrapper && imgQuery() };

--- a/lib/modules/tableTools.js
+++ b/lib/modules/tableTools.js
@@ -21,7 +21,7 @@ module.options = {
 
 module.shouldRun = () => !isCurrentSubreddit('dashboard');
 
-module.go = () => {
+module.contentStart = () => {
 	if (module.options.sort.value) {
 		$(document).on('click', '.md th', (e: Event) => sortTableColumn(e.currentTarget));
 	}

--- a/lib/modules/temporaryDropdownLinks.js
+++ b/lib/modules/temporaryDropdownLinks.js
@@ -20,7 +20,7 @@ module.include = [
 	/\/(?:top|controversial)\/$/,
 ];
 
-module.go = () => {
+module.contentStart = () => {
 	setupMenu();
 };
 

--- a/lib/modules/userHighlight.js
+++ b/lib/modules/userHighlight.js
@@ -6,7 +6,7 @@ import {
 	Alert,
 	Thing,
 	addCSS,
-	frameThrottle,
+	throttle,
 	hashCode,
 	isPageType,
 	loggedInUser,
@@ -286,7 +286,7 @@ module.beforeLoad = () => {
 	}
 };
 
-module.go = () => {
+module.contentStart = () => {
 	const username = loggedInUser();
 	if (module.options.highlightSelf.value && username) {
 		highlight(`author[href$="/${username}"]`, module.options.selfColor.value, module.options.selfColorHover.value);
@@ -409,7 +409,7 @@ export function highlightUser(userid: string) {
 }
 
 const css = [];
-const throttled = frameThrottle(() => { addCSS(css.splice(0, css.length).join('\n')); });
+const throttled = throttle(() => { addCSS(css.splice(0, css.length).join('\n')); });
 const batch = v => { css.push(v); throttled(); };
 
 function highlight(selector, color, hoverColor, container = '') {

--- a/lib/modules/userInfo.js
+++ b/lib/modules/userInfo.js
@@ -102,7 +102,7 @@ module.options = {
 
 export const highlightedUsers = {};
 
-module.go = () => {
+module.contentStart = () => {
 	if (module.options.hoverInfo.value) {
 		$(document.body).on('mouseenter', usernameSelector, handleMouseEnter);
 	}

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -16,8 +16,8 @@ import {
 	loggedInUser,
 	preventCloning,
 	string,
-	watchForThings,
 	watchForElements,
+	watchForThings,
 	empty,
 	watchForRedditEvents,
 	isAppType,
@@ -29,7 +29,6 @@ import * as FilteReddit from './filteReddit';
 import * as Hover from './hover';
 import * as NightMode from './nightMode';
 import * as Notifications from './notifications';
-import * as SelectedEntry from './selectedEntry';
 
 export const module: Module<*> = new Module('userTagger');
 
@@ -137,7 +136,7 @@ const tagStorage = Storage.wrapPrefix('tag.', () => (null: ?{|
 |}), user => user.toLowerCase(), true);
 
 module.beforeLoad = () => {
-	// Immediately load data in order to have data ready on mutation
+	// Immediately load data in order to have it ready on mutation
 	watchForThings(null, thing => {
 		const user = thing.getAuthor();
 		if (user) Tag.get(user);
@@ -159,17 +158,7 @@ module.beforeLoad = () => {
 	});
 };
 
-module.go = () => {
-	// The `watchForElements` watcher above doesn't catch new comments
-	watchForThings(['comment'], thing => {
-		for (const ele of thing.entry.querySelectorAll(usernameSelector)) applyFromElement(ele);
-	});
-
-	// If we're on the dashboard, add a tab to it...
-	if (isCurrentSubreddit('dashboard')) {
-		addDashboardFunctionality();
-	}
-
+module.contentStart = () => {
 	if (module.options.trackVoteWeight.value && loggedInUser()) {
 		attachVoteHandler();
 	}
@@ -177,9 +166,16 @@ module.go = () => {
 	registerCommandLine();
 };
 
+module.go = () => {
+	// If we're on the dashboard, add a tab to it...
+	if (isCurrentSubreddit('dashboard')) {
+		addDashboardFunctionality();
+	}
+};
+
 function applyFromElement(element) {
 	const username = getUsernameFromLink(element);
-	if (username) applyToUser(element, { username });
+	if (username) return applyToUser(element, { username });
 }
 
 export function applyToUser(element: HTMLElement, {
@@ -549,7 +545,7 @@ function registerCommandLine() {
 
 	CommandLine.registerCommand('tag', `tag [text] - ${i18n('userTaggerCommandLineDescription')}`,
 		async (command, val) => {
-			const username = SelectedEntry.selectedThing && SelectedEntry.selectedThing.getAuthor();
+			const username = Thing.selected && Thing.selected.getAuthor();
 			tag = username && await Tag.get(username);
 			return tag ?
 				i18n(val ? 'userTaggerTagUserAs' : 'userTaggerTagUser', tag.id, val) :

--- a/lib/modules/userbarHider.js
+++ b/lib/modules/userbarHider.js
@@ -46,7 +46,7 @@ module.options = {
 
 let userbar, $userbarToggle;
 
-module.go = () => {
+module.contentStart = () => {
 	userbarHider();
 };
 

--- a/lib/modules/usernameHider.js
+++ b/lib/modules/usernameHider.js
@@ -58,7 +58,7 @@ module.options = {
 	},
 };
 
-module.go = () => {
+module.contentStart = () => {
 	hideUsernames();
 };
 

--- a/lib/modules/version.js
+++ b/lib/modules/version.js
@@ -25,7 +25,7 @@ module.beforeLoad = () => {
 	addVersionClasses();
 };
 
-module.go = () => {
+module.contentStart = () => {
 	reportVersion();
 };
 

--- a/lib/modules/voteEnhancements.js
+++ b/lib/modules/voteEnhancements.js
@@ -157,9 +157,7 @@ module.beforeLoad = () => {
 	if (module.options.colorCommentScore.value !== 'none') {
 		watchForThings(['comment'], applyCommentScoreColor);
 	}
-};
 
-module.go = () => {
 	if (module.options.highlightControversial.value) {
 		highlightControversial();
 	}

--- a/lib/modules/wheelBrowse.js
+++ b/lib/modules/wheelBrowse.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { Module } from '../core/module';
-import { isPageType, string } from '../utils';
+import { Thing, isPageType, string } from '../utils';
 import * as Floater from './floater';
 import * as SelectedEntry from './selectedEntry';
 import * as SettingsNavigation from './settingsNavigation';
@@ -15,7 +15,7 @@ module.description = 'wheelBrowseDesc';
 
 let behavior: ?(HTMLElement => (('down' | 'up', Event) => void));
 
-module.go = () => {
+module.contentStart = () => {
 	if (!behavior && isPageType('linklist')) useLinklistBehavior();
 	if (!behavior) return;
 
@@ -45,7 +45,7 @@ function useLinklistBehavior() {
 	let media;
 
 	function updateGalleryPart(direction?: 'up' | 'down') {
-		const expando = Expando.getEntryExpandoFrom(SelectedEntry.selectedThing);
+		const expando = Expando.getEntryExpandoFrom(Thing.selected);
 		media = expando && expando.media;
 
 		galleryPart.hidden = !(

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -3,12 +3,15 @@
 import _ from 'lodash';
 import { filterMap } from './array';
 import { frameThrottleQueuePositionReset } from './async';
+import { getPercentageVisibleYAxis, scrollToElement } from './dom';
 import { downcast } from './flow';
 import { currentSubreddit, regexes } from './location';
 
 const elementMap = new WeakMap();
 const things = new Set();
 const SECRET_TOKEN = new class {}();
+// This query may be expensive and performed fairly often
+const thingElementsCached = _.memoize(doc => Array.from(doc.querySelectorAll(Thing.thingSelector)));
 
 /**
  * Wrapper class around reddit's concept of a "Thing".
@@ -19,24 +22,28 @@ export class Thing {
 	static thingSelector = '.listing .thing, .linklisting .thing, .nestedlisting .thing, .search-result-link';
 	static entrySelector = '.entry, .search-result-link > :not(.thumbnail)';
 
-	static thingElements(): HTMLElement[] {
-		return Array.from(document.querySelectorAll(Thing.thingSelector));
+	static thingElements(doc: * = document.body): HTMLElement[] {
+		return thingElementsCached(doc);
 	}
 
-	static things(): Thing[] {
-		return Thing.thingElements().map(e => Thing.checkedFrom(e));
+	static things(doc: *): Thing[] {
+		return Thing.thingElements(doc).map(e => Thing.checkedFrom(e));
 	}
 
-	static visibleThingElements(): HTMLElement[] {
-		return Thing.thingElements().filter(v => v.offsetParent);
+	static visibleThingElements(doc: *): HTMLElement[] {
+		return Thing.thingElements(doc).filter(v => v.offsetParent);
 	}
 
-	static visibleThings(): Thing[] {
-		return filterMap(Thing.visibleThingElements(), ele => {
+	static visibleThings(doc: *): Thing[] {
+		return filterMap(Thing.visibleThingElements(doc), ele => {
 			const thing = Thing.from(ele);
 			if (thing) return [thing];
 		});
 	}
+
+	static registeredThings = (doc: * = document.body) => Array.from(things).filter(thing => doc.contains(thing.element));
+
+	static selected: ?Thing;
 
 	element: HTMLElement;
 	entry: HTMLElement;
@@ -44,8 +51,9 @@ export class Thing {
 	parent: ?Thing;
 	children = new Set();
 
-	// may be set by filters
-	matchingHideFilter: *; // FIXME Currently restricted to `hide` effect
+	// Tasks are added and generally executed by watchers
+	tasks: {| completed: boolean, visible: Array<() => any>, immediate: Array<() => any>, byId: WeakMap<mixed, () => any> |} =
+		{ completed: false, visible: [], immediate: [], byId: new WeakMap() };
 
 	static checkedFrom(element: HTMLElement | Thing): Thing {
 		const thing = Thing.from(element);
@@ -68,6 +76,7 @@ export class Thing {
 		const entry = thingElement.querySelector(Thing.entrySelector) || thingElement;
 		const thing = new Thing(SECRET_TOKEN, downcast(thingElement, HTMLElement), entry);
 
+		thingElementsCached.cache.clear();
 		elementMap.set(thingElement, thing);
 		things.add(thing);
 
@@ -87,9 +96,28 @@ export class Thing {
 		if (this.parent) this.parent.children.add(this);
 	}
 
+	runTasks() {
+		if (this.tasks.completed) return;
+		this.tasks.immediate.map(fn => fn());
+		this.tasks.visible.map(fn => fn());
+	}
+
+	select() {
+		Thing.selected = this;
+	}
+
+	anchor() {
+		// Keep the viewport anchored relative to this thing if it is in the viewport
+		const anchor = getPercentageVisibleYAxis(this.entry) && { to: this.entry.getBoundingClientRect().top };
+		if (!anchor) return;
+		requestAnimationFrame(() => {
+			if (!this.entry.offsetParent) return;
+			scrollToElement(this.entry, undefined, { scrollStyle: 'none', anchor });
+		});
+	}
+
 	setHideFilter(match: *) {
 		this.element.classList.toggle('res-thing-filter-hide', !!match);
-		this.matchingHideFilter = match;
 
 		if (this.isComment()) {
 			this.refreshPartialVisibility();
@@ -113,6 +141,11 @@ export class Thing {
 			Array.from(this.children).some(v => !v.isHiddenByFilter())
 		));
 	});
+
+	getDirectionOf(other: Thing): ?('down' | 'up') {
+		if (!this.isVisible() || !other.isVisible()) return;
+		return (other.entry.compareDocumentPosition(this.entry) & Node.DOCUMENT_POSITION_FOLLOWING) ? 'up' : 'down';
+	}
 
 	getThreadTop(): Thing {
 		let thing = this; // eslint-disable-line consistent-this
@@ -318,7 +351,7 @@ export class Thing {
 		return (this.entry.querySelector('.tagline a.author, .search-author .author'): any);
 	}
 
-	getSubreddit = _.once(function(): ?string {
+	getSubreddit(): ?string {
 		const data = this.element.getAttribute('data-subreddit');
 		if (data) {
 			return data;
@@ -332,7 +365,7 @@ export class Thing {
 		} else {
 			return currentSubreddit();
 		}
-	});
+	}
 
 	getSubredditLink(): ?HTMLAnchorElement {
 		if (this.isPost()) {

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -36,7 +36,7 @@ export function waitForChild(ele: Element, selector: string): Promise<HTMLElemen
 	});
 }
 
-export function watchForChildren(ele: Element, selector: string, callback: (ele: HTMLElement) => void | Promise<void>): void {
+export function watchForChildren(ele: Element, selector: string, callback: (ele: HTMLElement) => any): void {
 	for (const child of Array.from(ele.children).filter(child => child.matches(selector))) {
 		callback(child);
 	}
@@ -44,7 +44,7 @@ export function watchForChildren(ele: Element, selector: string, callback: (ele:
 	watchForFutureChildren(ele, selector, callback);
 }
 
-export function watchForFutureChildren(ele: Element, selector: string, callback: (ele: HTMLElement) => void | Promise<void>): void {
+export function watchForFutureChildren(ele: Element, selector: string, callback: (ele: HTMLElement) => any): void {
 	new MutationObserver(mutations => {
 		for (const mutation of mutations) {
 			for (const node of mutation.addedNodes) {
@@ -85,15 +85,15 @@ export function waitForDescendant(ele: Element, selector: string): Promise<HTMLE
 	});
 }
 
-export function watchForDescendants(ele: Element, selector: string, callback: (ele: HTMLElement) => void | Promise<void>): void {
+export function watchForDescendants(ele: Element, selector: string, callback: (ele: HTMLElement) => any, ignoreChildrenIfAddedNodeMatches: boolean = false): void {
 	for (const child of ele.querySelectorAll(selector)) {
 		callback(child);
 	}
 
-	watchForFutureDescendants(ele, selector, callback);
+	watchForFutureDescendants(ele, selector, callback, ignoreChildrenIfAddedNodeMatches);
 }
 
-export function watchForFutureDescendants(ele: Element, selector: string, callback: (ele: HTMLElement) => void | Promise<void>): void {
+export function watchForFutureDescendants(ele: Element, selector: string, callback: (ele: HTMLElement) => any, ignoreChildrenIfAddedNodeMatches: boolean = false): void {
 	new MutationObserver(mutations => {
 		// avoid calling the callback twice if streamed-in children match the same selectors as their parents
 		// i.e. nested comments that are rendered at pageload
@@ -104,6 +104,7 @@ export function watchForFutureDescendants(ele: Element, selector: string, callba
 					// the node itself may match...
 					if ((node: any).matches(selector)) {
 						children.add(node);
+						if (ignoreChildrenIfAddedNodeMatches) continue;
 					}
 					// ...or some of its children may match
 					for (const child of (node: any).querySelectorAll(selector)) {
@@ -216,18 +217,49 @@ const padBottom = _.once(() => {
 });
 
 let recentScroll = false;
+let scrollInvokationToken;
 
 export type ScrollStyle = 'none' | 'top' | 'adopt' | 'middle' | 'page' | 'legacy' | 'directional';
 type Direction = 'up' | 'down';
 type Anchor = {| to: number, from?: number |};
 
-export function scrollToElement(to: HTMLElement, from: ?HTMLElement, { scrollStyle, restrictDirectionTo, direction: selectedDirection, anchor }: {| scrollStyle: ScrollStyle, restrictDirectionTo?: Direction, direction?: Direction, anchor?: Anchor |}): void {
-	if (scrollStyle === 'none') {
-		if (anchor) {
-			const diff = to.getBoundingClientRect().top - anchor.to;
-			if (diff) window.scrollBy(0, diff);
-		}
+export function scrollToElement(to: HTMLElement, from: ?HTMLElement, {
+	scrollStyle,
+	restrictDirectionTo,
+	direction: selectedDirection,
+	anchor,
+	waitTillVisible,
+}: {|
+	scrollStyle: ScrollStyle,
+	restrictDirectionTo?: Direction,
+	direction?: Direction,
+	anchor?: Anchor,
+	waitTillVisible?: boolean,
+|}): void | Promise<void> {
+	const _scrollInvokationToken = scrollInvokationToken = {}; // Unique object in order to check whether invokation with `waitTillVisible` has been superseded
+
+	if (waitTillVisible && !to.offsetParent) {
+		// Try again next frame
+		return new Promise(res => {
+			requestAnimationFrame(() => {
+				if (scrollInvokationToken !== _scrollInvokationToken) return;
+				(scrollToElement(...arguments) || Promise.resolve()).then(res); // eslint-disable-line prefer-rest-params
+			});
+		});
+	}
+
+	if (scrollStyle === 'none' && !anchor) {
 		return;
+	}
+
+	if (!to.offsetParent) {
+		console.error('Element is not visible.');
+		return;
+	}
+
+	if (scrollStyle === 'none' && anchor) {
+		const diff = to.getBoundingClientRect().top - anchor.to;
+		if (diff) window.scrollBy(0, diff);
 	}
 
 	const viewport = getViewportDimensions();

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -31,6 +31,7 @@ export {
 	frameThrottle,
 	frameThrottleQueuePositionReset,
 	idleThrottle,
+	throttle,
 	keyedMutex,
 	mutex,
 	reifyPromise,
@@ -176,7 +177,8 @@ export {
 
 export {
 	registerPage,
-	initR2Watcher,
+	r2WatcherBodyReady,
+	r2WatcherSitetableStart,
 	watchForElements,
 	watchForThings,
 } from './watchers';

--- a/lib/utils/watchers.js
+++ b/lib/utils/watchers.js
@@ -4,12 +4,11 @@ import _ from 'lodash';
 import { Thing } from './Thing';
 import { isPageType } from './location';
 import { watchForChildren, watchForFutureDescendants } from './dom';
-import { forEachChunked, throttle } from './async';
 
-type WatcherOptions = {| immediate?: boolean |};
+type WatcherOptions = {| immediate?: boolean, id?: mixed |};
 
 type ElementWatcherType = 'page' | 'selfText';
-type ElementWatcherCallback = (e: any) => any | Promise<any>;
+type ElementWatcherCallback = (e: HTMLElement) => any;
 
 const elementWatchers: {
 	[ElementWatcherType]: Array<{
@@ -24,7 +23,7 @@ const elementWatchers: {
 };
 
 type ThingWatcherType = 'comment' | 'message' | 'post' | 'subreddit';
-type ThingWatcherCallback = (thing: Thing) => any | Promise<any>;
+type ThingWatcherCallback = (thing: Thing) => any;
 
 const thingWatchers: {
 	[ThingWatcherType]: Array<{
@@ -39,58 +38,30 @@ const thingWatchers: {
 	subreddit: [],
 };
 
-const runCallback = fn => { try { fn(); } catch (e) { console.error(e); } };
+// eslint-disable-next-line no-unused-vars
+const runCallback = fn => { try { return fn(); } catch (e) { console.error(e); } };
 
-let createChunks = true;
-type Chunks = Array<[Thing, Array<() => void>]>;
-const executeChunk = ([, callbacks]) => { for (const callback of callbacks) runCallback(callback); };
-const executeChunks = (chunks: Chunks) => { for (const chunk of chunks) executeChunk(chunk); };
-
-const chunkedCallbacks = new Map();
-
-const runChunkedCallbacks = throttle(async trigger => {
-	const chunks = Array.from(chunkedCallbacks);
-	chunkedCallbacks.clear();
-
-	const [visible, hidden]: any = _.partition(chunks, ([thing]) => thing.isVisible());
-	// Execute a few callbacks on the first frame, in an attempt to minimize the delay in mutation elements in the user's viewport
-	executeChunks(visible.splice(0, isPageType('comments') ? 1 : 10));
-	// Don't execute chunks in the following animation frame if this was trigged by a timeout
-	if (trigger === 'timeout') await new Promise(res => requestAnimationFrame(res));
-	// Run callbacks on visible things before hidden ones
-	return forEachChunked([...visible, ...hidden], executeChunk);
-});
-
-function addCallback(callback, actingOnElement, options) {
-	let chunk;
-	if (
-		createChunks &&
-		!(options && options.immediate) &&
-		document.contains(actingOnElement)
-	) {
-		// Avoid excessive number of chunked callbacks by tying the callback to a Thing
-		// By grouping callbacks acting on a common thing, the number of elements having to be reflowed is reduced
-		chunk = Thing.from(actingOnElement);
-	}
-
-	if (chunk) {
-		const callbacks = chunkedCallbacks.get(chunk);
-		if (callbacks) callbacks.push(callback);
-		else chunkedCallbacks.set(chunk, [callback]);
-		runChunkedCallbacks();
+const addCallback = (callback, actingOnElement, { immediate, id } = {}) => {
+	const thing = Thing.from(actingOnElement);
+	if (thing && !thing.tasks.completed) {
+		// XXX The callback ought not be wrapped so many times
+		const task = _.once(() => runCallback(callback));
+		if (id) thing.tasks.byId.set(id, task);
+		(immediate ? thing.tasks.immediate : thing.tasks.visible).push(task);
 	} else {
-		callback();
+		runCallback(callback);
 	}
-}
+};
 
 function registerElement(type, element) {
 	for (const { selector, callback, options, registered } of elementWatchers[type]) {
-		const elements = selector ? Array.from(element.querySelectorAll(selector)) : [element];
+		const elements = selector && !element.matches(selector) ?
+			Array.from(element.querySelectorAll(selector)) :
+			[element];
 		for (const e of elements) {
 			if (registered.has(e)) continue;
 			registered.add(e);
-			const fn = () => { callback(e); };
-			addCallback(fn, e, options);
+			addCallback(() => callback(e), e, options);
 		}
 	}
 }
@@ -108,9 +79,10 @@ function registerThing(element: HTMLElement) {
 	for (const { callback, options, registered } of thingWatcherCallbacks) {
 		if (registered.has(thing)) continue;
 		registered.add(thing);
-		const fn = () => { callback(thing); };
-		addCallback(fn, thing.element, options);
+		addCallback(() => callback(thing), thing.element, options);
 	}
+
+	return thing;
 }
 
 export function watchForThings(types: ?Array<ThingWatcherType>, callback: ThingWatcherCallback, options?: WatcherOptions) {
@@ -122,11 +94,32 @@ export function watchForElements(types: Array<ElementWatcherType>, selector: ?st
 	for (const type of types) elementWatchers[type].push({ selector, callback, options, registered: new WeakSet() });
 }
 
-export function registerPage(page: HTMLElement) {
+export function registerPage(
+	page: HTMLElement,
+	runCallbacksOnVisibleCounter: {| count: number |} = { count: 20 },
+	timeout: Promise<*> = new Promise(rej => setTimeout(rej, 2000))
+) {
+	const things = [];
+	// Always rerun the `registerThing` function on Thing elements, in case new Thing watchers has been added
+	if (page.matches(Thing.thingSelector)) things.push(registerThing(page));
+	for (const e of page.querySelectorAll(Thing.thingSelector)) things.push(registerThing(e));
+
 	registerElement('page', page);
+
+	const promise = things.map<*>(thing => {
+		thing.tasks.immediate.map(fn => fn());
+		// XXX This does not actually not process `remaining` number of actually visible things if some matching filters are not synchronous
+		if (runCallbacksOnVisibleCounter.count-- > 0 && thing.isVisible()) {
+			thing.runTasks();
+		}
+	});
+
+	// Return a promise that resolves when all initial callbacks have completed or timeout promise rejects
+	return Promise.race([promise, timeout]).catch(console.error);
 }
 
-export function initR2Watcher() {
+export function r2WatcherSitetableStart() {
+	// Add selftext observer
 	watchForThings(['post'], thing => {
 		const container = thing.entry.querySelector('div.expando');
 		if (!container) return;
@@ -136,18 +129,68 @@ export function initR2Watcher() {
 		});
 	});
 
+	// Only register top level things, to avoid processing incomplete comment trees--which may have bad side effects
+	const thingElements = Thing.thingElements()
+		.filter(e => !(e.parentElement: any).closest(Thing.thingSelector));
+
+	// If this there's no element in the DOM after the last thing, its DOM is likely to not be completed
+	let last = thingElements.slice(-1)[0];
+	if (!last) return;
+	do {
+		if (last.nextElementSibling) break;
+	} while ((last = last.parentElement));
+	if (!last) thingElements.pop();
+
+	// Run visible tasks on the first things
+	const counter = { count: 20 }; // Since `registerPage` is called multiple times, the counter must be referenced via an object
+
+	// In case some of the idle callbacks get stuck, escape on the first idle or after 2 s
+	const timeout = new Promise((res, rej) => {
+		requestIdleCallback(() => rej(new Error('Immediate callbacks was not completed timely')), { timeout: 2000 });
+	});
+
+	// $FlowIssue Array#flat
+	return Promise.all(thingElements.map(e => registerPage(e, counter, timeout)).flat());
+}
+
+export function r2WatcherBodyReady() {
+	// Execute non-immediate callbacks on things when they become visible
+	const io = new IntersectionObserver(entries => {
+		const intersecting = entries
+			.map(({ target, isIntersecting }) => isIntersecting && target)
+			.filter(Boolean);
+
+		if (!intersecting.length) return;
+
+		const thingElements = Thing.thingElements();
+
+		// Also complete a few of the surrounding things in order to reduce the number of mutation instances
+		const idxs = intersecting.map(e => thingElements.indexOf(e));
+		let _parent;
+		let min = Math.min(...idxs) - 10;
+		let max = Math.max(...idxs) + 10;
+		// If a `min` or `max` are contained by a comment, process the whole structure
+		if (min > 0 && (_parent = Thing.checkedFrom(thingElements[min]).getParents().pop())) min = thingElements.indexOf(_parent.element);
+		if (max < thingElements.length && (_parent = Thing.checkedFrom(thingElements[max]).getNextSibling())) max = thingElements.indexOf(_parent.element) - 1;
+
+		for (const e of thingElements.slice(Math.max(min, 0), max).filter(e => e.offsetParent)) {
+			const thing = Thing.from(e);
+			if (thing) thing.runTasks();
+		}
+	}, { rootMargin: '10%' });
+
+	watchForThings(null, thing => {
+		io.observe(thing.element);
+		addCallback(() => {
+			io.unobserve(thing.element);
+			thing.tasks.completed = true;
+		}, thing.element);
+	}, { immediate: true });
+
+	registerPage(document.body, { count: 0 });
+
 	if (isPageType('comments')) {
 		const commentarea = document.body.querySelector('.commentarea');
-		if (commentarea) watchForFutureDescendants(commentarea, '.thing', registerThing);
+		if (commentarea) watchForFutureDescendants(commentarea, '.thing', registerPage, true);
 	}
-
-	watchForElements(['page'], Thing.thingSelector, registerThing, { immediate: true });
-
-	registerPage(document.body);
-
-	// Run chunks only on the initial load
-	createChunks = false;
-
-	// Resolve when chunks are completed
-	return runChunkedCallbacks();
 }

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -1866,6 +1866,12 @@
 	"betteRedditCommentsLinksNewTabDesc": {
 		"message": "Open links found in comments in a new tab."
 	},
+	"filteRedditHideUntilProcessedTitle": {
+		"message": "Hide Until Processed"
+	},
+	"filteRedditHideUntilProcessedDesc": {
+		"message": "Don't show posts and comments until they have been processed by the filters."
+	},
 	"betteRedditFixHideLinksTitle": {
 		"message": "Fix Hide Links"
 	},

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -1986,6 +1986,12 @@
 	"betteRedditCommentCollapseInInboxDesc": {
 		"message": "Show the [-] collapse button in the inbox."
 	},
+	"betteRedditRestrictScrollEventsTitle": {
+		"message": "Restrict Scroll Events"
+	},
+	"betteRedditRestrictScrollEventsDesc": {
+		"message": "Reddit performs much work every time you scroll, which may cause lag on pages with many comments. Reducing the number of scroll events it processes improves performance."
+	},
 	"betteRedditHideLinkLabel": {
 		"message": "hide"
 	},

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -2907,9 +2907,6 @@
 	"selectedEntryAutoSelectOnScrollDesc": {
 		"message": "Automatically select the topmost item while scrolling"
 	},
-	"selectedEntryScrollToSelectedThingOnLoadDesc": {
-		"message": "Automatically scroll to the post/comment that is selected when the page loads"
-	},
 	"selectedEntryAddLineDesc": {
 		"message": "Show a line on right side."
 	},
@@ -3174,9 +3171,6 @@
 	},
 	"selectedEntryAutoSelectOnScrollTitle": {
 		"message": "Auto Select On Scroll"
-	},
-	"selectedEntryScrollToSelectedThingOnLoadTitle": {
-		"message": "Scroll To Selected Thing On Load"
 	},
 	"selectedEntryAddLineTitle": {
 		"message": "Add Line"


### PR DESCRIPTION
This change adds the module init phase `contentStart`, which is invoked when the browser starts processing `siteTable`. By moving several DOM mutations to this stage, rather than waiting for `go`, RES will be mostly done manipulating the visible parts of the page before it is rendered. The page becomes a little slower to reach that point, but a stable point—without further distracting changes—is reached far earlier.

Ordinary watchers tasks for posts are now executed when the viewport gets close. This is especially helpful on large comment pages, and makes the browser less busy initially. 

Before:
![before](https://user-images.githubusercontent.com/1748521/54020120-4d06db80-418d-11e9-99f1-c86036a5523d.gif)

After:
![after](https://user-images.githubusercontent.com/1748521/54020126-4e380880-418d-11e9-9e7c-b67e63fade8c.gif)

Tested in browser: Firefox 67, Chrome 74. Edge 16 is unstable.
