### PR TITLE
Remove object-rest-spread transform

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,6 @@
     "plugins": [
 		"@babel/plugin-proposal-export-namespace-from",
 		["@babel/plugin-proposal-class-properties", { "loose": true }],
-		["@babel/plugin-proposal-object-rest-spread", { "loose": true, "useBuiltIns": true }],
 		"@babel/plugin-transform-modules-commonjs",
 		"@babel/plugin-transform-flow-strip-types"
 	],

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "@babel/core": "7.4.3",
     "@babel/plugin-proposal-class-properties": "7.4.0",
     "@babel/plugin-proposal-export-namespace-from": "7.2.0",
-    "@babel/plugin-proposal-object-rest-spread": "7.4.3",
     "@babel/plugin-transform-flow-strip-types": "7.4.0",
     "@babel/plugin-transform-modules-commonjs": "7.4.3",
     "@babel/register": "7.4.0",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -70,7 +70,6 @@ export default (env = {}, argv = {}) => {
 							plugins: [
 								'@babel/plugin-proposal-export-namespace-from',
 								['@babel/plugin-proposal-class-properties', { loose: true }],
-								['@babel/plugin-proposal-object-rest-spread', { loose: true, useBuiltIns: true }],
 								'@babel/plugin-transform-flow-strip-types',
 								'minify-dead-code-elimination',
 								['transform-define', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -391,14 +391,6 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-json-strings" "^7.2.0"
 
-"@babel/plugin-proposal-object-rest-spread@7.4.3":
-  version "7.4.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz#be27cd416eceeba84141305b93c282f5de23bbb4"
-  integrity sha512-xC//6DNSSHVjq8O2ge0dyYlhshsH4T7XdCVoxbi5HzLYWfsC5ooFlJjrXk8RcAT+hjHAK9UjBXdylzSoDK3t4g==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
-
 "@babel/plugin-proposal-object-rest-spread@^7.0.0", "@babel/plugin-proposal-object-rest-spread@^7.3.1":
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.2.tgz#6d1859882d4d778578e41f82cc5d7bf3d5daf6c1"


### PR DESCRIPTION
Tested in browser: Chrome 76

Now that Edge is slated to use Chromium, all supported browsers support this natively. Hopefully all the tools we use do too.