### PR TITLE
nightMode: Add option to follow media query 'prefers-color-scheme: dark'

### DIFF
--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -14,7 +14,6 @@ import {
 	currentSubreddit,
 	waitForChild,
 	HOUR,
-	MINUTE,
 } from '../utils';
 import { Session, Storage, i18n } from '../environment';
 import * as CustomToggles from './customToggles';
@@ -51,6 +50,9 @@ module.options = {
 		}, {
 			name: 'nightModeAutomaticNightModeUser',
 			value: 'user',
+		}, {
+			name: 'nightModeAutomaticNightModeSystem',
+			value: 'system',
 		}],
 		description: 'nightModeAutomaticNightModeDesc',
 		title: 'nightModeAutomaticNightModeTitle',
@@ -100,58 +102,40 @@ module.options = {
 };
 
 const localStorageKey = 'RES_nightMode';
-const nightModeActive = () => typeof localStorage === 'object' && !!localStorage.getItem(localStorageKey);
+export const nightModeActive = () => typeof localStorage === 'object' && !!localStorage.getItem(localStorageKey);
 const nightmodeOverrideStorage = Storage.wrap('RESmodules.nightMode.nightModeOverrideStart', (null: null | number));
 let toggle;
-
-module.onToggle = enabled => {
-	// If the module is turned off, disable night mode completely
-	if (toggle && toggle.enabled && !enabled) toggle.toggle();
-};
 
 module.onInit = () => {
 	// To avoid the flash of unstyled content, the very first thing we should do is get a hold
 	// of the document object and add necessary classes...
-	if (nightModeActive()) addNightMode();
+	if (nightModeActive()) addStyle();
 };
 
 module.beforeLoad = () => {
-	if (isNightModeOn()) {
-		addNightMode();
-	} else {
-		removeNightMode();
-	}
-
 	toggle = new CustomToggles.Toggle('nightMode', i18n('nightModeToggleText'), module.options.nightModeOn.value);
 	toggle.onToggle(type => {
-		if (type === 'manual') overrideNightMode();
-		module.options.nightModeOn.value = toggle.enabled;
 		Options.save(module.options.nightModeOn);
-	});
-	toggle.onStateChange(() => {
-		if (toggle.enabled) addNightMode();
-		else removeNightMode();
 		// Update cache
 		isNightmodeCompatible();
+		if (type === 'manual') nightmodeOverrideStorage.set(Date.now());
+	});
+	toggle.onStateChange(() => {
+		module.options.nightModeOn.value = toggle.enabled;
+		refreshStyle();
 	});
 	toggle.addCLI('ns');
 	if (module.options.nightSwitch.value) toggle.addMenuItem(i18n('nightModeToggleTitle'), 7, '☽', '☀');
 
-	handleAutomaticNightMode();
-};
-
-module.always = () => {
-	if (!Modules.isRunning(module)) {
-		// Nightmode might have been erronously applied in `onInit`
-		removeNightMode();
+	if (module.options.automaticNightMode.value !== 'none') {
+		refreshAutomaticNightMode();
 	}
 };
 
-export function isNightModeOn(): boolean {
-	if (!Modules.isRunning(module)) return false;
-	// `toggle` contains the current nightMode state
-	return toggle ? toggle.enabled : module.options.nightModeOn.value;
-}
+module.always = () => {
+	// Nightmode might have been erronously applied in `onInit`
+	refreshStyle();
+};
 
 export async function isNightmodeCompatible(useCache: boolean = false): Promise<boolean> {
 	const subreddit = currentSubreddit();
@@ -169,7 +153,7 @@ export async function isNightmodeCompatible(useCache: boolean = false): Promise<
 	const isAllowedByOptions = async () => {
 		await Init.loadOptions;
 
-		if (!isNightModeOn()) {
+		if (!nightModeActive()) {
 			// nightmode is off
 			return true;
 		}
@@ -213,7 +197,7 @@ export async function isNightmodeCompatible(useCache: boolean = false): Promise<
 
 export async function toggledSubredditStyle(toggledOn: boolean): Promise<void> {
 	const currSub = currentSubreddit();
-	if (!isNightModeOn() || !currSub) {
+	if (!nightModeActive() || !currSub) {
 		// nightmode is off or not in a subreddit, subreddit style toggling is irrelevant
 		return;
 	}
@@ -235,41 +219,13 @@ export async function toggledSubredditStyle(toggledOn: boolean): Promise<void> {
 	return Options.save(module.options.subredditStylesWhitelist);
 }
 
-const handleAutomaticNightMode = _.once(async function check() {
-	if (module.options.automaticNightMode.value === 'none') {
-		return;
-	}
-
-	// Handle automatic night mode override
-	// Grab the override start time, if it exists
+async function refreshAutomaticNightMode() {
 	const nightModeOverrideStart = await nightmodeOverrideStorage.get();
 	const nightModeOverrideLength = HOUR * parseFloat(module.options.nightModeOverrideHours.value);
-
 	const nightModeOverrideEnd = (parseInt(nightModeOverrideStart, 10) || 0) + nightModeOverrideLength;
+	if (Date.now() <= nightModeOverrideEnd) return;
 
-	const isOverrideActive = (Date.now() <= nightModeOverrideEnd);
-
-	// Toggle is needed if night mode time is reached but night mode is
-	// disabled, or vice versa, *unless* override is active
-	const needsNightModeToggle = !isOverrideActive &&
-		(isNightModeOn() !== await isTimeForNightMode());
-
-	if (needsNightModeToggle) {
-		toggle.toggle('auto');
-	}
-
-	// wait 5 minutes, then wait for the next frame (i.e. wait for the tab to be focused)
-	setTimeout(() => requestAnimationFrame(check), 5 * MINUTE);
-});
-
-function overrideNightMode() {
-	if (module.options.automaticNightMode.value === 'none') {
-		return;
-	}
-
-	// Temporarily disable automatic night mode by setting the start time
-	// of override
-	nightmodeOverrideStorage.set(Date.now());
+	toggle.toggle('auto', await isTimeForNightMode());
 }
 
 /**
@@ -332,6 +288,10 @@ async function getNightModeTimes() {
 }
 
 async function isTimeForNightMode() {
+	if (module.options.automaticNightMode.value === 'system') {
+		return window.matchMedia('(prefers-color-scheme: dark)').matches;
+	}
+
 	const currentTime = new Date();
 	const { startingTime, endingTime } = await getNightModeTimes();
 
@@ -366,13 +326,16 @@ const className = () => {
 	}
 };
 
-const addNightMode = () => {
-	BodyClasses.add(className());
-	// Set a localStorage token so that in the future we can add nightmode to the page prior to page load.
-	localStorage.setItem(localStorageKey, 'true');
-};
+const addStyle = () => BodyClasses.add(className());
+const removeStyle = () => BodyClasses.remove(className());
 
-const removeNightMode = () => {
-	BodyClasses.remove(className());
-	localStorage.removeItem(localStorageKey);
+const refreshStyle = () => {
+	if (Modules.isRunning(module) && module.options.nightModeOn.value) {
+		addStyle();
+		// Set a localStorage token so that in the future we can add nightmode to the page prior to page load.
+		localStorage.setItem(localStorageKey, 'true');
+	} else {
+		removeStyle();
+		localStorage.removeItem(localStorageKey);
+	}
 };

--- a/lib/modules/submitIssue.js
+++ b/lib/modules/submitIssue.js
@@ -113,7 +113,7 @@ const submitIssueDefaultBody = `
 
 export const diagnostics = _.once(() => `
 
-- Night mode: ${String(NightMode.isNightModeOn())}
+- Night mode: ${String(NightMode.nightModeActive())}
 - RES Version: ${Metadata.version}
 - Browser: ${BrowserDetect.browser}
 - Browser Version: ${BrowserDetect.version}

--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -660,7 +660,7 @@ function getVoteWeightStyle({ votes, votesUp, votesDown }) {
 	}
 
 	const color = `rgba(${red}, ${green}, ${blue}, ${0.2 + alpha * 0.8})`;
-	return NightMode.isNightModeOn() ?
+	return NightMode.nightModeActive() ?
 		`color: ${color};` :
 		`background-color: ${color};`;
 }

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -2761,7 +2761,7 @@
 		"message": "Automatic Night Mode"
 	},
 	"nightModeAutomaticNightModeDesc": {
-		"message": "Enable automatic night mode.\n\nIn automatic mode, you will be prompted to share your location. Your location will only be used to calculate sunrise & sunset times.\n\nIn user-defined hours mode, night mode automatically starts and stops at the times configured below.\n\nFor the times below, a 24-hour clock (\"military time\") from 0:00 to 23:59 is used.\ne.g. the time 8:20pm would be written as 20:20, and 12:30am would be written as 00:30 or 0:30.\n\nTo temporarily override automatic night mode, manually flip the night mode switch.\nConfigure how long the override lasts below."
+		"message": "Enable automatic night mode.\n\nIn **automatic** mode, you will be prompted to share your location. Your location will only be used to calculate sunrise & sunset times.\n\nIn **user-defined hours** mode, night mode automatically starts and stops at the times configured below.\n\nFor the times below, a 24-hour clock (\"military time\") from 0:00 to 23:59 is used.\ne.g. the time 8:20pm would be written as 20:20, and 12:30am would be written as 00:30 or 0:30.\n\nBy choosing **system preference**, night mode is enabled only when the browser or OS indicates that a dark theme is preferred.\n\nTo temporarily override automatic night mode, manually flip the night mode switch.\nConfigure how long the override lasts below."
 	},
 	"nightModeAutomaticNightModeNone": {
 		"message": "Disabled"
@@ -2771,6 +2771,9 @@
 	},
 	"nightModeAutomaticNightModeUser": {
 		"message": "User-defined hours"
+	},
+	"nightModeAutomaticNightModeSystem": {
+		"message": "System preference"
 	},
 	"nightModeAutomaticNightModeDenied": {
 		"message": "Access to your current location was denied. It is required to calculate sunset and sunrise times for automatic night mode. To disable this functionality, click \"$1\"."


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme

Tested in browser: Firefox 71, Chrome 79