### PR TITLE
Update twitchclips regex for new clip names.

### DIFF
--- a/lib/environment/background/auth.js
+++ b/lib/environment/background/auth.js
@@ -3,7 +3,7 @@ import { apiToPromise } from '../utils/api';
 import { addListener } from './messaging';
 
 addListener('authFlow', ({ domain, clientId, scope, interactive }) => {
-	const redirectUri = process.env.BUILD_TARGET !== 'firefox'  ? 'https://redditenhancementsuite.com/oauth' : chrome.identity.getRedirectURL();
+	const redirectUri = process.env.BUILD_TARGET !== 'firefox' ? 'https://redditenhancementsuite.com/oauth' : chrome.identity.getRedirectURL();
 	const url = new URL(domain);
 	url.searchParams.set('client_id', clientId);
 	url.searchParams.set('scope', scope);

--- a/lib/modules/hosts/twitchclips.js
+++ b/lib/modules/hosts/twitchclips.js
@@ -11,10 +11,12 @@ export default new Host('twitchclips', {
 	//   old: /username/NameOfClip
 	//   new: /NameOfClip
 	//        /NameOfClip/edit (bad link to private edit page, but Twitch redirects so we should handle it)
+	//        /NameOfClip-aBc123dEf
+	//        /NameOfClip-aBc123dEf-gHi456jKl (there are clips with more than one sets of hyphen groups)
 	// (www.)twitch.tv domain:
 	//   support clip name as a subcomponent of a channel URL
 	//   ex: www.twitch.tv/<CHANNEL_NAME>/clip/<CLIP_NAME>
-	detect: ({ hostname, pathname }) => hostname === 'clips.twitch.tv' ? (/^\/(\w+(?:\/[A-Z]\w+)?)(?:\/|$)/).exec(pathname) : (/^\/\w+\/clip\/(\w+(?:\/[A-Z]\w+)?)(?:\/|$)/).exec(pathname),
+	detect: ({ hostname, pathname }) => hostname === 'clips.twitch.tv' ? (/^\/(\w+(?:\/[A-Z]\w+)?(?:\-\w+)*)(?:\/|$)/).exec(pathname) : (/^\/\w+\/clip\/(\w+(?:\/[A-Z]\w+)?(?:\-\w+)*)(?:\/|$)/).exec(pathname),
 	handleLink(href, [, clipId]) {
 		const embed = `https://clips.twitch.tv/embed?clip=${clipId}&parent=${location.hostname}`;
 


### PR DESCRIPTION
Twitch has started appending hyphen + random string to the end of their auto-generated clip names, causing the twitchclips regex to not match anymore.

Fixes the issue mentioned in /r/Enhancement:  
[[Request] Twitch recently changed the format of their clips URLs which has affected functionality.](https://reddit.com/r/Enhancement/comments/lhk8hq/request_twitch_recently_changed_the_format_of/)

Tested in browsers:
* Firefox 85.0.1
* Chrome 88.0.4324.150