### PR TITLE
Add captions to reddit gallery expandos

### DIFF
--- a/lib/modules/hosts/redditgallery.js
+++ b/lib/modules/hosts/redditgallery.js
@@ -13,6 +13,7 @@ export default new Host('redditgallery', {
 	async handleLink(href, [, id]) {
 		const {
 			media_metadata = {},
+			selftext_html,
 			gallery_data: {
 				items = [],
 			} = {},
@@ -24,6 +25,6 @@ export default new Host('redditgallery', {
 			return type === 'IMAGE' ? [{ type, caption, src: `https://i.redd.it/${media_id}.${m.substr(6)}` }] : undefined;
 		});
 		if (!pieces.length) throw new Error('Gallery has no valid pieces.');
-		return { type: 'GALLERY', src: pieces };
+		return { type: 'GALLERY', src: pieces, caption: selftext_html && selftext_html.replace(/<\/?p>/g, '') };
 	},
 });


### PR DESCRIPTION
Reddit posts with multiple images can also have selftext, which is replaced by expandos / doesn't display in post list views.
Pass through the selftext_html as per #5444.

Tested in browser: Chrome 111.0.5563.147