### PR TITLE
Add Github Expando Host

### DIFF
--- a/lib/modules/hosts/github-gist.js
+++ b/lib/modules/hosts/github-gist.js
@@ -1,0 +1,42 @@
+/* @flow */
+
+import { markdown } from 'snudown-js';
+import { Host } from '../../core/host';
+import { DAY, string } from '../../utils';
+import { ajax } from '../../environment';
+
+export default new Host('github-gist', {
+	domains: ['gist.github.com'],
+	logo: 'https://assets-cdn.github.com/favicon.ico',
+	name: 'github gists',
+	detect: ({ pathname }) => (/^\/(?:[\w-]+\/)?([a-z0-9]{20,}|\d+)/i).exec(pathname),
+	async handleLink(href, [, id]) {
+		const { files, description } = await ajax({
+			url: `https://api.github.com/gists/${id}`,
+			type: 'json',
+			cacheFor: DAY,
+		});
+
+		let src = '';
+
+		for (const [filename, { content, language, truncated }] of Object.entries(files)) {
+			src += string.escape`<h5>${filename}:</h5>`;
+
+			if (language === 'Markdown') {
+				src += markdown(content);
+			} else {
+				src += string.escape`<pre><code>${content}</code></pre>`;
+			}
+
+			if (truncated) {
+				src += '<p>&lt;file truncated&gt;</p>';
+			}
+		}
+
+		return {
+			type: 'TEXT',
+			title: description,
+			src,
+		};
+	},
+});

--- a/lib/modules/hosts/github.js
+++ b/lib/modules/hosts/github.js
@@ -1,42 +1,19 @@
 /* @flow */
 
-import { markdown } from 'snudown-js';
 import { Host } from '../../core/host';
-import { DAY, string } from '../../utils';
 import { ajax } from '../../environment';
+import { DAY } from '../../utils';
 
 export default new Host('github', {
-	domains: ['gist.github.com'],
-	logo: 'https://assets-cdn.github.com/favicon.ico',
-	name: 'github gists',
-	detect: ({ pathname }) => (/^\/(?:[\w-]+\/)?([a-z0-9]{20,}|\d+)/i).exec(pathname),
-	async handleLink(href, [, id]) {
-		const { files, description } = await ajax({
-			url: `https://api.github.com/gists/${id}`,
-			type: 'json',
-			cacheFor: DAY,
-		});
-
-		let src = '';
-
-		for (const [filename, { content, language, truncated }] of Object.entries(files)) {
-			src += string.escape`<h5>${filename}:</h5>`;
-
-			if (language === 'Markdown') {
-				src += markdown(content);
-			} else {
-				src += string.escape`<pre><code>${content}</code></pre>`;
-			}
-
-			if (truncated) {
-				src += '<p>&lt;file truncated&gt;</p>';
-			}
-		}
-
+	name: 'GitHub',
+	domains: ['github.com'],
+	attribution: false, // shown in embed
+	// Match /user/repo only as nothing can do with user alone.
+	detect: ({ pathname }) => (/^\/([\w\-\_]+)\/([\w\-\_]+)/i).exec(pathname),
+	async handleLink(href, [, user, repo]) {
 		return {
-			type: 'TEXT',
-			title: description,
-			src,
+			type: 'IMAGE',
+			src: `https://opengraph.githubassets.com/res/${user}/${repo}`,
 		};
 	},
 });

--- a/lib/modules/hosts/github.js
+++ b/lib/modules/hosts/github.js
@@ -9,7 +9,7 @@ export default new Host('github', {
 	domains: ['github.com'],
 	attribution: false, // shown in embed
 	// Match /user/repo only as nothing can do with user alone.
-	detect: ({ pathname }) => (/^\/([\w\-\_]+)\/([\w\-\_]+)/i).exec(pathname),
+	detect: ({ hostname, pathname }) => hostname !== 'gist.github.com' && (/^\/([\w\-\_]+)\/([\w\-\_]+)/i).exec(pathname),
 	async handleLink(href, [, user, repo]) {
 		return {
 			type: 'IMAGE',

--- a/lib/modules/hosts/github.js
+++ b/lib/modules/hosts/github.js
@@ -9,7 +9,7 @@ export default new Host('github', {
 	domains: ['github.com'],
 	attribution: false, // shown in embed
 	// Match /user/repo only as nothing can do with user alone.
-	detect: ({ hostname, pathname }) => hostname !== 'gist.github.com' && (/^\/([\w\-\_]+)\/([\w\-\_]+)/i).exec(pathname),
+	detect: ({ hostname, pathname }) => hostname !== 'gist.github.com' && (/^\/([\w\-\_\.]+)\/([\w\-\_\.]+)/i).exec(pathname),
 	async handleLink(href, [, user, repo]) {
 		return {
 			type: 'IMAGE',


### PR DESCRIPTION
Use the new GitHub open graph embeds to create an expando host for linked github repositories. 

Example below taken from from https://old.reddit.com/domain/github.com/

![image](https://user-images.githubusercontent.com/887397/120545239-502db800-c3e6-11eb-933b-e67715a97d7d.png)

Currently the host will ignore github.com/user/ routes as there's nothing built in to show (Unless someone wanted to use the GH public API data to build a profile for these from scratch).

I've tested this next to the now renamed `github-gist` embed and it appears to function correctly  (Matching the [gist.github](https://old.reddit.com/domain/gist.github.com/) to the gist expando and the direct github ones to this. I have additionally added a secondary hostname check to ensure it can't accidentally fall through).

Very open to any feedback as been quite a while since I played with the hosts/RES code in general.

Relevant issue:  N/A (I can raise on is useful)
Tested in browser:  Chrome
