### PR TITLE
Option to hide Spoilers in Inline Image Viewer

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -181,6 +181,12 @@ module.options = {
 		value: false,
 		description: 'showImagesHideNSFWDesc',
 	},
+	hideSpoiler: {
+		title: 'showImagesHideSpoilerTitle',
+		type: 'boolean',
+		value: false,
+		description: 'showImagesHideSpoilerDesc',
+	},
 	highlightNSFWButton: {
 		title: 'showImagesHighlightNSFWButtonTitle',
 		type: 'boolean',
@@ -899,6 +905,11 @@ async function checkElementForMedia(element: HTMLAnchorElement) {
 	const nativeExpando = entryExpando instanceof Expando ? null : entryExpando;
 
 	if (module.options.hideNSFW.value && thing && thing.isNSFW()) {
+		if (nativeExpando) nativeExpando.detach();
+		return;
+	}
+
+	if (module.options.hideSpoiler.value && thing && thing.isSpoiler()) {
 		if (nativeExpando) nativeExpando.detach();
 		return;
 	}

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -4177,6 +4177,13 @@
 	"showImagesHideNSFWDesc": {
 		"message": "If checked, do not show images marked NSFW."
 	},
+	"showImagesHideSpoilerTitle": {
+        "message": "Hide Spoilers",
+        "description": ""
+	},
+	"showImagesHideSpoilerDesc": {
+		"message": "If checked, do not show images marked as a Spoiler."
+	},
 	"showImagesHighlightNSFWButtonTitle": {
 		"message": "Highlight NSFW Button"
 	},


### PR DESCRIPTION
This adds an option identical to the one for NSFW content. This way if a user clicks "Show Images" and images marked as Spoilers exist the user will be able to more easily ignore them.

<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: No issue currently exists, but this type of functionality [has been brought up on /r/Enhancement a fair amount](https://old.reddit.com/r/Enhancement/search?q=spoiler+images&restrict_sr=on&sort=relevance&t=all).
Tested in browser: Chrome 91.0.4472.106
