### PR TITLE
Add new configuration options to allow use of raw twitch clips

### DIFF
--- a/lib/modules/hosts/twitchclips.js
+++ b/lib/modules/hosts/twitchclips.js
@@ -61,8 +61,8 @@ export default new Host('twitchclips', {
 		},
 	},
 	async handleLink(href, [, clipId]) {
-		function _embeddedTwitchPlayer(clipId) {
-			const embed = `https://clips.twitch.tv/embed?clip=${clipId}&parent=${location.hostname}`;
+		function _embeddedTwitchPlayer(_clipId) {
+			const embed = `https://clips.twitch.tv/embed?clip=${_clipId}&parent=${location.hostname}`;
 			return {
 				type: 'IFRAME',
 				embed: `${embed}&autoplay=false`,
@@ -119,7 +119,7 @@ export default new Host('twitchclips', {
 			const parsedUrl = new URL(sourceUrl);
 			parsedUrl.searchParams.append('sig', rawTwitchClipMetadata.data.clip.playbackAccessToken.signature);
 			parsedUrl.searchParams.append('token', rawTwitchClipMetadata.data.clip.playbackAccessToken.value);
-			sourceUrl = new URL(parsedUrl).href;
+			sourceUrl = parsedUrl.href;
 		}
 
 		return {

--- a/lib/modules/hosts/twitchclips.js
+++ b/lib/modules/hosts/twitchclips.js
@@ -1,6 +1,10 @@
 /* @flow */
-
-import { Host } from '../../core/host';
+import {
+	Host,
+} from '../../core/host';
+import {
+	ajax,
+} from '../../environment';
 
 export default new Host('twitchclips', {
 	name: 'twitch.tv clips',
@@ -17,15 +21,110 @@ export default new Host('twitchclips', {
 	// (www.)twitch.tv domain:
 	//   support clip name as a subcomponent of a channel URL
 	//   ex: www.twitch.tv/<CHANNEL_NAME>/clip/<CLIP_NAME>
-	detect: ({ hostname, pathname }) => hostname === 'clips.twitch.tv' ? (/^\/(\w+(?:\/[A-Z]\w+)?(?:[\-\w]*))(?:\/|$)/).exec(pathname) : (/^\/\w+\/clip\/(\w+(?:\/[A-Z]\w+)?(?:[\-\w]*))(?:\/|$)/).exec(pathname),
-	handleLink(href, [, clipId]) {
-		const embed = `https://clips.twitch.tv/embed?clip=${clipId}&parent=${location.hostname}`;
+	detect: ({
+		hostname,
+		pathname,
+	}) => hostname === 'clips.twitch.tv' ? (/^\/(\w+(?:\/[A-Z]\w+)?(?:[\-\w]*))(?:\/|$)/).exec(pathname) : (/^\/\w+\/clip\/(\w+(?:\/[A-Z]\w+)?(?:[\-\w]*))(?:\/|$)/).exec(pathname),
+	options: {
+		forceRawTwitchClipVideo: {
+			title: 'showImagesForceRawTwitchClipTitle',
+			description: 'showImagesForceRawTwitchClipDesc',
+			value: false,
+			type: 'boolean',
+		},
+		rawTwitchClipQualityPreference: {
+			title: 'showImagesrawTwitchClipQualityPreferenceTitle',
+			description: 'showImagesrawTwitchClipQualityPreferenceDesc',
+			type: 'enum',
+			value: 'highest',
+			values: [{
+				name: 'Highest available',
+				value: 'highest',
+			}, {
+				name: 'Lowest available',
+				value: 'lowest',
+			}],
+		},
+		rawTwitchClipAlternativeUrlToggle: {
+			title: 'showImagesRawTwitchClipAlternativeUrlToggleTitle',
+			description: 'showImagesRawTwitchClipAlternativeUrlToggleDesc',
+			value: false,
+			type: 'boolean',
+		},
+		rawTwitchClipAlternativeUrl: {
+			title: 'showImagesRawTwitchClipAlternativeUrlTitle',
+			description: 'showImagesRawTwitchClipAlternativeUrlDesc',
+			type: 'text',
+			// deliberately not setting a default value as third party sites may change
+			// one example to be manually configured is https://clipstream.spacex.workers.dev/clips/
+			value: '',
+		},
+	},
+	async handleLink(href, [, clipId]) {
+		function _embeddedTwitchPlayer(clipId) {
+			const embed = `https://clips.twitch.tv/embed?clip=${clipId}&parent=${location.hostname}`;
+			return {
+				type: 'IFRAME',
+				embed: `${embed}&autoplay=false`,
+				embedAutoplay: `${embed}&autoplay=true`,
+				fixedRatio: true,
+			};
+		}
+
+		if (!this.options.forceRawTwitchClipVideo.value) {
+			return _embeddedTwitchPlayer(clipId);
+		}
+
+		const rawTwitchClipMetadataContainer = await ajax({
+			method: 'POST',
+			url: 'https://gql.twitch.tv/gql',
+			data: JSON.stringify([{
+				query: `query ClipInfo($slug: ID!) {
+					clip(slug: $slug) {
+						rawVideoQualities {
+							quality
+							sourceURL
+						}
+						thumbnailURL(width: 480, height: 272)
+					}
+				}`,
+				variables: {
+					slug: clipId,
+				},
+			}]),
+			headers: {
+				'Client-ID': 'kimne78kx3ncx6brgo4mv6wki5h1ko',
+			},
+			type: 'json',
+		});
+		const rawTwitchClipMetadata = rawTwitchClipMetadataContainer[0];
+
+		// no raw video quality available, return embedded Twitch player
+		if (!Array.isArray(rawTwitchClipMetadata.data.clip.rawVideoQualities) || rawTwitchClipMetadata.data.clip.rawVideoQualities.length === 0) {
+			return _embeddedTwitchPlayer(clipId);
+		}
+
+		// defaults to the highest (first) available quality
+		let selectedRawVideoQuality = rawTwitchClipMetadata.data.clip.rawVideoQualities[0];
+		if (this.options.rawTwitchClipQualityPreference.value === 'lowest') {
+			const lastQualityIndex = rawTwitchClipMetadata.data.clip.rawVideoQualities.length - 1;
+			selectedRawVideoQuality = rawTwitchClipMetadata.data.clip.rawVideoQualities[lastQualityIndex];
+		}
+
+		let sourceUrl = selectedRawVideoQuality.sourceURL;
+		if (this.options.rawTwitchClipAlternativeUrlToggle.value && this.options.rawTwitchClipAlternativeUrl.value) {
+			sourceUrl = sourceUrl.replace('https://clips-media-assets2.twitch.tv/raw_media/', this.options.rawTwitchClipAlternativeUrl.value);
+		}
 
 		return {
-			type: 'IFRAME',
-			embed: `${embed}&autoplay=false`,
-			embedAutoplay: `${embed}&autoplay=true`,
-			fixedRatio: true,
+			type: 'VIDEO',
+			loop: true,
+			muted: false,
+			sources: [{
+				source: sourceUrl,
+				type: 'video/mp4',
+			}],
+			poster: rawTwitchClipMetadata.data.clip.thumbnailURL,
 		};
 	},
 });

--- a/lib/modules/hosts/twitchclips.js
+++ b/lib/modules/hosts/twitchclips.js
@@ -78,20 +78,20 @@ export default new Host('twitchclips', {
 		const rawTwitchClipMetadataContainer = await ajax({
 			method: 'POST',
 			url: 'https://gql.twitch.tv/gql',
-			data: JSON.stringify([{
-				query: `query ClipInfo($slug: ID!) {
-					clip(slug: $slug) {
-						rawVideoQualities {
-							quality
-							sourceURL
-						}
-						thumbnailURL(width: 480, height: 272)
-					}
-				}`,
-				variables: {
-					slug: clipId,
+			data: JSON.stringify([
+				{
+					operationName: 'VideoAccessToken_Clip',
+					variables: {
+						slug: clipId,
+					},
+					extensions: {
+						persistedQuery: {
+							version: 1,
+							sha256Hash: '36b89d2507fce29e5ca551df756d27c1cfe079e2609642b4390aa4c35796eb11',
+						},
+					},
 				},
-			}]),
+			]),
 			headers: {
 				'Client-ID': 'kimne78kx3ncx6brgo4mv6wki5h1ko',
 			},
@@ -100,20 +100,26 @@ export default new Host('twitchclips', {
 		const rawTwitchClipMetadata = rawTwitchClipMetadataContainer[0];
 
 		// no raw video quality available, return embedded Twitch player
-		if (!Array.isArray(rawTwitchClipMetadata.data.clip.rawVideoQualities) || rawTwitchClipMetadata.data.clip.rawVideoQualities.length === 0) {
+		if (!Array.isArray(rawTwitchClipMetadata.data.clip.videoQualities) ||
+				rawTwitchClipMetadata.data.clip.videoQualities.length === 0) {
 			return _embeddedTwitchPlayer(clipId);
 		}
 
 		// defaults to the highest (first) available quality
-		let selectedRawVideoQuality = rawTwitchClipMetadata.data.clip.rawVideoQualities[0];
+		let selectedRawVideoQuality = rawTwitchClipMetadata.data.clip.videoQualities[0];
 		if (this.options.rawTwitchClipQualityPreference.value === 'lowest') {
-			const lastQualityIndex = rawTwitchClipMetadata.data.clip.rawVideoQualities.length - 1;
-			selectedRawVideoQuality = rawTwitchClipMetadata.data.clip.rawVideoQualities[lastQualityIndex];
+			const lastQualityIndex = rawTwitchClipMetadata.data.clip.videoQualities.length - 1;
+			selectedRawVideoQuality = rawTwitchClipMetadata.data.clip.videoQualities[lastQualityIndex];
 		}
 
 		let sourceUrl = selectedRawVideoQuality.sourceURL;
 		if (this.options.rawTwitchClipAlternativeUrlToggle.value && this.options.rawTwitchClipAlternativeUrl.value) {
-			sourceUrl = sourceUrl.replace('https://clips-media-assets2.twitch.tv/raw_media/', this.options.rawTwitchClipAlternativeUrl.value);
+			sourceUrl = sourceUrl.replace('https://production.assets.clips.twitchcdn.net/', this.options.rawTwitchClipAlternativeUrl.value);
+		} else {
+			const parsedUrl = new URL(sourceUrl);
+			parsedUrl.searchParams.append('sig', rawTwitchClipMetadata.data.clip.playbackAccessToken.signature);
+			parsedUrl.searchParams.append('token', rawTwitchClipMetadata.data.clip.playbackAccessToken.value);
+			sourceUrl = new URL(parsedUrl).href;
 		}
 
 		return {

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -4366,6 +4366,30 @@
 	"showImagesForceReplaceNativeExpandoTitle": {
 		"message": "Force Replace Native Expando"
 	},
+    "showImagesForceRawTwitchClipTitle": {
+		"message": "Raw Twitch clips"
+	},
+    "showImagesForceRawTwitchClipDesc": {
+		"message": "Use the raw Twitch clip URL instead of the embedded player."
+	},
+  	"showImagesrawTwitchClipQualityPreferenceTitle": {
+		"message": "Raw Twitch clips quality"
+	},
+    "showImagesrawTwitchClipQualityPreferenceDesc": {
+		"message": "Determines whether to use the highest or lowest resolution for raw Twitch clips."
+	},
+    "showImagesRawTwitchClipAlternativeUrlToggleTitle": {
+		"message": "Raw Twitch clip proxy"
+	},
+    "showImagesRawTwitchClipAlternativeUrlToggleDesc": {
+		"message": "Toggles the option to use a proxy for raw Twitch clips."
+	},
+  	"showImagesRawTwitchClipAlternativeUrlTitle": {
+		"message": "Raw Twitch clip proxy url"
+	},
+    "showImagesRawTwitchClipAlternativeUrlDesc": {
+		"message": "Use this url as a proxy for raw Twitch clips. Useful for accessing cached deleted clips."
+	},
 	"showImagesForceReplaceNativeExpandoDesc": {
 		"message": "Always replace Reddit's player."
 	},


### PR DESCRIPTION
- Toggle to disable using the default embedded player
- Option to alternate between the highest/lowest quality
- Toggle/configuration for a proxied raw twitch clip domain
- Added English translations for added options

Tested in browser: Chrome, Firefox

By default, this feature is disabled, and the regular twitch embedded player is used:
![image](https://user-images.githubusercontent.com/22506439/191644042-e588411b-ff32-4360-beeb-fd24d1e068fa.png)

When configured, it may look like this:
![image](https://user-images.githubusercontent.com/22506439/191644102-1f5bc08b-51ba-4868-9fdd-d162374d0f88.png)

Here is a short video showing the differences:
https://user-images.githubusercontent.com/22506439/191645125-481c21f1-4486-4b01-9fad-f864394af3e0.mp4




