### PR TITLE
Move invisible comment-expand text off-screen

### DIFF
--- a/lib/css/modules/_commentQuickCollapse.scss
+++ b/lib/css/modules/_commentQuickCollapse.scss
@@ -49,5 +49,6 @@
 	.comment > .entry > .tagline > .expand:hover,
 	.comment > .entry > .tagline > .expand {
 		color: transparent !important;
+		text-indent: -9999px;
 	}
 }


### PR DESCRIPTION
This prevents clicks on the upvote arrow from registering on the invisible text when quick collapse is enabled.

I have only tested this with developer tools; I don't have a cloned repo.
