### PR TITLE
Update showImages.js to fix google reverse image search URL

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1348,7 +1348,7 @@ export class Media {
 					lookupUrl = new URL(downcast(lookupUrl, 'string'), location.href).href;
 
 					// Escape query string parameters
-					openNewTab(string.encode`https://images.google.com/searchbyimage?client=app&image_url=${lookupUrl}`);
+					openNewTab(string.encode`https://images.google.com/searchbyimage?client=app&sbisrc=cr_1_5_2&image_url=${lookupUrl}`);
 					break;
 				case 'showImageSettings':
 					SettingsNavigation.open(module.moduleID, 'mediaControls');


### PR DESCRIPTION
Google added an additional `sbisrc` parameter to continue to access the non-Lens type of reverse image search