### PR TITLE
Limit api.twitter.com permission to the only endpoint we use

### DIFF
--- a/chrome/beta/manifest.json
+++ b/chrome/beta/manifest.json
@@ -71,7 +71,7 @@
 	"optional_permissions": [
 		"downloads",
 
-		"https://api.twitter.com/*",
+		"https://api.twitter.com/1/statuses/oembed.json",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
 		"https://codepen.io/api/oembed",

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -71,7 +71,7 @@
 	"optional_permissions": [
 		"downloads",
 
-		"https://api.twitter.com/*",
+		"https://api.twitter.com/1/statuses/oembed.json",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
 		"https://codepen.io/api/oembed",

--- a/firefox/beta/manifest.json
+++ b/firefox/beta/manifest.json
@@ -74,7 +74,7 @@
 	"optional_permissions": [
 		"downloads",
 
-		"https://api.twitter.com/*",
+		"https://api.twitter.com/1/statuses/oembed.json",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
 		"https://codepen.io/api/oembed",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -74,7 +74,7 @@
 	"optional_permissions": [
 		"downloads",
 
-		"https://api.twitter.com/*",
+		"https://api.twitter.com/1/statuses/oembed.json",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
 		"https://codepen.io/api/oembed",

--- a/lib/modules/hosts/twitter.js
+++ b/lib/modules/hosts/twitter.js
@@ -8,7 +8,7 @@ import { ajax } from '../../environment';
 export default new Host('twitter', {
 	name: 'twitter',
 	domains: ['twitter.com'],
-	permissions: ['https://api.twitter.com/*'],
+	permissions: ['https://api.twitter.com/1/statuses/oembed.json'],
 	attribution: false,
 	detect: ({ href }) => (/^https?:\/\/(?:mobile\.)?twitter\.com\/(?:#!\/)?[\w]+\/status(?:es)?\/([\d]+)/i).exec(href),
 	async handleLink(href, [, id]) {

--- a/lib/modules/requestPermissions.js
+++ b/lib/modules/requestPermissions.js
@@ -13,7 +13,7 @@ module.permissions = {
 	requiredPermissions: process.env.BUILD_TARGET === 'firefox' ? [
 		'downloads',
 
-		'https://api.twitter.com/*',
+		'https://api.twitter.com/1/statuses/oembed.json',
 		'https://backend.deviantart.com/oembed',
 		'https://api.gyazo.com/api/oembed',
 		'https://codepen.io/api/oembed',
@@ -25,7 +25,7 @@ module.permissions = {
 	] : [
 		'downloads',
 
-		'https://api.twitter.com/*',
+		'https://api.twitter.com/1/statuses/oembed.json',
 		'https://backend.deviantart.com/oembed',
 		'https://api.gyazo.com/api/oembed',
 		'https://codepen.io/api/oembed',


### PR DESCRIPTION
Tested in browser: Chrome 76, Firefox 66

From #4471. Now that we have optional permissions in Firefox (#4989), we can change this permission.

This doesn't actually change the user prompt (it still looks like you're granting permission for all of api.twitter.com), but oh well.