### PR TITLE
Stylesheet: set textContent of <style> nodes directly to avoid escaping > in  `.parent > .child`

### DIFF
--- a/lib/modules/stylesheet.js
+++ b/lib/modules/stylesheet.js
@@ -281,7 +281,11 @@ function applyCssSnippets() {
 	snippetManager.sync(snippets);
 }
 
-const snippetManager = stylesheetElementManager(css => string.html`<style>${css}</style>`);
+const snippetManager = stylesheetElementManager(css => {
+	const style = document.createElement('style');
+	style.textContent = css;
+	return style;
+});
 
 function stylesheetElementManager<T>(generateElement: (x: T) => HTMLElement): { sync(xs: T[]): void } {
 	const current = new Map();


### PR DESCRIPTION
Tested in browser: Chrome 76
