### PR TITLE
neverEndingComment: Use IntersectionObserver, improve loadChildComments

### DIFF
--- a/lib/modules/neverEndingComments.js
+++ b/lib/modules/neverEndingComments.js
@@ -1,8 +1,7 @@
 /* @flow */
 
-import * as _ from 'lodash';
 import { Module } from '../core/module';
-import { elementInViewport } from '../utils/dom';
+import { Thing, frameDebounce, mutex, watchForDescendants, waitForRemoval } from '../utils';
 
 export const module: Module<*> = new Module('neverEndingComments');
 
@@ -22,22 +21,49 @@ module.include = [
 	'comments',
 ];
 
-module.go = () => {
-	window.addEventListener('scroll', _.debounce(handleScroll, 300));
+module.afterLoad = () => {
+	const context = document.body.querySelector(module.options.loadChildComments.value ? '.nestedlisting' : '.nestedlisting > .thing.morechildren');
+	if (!context) return;
+
+	const visibleLoaders = new Set();
+
+	const io = new IntersectionObserver(entries => {
+		for (const { isIntersecting, target } of entries) {
+			if (!context.contains(target)) io.unobserve(target);
+			if (isIntersecting) visibleLoaders.add(target);
+			else visibleLoaders.delete(target);
+		}
+
+		if (visibleLoaders.size) {
+			window.addEventListener('scroll', loadFirst);
+			loadFirst();
+		} else {
+			window.removeEventListener('scroll', loadFirst);
+		}
+		// Don't load the top comments, as they may are likely above the current focused comment and may mess up scroll anchoring
+		// also load comments that are a little beneath the viewport so this works a bit more seamlessly
+	}, { rootMargin: '-10% 0px 10% 0px' });
+
+	// Wait a little before starting load, in case the user is just quickly scrolling through
+	const loadFirst = frameDebounce(mutex(async () => {
+		// Load one at a time to reduce the latency
+		// The uppermost is loaded first, as that is likely the one the user is interested having expanded
+		const loader = Array.from(visibleLoaders.values()).sort((a, b) => 3 - (a.compareDocumentPosition(b) & 6))
+			.find(e => {
+				// Don't load any above the selected thing
+				const thing = Thing.from(e);
+				return !Thing.selected || !thing || (Thing.selected.getDirectionOf(thing) === 'down');
+			});
+		if (loader) {
+			loader.click();
+			await waitForRemoval(
+				loader,
+				// The load may fail
+				new Promise(res => setTimeout(res, 3000))
+			);
+			loadFirst();
+		}
+	}), 5);
+
+	watchForDescendants(context, '.morecomments a', ele => { io.observe(ele); });
 };
-
-function firstVisibleLoader() {
-	const context = module.options.loadChildComments.value ? '' : '.nestedlisting > .thing.morechildren';
-	const loaders = document.querySelectorAll(`${context} .morecomments a:not([res-clicked])`);
-
-	return Array.from(loaders).find(el => elementInViewport(el));
-}
-
-const handleScroll = _.throttle(() => {
-	const link = firstVisibleLoader();
-	if (link) {
-		link.setAttribute('res-clicked', '');
-		link.click();
-		handleScroll(); // throttled, so this call will be delayed
-	}
-}, 2000);

--- a/lib/utils/async.js
+++ b/lib/utils/async.js
@@ -251,7 +251,7 @@ export function throttle(callback: () => void | Promise<void>): () => Promise<vo
 }
 
 // Invokes callback after the returned function has not been invoked for `debounce` number of frames
-export function frameDebounce(callback: () => void, debounce: number = 1): () => void {
+export function frameDebounce(callback: () => any, debounce: number = 1): () => void {
 	let remaining: number;
 
 	const update = frameThrottle(() => {

--- a/tests/selectedEntry.js
+++ b/tests/selectedEntry.js
@@ -20,6 +20,9 @@ module.exports = {
 			.url('https://en.reddit.com/wiki/pages#res:settings-redirect-standalone-options-page/userInfo')
 			.waitForElementVisible('#RESConsoleContainer')
 			.click('.moduleToggle')
+			// Disable neverEndigComments, as that may auto click the "load more comments" buttons
+			.url('https://en.reddit.com/wiki/pages#res:settings-redirect-standalone-options-page/neverEndingComments')
+			.click('.moduleToggle')
 
 			// Run the actual test...
 			.url('https://en.reddit.com/r/RESIntegrationTests/comments/5lfy0v/selected_entry_selecting_comments/?limit=1')


### PR DESCRIPTION
More comments are now started loading instantly (after scrolling), and only one at a time (as loading may otherwise crash).

Tested in browser: Firefox 67, Chrome 76
