### PR TITLE
Remove Husky pre-push checks.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,11 +39,6 @@
     "deploy-changelog": "node build/deployChangelog.js",
     "version": "node build/version.js"
   },
-  "husky": {
-    "hooks": {
-      "pre-push": "npm run flow && npm run lint && npm test"
-    }
-  },
   "nyc": {
     "all": true,
     "exclude": [
@@ -104,7 +99,6 @@
     "firefox-extension-deploy": "1.1.2",
     "flow-bin": "0.84.0",
     "html-loader": "0.5.5",
-    "husky": "4.2.3",
     "inert-entry-webpack-plugin": "4.0.2",
     "interpolate-loader": "2.0.1",
     "jscodeshift": "0.7.0",


### PR DESCRIPTION
They are mismatched against buildservers and can take ages to complete preventing pushes and causing poor UX with the RES repo.

<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: 
Tested in browser: 
