### PR TITLE
Reliably detect reddit gallery posts with a caption link

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -812,9 +812,8 @@ function resolveMediaUrl(element, thing) {
 	) {
 		// In old.reddit.com, a reddit gallery's title link can be misleadingly set
 		// to the source link in the gallery's caption instead of the normal reddit.com/gallery/<id> URL.
-		// The only reliable gallery detection is the "data-is-gallery" attribute in the Thing element.
-		const isGallery = thing.element.getAttribute('data-is-gallery') === 'true';
-		if (isGallery) {
+		// The only reliable way to detect a reddit gallery is to check the "data-is-gallery" attribute in the Thing element.
+		if (thing.element.dataset.isGallery === 'true') {
 			const galleryId = thing.getFullname().replace('t3_', '');
 			return new URL(`/gallery/${galleryId}`, location.href);
 		}

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -818,7 +818,7 @@ function resolveMediaUrl(element, thing) {
 			const galleryId = thing.getFullname().replace('t3_', '');
 			return new URL(`/gallery/${galleryId}`, location.href);
 		}
-		
+
 		const dataUrl = thing.element.getAttribute('data-url');
 		const fullDataUrl = dataUrl && new URL(dataUrl, location.href);
 		const commentLink = thing.getCommentsLink();

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -810,6 +810,15 @@ function resolveMediaUrl(element, thing) {
 		thing &&
 		element.classList.contains('title')
 	) {
+		// In old.reddit.com, a reddit gallery's title link can be misleadingly set
+		// to the source link in the gallery's caption instead of the normal reddit.com/gallery/<id> URL.
+		// The only reliable gallery detection is the "data-is-gallery" attribute in the Thing element.
+		const isGallery = thing.element.getAttribute('data-is-gallery') === 'true';
+		if (isGallery) {
+			const galleryId = thing.getFullname().replace('t3_', '');
+			return new URL(`/gallery/${galleryId}`, location.href);
+		}
+		
 		const dataUrl = thing.element.getAttribute('data-url');
 		const fullDataUrl = dataUrl && new URL(dataUrl, location.href);
 		const commentLink = thing.getCommentsLink();


### PR DESCRIPTION
In old.reddit.com, a reddit gallery's title link can be misleadingly set to the source link in the gallery's caption instead of the normal reddit.com/gallery/\<id\> URL. The only reliable indication that a post is a reddit gallery is by checking the "data-is-gallery" attribute in the Thing element.

An example of reddit gallery post with a mangled title link: https://old.reddit.com/r/manga/comments/stv143/disc_sir_liebe_von_trapp_ch_4_5_by_isiyumi/

Tested in browser: Chrome
