### PR TITLE
Minor CSS fix for button alignments on multis

### DIFF
--- a/lib/css/res.scss
+++ b/lib/css/res.scss
@@ -348,6 +348,10 @@ div.usertext-edit {
 	}
 }
 
+.subscription-box .subButtons {
+	font-size: larger;
+}
+
 span.multi-count {
 	@extend %res-fancy-toggle-button;
 	background: #FF7500;


### PR DESCRIPTION
Minor CSS adjustment to fix alignment of buttons on url-scheme multireddits

**Example link:** `https://old.reddit.com/r/news+worldnews+politics`
**Before and after:** https://i.imgur.com/hAYwKUm.gifv
**Tested in browser:** Chrome, Firefox
