### PR TITLE
showParent: Fix Shift-P not working

### DIFF
--- a/lib/modules/showParent.js
+++ b/lib/modules/showParent.js
@@ -60,8 +60,8 @@ module.contentStart = () => {
 			fadeDelay: parseFloat(module.options.fadeDelay.value),
 			fadeSpeed: parseFloat(module.options.fadeSpeed.value),
 		})
-		.populateWith(card => showCommentHover(Thing.checkedFrom(card.getCheckedTarget())))
-		.watch('.comment .buttons :not(:first-child) .bylink');
+		.populateWith(card => showCommentHover(Thing.checkedFrom(card.getCheckedTarget())));
+	hover.watch('.comment .buttons :not(:first-child) .bylink');
 };
 
 export function startHover(button: HTMLElement) {


### PR DESCRIPTION
The <kbd>Shift</kbd>-<kbd>P</kbd> shortcut which shows parent posts is currently broken—it does nothing when pressed.

Luckily the fix was simple. `Hover`'s `watch` method doesn't return anything, and the `hover` variable was always assigned `undefined` instead of the `HoverInfoCard` object that was intended.

(Chromium: 91.0.4472.124)