### PR TITLE
#5233: RedGIFs expandos do not expand when clicking "Show Images"

### DIFF
--- a/lib/modules/hosts/redgifs.js
+++ b/lib/modules/hosts/redgifs.js
@@ -40,6 +40,7 @@ export default new Host('redgifs', {
 				fixedRatio: false,
 				width: `${width}px`,
 				height: `${height}px`,
+				muted: true,
 			};
 		} catch (error) { // Fallback to a fixedRatio embed
 			return {
@@ -47,6 +48,7 @@ export default new Host('redgifs', {
 				embed: `${embed}?autoplay=0`,
 				embedAutoplay: embed,
 				fixedRatio: true,
+				muted: true,
 			};
 		}
 	},


### PR DESCRIPTION
This change is safe to make as RedGIFs are always muted even if they have audio.

<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: #5233
Tested in browser: Firefox
