### PR TITLE
Resolves #5360 and restores Home button

### DIFF
--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -221,7 +221,7 @@ const loadShortcuts = async () => { mySubredditShortcuts = await subredditShortc
 const initialShortcutsLoad = once(loadShortcuts);
 
 module.beforeLoad = () => {
-	PagePhases.bodyStart.then(body => waitForDescendant(body, '#sr-header-area')).then(createSubredditBar);
+	PagePhases.bodyStart.then(body => waitForDescendant(body, '#sr-header-area .sr-list')).then(list => createSubredditBar(list.parentElement));
 };
 
 module.contentStart = () => {


### PR DESCRIPTION
Resolves #5360 by waiting for the child element that isn't getting loaded in time instead of the parent, then passes parent to `createSubredditBar()`

<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: 
Tested in browser: 
