### PR TITLE
Move Chrome geolocation as required permission

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -65,11 +65,11 @@
 		"history",
 		"storage",
 		"unlimitedStorage",
-		"webRequest"
+		"webRequest",
+		"geolocation"
 	],
 	"optional_permissions": [
 		"downloads",
-		"geolocation",
 
 		"https://publish.twitter.com/oembed",
 		"https://backend.deviantart.com/oembed",


### PR DESCRIPTION
Chrome does not allow geolocation to be a optional permission: https://developer.chrome.com/docs/extensions/reference/permissions/#step-2-declare-optional-permissions-in-the-manifest

Resolves in-browser alert: 
![image](https://user-images.githubusercontent.com/9434920/149604010-cead17ac-42c8-47ea-9878-8ecbb62673c3.png)
