### PR TITLE
Fix nightmode issue with links on old reddit profiles.

### DIFF
--- a/lib/css/modules/_nightMode.scss
+++ b/lib/css/modules/_nightMode.scss
@@ -24,7 +24,8 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 	.modactionlisting table *,
 	.side .recommend-box .rec-item,
 	.crosspost-preview,
-	.crosspost-thing-preview {
+	.crosspost-thing-preview,
+	.link {
 		background-color: $background-color;
 		border-color: $border-color;
 	}


### PR DESCRIPTION
Relevant issue: 
Tested in browser: Microsoft Edge Version 76.0.167.1 (Official build) dev (64-bit)

Night mode was displaying a white background on link posts on old profiles. Tested fixed.
