### PR TITLE
keyboardNav: Scroll to top of inline gallery on browse

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -21,6 +21,7 @@ import {
 	loggedInUser,
 	matchesPageLocation,
 	niceKeyCode,
+	scrollToElement,
 	string,
 	watchForElements,
 	waitForEvent,
@@ -448,9 +449,7 @@ module.options = {
 		value: [219, false, false, false, false], // [
 		description: 'keyboardNavPreviousGalleryImageDesc',
 		title: 'keyboardNavPreviousGalleryImageTitle',
-		callback() {
-			getMostVisibleElementInThingByQuery('.res-gallery .res-gallery-previous', ASSERT).click();
-		},
+		callback() { navigateGallery('previous'); },
 	},
 	nextGalleryImage: {
 		type: 'keycode',
@@ -458,9 +457,14 @@ module.options = {
 		value: [221, false, false, false, false], // ]
 		description: 'keyboardNavNextGalleryImageDesc',
 		title: 'keyboardNavNextGalleryImageTitle',
-		callback() {
-			getMostVisibleElementInThingByQuery('.res-gallery .res-gallery-next', ASSERT).click();
-		},
+		callback() { navigateGallery('next'); },
+	},
+	scrollOnGalleryNavigate: {
+		type: 'boolean',
+		value: true,
+		description: 'keyboardNavScrollOnGalleryNavigateDesc',
+		title: 'keyboardNavScrollOnGalleryNavigateTitle',
+		advanced: true,
 	},
 	toggleViewImages: {
 		type: 'keycode',
@@ -1153,6 +1157,14 @@ function imageResize({ factor = 1, removeHeightRestriction = false }: {| factor?
 function imageMove(deltaX, deltaY) {
 	const mostVisible = getMostVisibleElementInThingByQuery('.res-media-movable', ASSERT);
 	ShowImages.moveMedia(mostVisible, deltaX, deltaY);
+}
+
+function navigateGallery(direction: 'previous' | 'next') {
+	const gallery = getMostVisibleElementInThingByQuery('.res-gallery', ASSERT);
+	assertElement(gallery.querySelector(`.res-gallery-${direction}`)).click();
+	if (module.options.scrollOnGalleryNavigate.value) {
+		scrollToElement(assertElement(gallery.querySelector('.res-gallery-pieces')), null, { scrollStyle: 'directional', restrictDirectionTo: 'up' });
+	}
 }
 
 function followLink(newWindow = false, selected = getSelected()) {

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -693,6 +693,12 @@
 	"keyboardNavNextGalleryImageDesc": {
 		"message": "View the next image of an inline gallery."
 	},
+	"keyboardNavScrollOnGalleryNavigateTitle": {
+		"message": "Scroll To Gallery Image"
+	},
+	"keyboardNavScrollOnGalleryNavigateDesc": {
+		"message": "Scroll window to top of gallery image when browsing using keyboard."
+	},
 	"keyboardNavToggleViewImagesTitle": {
 		"message": "Toggle View Images"
 	},


### PR DESCRIPTION
Adds an option to scroll back to the top of an inline gallery image when using keyboard navigation.

This has always been a small annoyance for me when when browsing galleries of large-ish images (e.g. comics). Hopefully this will be useful for other users as well.

Maybe a few issues to consider:
- Should this default to *on* as it is now? Because it only scrolls *up*, most users will probably not experience any change in behavior for fully visible galleries.
It may cause some confusion if a user has a post w/ gallery selected, but then continues reading further down the page, before attempting to browse a gallery (without selecting the correct comment first).
- I have chosen to scroll to the top of the `.res-gallery-pieces` container, which contains the image + caption (if the user has changed *`captionsPosition`* to show it above), but not the gallery title or navigation controls. Maybe it should scroll to include the controls?
- The call to `getMostVisibleElementInThingByQuery` was changed from the navigation buttons to the whole gallery, maybe this can cause some issues with multiple galleries of different sizes in the same post? (Not sure).

Please let me know if I missed anything.