### PR TITLE
Add YouTube clips "expando"

### DIFF
--- a/lib/modules/hosts/youtubeclips.js
+++ b/lib/modules/hosts/youtubeclips.js
@@ -13,13 +13,10 @@ export default new Host('youtubeclips', {
 		return clipId;
 	},
 	async handleLink(href, clipId) {
-		const youtubeResponseBody = await ajax({
-			url: `https://web.scraper.workers.dev/?url=https://www.youtube.com/clip/${clipId}&selector=body`,
+		const {iframeUrl} = await ajax({
+			url: `https://youtube-clip-embed-extractor.544146.workers.dev/?clipId=${clipId}`,
 			type: 'json',
 		});
-
-		const [ytInitialPlayerResponse] = youtubeResponseBody.result.body[0].match(/(?<=var ytInitialPlayerResponse = ).*?}(?=;)/);
-		const { microformat: { playerMicroformatRenderer: { embed: { iframeUrl } } } } = JSON.parse(ytInitialPlayerResponse);
 
 		const url = new URL(iframeUrl);
 		url.searchParams.append('version', '3');

--- a/lib/modules/hosts/youtubeclips.js
+++ b/lib/modules/hosts/youtubeclips.js
@@ -1,0 +1,40 @@
+/* @flow */
+import { Host } from '../../core/host';
+import { ajax } from '../../environment';
+
+export default new Host('youtubeclips', {
+	name: 'youtube clips',
+	attribution: false,
+	// `https://youtube.com/clip/UgkxflsQSOP0_GmchSvIeAbqdHF3MzI_y2Pm`
+	domains: ['youtube.com'],
+	detect: ({ pathname }) => {
+		// Example pathname: `/clip/UgkxflsQSOP0_GmchSvIeAbqdHF3MzI_y2Pm`
+		const [clipId] = pathname.match(/(?<=\/clip\/)[\w-]{36}/);
+		return clipId;
+	},
+	async handleLink(href, clipId) {
+		const youtubeResponseBody = await ajax({
+			url: `https://web.scraper.workers.dev/?url=https://www.youtube.com/clip/${clipId}&selector=body`,
+			type: 'json',
+		});
+
+		const [ytInitialPlayerResponse] = youtubeResponseBody.result.body[0].match(/(?<=var ytInitialPlayerResponse = ).*?}(?=;)/);
+		const { microformat: { playerMicroformatRenderer: { embed: { iframeUrl } } } } = JSON.parse(ytInitialPlayerResponse);
+
+		const url = new URL(iframeUrl);
+		url.searchParams.append('version', '3');
+		url.searchParams.append('rel', '0');
+		url.searchParams.append('enablejsapi', '1');
+
+		return {
+			type: 'IFRAME',
+			embed: url.href,
+			embedAutoplay: `${url.href}&autoplay=1`,
+			pause: '{"event":"command","func":"stopVideo","args":""}',
+			play: '{"event":"command","func":"playVideo","args":""}',
+			fixedRatio: true,
+		};
+	},
+});
+
+

--- a/lib/modules/hosts/youtubeclips.js
+++ b/lib/modules/hosts/youtubeclips.js
@@ -9,7 +9,7 @@ export default new Host('youtubeclips', {
 	domains: ['youtube.com'],
 	detect: ({ pathname }) => {
 		// Example pathname: `/clip/UgkxflsQSOP0_GmchSvIeAbqdHF3MzI_y2Pm`
-		const [clipId] = pathname.match(/(?<=\/clip\/)[\w-]{36}/);
+		const [clipId] = (/(?<=\/clip\/)[\w-]{36}/).exec(pathname) || [null];
 		return clipId;
 	},
 	async handleLink(href, clipId) {


### PR DESCRIPTION
- Can now expand and watch YouTube clips
- Supports full embedded player functionality

Image of the new expando option:
![image](https://user-images.githubusercontent.com/22506439/191857313-2fcec81b-42fa-47a2-9552-9bc6dc40d89e.png)

Video demo to see it in action;
https://user-images.githubusercontent.com/22506439/191857353-ee5bff89-7aef-4488-882c-73b3de544c99.mp4

I see there is an existing old implementation in #5358, which may still work.  It however uses `https://opengraph.io/` and requires an `app_id` query parameter to extract the embed link, in contrast, the implementation in this PR uses `https://web.scraper.workers.dev/` to do the same thing, just without any required authentication.  

With that being said, it is a third-party dependency and could stop working or change it's underlying functionality, it may also end up hitting issues given YouTube's underlying implementation changes, although it is working at this time of raising this PR.

Relevant issue: #5344 
Other implementations: #5358 
Tested in browser: Chrome, Firefox
