### PR TITLE
Remove unused permissions

### DIFF
--- a/chrome/beta/manifest.json
+++ b/chrome/beta/manifest.json
@@ -61,8 +61,6 @@
 	"content_security_policy": "default-src 'self'; img-src 'self' data:; connect-src https:; font-src 'self' data:; frame-ancestors https://*.reddit.com",
 	"permissions": [
 		"https://*.reddit.com/*",
-		"cookies",
-		"identity",
 		"tabs",
 		"history",
 		"storage",

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -61,8 +61,6 @@
 	"content_security_policy": "default-src 'self'; img-src 'self' data:; connect-src https:; font-src 'self' data:; frame-ancestors https://*.reddit.com",
 	"permissions": [
 		"https://*.reddit.com/*",
-		"cookies",
-		"identity",
 		"tabs",
 		"history",
 		"storage",

--- a/firefox/beta/manifest.json
+++ b/firefox/beta/manifest.json
@@ -66,7 +66,6 @@
 	"content_security_policy": "default-src 'self'; img-src 'self' data:; connect-src https:; font-src 'self' data:; frame-ancestors https://*.reddit.com",
 	"permissions": [
 		"https://*.reddit.com/*",
-		"cookies",
 		"identity",
 		"tabs",
 		"history",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -66,7 +66,6 @@
 	"content_security_policy": "default-src 'self'; img-src 'self' data:; connect-src https:; font-src 'self' data:; frame-ancestors https://*.reddit.com",
 	"permissions": [
 		"https://*.reddit.com/*",
-		"cookies",
 		"identity",
 		"tabs",
 		"history",


### PR DESCRIPTION
It looks like we dont use cookies at all and identity is only used on FF. Chrome team rejected RES due to cookies and identity perms when not used.