### PR TITLE
Add ~ as defined illegal character.

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1256,7 +1256,7 @@ export class Media {
 						if (title && ext) {
 							let extension = ext[1];
 							if (extension.includes('?')) extension = extension.split('?')[0];
-							title = title.replace(/[*|?:"<>\\\/]/gi, '');
+							title = title.replace(/[*|?:"~<>\\\/]/gi, '');
 							const filename = `${title}.${extension}`;
 							download(downloadUrl, filename);
 						} else download(downloadUrl);


### PR DESCRIPTION
Per chromium code, ~ is a illegal character and will not allow downloads if this is in the filename.

https://github.com/chromium/chromium/blob/master/base/i18n/file_util_icu.cc#L81

<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->

Relevant issue: https://www.reddit.com/r/RESissues/comments/fzv2x4/media_download_fails_when_title_contains_certain/
Tested in browser: Edge Version 80.0.361.111 (Official build) (64-bit)
