### PR TITLE
trimmed title for image download to prevent leading whitespace

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1329,6 +1329,7 @@ export class Media {
 							let extension = ext[1];
 							if (extension.includes('?')) extension = extension.split('?')[0];
 							title = title.replace(/[*|?:"~<>\\\/]|(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/gi, '');
+							title = title.trim();
 							const filename = `${title}.${extension}`;
 							download(downloadUrl, filename);
 						} else download(downloadUrl);


### PR DESCRIPTION
Relevant issue: #5354
Tested in browser: Chrome version 97.0.4692.71
