### PR TITLE
fix: Add old Reddit dashboard link

### DIFF
--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -12,6 +12,7 @@ import {
 	loggedInUser,
 	string,
 	registerPage,
+	isAppType,
 } from '../utils';
 import { i18n, Storage, ajax } from '../environment';
 import * as Init from '../core/init';
@@ -100,8 +101,9 @@ module.shouldRun = () => isCurrentSubreddit('dashboard');
 module.always = () => {
 	if (Modules.isEnabled(module)) {
 		if (module.options.menuItem.value) {
+			const dashboardUrl = isAppType('d2x') ? 'https://old.reddit.com/r/Dashboard' : '/r/Dashboard';
 			Menu.addMenuItem(
-				() => string.html`<a href="/r/Dashboard">${i18n('myDashboard')}</a>`,
+				() => string.html`<a href="${dashboardUrl}">${i18n('myDashboard')}</a>`,
 				undefined,
 				-7
 			);


### PR DESCRIPTION
If the user is on the redesign, My Dashboard will redirect to old.reddit.com/r/dashboard

*GIF for the dashboard*
![dashboard](https://user-images.githubusercontent.com/20063271/54151639-4ca66300-4461-11e9-9346-5974f750ae38.gif)


Relevant issue: fixes #5085 
Tested in browser: Chrome 72, Firefox 65
