### PR TITLE
Add VLive to media hosts

### DIFF
--- a/lib/modules/hosts/vlive.js
+++ b/lib/modules/hosts/vlive.js
@@ -5,7 +5,7 @@ import { Host } from '../../core/host';
 export default new Host('vlive', {
 	name: 'VLive',
 	domains: ['vlive.tv'],
-	logo: 'https://www.vlive.tv/favicon.ico?2018042316',
+	logo: 'https://www.vlive.tv/favicon.ico',
 	detect: ({ pathname }) => (/^\/(?:video)\/([0-9]+)/i).exec(pathname),
 	handleLink(href, [, id]) {
 		const embed = `https://vlive.tv/embed/${id}`;
@@ -14,5 +14,6 @@ export default new Host('vlive', {
 			embed,
 			embedAutoplay: `${embed}?autoPlay=true`,
 			fixedRatio: true,
-	}},
+		};
+	},
 });

--- a/lib/modules/hosts/vlive.js
+++ b/lib/modules/hosts/vlive.js
@@ -1,0 +1,18 @@
+/* @flow */
+
+import { Host } from '../../core/host';
+
+export default new Host('vlive', {
+	name: 'VLive',
+	domains: ['vlive.tv'],
+	logo: 'https://www.vlive.tv/favicon.ico?2018042316',
+	detect: ({ pathname }) => (/^\/(?:video)\/([0-9]+)/i).exec(pathname),
+	handleLink(href, [, id]) {
+		const embed = `https://vlive.tv/embed/${id}`;
+		return {
+			type: 'IFRAME',
+			embed,
+			embedAutoplay: `${embed}?autoplay=true`,
+			fixedRatio: true,
+	}},
+});

--- a/lib/modules/hosts/vlive.js
+++ b/lib/modules/hosts/vlive.js
@@ -12,7 +12,7 @@ export default new Host('vlive', {
 		return {
 			type: 'IFRAME',
 			embed,
-			embedAutoplay: `${embed}?autoplay=true`,
+			embedAutoplay: `${embed}?autoPlay=true`,
 			fixedRatio: true,
 	}},
 });


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
VLive is a livestreaming service (with VODs too) for Korean-based celebrities (Kpop, makeup/beauty, etc...)

This should add embed support for VLive videos as an expando. You can test [here](https://www.reddit.com/domain/vlive.tv/) 
Tested in browser: Chrome 72
