### PR TITLE
showImages: Option to collapse inline media

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -114,6 +114,12 @@ module.options = {
 		value: '2',
 		description: 'showImagesGalleryPreloadCountDesc',
 	},
+	collapseInlineMedia: {
+		title: 'showImagesCollapseInlineMediaTitle',
+		type: 'boolean',
+		value: false,
+		description: 'showImagesCollapseInlineMediaDesc',
+	},
 	conserveMemory: {
 		title: 'showImagesConserveMemoryTitle',
 		type: 'boolean',
@@ -860,7 +866,20 @@ const generateSiteModuleLock = memoize(async siteModule => {
 function scanBody(element: ?Element) {
 	if (!element) return;
 	const promises = [...element.querySelectorAll('a')]
-		.filter(link => !link.querySelector('img, video')) // Skip links that already have media
+		.filter(link => {
+			// Skip links that already have media
+			const existingContent = link.querySelector('img, video');
+
+			// Except those inline in posts -- let's just remove them and create an expando instead
+			if (existingContent && module.options.collapseInlineMedia.value && existingContent.matches('[src^="https://external-preview.redd.it"')) {
+				// Rewrite the anchor to avoid RES querying the 3rd party host for media data
+				if (existingContent.hasAttribute('src')) { (link: any).href = existingContent.getAttribute('src'); }
+				existingContent.replaceWith(string.html`<i>Collapsed inline media</i>`);
+				return true;
+			}
+
+			return !existingContent;
+		})
 		.map(link => checkElementForMedia(downcast(link, HTMLAnchorElement)));
 	// $FlowIssue Promise#allSettled is not typed
 	return Promise.allSettled(promises);

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -4117,6 +4117,12 @@
 	"showImagesGalleryPreloadCountDesc": {
 		"message": "Number of preloaded gallery pieces for faster browsing."
 	},
+	"showImagesCollapseInlineMediaTitle": {
+		"message": "Collapse Inline Media"
+	},
+	"showImagesCollapseInlineMediaDesc": {
+		"message": "Replace Reddit's inline media with an expando."
+	},
 	"showImagesConserveMemoryTitle": {
 		"message": "Conserve Memory"
 	},


### PR DESCRIPTION
Fixes #5275 

Collapses inline media which is hosted on `https://external-preview.redd.it`. The `collapseInlineMedia` option is currently set to `true` as the default value.

![image](https://user-images.githubusercontent.com/1748521/106058201-39eab500-60f1-11eb-9134-2c9e2a7f2156.png)
