### PR TITLE
Fix YouTube's video pausing

### DIFF
--- a/lib/modules/hosts/youtube.js
+++ b/lib/modules/hosts/youtube.js
@@ -66,7 +66,7 @@ export default new Host('youtube', {
 			type: 'IFRAME',
 			embed: url.href,
 			embedAutoplay: `${url.href}&autoplay=1`,
-			pause: '{"event":"command","func":"pauseVideo","args":""}',
+			pause: '{"event":"command","func":"stopVideo","args":""}',
 			play: '{"event":"command","func":"playVideo","args":""}',
 			fixedRatio: true,
 		};

--- a/lib/modules/hosts/youtube.js
+++ b/lib/modules/hosts/youtube.js
@@ -32,6 +32,7 @@ export default new Host('youtube', {
 		const url = new URL(`https://www.youtube.com/embed/${id}`);
 		url.searchParams.set('version', '3');
 		url.searchParams.set('rel', '0');
+		url.searchParams.set('enablejsapi', '1');
 
 		const tParam = searchParams.get('t');
 		if (tParam) {
@@ -65,6 +66,8 @@ export default new Host('youtube', {
 			type: 'IFRAME',
 			embed: url.href,
 			embedAutoplay: `${url.href}&autoplay=1`,
+			pause: '{"event":"command","func":"pauseVideo","args":""}',
+			play: '{"event":"command","func":"playVideo","args":""}',
 			fixedRatio: true,
 		};
 	},


### PR DESCRIPTION
Relevant issue: #5364
Tested in browser: Firefox 90.0.1/99.0.1

No pause/play commands were defined for YouTube. This PR adds such commands, accessible through the [iframe API](https://developers.google.com/youtube/iframe_api_reference)