### PR TITLE
Updated pixiv host to accept new url format

### DIFF
--- a/lib/modules/hosts/pixiv.js
+++ b/lib/modules/hosts/pixiv.js
@@ -6,8 +6,9 @@ export default new Host('pixiv', {
 	name: 'pixiv',
 	domains: ['pixiv.net'],
 	logo: 'https://www.pixiv.net/favicon.ico',
-	detect: ({ pathname, searchParams }) => pathname === '/member_illust.php' && searchParams.get('illust_id'),
-	handleLink(href, id) {
+	detect: ({ pathname, search }) => (pathname === '/member_illust.php' && (/illust_id=(\d+)/).exec(search)) ||
+										(/(?:\/en|^)\/artworks\/(\d+)\/?$/).exec(pathname),
+	handleLink(href, [, id]) {
 		return {
 			type: 'IFRAME',
 			expandoClass: 'image',


### PR DESCRIPTION
Relevant issue: N/A
Tested in browser: Chrome 77.0.3865.90, Firefox 69.0.2

Updated the Pixiv host to work with their new URL format.

Tested on this post: https://old.reddit.com/r/RESissues/comments/d9j1rl/pixiv_expandos_not_working_on_their_new_link_style/