### PR TITLE
Update snudown-js to 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "favico.js": "0.3.10",
     "jquery": "3.5.1",
     "lodash-es": "4.17.15",
-    "snudown-js": "3.1.10",
+    "snudown-js": "3.2.0",
     "sortablejs": "1.10.2",
     "suncalc": "1.8.0",
     "tinycolor2": "1.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6855,10 +6855,10 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-snudown-js@3.1.10:
-  version "3.1.10"
-  resolved "https://registry.yarnpkg.com/snudown-js/-/snudown-js-3.1.10.tgz#072e8d9f70493f2ec232a665cf5f4d1585ab6070"
-  integrity sha512-1VL1RG5wgsgDc0HfdVDy3k3F2UoHHGMHpKTVsxUBv8uyoEr9ZNMY5M/PE+4f62wtacGuTWplOz6WzxIDHLirbw==
+snudown-js@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/snudown-js/-/snudown-js-3.2.0.tgz#d2108bf0fbf4c9dc080aa8a3f5b03e15296a2ec2"
+  integrity sha512-Hs3wf7k9mESAiQhsi7K/3o6FpGWYF/VAcK9RvlDYRtqhbyM7YnxMnOjkip9SjsAaU2HvB6YdBVYmMUd+51/b1g==
   dependencies:
     esm "^3.0.28"
 


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: fixes #5253
Tested in browser: Chrome 87, Firefox 82

See commit message.

Before:
![image](https://user-images.githubusercontent.com/7673145/94347681-355ba600-0004-11eb-8625-d8eb48e25125.png)

After:
![image](https://user-images.githubusercontent.com/7673145/94347546-36d89e80-0003-11eb-8094-9490fa8f6a0c.png)

The other 262k buffer is from fast-levenshtein.