### PR TITLE
Fix Streamvi link expansion

### DIFF
--- a/lib/modules/hosts/streamvi.js
+++ b/lib/modules/hosts/streamvi.js
@@ -7,8 +7,8 @@ export default new Host('streamvi', {
 	domains: ['streamvi.com'],
 	logo: 'https://streamvi.com/assets/logo.png',
 	detect: ({ searchParams }) => {
-		const code = searchParams.get('video') || '';
-		return [code.toString()];
+		const code = searchParams.get('video');
+		if (code) return [code.toString()];
 	},
 	handleLink(href, [code]) {
 		return {

--- a/lib/modules/hosts/streamvi.js
+++ b/lib/modules/hosts/streamvi.js
@@ -5,9 +5,12 @@ import { Host } from '../../core/host';
 export default new Host('streamvi', {
 	name: 'streamvi',
 	domains: ['streamvi.com'],
-	logo: 'https://streamvi.com/favicon.ico',
-	detect: ({ pathname }) => (/^\/([^\/]+)$/i).exec(pathname),
-	handleLink(href, [, code]) {
+	logo: 'https://streamvi.com/assets/logo.png',
+	detect: ({ searchParams }) => {
+		const code = searchParams.get('video') || '';
+		return [code.toString()];
+	},
+	handleLink(href, [code]) {
 		return {
 			type: 'VIDEO',
 			loop: true,


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->

This pull request fixes a bug that is preventing Streamvi links from being loaded from RES.

RES incorrectly loads the video, image, and logo from Streamvi links in Chrome and Firefox. For example, video requests were being sent to `https://cdn.streamvi.com/uploads/watch.php.mp4` instead of `https://cdn.streamvi.com/uploads/{id}.mp4`.

Streamvi is a popular site for hosting soccer clips on the r/soccer subreddit, and this bug is currently affecting 4/10 top posts on the subreddit right now.

Tested in browser: *Chrome*, *Firefox*
