### PR TITLE
Activate RES in redesign embedded iframes. Fixes  #5126

### DIFF
--- a/chrome/beta/manifest.json
+++ b/chrome/beta/manifest.json
@@ -30,6 +30,7 @@
 		"matches": [
 			"https://*.reddit.com/*"
 		],
+		"all_frames": true,
 		"exclude_matches": [
 			"https://mod.reddit.com/*",
 			"https://ads.reddit.com/*",

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -30,6 +30,7 @@
 		"matches": [
 			"https://*.reddit.com/*"
 		],
+		"all_frames": true,
 		"exclude_matches": [
 			"https://mod.reddit.com/*",
 			"https://ads.reddit.com/*",

--- a/firefox/beta/manifest.json
+++ b/firefox/beta/manifest.json
@@ -34,6 +34,7 @@
 		"matches": [
 			"https://*.reddit.com/*"
 		],
+		"all_frames": true,
 		"exclude_matches": [
 			"https://mod.reddit.com/*",
 			"https://ads.reddit.com/*",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -34,6 +34,7 @@
 		"matches": [
 			"https://*.reddit.com/*"
 		],
+		"all_frames": true,
 		"exclude_matches": [
 			"https://mod.reddit.com/*",
 			"https://ads.reddit.com/*",

--- a/lib/css/modules/_nightMode.scss
+++ b/lib/css/modules/_nightMode.scss
@@ -29,12 +29,12 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 		border-color: $border-color;
 	}
 
-	.embedded-page .content>.sitetable,
+	.embedded-page .content > .sitetable,
 	.embedded-page.helpcenter-page .content,
 	.embedded-page.compose-page .content,
-	.embedded-page .content>.sitetable>div:nth-of-type(4n+1),
-	.embedded-page.helpcenter-page .content>div:nth-of-type(4n+1),
-	.embedded-page.compose-page .content>div:nth-of-type(4n+1) {
+	.embedded-page .content > .sitetable > div:nth-of-type(4n+1),
+	.embedded-page.helpcenter-page .content > div:nth-of-type(4n+1),
+	.embedded-page.compose-page .content > div:nth-of-type(4n+1) {
 		background-color: $background-color;
 		color: $color;
 	}

--- a/lib/css/modules/_nightMode.scss
+++ b/lib/css/modules/_nightMode.scss
@@ -29,6 +29,16 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 		border-color: $border-color;
 	}
 
+	.embedded-page .content>.sitetable,
+	.embedded-page.helpcenter-page .content,
+	.embedded-page.compose-page .content,
+	.embedded-page .content>.sitetable>div:nth-of-type(4n+1),
+	.embedded-page.helpcenter-page .content>div:nth-of-type(4n+1),
+	.embedded-page.compose-page .content>div:nth-of-type(4n+1) {
+		background-color: $background-color;
+		color: $color;
+	}
+
 	.link,
 	.helpcenter-form .section-content {
 		background-color: $background-color;

--- a/lib/css/res.scss
+++ b/lib/css/res.scss
@@ -371,7 +371,7 @@ span.multi-count {
 	padding: 3px 5px;
 	font-size: 12px;
 	line-height: 15px;
-	color: #fff;
+	color: #fff !important;
 	border: 1px solid #636363;
 	border-radius: 3px;
 	background-color: #107ac4;

--- a/lib/foreground.entry.js
+++ b/lib/foreground.entry.js
@@ -27,6 +27,10 @@ if (document.documentElement && document.documentElement.classList.contains('res
 	blockers.push('RES is previously loaded on this page.');
 }
 
+if (window !== window.parent && (new URL(location.href)).searchParams.get('embedded') !== 'true') {
+	blockers.push('Not an embedded reddit iframe RES will not load.');
+}
+
 if (blockers.length) {
 	console.warn('Preventing initalization of RES:', blockers);
 } else {

--- a/lib/foreground.entry.js
+++ b/lib/foreground.entry.js
@@ -28,7 +28,7 @@ if (document.documentElement && document.documentElement.classList.contains('res
 }
 
 if (window !== window.parent && (new URL(location.href)).searchParams.get('embedded') !== 'true') {
-	blockers.push('Not an embedded reddit iframe RES will not load.');
+	blockers.push('Conditions for running on an embedded page are not met.');
 }
 
 if (blockers.length) {


### PR DESCRIPTION
Relevant issue:  #5126
Tested in browser: Firefox and Chrome

Does exactly what it says in the title. Only activates in redesign embedded pages to prevent issues with other iframes.

I have tested a variety of functions: 
- Tagging
- User hover popup
- Neverending reddit

All of those appear to be working fine. 

![image](https://user-images.githubusercontent.com/2502190/59459862-1c82ad80-8e1e-11e9-908f-6a3e6f5a80e2.png)

As is visible in the screenshot there is one small visual issue with `.blueButton` which I haven't fixed yet as I don't know if there are guidelines about specificity. When changing the selector to `.res .blueButton` it did show up fine. 


