### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/core/migrate/migrate.js
+++ b/lib/core/migrate/migrate.js
@@ -92,7 +92,7 @@ const migrations = [
 				(subreddits || []).map(subreddit => {
 					const check = subreddit[0];
 					if (check.startsWith('/r/')) {
-						subreddit[0] = check.substr(3);
+						subreddit[0] = check.slice(3);
 					}
 					return subreddit;
 				}),

--- a/lib/modules/commentTools.js
+++ b/lib/modules/commentTools.js
@@ -576,13 +576,13 @@ export function makeEditBar() {
 						generatedTableSeparation += '-'.repeat(text.length);
 						generatedTableSeparation += '|';
 					});
-					generatedTableSeparation = generatedTableSeparation.substr(0, generatedTableSeparation.length - 1);
-					generatedTable = `${generatedTable.substr(0, generatedTable.length - 3)}\n${generatedTableSeparation}\n`;
+					generatedTableSeparation = generatedTableSeparation.slice(0, -1);
+					generatedTable = `${generatedTable.slice(0, -3)}\n${generatedTableSeparation}\n`;
 					$('tr:gt(0)', element).each(function() {
 						$(this).find('td').each(function() {
 							generatedTable += `${$(this).text().replace(/[\n|]/g, '')} | `;
 						});
-						generatedTable = `${generatedTable.substr(0, generatedTable.length - 3)}\n`;
+						generatedTable = `${generatedTable.slice(0, -3)}\n`;
 					});
 					if (isTable) {
 						replaceSelection(box, generatedTable);
@@ -1085,8 +1085,8 @@ const autoComplete = memoize(textarea => {
 	element.addEventListener('click', (e: MouseEvent) => {
 		const text = (e.target.closest('.choice') || e.target).textContent;
 		const caretPos = textarea.selectionStart;
-		let left = textarea.value.substr(0, caretPos);
-		const right = textarea.value.substr(caretPos);
+		let left = textarea.value.slice(0, caretPos);
+		const right = textarea.value.slice(caretPos);
 		left = left.replace(autoCompleteMatchRegExp, `$1${text} `);
 		textarea.value = left + right;
 		textarea.selectionStart = textarea.selectionEnd = left.length;

--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -252,12 +252,12 @@ function showEditForm() {
 	$('#RESDashboardEditComponent').css('top', `${eleTop}px`).css('left', '5px').css('width', `${eleWidth + 2}px`);
 	if (basePath.startsWith('/search?q=')) {
 		$('#editSearchDisplayName').val(widgetBeingEdited.displayName);
-		$('#editSearch').val(decodeURIComponent(basePath.substr(10)));
+		$('#editSearch').val(decodeURIComponent(basePath.slice(10)));
 		$('#editSearchForm').show();
 		$('#editRedditForm').hide();
 		$('#RESDashboardEditComponent').fadeIn('fast');
 	} else {
-		$('#editReddit').val(widgetBeingEdited.basePath.substr(3));
+		$('#editReddit').val(widgetBeingEdited.basePath.slice(3));
 		$('#editRedditDisplayName').val(widgetBeingEdited.displayName);
 		$('#editRedditForm').show();
 		$('#editSearchForm').hide();

--- a/lib/modules/easterEgg.js
+++ b/lib/modules/easterEgg.js
@@ -52,14 +52,14 @@ function createKonami(callback) {
 				konami.input += event.keyCode;
 
 				if (konami.input.length > konami.pattern.length) {
-					konami.input = konami.input.substr((konami.input.length - konami.pattern.length));
+					konami.input = konami.input.slice(-konami.pattern.length);
 				}
 
 				if (konami.input === konami.pattern) {
 					konami.code();
 					konami.input = '';
 					event.preventDefault();
-				} else if ((konami.input === konami.prepattern) || (konami.input.substr(2, konami.input.length) === konami.prepattern)) {
+				} else if ((konami.input === konami.prepattern) || (konami.input.slice(2) === konami.prepattern)) {
 					konami.almostThere = true;
 
 					setTimeout(() => {

--- a/lib/modules/hosts/redditgallery.js
+++ b/lib/modules/hosts/redditgallery.js
@@ -21,7 +21,7 @@ export default new Host('redditgallery', {
 			// `m` is something like `image/png`
 			const { m } = media_metadata[media_id] || {};
 			const type = m.startsWith('image') ? 'IMAGE' : 'Unknown';
-			return type === 'IMAGE' ? [{ type, caption, src: `https://i.redd.it/${media_id}.${m.substr(6)}` }] : undefined;
+			return type === 'IMAGE' ? [{ type, caption, src: `https://i.redd.it/${media_id}.${m.slice(6)}` }] : undefined;
 		});
 		if (!pieces.length) throw new Error('Gallery has no valid pieces.');
 		return { type: 'GALLERY', src: pieces };

--- a/lib/modules/hosts/wikipedia.js
+++ b/lib/modules/hosts/wikipedia.js
@@ -19,9 +19,9 @@ export default new Host('wikipedia', {
 	domains: ['wikipedia.org', 'wikipedia.com'],
 	logo: 'https://en.wikipedia.org/static/favicon/wikipedia.ico',
 	detect: url => (url.pathname.startsWith('/wiki/') && {
-		article: url.pathname.substr(6), // remove "/wiki/"
+		article: url.pathname.slice(6), // remove "/wiki/"
 		language: url.host.split('.')[0],
-		hash: decodeURIComponent(url.hash.substr(1)),
+		hash: decodeURIComponent(url.hash.slice(1)),
 	}),
 	async handleLink(href, { language, article, hash }) {
 		// Fix links with a www, or no lang code. These default to en

--- a/lib/modules/subredditManager.js
+++ b/lib/modules/subredditManager.js
@@ -395,12 +395,12 @@ function showSubredditGroupDropdown(obj) {
 			// for shortcuts like a/x+b/y, just split them a la pre-4.5.0
 			let pos;
 			if ((pos = cleanSubreddits.lastIndexOf('?')) > cleanSubreddits.lastIndexOf('+')) {
-				suffix = cleanSubreddits.substr(pos);
-				cleanSubreddits = cleanSubreddits.substr(0, pos);
+				suffix = cleanSubreddits.slice(pos);
+				cleanSubreddits = cleanSubreddits.slice(0, pos);
 			}
 			if ((pos = cleanSubreddits.lastIndexOf('/')) > cleanSubreddits.lastIndexOf('+')) { // check both existance and correct form (i.e. not foo/new+bar)
-				suffix = cleanSubreddits.substr(pos) + suffix;
-				cleanSubreddits = cleanSubreddits.substr(0, pos);
+				suffix = cleanSubreddits.slice(pos) + suffix;
+				cleanSubreddits = cleanSubreddits.slice(0, pos);
 			}
 		}
 		subreddits = cleanSubreddits.replace(/\?\+/g, '+').split('+');

--- a/lib/modules/userHighlight.js
+++ b/lib/modules/userHighlight.js
@@ -450,14 +450,14 @@ function doTextColor(selector, colorData) {
 
 function generateHoverColor(color) { // generate a darker color
 	if (!(/^#[0-9A-F]{6}$/i).test(color)) throw new Error('Input color must be a six digit hex value');
-	let R = parseInt(color.substr(1, 2), 16);
-	let G = parseInt(color.substr(3, 2), 16);
-	let B = parseInt(color.substr(5, 2), 16);
+	let R = parseInt(color.slice(1, 3), 16);
+	let G = parseInt(color.slice(3, 5), 16);
+	let B = parseInt(color.slice(5, 7), 16);
 	// R = R + 0.25 *(255-R); // 25% lighter
 	R = Math.round(0.75 * R) + 256; // we add 256 to add a 1 before the color in the hex format
 	G = Math.round(0.75 * G) + 256; // then we remove the 1, this have for effect to
 	B = Math.round(0.75 * B) + 256; // add a 0 before one char color in hex format (i.e. 0xA -> 0x10A -> 0x0A)
-	return `#${R.toString(16).substr(1)}${G.toString(16).substr(1)}${B.toString(16).substr(1)}`;
+	return `#${R.toString(16).slice(1)}${G.toString(16).slice(1)}${B.toString(16).slice(1)}`;
 }
 
 function generateHoverColors() { // apply generateHoverColor on all option

--- a/lib/options/settingsConsole.js
+++ b/lib/options/settingsConsole.js
@@ -585,7 +585,7 @@ function drawConfigOptions(mod) {
 			case 'color':
 				niceDefaultOption = option.default;
 				if (option.default.startsWith('#')) {
-					niceDefaultOption += ` (R:${parseInt(option.default.substr(1, 2), 16)}, G:${parseInt(option.default.substr(3, 2), 16)}, B:${parseInt(option.default.substr(5, 2), 16)})`;
+					niceDefaultOption += ` (R:${parseInt(option.default.slice(1, 3), 16)}, G:${parseInt(option.default.slice(3, 5), 16)}, B:${parseInt(option.default.slice(5, 7), 16)})`;
 				}
 				break;
 			case 'boolean':

--- a/lib/vendor/guiders.js
+++ b/lib/vendor/guiders.js
@@ -348,7 +348,7 @@ export const guiders = {};
     var GUIDER_HASH_TAG = "guider=";
     var hashIndex = window.location.hash.indexOf(GUIDER_HASH_TAG);
     if (hashIndex !== -1) {
-      var hashGuiderId = window.location.hash.substr(hashIndex + GUIDER_HASH_TAG.length);
+      var hashGuiderId = window.location.hash.slice(hashIndex + GUIDER_HASH_TAG.length);
       if (myGuider.id.toLowerCase() === hashGuiderId.toLowerCase()) {
         guiders.show(myGuider.id);
       }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.