### PR TITLE
Relax regex on twitch clip names.

### DIFF
--- a/lib/modules/hosts/twitchclips.js
+++ b/lib/modules/hosts/twitchclips.js
@@ -13,10 +13,11 @@ export default new Host('twitchclips', {
 	//        /NameOfClip/edit (bad link to private edit page, but Twitch redirects so we should handle it)
 	//        /NameOfClip-aBc123dEf
 	//        /NameOfClip-aBc123dEf-gHi456jKl (there are clips with more than one sets of hyphen groups)
+	//        /NameOfClip-aBc123dEf--gHi456jKl- (hyphens may appear more than once, and can appear at the end)
 	// (www.)twitch.tv domain:
 	//   support clip name as a subcomponent of a channel URL
 	//   ex: www.twitch.tv/<CHANNEL_NAME>/clip/<CLIP_NAME>
-	detect: ({ hostname, pathname }) => hostname === 'clips.twitch.tv' ? (/^\/(\w+(?:\/[A-Z]\w+)?(?:\-\w+)*)(?:\/|$)/).exec(pathname) : (/^\/\w+\/clip\/(\w+(?:\/[A-Z]\w+)?(?:\-\w+)*)(?:\/|$)/).exec(pathname),
+	detect: ({ hostname, pathname }) => hostname === 'clips.twitch.tv' ? (/^\/(\w+(?:\/[A-Z]\w+)?(?:[\-\w]*))(?:\/|$)/).exec(pathname) : (/^\/\w+\/clip\/(\w+(?:\/[A-Z]\w+)?(?:[\-\w]*))(?:\/|$)/).exec(pathname),
 	handleLink(href, [, clipId]) {
 		const embed = `https://clips.twitch.tv/embed?clip=${clipId}&parent=${location.hostname}`;
 


### PR DESCRIPTION
Twitch has a few additional formats for the clip names, including double
hyphens and also ending with a hyphen. Relaxed the Regex for twitch clip
name matching so that the hyphen character will be treated as one of the
characters in the randomly generated string.

This means this will now match any additional string appended that uses
the hyphen or the characters from the \w set (A-Za-z0-9_).

Relevant issue: Fixes #5284 
Tested in browser:
* Firefox 85.0.2
* Chrome 88.0.4324.182
