### PR TITLE
backupAndRestore: Fix Google Drive token retrieval

### DIFF
--- a/chrome/beta/manifest.json
+++ b/chrome/beta/manifest.json
@@ -82,7 +82,7 @@
 		"https://www.flickr.com/services/oembed",
 
 		"https://redditenhancementsuite.com/oauth",
-		"https://accounts.google.com/o/oauth2/v2/auth",
+		"https://accounts.google.com/signin/oauth",
 		"https://www.dropbox.com/oauth2/authorize",
 		"https://login.live.com/oauth20_authorize.srf"
 	],

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -82,7 +82,7 @@
 		"https://www.flickr.com/services/oembed",
 
 		"https://redditenhancementsuite.com/oauth",
-		"https://accounts.google.com/o/oauth2/v2/auth",
+		"https://accounts.google.com/signin/oauth",
 		"https://www.dropbox.com/oauth2/authorize",
 		"https://login.live.com/oauth20_authorize.srf"
 	],

--- a/lib/modules/backupAndRestore/providers/GoogleDrive.js
+++ b/lib/modules/backupAndRestore/providers/GoogleDrive.js
@@ -16,10 +16,10 @@ export class GoogleDrive extends Provider {
 
 	async init({ googleLoginHint }: *): Promise<Provider> {
 		this.accessToken = await launchAuthFlow({
-			domain: `https://accounts.google.com/o/oauth2/v2/auth?login_hint=${googleLoginHint}`,
+			domain: `https://accounts.google.com/signin/oauth?login_hint=${googleLoginHint}`,
 			clientId: '568759524377-nv0o2u4afuuulkfcjd7f6guf27qkevpt.apps.googleusercontent.com',
 			scope: 'https://www.googleapis.com/auth/drive.appdata',
-			permissions: process.env.BUILD_TARGET === 'firefox' ? ['https://www.googleapis.com/drive/v3/*'] : ['https://www.googleapis.com/drive/v3/*', 'https://accounts.google.com/o/oauth2/v2/auth'],
+			permissions: process.env.BUILD_TARGET === 'firefox' ? ['https://www.googleapis.com/drive/v3/*'] : ['https://www.googleapis.com/drive/v3/*', 'https://accounts.google.com/signin/oauth'],
 		}, async message => {
 			await Alert.open(`
 				<p><b>RES needs your permission to backup to Google Drive.</b></p>


### PR DESCRIPTION
The Google OAuth token retrieval did an additional redirection before landing at `redditenhancementsuite.com`, which was unnecessary and not support by our system.

Relevant issue: Fixes #5212
Tested in browser: Chrome 84, Chrome 75
