### PR TITLE
Add support for twitter e𝕏pandos on 𝕏.com links (twitter rename)

### DIFF
--- a/lib/modules/hosts/twitter.js
+++ b/lib/modules/hosts/twitter.js
@@ -6,10 +6,10 @@ import { ajax } from '../../environment';
 
 export default new Host('twitter', {
 	name: 'twitter',
-	domains: ['twitter.com'],
+	domains: ['twitter.com', 'x.com'],
 	permissions: ['https://publish.twitter.com/oembed'],
 	attribution: false,
-	detect: ({ href }) => (/^https?:\/\/(?:mobile\.)?(twitter|x)\.com\/(?:#!\/)?[\w]+\/status\/?[\w]+/i).exec(href),
+	detect: ({ href }) => (/^https?:\/\/(?:mobile\.)?(twitter|x)\.com\/(?:#!\/)?[\w]+\/status\/?[\w]+/i).exec(href.replace("x.com", "twitter.com")),
 	async handleLink(href, [url]) {
 		// we have to omit the script tag and all of the nice formatting it brings us in Firefox
 		// because AMO does not permit externally hosted script tags being pulled in from

--- a/lib/modules/hosts/twitter.js
+++ b/lib/modules/hosts/twitter.js
@@ -9,7 +9,7 @@ export default new Host('twitter', {
 	domains: ['twitter.com', 'x.com'],
 	permissions: ['https://publish.twitter.com/oembed'],
 	attribution: false,
-	detect: ({ href }) => (/^https?:\/\/(?:mobile\.)?(twitter|x)\.com\/(?:#!\/)?[\w]+\/status\/?[\w]+/i).exec(href.replace("x.com", "twitter.com")),
+	detect: ({ href }) => (/^https?:\/\/(?:mobile\.)?(twitter|x)\.com\/(?:#!\/)?[\w]+\/status\/?[\w]+/i).exec(href.replace('x.com', 'twitter.com')),
 	async handleLink(href, [url]) {
 		// we have to omit the script tag and all of the nice formatting it brings us in Firefox
 		// because AMO does not permit externally hosted script tags being pulled in from

--- a/lib/modules/hosts/twitter.js
+++ b/lib/modules/hosts/twitter.js
@@ -9,7 +9,7 @@ export default new Host('twitter', {
 	domains: ['twitter.com'],
 	permissions: ['https://publish.twitter.com/oembed'],
 	attribution: false,
-	detect: ({ href }) => (/^https?:\/\/(?:mobile\.)?twitter\.com\/(?:#!\/)?[\w]+\/status\/?[\w]+/i).exec(href),
+	detect: ({ href }) => (/^https?:\/\/(?:mobile\.)?(twitter|x)\.com\/(?:#!\/)?[\w]+\/status\/?[\w]+/i).exec(href),
 	async handleLink(href, [url]) {
 		// we have to omit the script tag and all of the nice formatting it brings us in Firefox
 		// because AMO does not permit externally hosted script tags being pulled in from


### PR DESCRIPTION
Relevant issue: The Twitter rename to 𝕏 means that any  `𝕏.com` links won't be detected for e𝕏pandos--this is a quick fi𝕏 to resolve the issue.
Tested in browser: chrome, firefo𝕏, arc
