### PR TITLE
Display user tags that have a colour without any text

### DIFF
--- a/lib/modules/userTagger.js
+++ b/lib/modules/userTagger.js
@@ -707,7 +707,7 @@ async function addDashboardFunctionality(tabPage) {
 		table.createSearchElement(tag => tag.text, 'Tag'),
 		table.createSelectFilterElement([
 			{ name: i18n('userTaggerAllUsers'), filter: () => true, initialSelected: false },
-			{ name: i18n('userTaggerTaggedUsers'), filter: tag => tag.text, initialSelected: true },
+			{ name: i18n('userTaggerTaggedUsers'), filter: tag => tag.text || tag.color, initialSelected: true },
 		]),
 		table.createPaginationElement(),
 		table.element,


### PR DESCRIPTION
Relevant issue: #5351 
Tested in browser: Chrome 97
