### PR TITLE
Now images from emoji-only or extra long titled posts can be downloaded

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1333,11 +1333,12 @@ export class Media {
 						const ext = re.exec(downloadUrl);
 						const thing = Thing.from(wrapper);
 						let title = thing && thing.getTitle();
+						title = title.replace(/[*|?:"~<>\\\/]|(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/gi, '');
+						title = title.slice(0, 120); // titles may be longer than the filesystem allows
+						title = title.trim();
 						if (title && ext) {
 							let extension = ext[1];
 							if (extension.includes('?')) extension = extension.split('?')[0];
-							title = title.replace(/[*|?:"~<>\\\/]|(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/gi, '');
-							title = title.trim();
 							const filename = `${title}.${extension}`;
 							download(downloadUrl, filename);
 						} else download(downloadUrl);


### PR DESCRIPTION
Tested in browser: Google Chrome 112.0.5615.165 

Examples of images from posts with complicated titles that can be downloaded with the fix:

Long title: https://www.reddit.com/r/Steam/comments/116atn0/steam_is_constantly_taking_screenshots_while/
Emoji-only: https://www.reddit.com/r/electricians/comments/xay4ar/_/