### PR TITLE
Also clear cite errors in Wikipedia

### DIFF
--- a/lib/modules/hosts/wikipedia.js
+++ b/lib/modules/hosts/wikipedia.js
@@ -37,7 +37,7 @@ export default new Host('wikipedia', {
 		const cleanDoc = new DOMParser().parseFromString(html.text['*'], 'text/html');
 
 		// Remove unwanted sections
-		for (const e of cleanDoc.querySelectorAll('.metadata, .hatnote, .mw-editsection, .mwe-math-mathml-inline, .reference, .references')) e.remove();
+		for (const e of cleanDoc.querySelectorAll('.metadata, .hatnote, .mw-editsection, .mw-ext-cite-error, .mwe-math-mathml-inline, .reference, .references')) e.remove();
 
 		// Update all links to use the article's URL as baseURL
 		for (const e of cleanDoc.querySelectorAll('a')) {


### PR DESCRIPTION
Relevant issue: Often these errors appear because a notelist appears in the article but not in the lede. 
Tested in browser: Waterfox with [this post](https://www.reddit.com/r/todayilearned/comments/14awpft/til_that_gerard_way_started_my_chemical_romance/)
