### PR TITLE
Set Firefox min version to 69 for ResizeObserver

### DIFF
--- a/firefox/beta/manifest.json
+++ b/firefox/beta/manifest.json
@@ -8,7 +8,7 @@
 	"applications": {
 		"gecko": {
 			"id": "jid1-xUfzOsOFlzSOXg@jetpack",
-			"strict_min_version": "68.0"
+			"strict_min_version": "69.0"
 		}
 	},
 	"icons": {

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -8,7 +8,7 @@
 	"applications": {
 		"gecko": {
 			"id": "jid1-xUfzOsOFlzSOXg@jetpack",
-			"strict_min_version": "68.0"
+			"strict_min_version": "69.0"
 		}
 	},
 	"icons": {


### PR DESCRIPTION
It seems that ResizeObserver was pushed back to 69 due to regressions: https://bugzilla.mozilla.org/show_bug.cgi?id=1555786

We could also revert #5132 but we can probably just wait 3 weeks for FF69
