### PR TITLE
Remove clear: both from live previews

### DIFF
--- a/lib/css/res.scss
+++ b/lib/css/res.scss
@@ -182,7 +182,6 @@ body.res-console-open {
 	}
 
 	.RESDialogContents {
-		clear: both;
 		padding: 0 12px 12px 12px;
 	}
 }


### PR DESCRIPTION
clear: left is already used for usertext and wiki live previews. This fixes an issue when providing ban notes; the live preview is shifted extremely far down due to how floating elements work.

Tested in browser: Firefox 90 on Windows 10 Pro.
