### PR TITLE
Scanning for tables in redesign (#4973)

### DIFF
--- a/lib/modules/tableTools.js
+++ b/lib/modules/tableTools.js
@@ -23,14 +23,9 @@ module.shouldRun = () => !isCurrentSubreddit('dashboard');
 
 module.contentStart = () => {
 	if (module.options.sort.value) {
-		$(document).on('click', '.md th, .Comment th, .Post th', tableSortEvent);
+		$(document).on('click', '.md th, .Comment th, .Post th', (e: Event) => sortTableColumn(e.currentTarget));
 	}
 };
-
-// Event handler for click in table column
-function tableSortEvent(e: Event) {
-	sortTableColumn(e.currentTarget);
-}
 
 // Add sorting to a column
 function sortTableColumn(target) {

--- a/lib/modules/tableTools.js
+++ b/lib/modules/tableTools.js
@@ -23,9 +23,16 @@ module.shouldRun = () => !isCurrentSubreddit('dashboard');
 
 module.contentStart = () => {
 	if (module.options.sort.value) {
-		$(document).on('click', '.md th', (e: Event) => sortTableColumn(e.currentTarget));
+		$(document).on('click', '.md th', tableSortEvent);
+		$(document).on('click', '.Comment th', tableSortEvent);
+		$(document).on('click', '.Post th', tableSortEvent);
 	}
 };
+
+// Event handler for click in table column
+function tableSortEvent(e: Event) {
+	sortTableColumn(e.currentTarget);
+}
 
 // Add sorting to a column
 function sortTableColumn(target) {

--- a/lib/modules/tableTools.js
+++ b/lib/modules/tableTools.js
@@ -23,9 +23,7 @@ module.shouldRun = () => !isCurrentSubreddit('dashboard');
 
 module.contentStart = () => {
 	if (module.options.sort.value) {
-		$(document).on('click', '.md th', tableSortEvent);
-		$(document).on('click', '.Comment th', tableSortEvent);
-		$(document).on('click', '.Post th', tableSortEvent);
+		$(document).on('click', '.md th, .Comment th, .Post th', tableSortEvent);
 	}
 };
 


### PR DESCRIPTION
Relevant issue: fixes #4973 
Tested in browser: Google Chrome 74.0.3729.108 (Official Build) (64-bit)

Tables in redesign are now identified by RES and behave like in old Reddit.
Before to this PR only tables in wikis used to work on redesign, now all tables in posts and comments are identified by RES..

Table in post
![image](https://user-images.githubusercontent.com/48102075/57096321-3a62db80-6cd2-11e9-8475-429378ebfcc7.png)
Table in comment
![image](https://user-images.githubusercontent.com/48102075/57096359-4ea6d880-6cd2-11e9-87ca-00bbf60c7361.png)
Tested in [this post](https://www.reddit.com/r/tabled/comments/abq1ou/test/).

Due to redesign not using a class name like user-text for both posts and comments content, it was necessary to work around by looking for both post and comments in separated callbacks based in the class names _Post_ and _Comment_ which are the only consistent class names in the redesign.