### PR TITLE
Added visual indication of account switching

### DIFF
--- a/lib/css/modules/_accountSwitcher.scss
+++ b/lib/css/modules/_accountSwitcher.scss
@@ -19,6 +19,11 @@ div.RESAccountSwitcherDropdown {
 	}
 }
 
+html.res-accountSwitcher-in-progress {
+	cursor: wait;
+	body { pointer-events: none; }
+}
+
 #RESAccountSwitcherIcon {
 	cursor: pointer;
 	display: inline-block;

--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -226,6 +226,10 @@ const switchTo = mutex(async (username: string) => {
 	}
 
 	await logoutPromise;
+	
+	// Provide some form of indication that the account switch is being processed
+	let oldCursorStyle = document.body.style.cursor;
+	document.body.style.cursor = "wait";
 
 	const { success, jquery } = await ajax({
 		method: 'POST',
@@ -245,6 +249,8 @@ const switchTo = mutex(async (username: string) => {
 
 		throw e;
 	});
+	
+	document.body.style.cursor = oldCursorStyle;
 
 	if (module.options.updateOtherTabs.value) {
 		switchedAccountElsewhere(success ? username : null);

--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -202,7 +202,7 @@ async function createAccountMenu() {
 			document.documentElement.style.cursor = 'wait';
 			document.body.style.pointerEvents = 'none';
 			try {
-				await switchTo(username)
+				await switchTo(username);
 			} catch (e) {
 				document.body.style.cursor = oldCursorStyle;
 				console.error(e);

--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -226,11 +226,9 @@ const switchTo = mutex(async (username: string) => {
 	}
 
 	await logoutPromise;
-	
 	// Provide some form of indication that the account switch is being processed
-	let oldCursorStyle = document.body.style.cursor;
-	document.body.style.cursor = "wait";
-
+	const oldCursorStyle = document.body.style.cursor;
+	document.body.style.cursor = 'wait';
 	const { success, jquery } = await ajax({
 		method: 'POST',
 		url: '/api/login',
@@ -251,7 +249,6 @@ const switchTo = mutex(async (username: string) => {
 	});
 	
 	document.body.style.cursor = oldCursorStyle;
-
 	if (module.options.updateOtherTabs.value) {
 		switchedAccountElsewhere(success ? username : null);
 	}

--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -197,12 +197,17 @@ async function createAccountMenu() {
 				<a style="margin-left: 4px" onclick="event.stopPropagation()" href="/user/${username}" class="res-icon linkIcon"></a>
 			</li>
 		`;
-        element.addEventListener('click', () => {
-            const oldCursorStyle = document.body.style.cursor;
-            document.body.style.cursor = 'wait';
-            await switchTo(username).catch(console.error);
-            document.body.style.cursor = oldCursorStyle;
-        });
+		element.addEventListener('click', async () => {
+			const oldCursorStyle = document.body.style.cursor;
+			document.documentElement.style.cursor = 'wait';
+			document.body.style.pointerEvents = 'none';
+			try {
+				await switchTo(username)
+			} catch (e) {
+				document.body.style.cursor = oldCursorStyle;
+				console.error(e);
+			}
+		});
 		accountMenu.append(element);
 	}
 
@@ -231,7 +236,7 @@ const switchTo = mutex(async (username: string) => {
 	}
 
 	await logoutPromise;
-	
+
 	const { success, jquery } = await ajax({
 		method: 'POST',
 		url: '/api/login',
@@ -250,7 +255,7 @@ const switchTo = mutex(async (username: string) => {
 
 		throw e;
 	});
-	
+
 	if (module.options.updateOtherTabs.value) {
 		switchedAccountElsewhere(success ? username : null);
 	}

--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -230,10 +230,6 @@ const switchTo = mutex(async (username: string) => {
 		};
 	}
 
-	// Provide some form of indication that the account switch is being processed
-	const oldCursorStyle = document.body.style.cursor;
-	document.body.style.cursor = 'wait';
-	
 	await logoutPromise;
 	
 	const { success, jquery } = await ajax({
@@ -254,8 +250,6 @@ const switchTo = mutex(async (username: string) => {
 
 		throw e;
 	});
-	
-	document.body.style.cursor = oldCursorStyle;
 	
 	if (module.options.updateOtherTabs.value) {
 		switchedAccountElsewhere(success ? username : null);

--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -225,10 +225,12 @@ const switchTo = mutex(async (username: string) => {
 		};
 	}
 
-	await logoutPromise;
 	// Provide some form of indication that the account switch is being processed
 	const oldCursorStyle = document.body.style.cursor;
 	document.body.style.cursor = 'wait';
+	
+	await logoutPromise;
+	
 	const { success, jquery } = await ajax({
 		method: 'POST',
 		url: '/api/login',
@@ -249,6 +251,7 @@ const switchTo = mutex(async (username: string) => {
 	});
 	
 	document.body.style.cursor = oldCursorStyle;
+	
 	if (module.options.updateOtherTabs.value) {
 		switchedAccountElsewhere(success ? username : null);
 	}

--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -199,11 +199,11 @@ async function createAccountMenu() {
 			</li>
 		`;
 		element.addEventListener('click', async () => {
-			BodyClasses.add('res-accountSwitcher-in-progress')
+			BodyClasses.add('res-accountSwitcher-in-progress');
 			try {
 				await switchTo(username);
 			} catch (e) {
-				BodyClasses.remove('res-accountSwitcher-in-progress')
+				BodyClasses.remove('res-accountSwitcher-in-progress');
 				console.error(e);
 			}
 		});

--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import { Module } from '../core/module';
 import {
 	Alert,
+	BodyClasses,
 	addFloater,
 	formatDate,
 	formatDateDiff,
@@ -198,13 +199,11 @@ async function createAccountMenu() {
 			</li>
 		`;
 		element.addEventListener('click', async () => {
-			const oldCursorStyle = document.body.style.cursor;
-			document.documentElement.style.cursor = 'wait';
-			document.body.style.pointerEvents = 'none';
+			BodyClasses.add('res-accountSwitcher-in-progress')
 			try {
 				await switchTo(username);
 			} catch (e) {
-				document.body.style.cursor = oldCursorStyle;
+				BodyClasses.remove('res-accountSwitcher-in-progress')
 				console.error(e);
 			}
 		});

--- a/lib/modules/accountSwitcher.js
+++ b/lib/modules/accountSwitcher.js
@@ -197,7 +197,12 @@ async function createAccountMenu() {
 				<a style="margin-left: 4px" onclick="event.stopPropagation()" href="/user/${username}" class="res-icon linkIcon"></a>
 			</li>
 		`;
-		element.addEventListener('click', () => switchTo(username));
+        element.addEventListener('click', () => {
+            const oldCursorStyle = document.body.style.cursor;
+            document.body.style.cursor = 'wait';
+            await switchTo(username).catch(console.error);
+            document.body.style.cursor = oldCursorStyle;
+        });
 		accountMenu.append(element);
 	}
 


### PR DESCRIPTION
Currently, the page just sits and appears to be doing nothing when you choose an account to switch to. This change makes the cursor spin while the ajax request is being made and resets the cursor after the ajax request is complete. 

Tested in chrome 78
