### PR TITLE
Xpost links compatible with redesign (#4955)

### DIFF
--- a/lib/core/init.js
+++ b/lib/core/init.js
@@ -104,7 +104,7 @@ export const beforeLoad: Promise<void> = loadOptions
 export const contentStart: Promise<*> = Promise.all([beforeLoad, sitetableStarted])
 	.then(() => Promise.all([
 		_runModuleStage('contentStart'),
-		isAppType('r2') ? r2WatcherSitetableStart() : undefined,
+		isAppType('r2') || isAppType('d2x') ? r2WatcherSitetableStart() : undefined,
 	]));
 
 export const go: Promise<*> = Promise.all([beforeLoad, sitetableStarted])

--- a/lib/modules/tableTools.js
+++ b/lib/modules/tableTools.js
@@ -23,14 +23,9 @@ module.shouldRun = () => !isCurrentSubreddit('dashboard');
 
 module.contentStart = () => {
 	if (module.options.sort.value) {
-		$(document).on('click', '.md th, .Comment th, .Post th', tableSortEvent);
+		$(document).on('click', '.md th, .Comment th, .Post th', (e: Event) => sortTableColumn(e.currentTarget));
 	}
 };
-
-// Event handler for click in table column
-function tableSortEvent(e: Event) {
-	sortTableColumn(e.currentTarget);
-}
 
 // Add sorting to a column
 function sortTableColumn(target) {

--- a/lib/modules/tableTools.js
+++ b/lib/modules/tableTools.js
@@ -23,9 +23,16 @@ module.shouldRun = () => !isCurrentSubreddit('dashboard');
 
 module.contentStart = () => {
 	if (module.options.sort.value) {
-		$(document).on('click', '.md th', (e: Event) => sortTableColumn(e.currentTarget));
+		$(document).on('click', '.md th', tableSortEvent);
+		$(document).on('click', '.Comment th', tableSortEvent);
+		$(document).on('click', '.Post th', tableSortEvent);
 	}
 };
+
+// Event handler for click in table column
+function tableSortEvent(e: Event) {
+	sortTableColumn(e.currentTarget);
+}
 
 // Add sorting to a column
 function sortTableColumn(target) {

--- a/lib/modules/tableTools.js
+++ b/lib/modules/tableTools.js
@@ -23,9 +23,7 @@ module.shouldRun = () => !isCurrentSubreddit('dashboard');
 
 module.contentStart = () => {
 	if (module.options.sort.value) {
-		$(document).on('click', '.md th', tableSortEvent);
-		$(document).on('click', '.Comment th', tableSortEvent);
-		$(document).on('click', '.Post th', tableSortEvent);
+		$(document).on('click', '.md th, .Comment th, .Post th', tableSortEvent);
 	}
 };
 

--- a/lib/modules/xPostLinks.js
+++ b/lib/modules/xPostLinks.js
@@ -17,10 +17,10 @@ module.include = [
 	'comments',
 	'profile',
 	'search',
+	'd2x',
 ];
 
 module.exclude = [
-	'd2x',
 ];
 
 module.beforeLoad = () => {

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -274,8 +274,8 @@ export class Thing {
 	}
 
 	isPost(): boolean {
-		return this.element.classList.contains('link') || this.element.classList.contains('search-result-link')
-			|| this.element.classList.contains('Post');
+		return this.element.classList.contains('link') || this.element.classList.contains('search-result-link') ||
+			this.element.classList.contains('Post');
 	}
 
 	isLinkPost(): boolean {
@@ -316,7 +316,7 @@ export class Thing {
 	getTitleElement(): ?HTMLAnchorElement {
 		return (this.entry.querySelector('a.title, a.search-title') ||
 			this.entry.querySelector('.title') ||
-			this.entry.querySelector('.Post h2') : any);
+			this.entry.querySelector('.Post h2'): any);
 	}
 
 	getTitleUrl(): string {

--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -22,7 +22,7 @@ const thingElementsCached = _.memoize(doc => {
  * Uniqueness is guaranteed, i.e. `Thing.from(element) === Thing.from(element)`.
  */
 export class Thing {
-	static thingSelector = '.listing .thing, .linklisting .thing, .nestedlisting .thing, .search-result-link';
+	static thingSelector = '.Post, .listing .thing, .linklisting .thing, .nestedlisting .thing, .search-result-link';
 	static entrySelector = '.entry, .search-result-link > :not(.thumbnail)';
 
 	static thingElements(doc: * = document.body, topLevelOnly: boolean = false): HTMLElement[] {
@@ -274,7 +274,8 @@ export class Thing {
 	}
 
 	isPost(): boolean {
-		return this.element.classList.contains('link') || this.element.classList.contains('search-result-link');
+		return this.element.classList.contains('link') || this.element.classList.contains('search-result-link')
+			|| this.element.classList.contains('Post');
 	}
 
 	isLinkPost(): boolean {
@@ -314,7 +315,8 @@ export class Thing {
 
 	getTitleElement(): ?HTMLAnchorElement {
 		return (this.entry.querySelector('a.title, a.search-title') ||
-			this.entry.querySelector('.title'): any);
+			this.entry.querySelector('.title') ||
+			this.entry.querySelector('.Post h2') : any);
 	}
 
 	getTitleUrl(): string {
@@ -326,7 +328,7 @@ export class Thing {
 	}
 
 	getPostLink(): HTMLAnchorElement {
-		return downcast(this.entry.querySelector('a.title, a.search-link'), HTMLAnchorElement);
+		return downcast(this.entry.querySelector('a.title, a.search-link, a[data-click-id="timestamp"'), HTMLAnchorElement);
 	}
 
 	getPostUrl(): string {
@@ -575,7 +577,7 @@ export class Thing {
 	}
 
 	getUserattrsElement(): ?HTMLElement {
-		return this.entry.querySelector('.userattrs');
+		return this.entry.querySelector('.userattrs') || this.entry.querySelector('a[data-click-id="timestamp"]');
 	}
 
 	getRank(): ?number {


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: fixes #4955
Tested in browser: Google Chrome Version 74.0.3729.131 (Official Build) (64-bit)

**WORK IN PROGRESS**

This PR makes the module _xPostLinks_ to work on Reddit's redesign, but some other files had to be modified to allow the module to run.

First I had to allow the module to work on new Reddit since by default is settled to be ignored there.
Replaced in **xPostLinks.js**:
```javascript
module.include = [
	'linklist',
	'modqueue',
	'comments',
	'profile',
	'search',
];

module.exclude = [
	'd2x',
];
```
for
```javascript
module.include = [
	'linklist',
	'modqueue',
	'comments',
	'profile',
	'search',
	'd2x',
];

module.exclude = [
];
```
Then we had to modify some of the inner code since at this moment the module doesn't go any further than `beforeLoad`.
We had to allow `r2WatcherSitetableStart()` to be loaded in new Reddit changing in **init.js**:
```javascript
export const contentStart: Promise<*> = Promise.all([beforeLoad, sitetableStarted])
	.then(() => Promise.all([
		_runModuleStage('contentStart'),
		isAppType('r2') ? r2WatcherSitetableStart() : undefined,
	]));
```
to
```javascript
export const contentStart: Promise<*> = Promise.all([beforeLoad, sitetableStarted])
	.then(() => Promise.all([
		_runModuleStage('contentStart'),
		isAppType('r2') || isAppType('d2x') ? r2WatcherSitetableStart() : undefined,
	]));
```
And finally we had to define a set of elements to be found in new Reddit in **Thing.js**

`.Post` object was added as a selectable thing:
```javascript
export class Thing {
	static thingSelector = '.Post, .listing .thing, .linklisting .thing, .nestedlisting .thing, .search-result-link';
```
Defined that `isPost` can be true by finding `Post` in `classList`:
```javascript
isPost(): boolean {
	return this.element.classList.contains('link') || this.element.classList.contains('search-result-link')
		|| this.element.classList.contains('Post');
}
```
New Reddit doesn't have a clear indicator of where the title is in DOM, so we defined it as `.Post h2`:
```javascript
getTitleElement(): ?HTMLAnchorElement {
	return (this.entry.querySelector('a.title, a.search-title') ||
		this.entry.querySelector('.title') ||
		this.entry.querySelector('.Post h2') : any);
}
```
The same goes for the post link, but this time was harder since we couldn't take any `<a>`. I decided to use `a[data-click-id="timestamp` since it's an element that only exists in new Reddit and is present both in the dashboard and the single post view:
```javascript
getPostLink(): HTMLAnchorElement {
	return downcast(this.entry.querySelector('a.title, a.search-link, a[data-click-id="timestamp"'), HTMLAnchorElement);
}
```
User attributes needed to define the position of the module JQuery were harder to solve since there is no way of clearly locating them. `a[data-click-id="timestamp"]`  proved to be useful again since it's the closest object in DOM to said location:
```javascript
getUserattrsElement(): ?HTMLElement {
	return this.entry.querySelector('.userattrs') || this.entry.querySelector('a[data-click-id="timestamp"]');
}
```

This proved to work in new Reddit for both the Dashboard and the single post view.
![image](https://user-images.githubusercontent.com/48102075/57560251-cd3eee00-7342-11e9-9678-751476a44768.png)
![image](https://user-images.githubusercontent.com/48102075/57490312-12e1b500-7276-11e9-99a3-f9bf798de502.png)
But it doesn't work in the modal view.
![image](https://user-images.githubusercontent.com/48102075/57560315-142ce380-7343-11e9-8107-f862af7ab1ae.png)

The programmer that helped me to solve this issue wanted to see if he could apply the logic used in the module `userTagger` but we haven't figured it out yet.