### PR TITLE
showImages: Support embedding all v.redd.it videos 

### DIFF
--- a/lib/modules/hosts/vreddit.js
+++ b/lib/modules/hosts/vreddit.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { sortBy } from 'lodash-es';
+import { difference, sortBy } from 'lodash-es';
 import { Host } from '../../core/host';
 import { ajax } from '../../environment';
 
@@ -10,32 +10,59 @@ export default new Host('vreddit', {
 	permissions: ['https://v.redd.it/*/DASHPlaylist.mpd'],
 	attribution: false,
 	options: {
-		replaceNativeExpando: {
-			title: 'showImagesReplaceNativeExpandoTitle',
-			description: 'showImagesReplaceNativeExpandoDesc',
-			value: false,
+		forceReplaceNativeExpando: {
+			title: 'showImagesForceReplaceNativeExpandoTitle',
+			description: 'showImagesForceReplaceNativeExpandoDesc',
+			value: true,
 			type: 'boolean',
+		},
+		minimumVideoBandwidth: {
+			title: 'showImagesVredditMinimumVideoBandwidthTitle',
+			description: 'showImagesVredditMinimumVideoBandwidthDesc',
+			value: '3000', // In kB/s
+			type: 'text',
+			advanced: true,
 		},
 	},
 	detect: ({ pathname }) => pathname.slice(1),
 	async handleLink(href, id) {
 		const mpd = await ajax({ url: `https://v.redd.it/${id}/DASHPlaylist.mpd` });
 		const manifest = new DOMParser().parseFromString(mpd, 'text/xml');
-		// Audio is in a seperate stream, and requires a heavy dash dependency to add to the video
-		if (manifest.querySelector('AudioChannelConfiguration')) throw new Error('Audio is not supported');
-		const reps = Array.from(manifest.querySelectorAll('Representation'));
-		const sources = sortBy(reps, rep => parseInt(rep.getAttribute('bandwidth'), 10))
+
+		const minBandwidth = parseInt(this.options.minimumVideoBandwidth.value, 10) * 1000;
+		const reps = manifest.querySelectorAll('Representation[frameRate]');
+		const videoSourcesByBandwidth = sortBy(reps, rep => parseInt(rep.getAttribute('bandwidth'), 10))
 			.reverse()
-			.map(rep => rep.querySelector('BaseURL'))
-			.map(baseUrl => ({
-				source: `https://v.redd.it/${id}/${baseUrl.textContent}`,
+			.filter((rep, i, arr) => {
+				const bandwidth = parseInt(rep.getAttribute('bandwidth'), 10);
+				return rep === arr[0] || bandwidth >= minBandwidth;
+			});
+
+		// Removes unwanted entries from the from manifest
+		for (const rep of difference(reps, videoSourcesByBandwidth)) rep.remove();
+
+		// Update baseURL to absolute URL
+		for (const rep of manifest.querySelectorAll('Representation')) {
+			const baseURLElement = rep.querySelector('BaseURL');
+			baseURLElement.textContent = `https://v.redd.it/${id}/${baseURLElement.textContent}`;
+		}
+
+		// Audio is in a seperate stream, and requires a heavy dash dependency to add to the video
+		const muted = !manifest.querySelector('AudioChannelConfiguration');
+
+		const sources = (muted && id) ?
+			videoSourcesByBandwidth.map(rep => ({
+				source: rep.querySelector('BaseURL').textContent,
 				type: 'video/mp4',
-			}));
+			})) : [{
+				source: URL.createObjectURL(new Blob([(new XMLSerializer()).serializeToString(manifest)], { type: 'application/dash+xml' })),
+				type: 'application/dash+xml',
+			}];
 
 		return {
 			type: 'VIDEO',
 			loop: true,
-			muted: true,
+			muted,
 			sources,
 		};
 	},

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1,7 +1,12 @@
 /* @flow */
 
+// $FlowIgnore HLS media requires a fairly big dependency, so load it separately on demand
+import 'file-loader?name=dash.mediaplayer.min.js!../../node_modules/dashjs/dist/dash.mediaplayer.min.js'; // eslint-disable-line import/no-extraneous-dependencies
+/* global dashjs:readonly */
+/*:: import dashjs from 'dashjs' */
+
 import $ from 'jquery';
-import { compact, pull, without, once, memoize, intersection } from 'lodash-es';
+import { pull, without, once, memoize, intersection } from 'lodash-es';
 import DOMPurify from 'dompurify';
 import type {
 	ExpandoMedia,
@@ -14,10 +19,12 @@ import type {
 	GenericMedia,
 } from '../core/host';
 import { Host } from '../core/host';
+import { loadOptions } from '../core/init';
 import { Module } from '../core/module';
 import {
 	positiveModulo,
 	downcast,
+	filterMap,
 	Thing,
 	SelectedThing,
 	addCSS,
@@ -30,6 +37,7 @@ import {
 	frameThrottle,
 	isPageType,
 	isAppType,
+	stopPageContextScript,
 	string,
 	waitForEvent,
 	watchForElements,
@@ -44,9 +52,11 @@ import {
 	download,
 	isPrivateBrowsing,
 	openNewTab,
+	loadScript,
 	Permissions,
 	Storage,
 } from '../environment';
+import * as Modules from '../core/modules';
 import * as Options from '../core/options';
 import * as Notifications from './notifications';
 import * as SettingsNavigation from './settingsNavigation';
@@ -66,6 +76,7 @@ import {
 	expandos,
 	activeExpandos,
 } from './showImages/expando';
+import vreddit from './hosts/vreddit';
 import __hosts from 'sibling-loader?import=default!./hosts/default';
 
 const siteModules: Map<string, Host<any, any>> = new Map(
@@ -439,6 +450,25 @@ module.options = {
 		return options;
 	}, {}),
 };
+
+module.onInit = () => {
+	if (isAppType('r2')) {
+		// We'll probably replace Reddit's video player, so disable the script containing it for now
+		// This happens on `onInit` since RES' options load slower than the script's
+		const preventVideoPlayerScriptTasks = [
+			stopPageContextScript(script => (/^\/?videoplayer\./).test(new URL(script.src, location.origin).pathname), 'head'),
+			// Reddit loads scripts which initializes the video player, which will cause a slowdown if not blocked
+			stopPageContextScript(script => !!script.innerHTML.match('RedditVideoPlayer'), '#siteTable'),
+		];
+
+		loadOptions.then(() => {
+			// We might need to restore the native player
+			const removeNativePlayer = Modules.isRunning(module) && isSiteModuleEnabled(vreddit) && vreddit.options && vreddit.options.forceReplaceNativeExpando.value;
+			if (!removeNativePlayer) forEachSeq(preventVideoPlayerScriptTasks, ({ undo }) => undo());
+		});
+	}
+};
+
 module.exclude = [
 	/^\/ads\/[\-\w\._\?=]*/i,
 	'submit',
@@ -833,11 +863,6 @@ async function checkElementForMedia(element: HTMLAnchorElement) {
 
 	if (nativeExpando) {
 		trackNativeExpando(nativeExpando, element, thing);
-
-		if (nativeExpando.open) {
-			console.log('Native expando has already been opened; skipping.', element.href);
-			return;
-		}
 	}
 
 	if (thing && thing.isCrosspost() && module.options.crossposts.value === 'none') {
@@ -852,17 +877,21 @@ async function checkElementForMedia(element: HTMLAnchorElement) {
 	}
 
 	for (const siteModule of modulesForHostname(mediaUrl.hostname)) {
-		if (nativeExpando) {
-			const { options: { replaceNativeExpando } = {} } = siteModule;
-			if (replaceNativeExpando && !replaceNativeExpando.value) continue;
-		}
-
 		const detectResult = siteModule.detect(mediaUrl, thing);
 		if (!detectResult) continue;
 
+		if (nativeExpando) {
+			const forceReplaceNativeExpandoOption = siteModule.options && siteModule.options.forceReplaceNativeExpando;
+			if (nativeExpando.open && !(forceReplaceNativeExpandoOption && forceReplaceNativeExpandoOption.value)) {
+				console.log('Native expando has already been opened; skipping.', element.href);
+				return;
+			}
+
+			nativeExpando.detach();
+		}
+
 		const expando = new Expando(mediaUrl.href);
 
-		if (nativeExpando) nativeExpando.detach();
 		placeExpando(expando, element, thing);
 		expando.onExpand(() => { trackMediaLoad(element, thing); });
 		linksMap.set(element, expando);
@@ -1089,8 +1118,8 @@ export class Media {
 
 	supportsUnload(): boolean { return false; }
 	_state: 'loaded' | 'unloaded' = 'loaded';
-	_unload(): void {}
-	_restore(): void {}
+	_unload(): any {}
+	_restore(): any {}
 
 	setLoaded(state: boolean) {
 		if (state) {
@@ -1832,6 +1861,7 @@ class Video extends Media {
 	time: number;
 	frameRate: number;
 	useVideoManager: boolean;
+	dashPlayer: *;
 
 	constructor({
 		title,
@@ -1883,14 +1913,32 @@ class Video extends Media {
 			}
 		};
 
-		const sourceElements = $(compact(sources.map(v => {
-			if (!this.video.canPlayType(v.type)) return null;
-			const source = document.createElement('source');
-			source.src = v.source;
-			source.type = v.type;
-			if (v.reverse) source.dataset.reverse = v.reverse;
-			return source;
-		}))).appendTo(this.video).get();
+		const sourceElements = filterMap(sources, v => {
+			if (this.video.canPlayType(v.type)) {
+				const source = document.createElement('source');
+				source.src = v.source;
+				source.type = v.type;
+				if (v.reverse) source.dataset.reverse = v.reverse;
+				return [source];
+			} else {
+				if (v.type === 'application/dash+xml') {
+					// Use external library
+					this.dashPlayer = loadScript('/dash.mediaplayer.min.js').then(() => {
+						dashjs.skipAutoCreate = true;
+
+						const player = dashjs.MediaPlayer().create(); // eslint-disable-line new-cap
+
+						player.initialize();
+						player.attachSource(v.source);
+						player.preload();
+
+						return player;
+					});
+
+					return [document.createElement('span')]; // Return dummy element as the proper `source` element has side effects
+				}
+			}
+		});
 
 		if (!sourceElements.length) {
 			if (fallback) {
@@ -1906,12 +1954,18 @@ class Video extends Media {
 			}
 		}
 
+		this.video.append(...sourceElements);
+
 		const lastSource = sourceElements[sourceElements.length - 1];
 		lastSource.addEventListener('error', displayError);
 
 		if (reversed) this.reverse();
 
-		this.ready = Promise.race([waitForEvent(this.video, 'suspend'), waitForEvent(lastSource, 'error')]);
+		this.ready = Promise.race([
+			waitForEvent(this.video, 'suspend'),
+			waitForEvent(lastSource, 'error'),
+			waitForEvent(this.video, 'ended'),
+		]);
 
 		const setPlayIcon = () => {
 			if (!this.video.paused) this.element.setAttribute('playing', '');
@@ -1960,7 +2014,7 @@ class Video extends Media {
 
 		this.setMaxSize(this.video);
 		this.makeZoomable(this.video);
-		this.addControls(this.video, undefined, sources[0].source);
+		this.addControls(this.video, undefined, sourceElements[0].getAttribute('src'));
 		this.makeMovable(container);
 		this.keepVisible(container);
 		this.makeIndependent(container);
@@ -2082,23 +2136,40 @@ class Video extends Media {
 		return this.video.paused;
 	}
 
-	_unload() {
+	async _unload() {
 		// Video is auto-paused when detached from DOM
 		if (!this.isAttached()) return;
 
 		if (!this.video.paused) this.video.pause();
 
 		this.time = this.video.currentTime;
-		this.video.setAttribute('src', ''); // this.video.src has precedence over any child source element
-		this.video.load();
+
+		const dashPlayer = await this.dashPlayer;
+		if (dashPlayer) {
+			dashPlayer.updateSettings({ streaming: { bufferToKeep: 0, bufferAheadToKeep: 0 } });
+		} else {
+			this.video.setAttribute('src', ''); // this.video.src has precedence over any child source element
+			this.video.load();
+		}
 
 		if (this.useVideoManager) mutedVideoManager().unobserve(this.video);
 	}
 
-	_restore() {
-		if (this.video.hasAttribute('src')) {
+	async _restore() {
+		if (!this.dashPlayer && this.video.hasAttribute('src')) {
 			this.video.removeAttribute('src');
 			this.video.load();
+		}
+
+		const dashPlayer = await this.dashPlayer;
+		if (dashPlayer) {
+			try {
+				/* if this throws an error,  video is not attached */
+				dashPlayer.getVideoElement();
+			} catch (err) {
+				dashPlayer.attachView(this.video);
+			}
+			dashPlayer.resetSettings(); // Assumes that the only settings changes are done so in `_unload`
 		}
 
 		this.video.currentTime = this.time;

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -4366,11 +4366,17 @@
 	"temporaryDropdownLinksTemporarily": {
 		"message": "(temporarily?)"
 	},
-	"showImagesReplaceNativeExpandoTitle": {
-		"message": "Replace Native Expando"
+	"showImagesForceReplaceNativeExpandoTitle": {
+		"message": "Force Replace Native Expando"
 	},
-	"showImagesReplaceNativeExpandoDesc": {
-		"message": "Should RES also attempt to replace Reddit's expando?"
+	"showImagesForceReplaceNativeExpandoDesc": {
+		"message": "Always replace Reddit's player."
+	},
+	"showImagesVredditMinimumVideoBandwidthTitle": {
+		"message": "Minimum Video Bandwidth"
+	},
+	"showImagesVredditMinimumVideoBandwidthDesc": {
+		"message": "The lowest video quality (in kB/s) the adaptive player shall use."
 	},
 	"imgurPreferResAlbumsTitle": {
 		"message": "Prefer RES Albums"

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "firefox 78"
   ],
   "dependencies": {
+    "dashjs": "3.1.1",
     "dayjs": "1.8.29",
     "dompurify": "2.0.12",
     "fast-levenshtein": "2.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1652,6 +1652,11 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
+codem-isoboxer@0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/codem-isoboxer/-/codem-isoboxer-0.3.6.tgz#867f670459b881d44f39168d5ff2a8f14c16151d"
+  integrity sha512-LuO8/7LW6XuR5ERn1yavXAfodGRhuY2yP60JTZIw5yNYMCE5lUVbk3NFUCJxjnphQH+Xemp5hOGb1LgUXm00Xw==
+
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
@@ -1985,6 +1990,19 @@ dashdash@^1.12.0:
   integrity sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
   dependencies:
     assert-plus "^1.0.0"
+
+dashjs@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/dashjs/-/dashjs-3.1.1.tgz#8ef0000d6accb4f80f1332c7c47f28f82b2732db"
+  integrity sha512-nss4D6keV63Vr+5yhpMAu6rdlqAngf08ZbEPF0ZxBvv2BaDi/FfEmORMrHLw0yux5e2LTZ/OMp6kbjT9/9Jn/g==
+  dependencies:
+    codem-isoboxer "0.3.6"
+    fast-deep-equal "2.0.1"
+    html-entities "^1.2.1"
+    imsc "^1.0.2"
+    localforage "^1.7.1"
+    request "^2.87.0"
+    request-promise "^4.2.2"
 
 data-uri-to-buffer@1:
   version "1.2.0"
@@ -2916,6 +2934,11 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
+fast-deep-equal@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -3629,6 +3652,11 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
   integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
 
+html-entities@^1.2.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.3.1.tgz#fb9a1a4b5b14c5daba82d3e34c6ae4fe701a0e44"
+  integrity sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA==
+
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
@@ -3748,6 +3776,11 @@ ignore@^5.1.1, ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
+
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
@@ -3803,6 +3836,13 @@ import-modules@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-modules/-/import-modules-2.0.0.tgz#9c1e13b4e7a15682f70a6e3fa29534e4540cfc5d"
   integrity sha512-iczM/v9drffdNnABOKwj0f9G3cFDon99VcG1mxeBsdqnbd+vnQ5c2uAiCHNQITqFTOPaEvwg3VjoWCur0uHLEw==
+
+imsc@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/imsc/-/imsc-1.1.1.tgz#5c2cdfd26881bcfd2355b994f4706e7defb0a44b"
+  integrity sha512-kfWjrmg/vdcqM65FPxpq46RyxKTpfMikDk0PhXOeAlZ6o1OkWBZsll4TlmSj261WcuNT252VBB0aGqSQ+vBZ/A==
+  dependencies:
+    sax "1.2.1"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -4539,6 +4579,13 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+lie@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
+  integrity sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=
+  dependencies:
+    immediate "~3.0.5"
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -4587,6 +4634,13 @@ loader-utils@^2.0.0:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^2.1.2"
+
+localforage@^1.7.1:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.7.4.tgz#88b59cc9b25ae54c76bb2c080b21ec832c22d3f6"
+  integrity sha512-3EmVZatmNVeCo/t6Te7P06h2alGwbq8wXlSkcSXMvDE2/edPmsVqTPlzGnZaqwZZDBs6v+kxWpqjVsqsNJT8jA==
+  dependencies:
+    lie "3.1.1"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -6264,7 +6318,7 @@ request-promise-core@1.1.3:
   dependencies:
     lodash "^4.17.15"
 
-request-promise@^4.2.5:
+request-promise@^4.2.2, request-promise@^4.2.5:
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.5.tgz#186222c59ae512f3497dfe4d75a9c8461bd0053c"
   integrity sha512-ZgnepCykFdmpq86fKGwqntyTiUrHycALuGggpyCZwMvGaZWgxW6yagT0FHkgo5LzYvOaCNvxYwWYIjevSH1EDg==
@@ -6274,7 +6328,7 @@ request-promise@^4.2.5:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.88.2:
+request@^2.87.0, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -6517,6 +6571,11 @@ sass@1.26.10:
   integrity sha512-bzN0uvmzfsTvjz0qwccN1sPm2HxxpNI/Xa+7PlUEMS+nQvbyuEK7Y0qFqxlPHhiNHb1Ze8WQJtU31olMObkAMw==
   dependencies:
     chokidar ">=2.0.0 <4.0.0"
+
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
 
 schema-utils@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Allows inlining v.redd.it links, and to replace the native player for faster and improved user experience.

- Uses the dash.js library
  - Since it is fairly large, it's loaded separate from the foreground bundle and only on demand
- When `forceReplaceNativeExpando` is enabled, Reddit's video player script is no longer loaded
  - Improves load times a little

Relevant issue: Fixes #4745
Tested in browser: Firefox 79, Chrome 85
