### PR TITLE
xPostLinks is now compatible with redesign

### DIFF
--- a/lib/modules/tableTools.js
+++ b/lib/modules/tableTools.js
@@ -23,14 +23,9 @@ module.shouldRun = () => !isCurrentSubreddit('dashboard');
 
 module.contentStart = () => {
 	if (module.options.sort.value) {
-		$(document).on('click', '.md th, .Comment th, .Post th', tableSortEvent);
+		$(document).on('click', '.md th, .Comment th, .Post th', (e: Event) => sortTableColumn(e.currentTarget));
 	}
 };
-
-// Event handler for click in table column
-function tableSortEvent(e: Event) {
-	sortTableColumn(e.currentTarget);
-}
 
 // Add sorting to a column
 function sortTableColumn(target) {

--- a/lib/modules/tableTools.js
+++ b/lib/modules/tableTools.js
@@ -23,9 +23,16 @@ module.shouldRun = () => !isCurrentSubreddit('dashboard');
 
 module.contentStart = () => {
 	if (module.options.sort.value) {
-		$(document).on('click', '.md th', (e: Event) => sortTableColumn(e.currentTarget));
+		$(document).on('click', '.md th', tableSortEvent);
+		$(document).on('click', '.Comment th', tableSortEvent);
+		$(document).on('click', '.Post th', tableSortEvent);
 	}
 };
+
+// Event handler for click in table column
+function tableSortEvent(e: Event) {
+	sortTableColumn(e.currentTarget);
+}
 
 // Add sorting to a column
 function sortTableColumn(target) {

--- a/lib/modules/tableTools.js
+++ b/lib/modules/tableTools.js
@@ -23,9 +23,7 @@ module.shouldRun = () => !isCurrentSubreddit('dashboard');
 
 module.contentStart = () => {
 	if (module.options.sort.value) {
-		$(document).on('click', '.md th', tableSortEvent);
-		$(document).on('click', '.Comment th', tableSortEvent);
-		$(document).on('click', '.Post th', tableSortEvent);
+		$(document).on('click', '.md th, .Comment th, .Post th', tableSortEvent);
 	}
 };
 

--- a/lib/modules/xPostLinks.js
+++ b/lib/modules/xPostLinks.js
@@ -2,7 +2,7 @@
 
 import { $ } from '../vendor';
 import { Module } from '../core/module';
-import { watchForThings, string } from '../utils';
+import { watchForThings, string, watchForRedditEvents } from '../utils';
 import { i18n } from '../environment';
 
 export const module: Module<*> = new Module('xPostLinks');
@@ -17,14 +17,19 @@ module.include = [
 	'comments',
 	'profile',
 	'search',
+	'd2x',
 ];
 
 module.exclude = [
-	'd2x',
 ];
 
 module.beforeLoad = () => {
 	watchForThings(['post'], createLinks);
+
+	watchForRedditEvents('post', (element, data) => {
+		if (data._.update) return;
+		d2xCreateLinks(data);
+	});
 };
 
 const xpostRe = /(?:x|cross)[\s-]?post\S*(.+)/i;
@@ -60,7 +65,23 @@ function appendToTagline(sub, thing) {
 		);
 }
 
+function d2xAppendToTagline(sub, data) {
+	$(document.querySelector(`.${data.id} a[data-click-id="timestamp"]`))
+		.after(
+			string.escape` ${i18n('xPostLinksXpostedFrom')} `,
+			$('<a>', {
+				class: 'subreddit hover',
+				href: `/r/${sub}`,
+				text: `/r/${sub}`,
+			}));
+}
+
 function createLinks(thing) {
 	const sub = parseSubreddit(thing.getTitle());
 	if (sub) appendToTagline(sub, thing);
+}
+
+function d2xCreateLinks(data) {
+	const sub = parseSubreddit(data.title);
+	if (sub) d2xAppendToTagline(sub, data);
 }


### PR DESCRIPTION
Relevant issue: fixes #4955 
Tested in browser: Google Chrome Version 74.0.3729.131 (Official Build) (64-bit)

This PR makes the module _xPostLinks_ compatible with redesign using watchForRedditEvents (thanks, @andytuba)

Based on the logic used in _usserTagger_, `watchForRedditEvents('post', (element, data)` was used to check for posts and call the link creator function, and like in _usserTagger_, a condition was used to prevent updates drawing the DOM elements more than once.

```javascript
watchForRedditEvents('post', (element, data) => {
	if (data._.update) return;
	d2xCreateLinks(data);
});
```

A version of the functions _createLinks_ and _appendToTagline_ were created to work with the data returned by _watchForRedditEvents_.

_d2xCreateLinks_ does the same jobs as _appendToTagline_, but with the data object returned by _watchForRedditEvents_.
```javascript
function d2xCreateLinks(data) {
	const sub = parseSubreddit(data.title);
	if (sub) d2xAppendToTagline(sub, data);
}
```
_d2xAppendToTagline_ also works similar to _appendToTagline_, but here the JQuery function uses the id contained in the data object returned by _watchForRedditEvents_ to locate the place where to place the xpost link.
```javascript
function d2xAppendToTagline(sub, data) {
	$(document.querySelector(`.${data.id} a[data-click-id="timestamp"]`))
		.after(
			string.escape` ${i18n('xPostLinksXpostedFrom')} `,
			$('<a>', {
				class: 'subreddit hover',
				href: `/r/${sub}`,
				text: `/r/${sub}`,
			}));
}
```