### PR TITLE
onboarding: Update notification type depends on last version installed

### DIFF
--- a/lib/core/migrate/migrate.js
+++ b/lib/core/migrate/migrate.js
@@ -843,6 +843,14 @@ const migrations = [
 
 			await Options.set('notifications', 'notificationTypes', Object.values(instances));
 		},
+	}, {
+		versionNumber: '5.17.0-firstRun-to-last',
+		async go() {
+			const firstRunStorage = Storage.wrapPrefix('RES.firstRun.', () => (null: null | boolean));
+			const versions = Object.keys(await firstRunStorage.getAll());
+			versions.sort((a, b) => a.localeCompare(b, undefined, { numerical: true }));
+			await Storage.set('highestVersion', versions.slice(-1)[0] || null); await firstRunStorage.deleteMultiple(versions);
+		},
 	},
 
 ]; // ^^ Add new migrations ^^

--- a/lib/modules/onboarding.js
+++ b/lib/modules/onboarding.js
@@ -1,8 +1,10 @@
 /* @flow */
 
+import semver from 'semver';
 import { Module } from '../core/module';
 import * as Metadata from '../core/metadata';
 import { Storage, openNewTab, i18n } from '../environment';
+import { filterMap } from '../utils';
 import * as Notifications from './notifications';
 
 export const module: Module<*> = new Module('onboarding');
@@ -63,41 +65,43 @@ module.options = {
 	},
 };
 
-const firstRunStorage = Storage.wrapPrefix('RES.firstRun.', () => (null: null | boolean));
+const highestVersionStorage = Storage.wrap('highestVersion', null);
 
 module.go = async () => {
-	// if this is the first time this version has been run, pop open the what's new tab, background focused.
-	if (!(await firstRunStorage.has(Metadata.version))) {
-		firstRunStorage.set(Metadata.version, true);
+	const highestVersion = await highestVersionStorage.get();
 
-		const notificationOption = (
-			Metadata.isBeta ? 'betaUpdateNotification' :
-			Metadata.isPatch ? 'patchUpdateNotification' :
-			/* Metadata.isMajor ||
-			Metadata.isMinor */ 'updateNotification'
-		);
-
-		switch (module.options[notificationOption].value) {
-			case 'releaseNotes':
-				openNewTab(Metadata.updatedURL, false);
-				break;
-			case 'notification':
-				Notifications.showNotification({
-					moduleID: module.moduleID,
-					optionKey: notificationOption,
-					message: `
-						${i18n('onboardingUpgradeMessage', Metadata.version)}
-						<p><a class="RESNotificationButtonBlue" href="${Metadata.updatedURL}" target="_blank">
-							${i18n('onboardingUpgradeCta')}
-						</a></p>
-					`.trim(),
-					closeDelay: 15000,
-				});
-				break;
-			case 'none':
-			default:
-				console.log(`RES upgraded to v${Metadata.version}.`);
-				break;
-		}
+	if (!highestVersion) {
+		highestVersionStorage.set(Metadata.version);
+		return;
 	}
+
+	if (highestVersion === Metadata.version || semver.gt(highestVersion, Metadata.version)) return;
+
+	const diff = semver.diff(Metadata.version, highestVersion);
+
+	const infoTypes = filterMap([
+		Metadata.isBeta && 'betaUpdateNotification',
+		diff === 'patch' && 'patchUpdateNotification',
+		(diff === 'major' || diff === 'minor') && 'updateNotification',
+	], notificationOption => notificationOption ? [module.options[notificationOption].value] : undefined);
+
+	if (infoTypes.includes('releaseNotes')) {
+		openNewTab(Metadata.updatedURL, false);
+	} else if (infoTypes.includes('notification')) {
+		Notifications.showNotification({
+			moduleID: module.moduleID,
+			notificationID: diff,
+			message: `
+				${i18n('onboardingUpgradeMessage', Metadata.version)}
+				<p><a class="RESNotificationButtonBlue" href="${Metadata.updatedURL}" target="_blank">
+					${i18n('onboardingUpgradeCta')}
+				</a></p>
+			`.trim(),
+			closeDelay: 15000,
+		});
+	} else {
+		console.log(`RES upgraded to v${Metadata.version}.`);
+	}
+
+	highestVersionStorage.set(Metadata.version);
 };


### PR DESCRIPTION
Previously the type was determined simply by checking if the version was beta, minor or a major, independent of the previously installed version. If the user upgrades directly from 5.16.10 to 5.18.2, now the "major" notification type will be used.

This also prevents the notification from being shown on first run.

Tested in browser: Chrome 77, Firefox 68