### PR TITLE
prevent neverEndingComments from loading duplicate comments

### DIFF
--- a/lib/modules/neverEndingComments.js
+++ b/lib/modules/neverEndingComments.js
@@ -30,7 +30,9 @@ module.afterLoad = () => {
 	const io = new IntersectionObserver(entries => {
 		for (const { isIntersecting, target } of entries) {
 			if (!context.contains(target)) io.unobserve(target);
-			if (isIntersecting) visibleLoaders.add(target);
+			const isLoading = target.innerText.includes('loading');
+
+			if (isIntersecting && !isLoading) visibleLoaders.add(target);
 			else visibleLoaders.delete(target);
 		}
 


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: https://www.reddit.com/r/Enhancement/comments/l1boqd/comments_duplicating_in_never_ending_reddit/
Tested in browser: chrome

To reproduce:
1. scroll to bottom of page, wait for /api/morechildren request to send
2. scroll up until the red loading... text exits the bottom of the viewport
3. scroll back down. A 2nd /api/morechildren request should be sent, causing duplicate comments.

Solution is to ensure that the same loader link is never clicked twice.

My current implementation is to check if the loader link has the loading text, if so then ignore it. 

It works, but will there be any issues with translations? Like will the loading text check fail for spanish users, etc? 
