### PR TITLE
Prevent Reddit cloning RES elements

### DIFF
--- a/lib/modules/commentPreview.js
+++ b/lib/modules/commentPreview.js
@@ -13,6 +13,7 @@ import {
 	currentSubreddit,
 	downcast,
 	isPageType,
+	preventCloning,
 	string,
 	empty,
 } from '../utils';
@@ -138,10 +139,7 @@ module.go = () => {
 		attachWikiPreview();
 		addBigEditorButton(document.querySelector('.markhelp'));
 	} else {
-		const attachedTo = new WeakSet();
 		$(document.body).on('focus', CommentTools.commentTextareaSelector, e => {
-			if (attachedTo.has(e.target)) return;
-			attachedTo.add(e.target);
 			addBigEditorButton(e.target);
 			attachPreview(e.target);
 		});
@@ -243,14 +241,14 @@ function markdownToHTML(md) {
 	}
 }
 
-function addBigEditorButton(ele) {
+const addBigEditorButton = _.memoize(ele => {
 	if (!module.options.enableBigEditor.value) return;
 
-	const bigEditorButton = string.html`
+	const bigEditorButton = preventCloning(string.html`
 		<button type="button" class="RESBigEditorPop" tabIndex="3">
 			<span class="res-icon res-icon-12">&#xF0A4;</span> big editor
 		</button>
-	`;
+	`);
 
 	if (isBan || isWiki) {
 		ele.after(bigEditorButton);
@@ -260,9 +258,9 @@ function addBigEditorButton(ele) {
 		const bottom = container.querySelector('.bottom-area');
 		bottom.prepend(bigEditorButton);
 	}
-}
+});
 
-function attachPreview(textarea) {
+const attachPreview = _.memoize(textarea => {
 	if (
 		!module.options.enableForComments.value && textarea.closest('.commentarea, .message') ||
 		!module.options.enableForPosts.value && (isPageType('submit') || textarea.closest('.link')) ||
@@ -275,7 +273,7 @@ function attachPreview(textarea) {
 	const container = textarea.closest('.usertext-edit, #banned');
 	if (!container) return;
 
-	const preview = makePreviewBox();
+	const preview = preventCloning(makePreviewBox());
 
 	const elements = [preview.querySelector('.RESDialogContents')];
 	if (module.options.sidebarPreview.value && textarea.getAttribute('name') === 'description') {
@@ -294,7 +292,7 @@ function attachPreview(textarea) {
 	});
 
 	container.append(preview);
-}
+});
 
 function attachWikiPreview() {
 	if (!module.options.enableForWiki.value) return;

--- a/lib/modules/saveComments.js
+++ b/lib/modules/saveComments.js
@@ -11,6 +11,7 @@ import {
 	formatDateTime,
 	isPageType,
 	niceKeyCode,
+	preventCloning,
 	string,
 	watchForThings,
 	Thing,
@@ -63,7 +64,7 @@ const unsaveElement = (e => () => e().cloneNode(true))(_.once(() => string.html`
 		<a class="RES-saved noCtrlF" href="/user/me/saved#comments" data-text="saved-RES"></a>
 	</li>
 `));
-const saveElement = (e => () => e().cloneNode(true))(_.once(() => {
+const saveElement = (e => () => preventCloning(e().cloneNode(true)))(_.once(() => {
 	$(document.body).on('click', 'li.saveComments', ({ currentTarget }: Event) => {
 		const thing = Thing.checkedFrom(currentTarget);
 		saveComment(thing);

--- a/lib/modules/sourceSnudown.js
+++ b/lib/modules/sourceSnudown.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import { $ } from '../vendor';
 import { Module } from '../core/module';
 import { ajax } from '../environment';
-import { watchForThings, regexes, keyedMutex, string } from '../utils';
+import { watchForThings, regexes, keyedMutex, preventCloning, string } from '../utils';
 
 export const module: Module<*> = new Module('sourceSnudown');
 
@@ -16,7 +16,7 @@ module.beforeLoad = () => {
 	watchForThings(['post', 'comment', 'message'], attachViewSourceButton);
 };
 
-const sourceButton = (e => () => e().cloneNode(true))(_.once(() => {
+const sourceButton = (e => () => preventCloning(e().cloneNode(true)))(_.once(() => {
 	$(document.body)
 		.on('click', 'li.viewSource a', function(e: Event) {
 			e.preventDefault();

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -15,6 +15,7 @@ import {
 	usernameSelector,
 	getUsernameFromLink,
 	loggedInUser,
+	preventCloning,
 	string,
 	watchForThings,
 	watchForElements,
@@ -360,14 +361,14 @@ export class Tag {
 	render(instance: *) {
 		if (instance.vw) instance.vw.remove();
 		if (instance.renderVoteWeight && (this.votesUp || this.votesDown)) {
-			instance.vw = string.html`
+			instance.vw = preventCloning(string.html`
 				<a
 					class="voteWeight"
 					href="javascript:void 0"
 					title="${i18n('userTaggerYourVotesFor', this.id, `+${this.votesUp} -${this.votesDown}`)}"
 					style="${getVoteWeightStyle(this)}"
 				>${module.options.vwNumber.value ? `[${this.votes > 0 ? '+' : ''}${this.votes}]` : '[vw]'}</a>
-			`;
+			`);
 			instance.vw.addEventListener('click', () => this.openPrompt(instance));
 			if (isAppType('d2x')) { // XXX: temp hack
 				(instance.tagger || instance.element).appendChild(instance.vw);
@@ -379,7 +380,7 @@ export class Tag {
 		if (instance.tagger) instance.tagger.remove();
 		if (this.text || this.color || instance.renderTaggingIcon) {
 			// `defaultTagElement` is a lot fast than `buildTagElement`
-			instance.tagger = (this.text || this.color) ? Tag.buildTagElement(this) : Tag.defaultTagElement();
+			instance.tagger = preventCloning((this.text || this.color) ? Tag.buildTagElement(this) : Tag.defaultTagElement());
 			instance.tagger.addEventListener('click', () => this.openPrompt(instance));
 			if (isAppType('d2x')) { // XXX: temp hack
 				instance.element.appendChild(instance.tagger);

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -412,3 +412,24 @@ function addStyle(css) {
 
 	return style;
 }
+
+// r2 Reddit clone certain elements, e.g. when replying or editing a post
+// This will remove elements that have a specific attribute, but have not been registered
+export const preventCloning = (() => {
+	const attribute = `res-prevent-cloning-${Date.now()}`; // Prevent the attribute being used in a selector
+	const elements = new WeakSet();
+
+	// Delay adding the observer a little, to not slow down init
+	waitForEvent(window, 'DOMContentLoaded', 'load').then(() => {
+		watchForFutureDescendants(document.body, `[${attribute}]`, e => {
+			if (!elements.has(e)) e.remove();
+		});
+	});
+
+	return (element: HTMLElement) => {
+		// $FlowIssue toggleAttribute
+		element.toggleAttribute(attribute, true);
+		elements.add(element);
+		return element;
+	};
+})();

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -52,6 +52,7 @@ export {
 	getHeaderOffset,
 	getD2xBodyOffset,
 	getPercentageVisibleYAxis,
+	preventCloning,
 	scrollToElement,
 	waitForChild,
 	waitForDescendant,


### PR DESCRIPTION
r2 Reddit in some cirumstances clones elements, e.g. when replying or editing a post, including RES elements.
The `preventCloning` interface removes elements that have a specific attribute (`res-prevent-cloning-...`), but have not been registered.

Relevant issue: Fixes #4310 
Tested in browser: Firefox 67
