### PR TITLE
Remove Emojis from image downloads

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1256,7 +1256,7 @@ export class Media {
 						if (title && ext) {
 							let extension = ext[1];
 							if (extension.includes('?')) extension = extension.split('?')[0];
-							title = title.replace(/[*|?:"~<>\\\/]/gi, '');
+							title = title.replace(/[*|?:"~<>\\\/]|(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/gi, '');
 							const filename = `${title}.${extension}`;
 							download(downloadUrl, filename);
 						} else download(downloadUrl);


### PR DESCRIPTION
Chrome gets funny with Emojis blocking downloads, theres no way to know which ones so this just removes all emojis from the title on save.

One potential issue is if images have an only emoji title.

<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: 
Tested in browser: Edge 81
