### PR TITLE
Cleanup build releases.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,8 @@ matrix:
             - dist/zip/chrome.zip
             - dist/zip/chrome-beta.zip
             - dist/zip/firefox.zip
-            - dist/zip/firefox-beta.zip
+            - dist/zip/opera.zip
+            - dist/zip/edge.zip
           skip_cleanup: true
           overwrite: true
           on:

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -25,10 +25,16 @@ const browserConfig = {
 		output: 'firefox',
 		noSourcemap: true,
 	},
-	firefoxbeta: {
-		target: 'firefox',
-		entry: 'firefox/beta/manifest.json',
-		output: 'firefox-beta',
+	opera: {
+		target: 'opera',
+		entry: 'chrome/manifest.json',
+		output: 'opera',
+		noSourcemap: true,
+	},
+	edge: {
+		target: 'edge',
+		entry: 'chrome/manifest.json',
+		output: 'edge',
 	},
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7778,6 +7778,14 @@ webpack-merge@^4.2.2:
   dependencies:
     lodash "^4.17.15"
 
+webpack-sources@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.2.0.tgz#058926f39e3d443193b6c31547229806ffd02bac"
+  integrity sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==
+  dependencies:
+    source-list-map "^2.0.1"
+    source-map "^0.6.1"
+
 webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
@@ -7785,14 +7793,6 @@ webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1:
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
-
-webpack-sources@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.2.0.tgz#058926f39e3d443193b6c31547229806ffd02bac"
-  integrity sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==
-  dependencies:
-    source-list-map "^2.0.1"
-    source-map "^0.6.1"
 
 webpack@4.44.2:
   version "4.44.2"


### PR DESCRIPTION
Removes Firefox beta since we don't use them anymore and adds Opera with no source map per their request and Edge for ease.