### PR TITLE
Revert ID change to 9 and 10

### DIFF
--- a/lib/utils/watchers.js
+++ b/lib/utils/watchers.js
@@ -77,7 +77,7 @@ function registerThing(element: HTMLElement) {
 	// Loading additional things ("load more comments", neverEndingReddit) may cause repeating posts; remove those
 	const id = thing.getFullname();
 	// Some posts may not have a have an id, e.g. those that are deleted or placeholders
-	if (id.length === 9 || id.length === 10) { // valid ids have 9 and 10 characters
+	if (id.length === 9) { // valid ids have 9 characters
 		const existing = dupeSet.get(id);
 		if (existing === element) return; // `registerThing` is being run on an already added thing
 		if (existing && document.contains(existing)) {


### PR DESCRIPTION
Fix did not resolve dupes in NER and caused further breakage. The dupe issue appears to be Reddit API side from what I can tell.