### PR TITLE
Optionally refresh the favicon every few seconds

### DIFF
--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -55,6 +55,12 @@ module.options = {
 		type: 'boolean',
 		value: false,
 	},
+	faviconRefreshRate: {
+		description: 'faviconRefreshRateDesc',
+		title: 'faviconRefreshRateTitle',
+		type: 'text',
+		value: '0',
+	},
 	faviconUseLegacy: {
 		description: 'faviconUseLegacyDesc',
 		title: 'faviconUseLegacyTitle',
@@ -138,6 +144,8 @@ module.options = {
 
 module.contentStart = () => {
 	if (module.options.faviconUseLegacy.value) setupFavicon();
+
+	if (module.options.faviconRefreshRate.value) refreshFavicon();
 
 	if (!loggedInUser()) {
 		return;
@@ -228,7 +236,21 @@ function updateMailCountElements(count) {
 function updateFaviconBadge(count) {
 	if (module.options.showUnreadCountInFavicon.value) {
 		setupFavicon().badge(count);
+		return true;
 	}
+}
+
+function refreshFavicon() {
+	const faviconRefreshRate = parseInt(module.options.faviconRefreshRate.value, 10);
+	if (!faviconRefreshRate) return;
+
+	if (lastCount) {
+		updateFaviconBadge(lastCount);
+	} else {
+		setupFavicon().badge(0);
+	}
+
+	setTimeout(refreshFavicon, faviconRefreshRate);
 }
 
 const setupFavicon = _.once(() => {

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -4396,6 +4396,12 @@
 		"message": "to",
 		"description": "[post/comment submitted...] to $subreddit"
 	},
+	"faviconRefreshRateTitle": {
+		"message": "Favicon Refresh Rate"
+	},
+	"faviconRefreshRateDesc": {
+		"message": "How often (in milliseconds) should the favicon be reset"
+	},
 	"faviconUseLegacyTitle": {
 		"message": "Use Legacy Favicon"
 	},


### PR DESCRIPTION
Reset the tab's favicon to the RES-controlled version periodically if the user has set a delay

Relevant issue:  https://www.reddit.com/r/Enhancement/comments/fud8yr/can_we_get_a_feature_that_disables_the_annoying/
Tested in browser: Chrome, but not with the dotted icon described 👆 
