### PR TITLE
Added support for screen readers to gallery view and tables

### DIFF
--- a/lib/modules/showImages/templates.js
+++ b/lib/modules/showImages/templates.js
@@ -25,12 +25,12 @@ export const galleryTemplate = <T>({ title, caption, credits, src }: {| title?: 
 		<div class="res-credits">${string.safe(credits)}</div>
 		`}
 		<div class="res-step-container">
-			<div class="res-step res-step-previous"></div>
+			<div class="res-step res-step-previous" role="button"></div>
 			<div class="res-step-progress">
 				<span class="res-step-position">1</span> of ${src.length}
 			</div>
-			<div class="res-step res-step-next"></div>
-			<div class="res-gallery-to-filmstrip" title="View as filmstrip"></div>
+			<div class="res-step res-step-next" role="button"></div>
+			<div class="res-gallery-to-filmstrip" title="View as filmstrip" role="button"></div>
 		</div>
 		<div class="res-gallery-pieces"></div>
 		<div class="res-gallery-below">

--- a/lib/utils/table.js
+++ b/lib/utils/table.js
@@ -145,11 +145,11 @@ export class RESTable {
 
 	createPaginationElement() {
 		const ele = string.html`<div class="res-step-container">
-			<div class="res-step res-step-previous"></div>
+			<div class="res-step res-step-previous" role="button"></div>
 			<div class="res-step-progress">
 				<span class="res-step-position"></span> of <span class="res-step-total"></span>
 			</div>
-			<div class="res-step res-step-next"></div>
+			<div class="res-step res-step-next" role="button"></div>
 		</div>`;
 
 		ele.querySelector('.res-step-previous').addEventListener('click', () => { this.page--; this.updatePage(); });


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: None, I just did this without creating one
Tested in browser: Chrome 85 on Windows 10
