### PR TITLE
Update node version requirement in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Thinking about contributing to RES? Awesome! We just ask that you follow a few s
 #### First time installation
 
 1. Install [git](https://git-scm.com/).
-1. Install [node.js](https://nodejs.org) (version >= 8).
+1. Install [node.js](https://nodejs.org) (version >= 10).
 1. Install [yarn](https://yarnpkg.com/lang/en/docs/install/)
 1. [Clone this repository](https://help.github.com/articles/cloning-a-repository/).
 1. Run `yarn` in that folder.


### PR DESCRIPTION
I got this error when I ran `yarn` with node version 8.
<img width="573" alt="Screen Shot 2020-11-14 at 10 54 15 am" src="https://user-images.githubusercontent.com/17612510/99132058-1030fe80-2669-11eb-9bef-e3b6c208f9be.png">

