### PR TITLE
Use getRedirectURL in Firefox to fix backups in 75 and later

### DIFF
--- a/lib/environment/background/auth.js
+++ b/lib/environment/background/auth.js
@@ -3,7 +3,7 @@ import { apiToPromise } from '../utils/api';
 import { addListener } from './messaging';
 
 addListener('authFlow', ({ domain, clientId, scope, interactive }) => {
-	const redirectUri = 'https://redditenhancementsuite.com/oauth';
+	const redirectUri = process.env.BUILD_TARGET === 'chrome' ? 'https://redditenhancementsuite.com/oauth' : chrome.identity.getRedirectURL();
 	const url = new URL(domain);
 	url.searchParams.set('client_id', clientId);
 	url.searchParams.set('scope', scope);

--- a/lib/modules/backupAndRestore.js
+++ b/lib/modules/backupAndRestore.js
@@ -33,7 +33,7 @@ module.options = {
 			text: p.text,
 			callback: () => getProvider(p).then(restore),
 		})),
-		description: 'backupAndRestoreRestoreDesc',
+		description: process.env.BUILD_TARGET === 'firefox' ? 'backupAndRestoreRestoreDescFirefox' : 'backupAndRestoreRestoreDesc',
 		title: 'backupAndRestoreRestoreTitle',
 	},
 	reloadWarning: {

--- a/lib/modules/backupAndRestore/providers/OneDrive.js
+++ b/lib/modules/backupAndRestore/providers/OneDrive.js
@@ -16,7 +16,7 @@ export class OneDrive extends Provider {
 	async init({}: *): Promise<Provider> { // eslint-disable-line no-empty-pattern
 		this.accessToken = await launchAuthFlow({
 			domain: 'https://login.live.com/oauth20_authorize.srf',
-			clientId: 'a1f95f80-0129-475b-9894-dfbb94f5ff1c',
+			clientId: process.env.BUILD_TARGET === 'firefox' ? '7f246fc1-2a98-4687-8931-69fbd6228e4f' : 'a1f95f80-0129-475b-9894-dfbb94f5ff1c',
 			scope: 'onedrive.appfolder',
 			permissions: process.env.BUILD_TARGET === 'firefox' ? [] : ['https://login.live.com/oauth20_authorize.srf'],
 		}, async message => {

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -1845,6 +1845,9 @@
 	"backupAndRestoreRestoreDesc": {
 		"message": "Restore a backup of your RES settings."
 	},
+	"backupAndRestoreRestoreDescFirefox": {
+		"message": "Restore a backup of your RES settings. Note that OneDrive backups for Firefox are separate from OneDrive backups for other browsers."
+	},
 	"backupAndRestoreImported": {
 		"message": "Your RES storage has been imported. Reloading reddit."
 	},


### PR DESCRIPTION
Fixes #5184

After this change, OneDrive backups in Firefox are separate from OneDrive backups in other browsers. Microsoft requires that all redirect URIs for an application are on the same domain. In Firefox 75 and later we are forced to use a Mozilla domain like f6be6623b0b4ed4e84464ff8b07afff3c421e497.extensions.allizom.org, which of course is different from redditenhancementsuite.com. So there is now a separate "Reddit Enhancement Suite (for Firefox)" OneDrive application used in Firefox.

Tested in browser: Firefox 75
