### PR TITLE
Fix nightmode on copyright takedowns.

### DIFF
--- a/lib/css/modules/_nightMode.scss
+++ b/lib/css/modules/_nightMode.scss
@@ -25,7 +25,8 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 	.modactionlisting table *,
 	.side .recommend-box .rec-item,
 	.crosspost-preview,
-	.crosspost-thing-preview {
+	.crosspost-thing-preview,
+	.admin_takedown {
 		background-color: $background-color;
 		border-color: $border-color;
 	}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/9434920/77851719-7d734a80-71d2-11ea-8fa5-b1e6d44a720c.png)

After:

![image](https://user-images.githubusercontent.com/9434920/77851710-76e4d300-71d2-11ea-94a5-92956c3ee39c.png)
