### PR TITLE
Fixed: userInfo popup not showing on crossposts

### DIFF
--- a/lib/utils/user.js
+++ b/lib/utils/user.js
@@ -54,7 +54,7 @@ const usernameRE = /(?:u|user)\/([\w\-]{3,20}(?![\w\-]))/;
 
 export const usernameSelector = [
 	'.contents .author',
-	'p.tagline a.author',
+	'.tagline a.author',
 	'#friend-table span.user a',
 	'.sidecontentbox .author',
 	'div.md a[href^="/u/"]:not([href*="/m/"])',


### PR DESCRIPTION
In crossposted posts the user tag was not visible and the user info popup didn't show when hovering. See screenshot: https://i.imgur.com/MlAPJFT.png

The cause was that the element with CSS-class "tagline" is a <p> in normal posts, but it's a <div> in crospossted elements. Removing the element type on usernameSelector fixes this.

Another option would be to keep "p.tagline a.author" and add "div.tagline a.author".

Let me know if I missed anything and feel free to reject this PR and apply the fix on your own if that's easier.
Thanks.
