### PR TITLE
Changed redgifs module to video instead of iframe

### DIFF
--- a/lib/modules/hosts/redgifs.js
+++ b/lib/modules/hosts/redgifs.js
@@ -8,14 +8,23 @@ export default new Host('redgifs', {
 	name: 'redgifs',
 	domains: ['redgifs.com'],
 	logo: 'https://redgifs.com/assets/favicon.ico',
+	options: {
+		useMobileGfycat: {
+			title: 'gfycatUseMobileGfycatTitle',
+			description: 'gfycatUseMobileGfycatDesc',
+			value: false,
+			type: 'boolean',
+		},
+	},
 	detect: ({ pathname }) => (/^\/(?:(?:ifr|watch)\/)(\w+)/i).exec(pathname),
 	async handleLink(href, [, id]) {
 		const embed = `https://redgifs.com/ifr/${id}`;
+		const isMobileResolution = this.options.useMobileGfycat.value;
 
 		// Load video width/height to show a responsive embed
 		try {
 			const info = (await ajax({
-				url: string.encode`https://api.redgifs.com/v1/gfycats/${id}`,
+				url: string.encode`https://napi.redgifs.com/v1/gfycats/${id}`,
 				type: 'json',
 				cacheFor: DAY,
 			})).gfyItem;
@@ -34,12 +43,23 @@ export default new Host('redgifs', {
 			}
 
 			return {
-				type: 'IFRAME',
-				embed: `${embed}?autoplay=0`,
-				embedAutoplay: embed,
-				fixedRatio: false,
-				width: `${width}px`,
-				height: `${height}px`,
+				type: 'VIDEO',
+				frameRate: info.frameRate,
+				loop: true,
+				muted: !info.hasAudio,
+				playbackRate: +(href.match(/[?|&]speed=([\d\.]+)/i) || [undefined, 1])[1],
+				poster: isMobileResolution ? info.mobilePosterUrl : info.posterUrl,
+				sources: [isMobileResolution && {
+					source: info.mobileUrl,
+					type: 'video/mp4',
+				}, {
+					source: info.webmUrl,
+					type: 'video/webm',
+				}, {
+					source: info.mp4Url,
+					type: 'video/mp4',
+				}].filter(x => x),
+				time: +(href.match(/[?|&]frameNum=([\d]+)/i) || [undefined, 0])[1] / info.frameRate,
 			};
 		} catch (error) { // Fallback to a fixedRatio embed
 			return {


### PR DESCRIPTION
- Used similar functionality found in the gfycat.js host file and
  implemented similar video options to have redgifs display as a video
  rather than iframe allowing for video size and volume adjustments
- fixed api url to reflect new api url

<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: None, better overall functionality
Tested in browser: Firefox
