### PR TITLE
Disable mouse selecting on subreddit info buttons

### DIFF
--- a/lib/css/modules/_subredditInfo.scss
+++ b/lib/css/modules/_subredditInfo.scss
@@ -20,4 +20,8 @@
 		float: right;
 		margin-left: 8px;
 	}
+	
+	.bottomButtons {
+		user-select: none;
+	}
 }


### PR DESCRIPTION

<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: No issue, but quite a few times I've clicked on 'Filter' and accidentally selected the text on the button, rather just clicking it. This resolves that entirely!

Tested in browser: Edited the CSS manually in Chrome to verify that `.subredditInfoToolTip .bottomButtons` is a selector and `user-select: none;` is the rule. 
