### PR TITLE
New module: autoHide for hiding seen posts

### DIFF
--- a/lib/modules/autoHide.js
+++ b/lib/modules/autoHide.js
@@ -1,0 +1,75 @@
+/* @flow */
+
+import { Module } from '../core/module';
+import * as Modules from '../core/modules';
+import { isPrivateBrowsing } from '../environment';
+import { Thing, batch, isPageType, watchForThings } from '../utils';
+import * as ThingHide from '../utils/thingHide';
+import * as ReadComments from './readComments';
+
+export const module: Module<*> = new Module('autoHide');
+
+module.moduleName = 'autoHideName';
+module.category = 'browsingCategory';
+module.description = 'autoHideDesc';
+
+module.options = {
+	types: {
+		type: 'enum',
+		values: [{
+			name: 'All',
+			value: '',
+		}, {
+			name: 'Only comments',
+			value: 'comment',
+		}, {
+			name: 'Only link posts',
+			value: 'post',
+		}],
+		value: 'comment',
+		description: 'autoHideTypesDesc',
+		title: 'autoHideTypesTitle',
+	},
+};
+
+const VISIBLE_MIN = 2000;
+const thingType = isPageType('comments', 'commentsLinklist') ? 'comment' : 'post';
+
+const hidePost = batch(
+	posts => ThingHide.send(ThingHide.HIDE, posts),
+	{ size: 50, delay: 5000, flushBeforeUnload: true }
+);
+
+module.shouldRun = () => !isPrivateBrowsing();
+
+module.beforeLoad = () => {
+	if (module.options.types.value && thingType !== module.options.types.value) return;
+
+	if (thingType === 'comment' && !Modules.isRunning(ReadComments)) {
+		console.warn('Auto-hiding comments requires readComments');
+		return;
+	}
+
+	const pending: Map<Thing, TimeoutID> = new Map();
+
+	const io = new IntersectionObserver(entries => {
+		for (const { target, isIntersecting } of entries) {
+			const thing = Thing.checkedFrom(target);
+			if (isIntersecting) {
+				pending.set(thing, setTimeout(() => {
+					if (thingType === 'post') hidePost(thing);
+					else ReadComments.add(thing);
+
+					io.unobserve(target);
+					pending.delete(thing);
+				}, VISIBLE_MIN));
+			} else {
+				pending.delete(thing);
+			}
+		}
+	}, { threshold: [0] });
+
+	watchForThings([thingType], thing => {
+		io.observe(thing.getButtons());
+	});
+};

