### PR TITLE
Fix Strawpoll URL redirect loop.

### DIFF
--- a/lib/modules/hosts/strawpollcom.js
+++ b/lib/modules/hosts/strawpollcom.js
@@ -12,7 +12,7 @@ export default new Host('strawpoll.com', {
 			type: 'IFRAME',
 			expandoClass: 'selftext',
 			muted: true,
-			embed: `https://www.strawpoll.com/embed/${id}`,
+			embed: `https://strawpoll.com/embed/${id}`,
 			height: '450px',
 			width: '700px',
 		};


### PR DESCRIPTION
URL no longer works on www. and causes error. Corrects to right URL for detection.