### PR TITLE
Fix Strawpoll.com expandos not handling URLs with 'polls' in the path correctly

### DIFF
--- a/lib/modules/hosts/strawpollcom.js
+++ b/lib/modules/hosts/strawpollcom.js
@@ -6,7 +6,7 @@ export default new Host('strawpoll.com', {
 	name: 'strawpoll.com',
 	domains: ['strawpoll.com'],
 	attribution: false,
-	detect: ({ pathname }) => (/^\/(?:embed\/)?([a-z0-9]+)/i).exec(pathname),
+	detect: ({ pathname }) => (/^\/(?:embed\/)?(?:polls\/)?([a-z0-9]+)/i).exec(pathname),
 	handleLink(href, [, id]) {
 		return {
 			type: 'IFRAME',


### PR DESCRIPTION
The following URL formats are currently handled:

- `https://strawpoll.com/{id}`
- `https://strawpoll.com/embed/{id}`

However, Strawpoll.com also allows URLs in the following formats, which this pull request adds handling for:

- `https://strawpoll.com/polls/{id}`
- `https://strawpoll.com/embed/polls/{id}`

Without this change, the latter two URLs would display an expando for an incorrect poll.