### PR TITLE
Update Twitter API

### DIFF
--- a/chrome/beta/manifest.json
+++ b/chrome/beta/manifest.json
@@ -72,7 +72,7 @@
 	"optional_permissions": [
 		"downloads",
 
-		"https://api.twitter.com/1/statuses/oembed.json",
+		"https://publish.twitter.com/oembed",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
 		"https://api.tumblr.com/v2/blog/*/posts",

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -72,7 +72,7 @@
 	"optional_permissions": [
 		"downloads",
 
-		"https://api.twitter.com/1/statuses/oembed.json",
+		"https://publish.twitter.com/oembed",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
 		"https://api.tumblr.com/v2/blog/*/posts",

--- a/firefox/beta/manifest.json
+++ b/firefox/beta/manifest.json
@@ -76,7 +76,7 @@
 	"optional_permissions": [
 		"downloads",
 
-		"https://api.twitter.com/1/statuses/oembed.json",
+		"https://publish.twitter.com/oembed",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
 		"https://api.tumblr.com/v2/blog/*/posts",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -76,7 +76,7 @@
 	"optional_permissions": [
 		"downloads",
 
-		"https://api.twitter.com/1/statuses/oembed.json",
+		"https://publish.twitter.com/oembed",
 		"https://backend.deviantart.com/oembed",
 		"https://api.gyazo.com/api/oembed",
 		"https://api.tumblr.com/v2/blog/*/posts",

--- a/lib/modules/hosts/twitter.js
+++ b/lib/modules/hosts/twitter.js
@@ -11,7 +11,7 @@ export default new Host('twitter', {
 	permissions: ['https://publish.twitter.com/oembed'],
 	attribution: false,
 	detect: ({ href }) => (/^https?:\/\/(?:mobile\.)?twitter\.com\/(?:#!\/)?[\w]+\/status\/?[\w]+/i).exec(href),
-	async handleLink(href, url) {
+	async handleLink(href, [url]) {
 		// we have to omit the script tag and all of the nice formatting it brings us in Firefox
 		// because AMO does not permit externally hosted script tags being pulled in from
 		// oEmbed like this...

--- a/lib/modules/hosts/twitter.js
+++ b/lib/modules/hosts/twitter.js
@@ -8,16 +8,16 @@ import { ajax } from '../../environment';
 export default new Host('twitter', {
 	name: 'twitter',
 	domains: ['twitter.com'],
-	permissions: ['https://api.twitter.com/1/statuses/oembed.json'],
+	permissions: ['https://publish.twitter.com/oembed'],
 	attribution: false,
-	detect: ({ href }) => (/^https?:\/\/(?:mobile\.)?twitter\.com\/(?:#!\/)?[\w]+\/status(?:es)?\/([\d]+)/i).exec(href),
-	async handleLink(href, [, id]) {
+	detect: ({ href }) => (/^https?:\/\/(?:mobile\.)?twitter\.com\/(?:#!\/)?[\w]+\/status\/?[\w]+/i).exec(href),
+	async handleLink(href, url) {
 		// we have to omit the script tag and all of the nice formatting it brings us in Firefox
 		// because AMO does not permit externally hosted script tags being pulled in from
 		// oEmbed like this...
 		const { html } = await ajax({
-			url: 'https://api.twitter.com/1/statuses/oembed.json',
-			query: { id, omit_script: process.env.BUILD_TARGET === 'firefox' },
+			url: 'https://publish.twitter.com/oembed',
+			query: { url, omit_script: process.env.BUILD_TARGET === 'firefox' },
 			type: 'json',
 		});
 


### PR DESCRIPTION
Twitter's got a new oEmbed API endpoint. This updates RES to use it.

This will prompt a new twitter api permissions request.

Tested on Edge 83/Firefox 76.