### PR TITLE
Update nightmode for happening now box.

### DIFF
--- a/lib/css/modules/_nightMode.scss
+++ b/lib/css/modules/_nightMode.scss
@@ -26,7 +26,8 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 	.side .recommend-box .rec-item,
 	.crosspost-preview,
 	.crosspost-thing-preview,
-	.admin_takedown {
+	.admin_takedown,
+	.happening-now {
 		background-color: $background-color;
 		border-color: $border-color;
 	}


### PR DESCRIPTION
Update nightmode so the COVID alert box isnt like a shining star.

![](https://i.imgur.com/J1bheyI.png)

Tested in browser: Edge 81.0.416.72
