### PR TITLE
Add module "Submission Shortcuts"

### DIFF
--- a/lib/modules/submissionShortcuts.js
+++ b/lib/modules/submissionShortcuts.js
@@ -1,0 +1,51 @@
+/* @flow */
+import $ from 'jquery';
+import { Module } from '../core/module';
+import { checkKeysForEvent, click } from '../utils';
+
+export const module: Module<*> = new Module('submissionShortcuts');
+
+module.moduleName = 'submissionShortcutsName';
+module.category = 'submissionsCategory';
+module.description = 'submissionShurtcutsDesc';
+module.options = {
+	markSpammed: {
+		type: 'keycode',
+		value: [70, true, false, false, false], // alt-f
+		description: 'submissionShortcutsMarkSpammedDesc',
+		title: 'submissionShortcutsMarkSpammedTitle',
+		mustBeLoggedIn: true,
+		buttonSelector: '.icon-spam',
+	},
+	remove: {
+		type: 'keycode',
+		value: [68, true, false, false, false], // alt-d
+		description: 'submissionShortcutsRemoveDesc',
+		title: 'submissionShortcutsRemoveTitle',
+		mustBeLoggedIn: true,
+		buttonSelector: '.icon-remove',
+	},
+	markApproved: {
+		type: 'keycode',
+		value: [63, true, false, false, false], // alt-s
+		description: 'submissionShortcutsMarkApprovedDesc',
+		title: 'submissionShortcutsMarkApprovedTitle',
+		mustBeLoggedIn: true,
+		buttonSelector: '.icon-approve',
+	},
+
+};
+
+module.contentStart = () => {
+	$(document.body).on('keydown', (e: KeyboardEvent) => {
+		Object.values(module.options).forEach(shortcut => {
+			if (checkKeysForEvent(e, shortcut.value)) {
+				const iconElement = document.querySelector(`:focus ${shortcut.buttonSelector}`);
+
+				if (iconElement) {
+					click(iconElement.parentNode);
+				}
+			}
+		});
+	});
+};

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -4456,10 +4456,34 @@
 	"quarantineHideFlairDesc": {
 		"message": "Hide \"Quarantined\" post flair (regardless of where the post is being viewed from)"
 	},
-    "quarantineHideInSubTitle": {
-        "message": "Hide subreddit warnings"
-    },
-    "quarantineHideInSubDesc": {
-        "message": "Hide all warnings of quarantine while viewing a quarantined subreddit"
-    }
+	"quarantineHideInSubTitle": {
+		"message": "Hide subreddit warnings"
+	},
+	"quarantineHideInSubDesc": {
+		"message": "Hide all warnings of quarantine while viewing a quarantined subreddit"
+	},
+	"submissionShortcutsName": {
+		"message": "Submission Shortcuts"
+	},
+	"submissionShurtcutsDesc": {
+		"message": "Add shortcuts to the currently focused submission."
+	},
+	"submissionShortcutsMarkSpammedDesc": {
+		"message": "Mark focused submission as spammed."
+	},
+	"submissionShortcutsMarkSpammedTitle": {
+		"message": "Mark as spammed"
+	},
+	"submissionShortcutsMarkApprovedDesc": {
+		"message": "Mark focused submission as approved."
+	},
+	"submissionShortcutsMarkApprovedTitle": {
+		"message": "Approve"
+	},
+	"submissionShortcutsRemoveDesc": {
+		"message": "Remove focused submission."
+	},
+	"submissionShortcutsRemoveTitle": {
+		"message": "Remove"
+	}
 }


### PR DESCRIPTION
## This PR adds the module "Submission Shortcuts":

Moderation is tedious, especially if you rely on the submission buttons to approve, remove or mark submissions as spam. For that reason, this module has been added to ease moderation with shortcuts:

   ![image](https://user-images.githubusercontent.com/13122796/233546550-464f296c-c272-4369-b930-b5f9fc4c78e7.png)


### Note

- This PR does not consider the alphabetic order in the locales file.
- There is no extensive use of existing utilities of RES but instead of regular browser features (such as querySelector)
- The feature does not work outside of submissions on feeds
- This module does not specify on moderation, but shortcuts for moderation have been implemented for the initial release.
- Tested in browser Microsoft Edge

