### PR TITLE
Get captions for crossposted reddit media

### DIFF
--- a/lib/modules/hosts/ireddit.js
+++ b/lib/modules/hosts/ireddit.js
@@ -9,7 +9,11 @@ export default new Host('ireddit', {
 	attribution: false,
 	detect({ pathname }, thing) { return (/\.(webp|gif|jpe?g|png|svg)$/i).test(pathname) && thing && thing.isLinkPost() && thing.getFullname(); },
 	async handleLink(href, fullname) {
-		const postMetadata = await getPostMetadata({ id: fullname.replace('t3_', '') });
+		let postMetadata = await getPostMetadata({ id: fullname.replace('t3_', '') });
+		// Pick out original metadata if this is a crosspost
+		if (postMetadata.crosspost_parent_list && postMetadata.crosspost_parent_list.length > 0) {
+			postMetadata = postMetadata.crosspost_parent_list[0];
+		}
 		if (!postMetadata.preview) throw new Error('Post has no preview.');
 		const preview = postMetadata.preview.images[0];
 		if (preview.variants.mp4) {

--- a/lib/modules/hosts/vreddit.js
+++ b/lib/modules/hosts/vreddit.js
@@ -55,7 +55,11 @@ export default new Host('vreddit', {
 		if (!videoSourcesByBandwidth.length) throw new Error('Video has no valid sources');
 
 		// Get postMetadata for video caption
-		const postMetadata = await getPostMetadata({ id: fullname.replace('t3_', '') });
+		let postMetadata = await getPostMetadata({ id: fullname.replace('t3_', '') });
+		// Pick out original metadata if this is a crosspost
+		if (postMetadata.crosspost_parent_list && postMetadata.crosspost_parent_list.length > 0) {
+			postMetadata = postMetadata.crosspost_parent_list[0];
+		}
 
 		const sources = (muted && id) ?
 			videoSourcesByBandwidth.map(rep => ({

--- a/lib/types/reddit.js
+++ b/lib/types/reddit.js
@@ -105,6 +105,7 @@ export type RedditLink = {
 				},
 			}>,
 		},
+		crosspost_parent_list?: Array<$PropertyType<RedditLink, 'data'>>,
 		selftext?: string,
 		selftext_html?: string,
 	},


### PR DESCRIPTION
A crosspost doesn't copy selftext but it can be retrieved via `crosspost_parent_list`.

It was a bit of a pain specifying the exact type of the list but I think this is the right way and `yarn flow check` is happy.

Relevant issue: https://www.reddit.com/r/RESissues/comments/zqvuis/inline_image_viewer_missing_text/jfb22mn/
Tested in browser: 111.0.5563.147