### PR TITLE
Add expando support for channel-based Twitch clip URL scheme

### DIFF
--- a/lib/modules/hosts/twitchclips.js
+++ b/lib/modules/hosts/twitchclips.js
@@ -4,13 +4,17 @@ import { Host } from '../../core/host';
 
 export default new Host('twitchclips', {
 	name: 'twitch.tv clips',
-	domains: ['clips.twitch.tv'],
+	domains: ['twitch.tv'],
 	logo: 'https://www.twitch.tv/favicon.ico',
-	// require capital first character for old-style URLs to avoid ambiguity
-	// old: /username/NameOfClip
-	// new: /NameOfClip
-	//      /NameOfClip/edit (bad link to private edit page, but Twitch redirects so we should handle it)
-	detect: ({ pathname }) => (/^\/(\w+(?:\/[A-Z]\w+)?)(?:\/|$)/).exec(pathname),
+	// clips.twitch.tv domain:
+	// 	 require capital first character for old-style URLs to avoid ambiguity
+	//   old: /username/NameOfClip
+	//   new: /NameOfClip
+	//        /NameOfClip/edit (bad link to private edit page, but Twitch redirects so we should handle it)
+	// (www.)twitch.tv domain:
+	//   support clip name as a subcomponent of a channel URL
+	//   ex: www.twitch.tv/<CHANNEL_NAME>/clip/<CLIP_NAME>
+	detect: ({ hostname, pathname }) => hostname === 'clips.twitch.tv' ? (/^\/(\w+(?:\/[A-Z]\w+)?)(?:\/|$)/).exec(pathname) : (/^\/\w+\/clip\/(\w+(?:\/[A-Z]\w+)?)(?:\/|$)/).exec(pathname),
 	handleLink(href, [, clipId]) {
 		const embed = `https://clips.twitch.tv/embed?clip=${clipId}`;
 


### PR DESCRIPTION
Relevant issue: #5147
Tested in browser: Chrome v77.0.3865.90, Firefox v69.0.1

Test case:
1. Go to Reddit linkpost that uses the form "twitch.tv/<CHANNEL>/clip/<CLIP_NAME>". [Here](https://redd.it/d8zx51) is an example as of this PR.
2. Click expando under post title.
3. Observe expanded media element.

Before this change, the channel's livestream player would be expanded. After this change, the linked clip's player should be expanded.