--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -337,8 +337,7 @@ function hideLink(clickedLink, action = clickedLink.getAttribute('action')) {
 		const expando = Expando.getEntryExpandoFrom(thing);
 		if (expando && expando.types.includes('native')) expando.collapse();
 
-		if (timeout === null) $(thing.element).hide();
-		else hideTimer.set(clickedLink, setTimeout(() => $(thing.element).fadeOut(300), timeout));
+		if (timeout === null) { if (!isPageType('comments')) $(thing.element).hide(); } else { hideTimer.set(clickedLink, setTimeout(() => $(thing.element).fadeOut(300), timeout)); }
 	}
 
 	try {

--- a/lib/modules/filteReddit.js
+++ b/lib/modules/filteReddit.js
@@ -481,6 +481,10 @@ let nsfwToggle;
 let filterline: Filterline;
 let visible: boolean;
 
+let _filterlineResolve;
+export const filterlinePromise: Promise<Filterline> = new Promise(res => { _filterlineResolve = res; });
+export let ensureFilterlineVisible;
+
 const initial = (async () => {
 	let { filters, visible, lastUsed } = (await filterlineStorage.get(): any); // eslint-disable-line prefer-const
 	if (!filters || !Object.values(filters).length) filters = await getDefaultFilters();
@@ -503,6 +507,8 @@ module.beforeLoad = async () => {
 
 	filterline.restoreState(filters);
 	populateFromOptions();
+
+	_filterlineResolve(filterline);
 
 	const hideUntilProcessed = module.options.hideUntilProcessed.value && filterline.getActiveFilters().length;
 
@@ -576,28 +582,28 @@ function makeFilterlineInteractable() {
 		},
 	});
 
-	const ensureVisible = () => { if (!visible) filterlineTab.click(); };
+	ensureFilterlineVisible = () => { if (!visible) filterlineTab.click(); };
 
 	const { getTip, executeCommand } = filterline.getCLI();
 	CommandLine.registerCommand(
 		/(fl|filterline)/,
 		'fl - modify Filterline',
 		(cmd, val) => getTip(val),
-		(cmd, val) => { ensureVisible(); executeCommand(val); },
+		(cmd, val) => { ensureFilterlineVisible(); executeCommand(val); },
 	);
 
 	CommandLine.registerCommand(
 		/fp/,
 		'fp - toggle filtering',
 		() => 'Toggle filtering',
-		() => { ensureVisible(); filterline.poweredElement.click(); },
+		() => { ensureFilterlineVisible(); filterline.poweredElement.click(); },
 	);
 
 	RESTips.addFeatureTip('filterline', {
 		...featureTips.filterline,
 		attachTo: filterlineTab,
 		continuation: () => {
-			ensureVisible();
+			ensureFilterlineVisible();
 			return 'filterlineVisible';
 		},
 	});

--- a/lib/modules/filteReddit/Filterline.js
+++ b/lib/modules/filteReddit/Filterline.js
@@ -453,7 +453,10 @@ export class Filterline {
 		if (this.deferredFilters.hasOwnProperty(id)) return this.createFilterFromStateValues(id, opts);
 
 		const CaseClass = Cases.get(type);
-		if (CaseClass.unique && this.getFiltersOfCase(CaseClass).length) throw new Error('Cannot create new instances of unique filters');
+		if (CaseClass.unique) {
+			const [existing] = this.getFiltersOfCase(CaseClass);
+			if (existing) return existing;
+		}
 
 		if (!conditions && criterion) {
 			// Legacy; `criterion` is no longer saved to storage

--- a/lib/modules/readComments.js
+++ b/lib/modules/readComments.js
@@ -3,10 +3,14 @@
 import { Module } from '../core/module';
 import { Storage, isPrivateBrowsing } from '../environment';
 import {
+	Thing,
+	batch,
 	execRegexes,
 	maybePruneOldEntries,
 } from '../utils';
+import * as FilteReddit from './filteReddit';
 import * as SelectedEntry from './selectedEntry';
+import * as Notifications from './notifications';
 
 export const module: Module<*> = new Module('readComments');
 
@@ -47,17 +51,54 @@ let ids;
 module.beforeLoad = async () => {
 	ids = await (initial.then(({ ids }) => new Set(Object.keys(ids))));
 
+	maybeHidePrevious();
+
 	if (!module.options.monitorWhenIncognito.value && isPrivateBrowsing()) return;
 
 	SelectedEntry.addListener(selected => {
-		if (selected.isComment() && selected.isContentVisible()) {
-			const id = selected.getFullname();
-			ids.add(id);
-			entryStorage.patch(currentId, { ids: { [id]: true }, updateTime: Date.now() });
-		}
+		if (selected.isComment() && selected.isContentVisible()) add(selected);
 	}, 'beforePaint');
 
 	maybePruneOldEntries('readComments', entryStorage, parseInt(module.options.cleanComments.value, 10));
+};
+
+async function maybeHidePrevious() {
+	if (!ids.size) return;
+
+	const filterline = await FilteReddit.filterlinePromise;
+	const filter = filterline.createFilter({ type: 'isRead', id: 'isRead' });
+	// Don't display notification if the filter is already active
+	if (filter.state === false && filter.effects.hide) return;
+
+	const hideButton = document.createElement('button');
+	hideButton.textContent = 'Hide now';
+	hideButton.addEventListener('click', () => {
+		filter.update(false, undefined, { hide: true /* `, propagate: true` may be desirable */ });
+		if (!filter.parent) filterline.addFilter(filter);
+		if (FilteReddit.ensureFilterlineVisible) FilteReddit.ensureFilterlineVisible();
+		notification.close();
+	});
+
+	const notification = Notifications.showNotification({
+		moduleID: module.moduleID,
+		notificationID: 'hidePrevious',
+		header: 'Previosuly viewed comments',
+		message: hideButton,
+		closeDelay: 5000,
+	});
+}
+
+const _add = batch(ids => (
+	entryStorage.patch(
+		currentId,
+		{ ids: ids.reduce((acc, id) => { acc[id] = true; return acc; }, {}), updateTime: Date.now() }
+	)
+), { size: Infinity, delay: 5000, flushBeforeUnload: true });
+
+export const add = (thing: Thing) => {
+	if (!ids) return;
+	const id = thing.getFullname();
+	_add(id);
 };
 
 export const isRead = (thing: *) => {

--- a/lib/utils/async.js
+++ b/lib/utils/async.js
@@ -72,7 +72,9 @@ export const forEachChunked = (() => {
  * If it throws, all promises will be rejected with the same error.
  * If one of the results is an instance of `Error`, the corresponding promise will be rejected with that error.
  */
-export function batch<T, V>(callback: (xs: T[]) => Promise<Iterable<Error | Promise<V> | V> | void> | void, { size = 100, delay = 50 }: {| size?: number, delay?: number |} = {}): (x: T) => Promise<V> {
+export function batch<T, V>(callback: (xs: T[]) => Promise<Iterable<Error | Promise<V> | V> | void> | void, { size = 100, delay = 50, flushBeforeUnload = false }: {| size?: number, delay?: number, flushBeforeUnload?: boolean |} = {}): (x: T) => Promise<V> {
+	let invoke;
+
 	function* batchAccumulator() {
 		const entries = [];
 		const promises = [];
@@ -85,8 +87,9 @@ export function batch<T, V>(callback: (xs: T[]) => Promise<Iterable<Error | Prom
 			}
 		}
 
-		const invoke = _.once(async () => {
+		invoke = _.once(async () => {
 			startNewBatch();
+			if (!entries.length) return;
 			try {
 				const results = await callback(entries) || [];
 				for (const [{ resolve, reject }, result] of zip(promises, results)) {
@@ -122,6 +125,8 @@ export function batch<T, V>(callback: (xs: T[]) => Promise<Iterable<Error | Prom
 	}
 
 	startNewBatch();
+
+	if (flushBeforeUnload) window.addEventListener('beforeunload', () => { invoke(); }, true);
 
 	return entry => {
 		const { value } = currentBatch.next(entry);

--- a/lib/utils/thingHide.js
+++ b/lib/utils/thingHide.js
@@ -3,12 +3,15 @@
 import { ajax } from '../environment';
 import type { Thing } from './Thing';
 import { batch } from './async';
+import { isLoggedIn } from './user';
 
 const hideEndpoint = '/api/hide';
 const unhideEndpoint = '/api/unhide';
-const [HIDE, UNHIDE] = [false, true];
+export const [HIDE, UNHIDE] = [false, true];
 
-const send = (state, things: Thing[]) => {
+export const send = async (state: boolean, things: Thing[]) => {
+	if (!isLoggedIn()) return Promise.reject(new Error('Not logged in'));
+
 	function setState(newState) {
 		for (const thing of things) {
 			const hideElement = thing.getHideElement();
@@ -26,11 +29,14 @@ const send = (state, things: Thing[]) => {
 
 	const fullnames = things.map(thing => thing.getFullname());
 
-	return ajax({
+	const r = await ajax({
 		method: 'POST',
 		url: state === HIDE ? hideEndpoint : unhideEndpoint,
 		data: { id: fullnames.join(',') },
-	}).then(() => { setState(HIDE); }, () => { setState(UNHIDE); });
+		type: 'json',
+	});
+	if (r.success) throw new Error('Failed to set hide state');
+	setState(state);
 };
 
 export const hide = batch(things => send(HIDE, things), { size: 50 });

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -306,6 +306,18 @@
 	"easterEggDesc": {
 		"message": "↑ ↑ ↓ ↓ ← → ← → B A."
 	},
+	"autoHideName": {
+		"message": "Auto Hide"
+	},
+	"autoHideDesc": {
+		"message": "Automatically mark link posts or comments as read when viewed for more than 2 seconds. To hide comments, make sure the module [readComments](#res:settings/readComments) is enabled."
+	},
+	"autoHideTypesTitle": {
+		"message": "Types"
+	},
+	"autoHideTypesDesc": {
+		"message": "Restrict post types which are hidden."
+	},
 	"filteRedditName": {
 		"message": "filteReddit"
 	},

--- a/tests/readComments.js
+++ b/tests/readComments.js
@@ -10,18 +10,20 @@ module.exports = {
 		const b = '#thing_t1_dcuk1bk';
 
 		browser
+			// disable auto hide
+			.url('https://en.reddit.com/wiki/pages#res:settings-redirect-standalone-options-page/autoHide')
+			.waitForElementVisible('#RESConsoleContainer')
+			.click('.moduleToggle')
+
 			.url('https://en.reddit.com/r/RESIntegrationTests/comments/5pxfg2/keyboard_nav/')
 			.waitForElementVisible('.res-toggle-filterline-visibility')
 			.click(`${a} > .entry`)
 
-			// See that the comment is remember read by filtering out read comments
 			.refresh()
-			.waitForElementVisible('.res-toggle-filterline-visibility')
-			.keys(['f'])
-			.waitForElementVisible('#keyCommandLineWidget')
-			.keys(['isRead', browser.Keys.ENTER])
-			.waitForElementPresent(`${b}.res-thing-filter-hide`)
-			.assert.elementNotPresent(`${a}.res-thing-filter-hide`)
+			.waitForElementVisible('.readComments-hidePrevious')
+			.click('.readComments-hidePrevious button')
+			.waitForElementPresent(`${a}.res-thing-filter-hide`)
+			.assert.elementNotPresent(`${b}.res-thing-filter-hide`)
 			.end();
 	},
 };


### PR DESCRIPTION
When the bottom (the buttons-row) of a post is shown for more than 2 s continuously, the post gets hidden. This may be tweaked in the future to reduce false negatives / false positives, e.g. by adjusting the IntersectionObserver margins / target, or improving the detection heuristic.

By default only comments are marked as read (via readComments), as comments are hidden by RES and can easily be made visible again. Link posts are hidden via thingHide, equivalent of clicking the 'hide' button. Changes are sent every 5 seconds, and flushed on `beforeload`.

Tested in browser: Chrome 77, Firefox 68
