### PR TITLE
host: fix osu.ppy.sh/ss/ expando

### DIFF
--- a/lib/modules/hosts/ppy.js
+++ b/lib/modules/hosts/ppy.js
@@ -6,7 +6,7 @@ export default new Host('ppy.sh', {
 	name: 'ppy.sh',
 	domains: ['osu.ppy.sh'],
 	logo: 'https://s.ppy.sh/favicon.ico',
-	detect: ({ pathname }) => (/^\/ss\/(\d+)/i).exec(pathname),
+	detect: ({ pathname }) => (/^\/ss\/(\d+(?:\/[0-9a-f]+)?)/i).exec(pathname),
 	handleLink(href, [, code]) {
 		return {
 			type: 'IMAGE',


### PR DESCRIPTION
Relevant issue: https://www.reddit.com/r/Enhancement/comments/c8fpw6/bug_expandos_for_osuppyshss_no_longer_working/
Tested in browser: Chrome 75

Recent `https://osu.ppy.sh/ss/` links have begun adding a short hash onto the end of the URL. This PR supports both new and old `https://osu.ppy.sh/ss/` links.

An example of a "new" link is `https://osu.ppy.sh/ss/13467161/573f` from [this](https://redd.it/c8f25n) reddit thread - refer to [the domain listing for osu.ppy.sh](https://www.reddit.com/domain/osu.ppy.sh/) for more examples.  
An example of an "old" link is `https://osu.ppy.sh/ss/6135901` from [this](https://redd.it/53l422) reddit thread.