### PR TITLE
nightmode: Silence geolocation permission issue in settings console

### DIFF
--- a/lib/modules/nightMode.js
+++ b/lib/modules/nightMode.js
@@ -254,6 +254,10 @@ async function getNightModeTimes() {
 
 				switch (err.code) {
 					case err.PERMISSION_DENIED:
+						// Ignore permission issues when the user is in the settings console
+						// The settings console requires different permissions than the content script
+						if (!location.protocol.startsWith('http')) throw err;
+
 						return Alert.open(i18n('nightModeAutomaticNightModeDenied', 'confirm'), { cancelable: true })
 							.then(() => {
 								// they clicked confirm, turn it off


### PR DESCRIPTION
The settings console doesn't run in the reddit.com-context, and requires that an additional permission to geolocation is provided in the manifest-file and granted by the user. Since automatic nightmode isn't really that useful for the settings console, the easiest solution is to just ignore the issue.

Relevant issue: #5290
Tested in browser: Firefox 87, Chrome 88
