### PR TITLE
Update showImages.js to fix google reverse image search URL

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1355,7 +1355,7 @@ export class Media {
 					lookupUrl = new URL(downcast(lookupUrl, 'string'), location.href).href;
 
 					// Escape query string parameters
-					openNewTab(string.encode`https://images.google.com/searchbyimage?image_url=${lookupUrl}`);
+					openNewTab(string.encode`https://images.google.com/searchbyimage?client=app&image_url=${lookupUrl}`);
 					break;
 				case 'showImageSettings':
 					SettingsNavigation.open(module.moduleID, 'mediaControls');


### PR DESCRIPTION
Google added a required `client` parameter to this type of reverse image search, noted at https://webapps.stackexchange.com/questions/167766/reverse-google-image-search-via-url-after-2022-switch-to-google-lens