### PR TITLE
update backup and restore module to be searchable for import/export t…

### DIFF
--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -57,7 +57,7 @@
 		"message": "Backup"
 	},
 	"aboutOptionsBackup": {
-		"message": "Back up and restore your RES settings."
+		"message": "Backup (export) and restore (import) your RES settings."
 	},
 	"aboutOptionsSearchSettingsTitle": {
 		"message": "Search Settings"
@@ -199,7 +199,7 @@
 		"message": "Backup & Restore"
 	},
 	"backupDesc": {
-		"message": "Backup and restore your Reddit Enhancement Suite settings."
+		"message": "Backup (export) and restore (import) your Reddit Enhancement Suite settings."
 	},
 	"betteRedditName": {
 		"message": "betteReddit"

--- a/locales/locales/en@lolcat.json
+++ b/locales/locales/en@lolcat.json
@@ -3288,7 +3288,7 @@
         "description": ""
     },
     "backupDesc": {
-        "message": "Backup and restore your Reddit Enhancement Suite settings.",
+        "message": "Backup (export) and restore (import) your Reddit Enhancement Suite settings.",
         "description": ""
     },
     "accountSwitcherDropDownStyleTitle": {
@@ -4992,7 +4992,7 @@
         "description": ""
     },
     "aboutOptionsBackup": {
-        "message": "Back up and restore your RES settings.",
+        "message": "Backup (export) and restore (import) your RES settings.",
         "description": ""
     },
     "showParentDesc": {

--- a/locales/locales/en@pirate.json
+++ b/locales/locales/en@pirate.json
@@ -4992,7 +4992,7 @@
         "description": ""
     },
     "aboutOptionsBackup": {
-        "message": "Back up 'n restore yer RES settin's.",
+        "message": "Backup 'n restore yer RES settin's.",
         "description": ""
     },
     "showParentDesc": {

--- a/locales/locales/en_CA.json
+++ b/locales/locales/en_CA.json
@@ -3288,7 +3288,7 @@
         "description": ""
     },
     "backupDesc": {
-        "message": "Backup and restore your Reddit Enhancement Suite settings.",
+        "message": "Backup (export) and restore (import) your Reddit Enhancement Suite settings.",
         "description": ""
     },
     "accountSwitcherDropDownStyleTitle": {
@@ -4992,7 +4992,7 @@
         "description": ""
     },
     "aboutOptionsBackup": {
-        "message": "Back up and restore your RES settings.",
+        "message": "Backup (export) and restore (import) your RES settings.",
         "description": ""
     },
     "showParentDesc": {

--- a/locales/locales/en_GB.json
+++ b/locales/locales/en_GB.json
@@ -3288,7 +3288,7 @@
         "description": ""
     },
     "backupDesc": {
-        "message": "Backup and restore your Reddit Enhancement Suite settings.",
+        "message": "Backup (export) and restore (import) your Reddit Enhancement Suite settings.",
         "description": ""
     },
     "accountSwitcherDropDownStyleTitle": {
@@ -4992,7 +4992,7 @@
         "description": ""
     },
     "aboutOptionsBackup": {
-        "message": "Back up and restore your RES settings.",
+        "message": "Backup (export) and restore (import) your RES settings.",
         "description": ""
     },
     "showParentDesc": {


### PR DESCRIPTION
updated terminology/descriptions so that backup/restore are searchable as export/import respectively

also fixed a consistency issue ("back up" vs "backup")

<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: 
Tested in browser: 
