### PR TITLE
Fix styling issues for subreddit names and fixed an issue with comment styles on profile overview page

### DIFF
--- a/lib/css/modules/_nightMode.scss
+++ b/lib/css/modules/_nightMode.scss
@@ -591,6 +591,7 @@ $title-link-visited-color: hsl(0, 0%, 65%);
 
 	a,
 	.md a,
+	.pagename a,
 	.share-button .option,
 	#subscribe a,
 	.share .option,

--- a/lib/modules/commentStyle.js
+++ b/lib/modules/commentStyle.js
@@ -56,7 +56,7 @@ module.options = {
 module.include = [
 	'profile',
 	'comments',
-	'commentsLinklist'
+	'commentsLinklist',
 ];
 
 module.exclude = [

--- a/lib/modules/commentStyle.js
+++ b/lib/modules/commentStyle.js
@@ -54,8 +54,9 @@ module.options = {
 };
 
 module.include = [
+	'profile',
 	'comments',
-	'commentsLinklist',
+	'commentsLinklist'
 ];
 
 module.exclude = [


### PR DESCRIPTION
Relevant issues: 
fixes #5419, see https://github.com/honestbleeps/Reddit-Enhancement-Suite/issues/5419
fixes #5415, see https://github.com/honestbleeps/Reddit-Enhancement-Suite/issues/5415

Tested in browser: Chrome, Firefox

Solutions:

#5419, added a selector to target the specific element and to correctly modify its color to match other header links
#5415,  included the 'profile' page type into the commentStyle module to gain access to the relevant stylings that the comment page has.

