### PR TITLE
[Minor] Include leading zeros on RES backup filename

### DIFF
--- a/lib/modules/backupAndRestore/providers/File.js
+++ b/lib/modules/backupAndRestore/providers/File.js
@@ -40,7 +40,7 @@ export class File extends Provider {
 		const link = document.createElement('a');
 		link.href = URL.createObjectURL(blob);
 		const date = new Date();
-		link.download = `RES-${date.getUTCFullYear()}-${date.getMonth() + 1}-${date.getDate()}-${Math.round(date.getTime() / 1000)}-${Metadata.version.replace(/\./g, '_')}.resbackup`;
+		link.download = `RES-${date.toISOString().split('T')[0]}-${Math.round(date.getTime() / 1000)}-${Metadata.version.replace(/\./g, '_')}.resbackup`;
 		click(link);
 		return Promise.resolve();
 	}


### PR DESCRIPTION
Saw this request popup on https://www.reddit.com/r/Enhancement/comments/nqq7dw/backup_file_names_to_include_leading_0s_in_date/ which seemed sensible and easy to add.

Effectively just tweaking the save filename so that it includes leading 0's on filename date for easier sorting of backup files.

Previous output was: `RES-2021-6-2-1622657669-xxx.resbackup`
New output is `RES-2021-06-02-1622657669-xxx.resbackup`

Relevant issue: Not yet logged.
Tested in browser: Chrome
