### PR TITLE
Prevent duplication of user tags when navigating posts

### DIFF
--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -146,11 +146,10 @@ module.beforeLoad = () => {
 
 	watchForRedditEvents('postAuthor', (element, { author, _: { update } }) => {
 		if (update) return;
-		// Remove the previously added tags
-		const previousTags = element.getElementsByClassName('RESUserTag');
-		if (previousTags.length) {
-			for (const tag of previousTags) tag.remove();
-		}
+
+		// Remove previously added tags, as Reddit may not empty the container when navigating posts
+		for (const tag of element.getElementsByClassName('RESUserTag')) tag.remove();
+
 		applyToUser(element, { username: author });
 	});
 	watchForRedditEvents('commentAuthor', (element, { author, _: { update } }) => {

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -146,6 +146,11 @@ module.beforeLoad = () => {
 
 	watchForRedditEvents('postAuthor', (element, { author, _: { update } }) => {
 		if (update) return;
+		// Remove the previously added tags
+		const previousTags = element.getElementsByClassName('RESUserTag');
+		if (previousTags.length) {
+			for (const tag of previousTags) tag.remove();
+		}
 		applyToUser(element, { username: author });
 	});
 	watchForRedditEvents('commentAuthor', (element, { author, _: { update } }) => {


### PR DESCRIPTION
*Before*
![Before](https://user-images.githubusercontent.com/20063271/54227226-7a54e000-4525-11e9-90f4-fb874139cc14.gif)

*After*
![UserTagger](https://user-images.githubusercontent.com/20063271/54227238-80e35780-4525-11e9-83ed-b465139274a2.gif)


Relevant issue: fixes #5068
Tested in browser: Chrome 72, Firefox 65
