### PR TITLE
Embed YouTube Shorts

### DIFF
--- a/lib/modules/hosts/youtube.js
+++ b/lib/modules/hosts/youtube.js
@@ -13,6 +13,8 @@ export default new Host('youtube', {
 		const split = pathname.substring(1).split('/');
 		// livestream channel url
 		if (split[0] === 'channel' && split[2] === 'live') return [`live_stream?channel=${split[1]}`, searchParams];
+		// shorts url
+		if (split[0] === 'shorts') return [split[1], searchParams];
 		// short url
 		if (hostname.endsWith('youtu.be')) return [split[0], searchParams];
 		// long url


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: 
Tested in browser: Firefox Nightly 113.0a1

This adds support for embedding YouTube videos from a shorts URL.