### PR TITLE
fix redgif host video and images

### DIFF
--- a/chrome/beta/manifest.json
+++ b/chrome/beta/manifest.json
@@ -86,7 +86,8 @@
 		"https://redditenhancementsuite.com/oauth",
 		"https://accounts.google.com/signin/oauth",
 		"https://www.dropbox.com/oauth2/authorize",
-		"https://login.live.com/oauth20_authorize.srf"
+		"https://login.live.com/oauth20_authorize.srf",
+		"https://*.redgifs.com/*"
 	],
 	"web_accessible_resources": [
 		"{{../../lib/environment/background/permissions/prompt.html}}",

--- a/chrome/beta/manifest.json
+++ b/chrome/beta/manifest.json
@@ -87,7 +87,7 @@
 		"https://accounts.google.com/signin/oauth",
 		"https://www.dropbox.com/oauth2/authorize",
 		"https://login.live.com/oauth20_authorize.srf",
-		"https://*.redgifs.com/*"
+		"https://api.redgifs.com/v2/*"
 	],
 	"web_accessible_resources": [
 		"{{../../lib/environment/background/permissions/prompt.html}}",

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -86,7 +86,8 @@
 		"https://redditenhancementsuite.com/oauth",
 		"https://accounts.google.com/signin/oauth",
 		"https://www.dropbox.com/oauth2/authorize",
-		"https://login.live.com/oauth20_authorize.srf"
+		"https://login.live.com/oauth20_authorize.srf",
+		"https://*.redgifs.com/*"
 	],
 	"web_accessible_resources": [
 		"{{../lib/environment/background/permissions/prompt.html}}",

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -87,7 +87,7 @@
 		"https://accounts.google.com/signin/oauth",
 		"https://www.dropbox.com/oauth2/authorize",
 		"https://login.live.com/oauth20_authorize.srf",
-		"https://*.redgifs.com/*"
+		"https://api.redgifs.com/v2/*"
 	],
 	"web_accessible_resources": [
 		"{{../lib/environment/background/permissions/prompt.html}}",

--- a/firefox/beta/manifest.json
+++ b/firefox/beta/manifest.json
@@ -87,7 +87,8 @@
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
 		"https://www.googleapis.com/drive/v3/*",
 		"https://*.redd.it/*",
-		"https://www.flickr.com/services/oembed"
+		"https://www.flickr.com/services/oembed",
+		"https://*.redgifs.com/*"
 	],
 	"web_accessible_resources": [
 		"{{../../lib/environment/background/permissions/prompt.html}}",

--- a/firefox/beta/manifest.json
+++ b/firefox/beta/manifest.json
@@ -88,7 +88,7 @@
 		"https://www.googleapis.com/drive/v3/*",
 		"https://*.redd.it/*",
 		"https://www.flickr.com/services/oembed",
-		"https://*.redgifs.com/*"
+		"https://api.redgifs.com/v2/*"
 	],
 	"web_accessible_resources": [
 		"{{../../lib/environment/background/permissions/prompt.html}}",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -87,7 +87,8 @@
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
 		"https://www.googleapis.com/drive/v3/*",
 		"https://*.redd.it/*",
-		"https://www.flickr.com/services/oembed"
+		"https://www.flickr.com/services/oembed",
+		"https://*.redgifs.com/*"
 	],
 	"web_accessible_resources": [
 		"{{../lib/environment/background/permissions/prompt.html}}",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -88,7 +88,7 @@
 		"https://www.googleapis.com/drive/v3/*",
 		"https://*.redd.it/*",
 		"https://www.flickr.com/services/oembed",
-		"https://*.redgifs.com/*"
+		"https://api.redgifs.com/v2/*"
 	],
 	"web_accessible_resources": [
 		"{{../lib/environment/background/permissions/prompt.html}}",

--- a/lib/modules/hosts/redgifs.js
+++ b/lib/modules/hosts/redgifs.js
@@ -1,48 +1,74 @@
 /* @flow */
 
 import { Host } from '../../core/host';
-import { DAY, string } from '../../utils';
+import { DAY, MINUTE, string } from '../../utils';
 import { ajax } from '../../environment';
 
 export default new Host('redgifs', {
 	name: 'redgifs',
 	domains: ['redgifs.com'],
+	permissions: ['https://*.redgifs.com/*'],
 	logo: 'https://redgifs.com/assets/favicon.ico',
-	detect: ({ pathname }) => (/^\/(?:(?:ifr|watch)\/)(\w+)/i).exec(pathname),
+	detect: ({ pathname }) => (/^\/(?:(?:ifr|watch|i)\/)(\w+)/i).exec(pathname),
 	async handleLink(href, [, id]) {
-		const embed = `https://redgifs.com/ifr/${id}`;
+		async function _getInfo(id, deleteCache) {
+			const authUrl = string.encode`https://api.redgifs.com/v2/auth/temporary`;
+			if (deleteCache === true) {
+				await ajax.invalidate(authUrl);
+			}
+			const token = (await ajax({
+				url: authUrl,
+				type: 'json',
+				cacheFor: MINUTE * 15,
+			})).token;
 
-		// Load video width/height to show a responsive embed
-		try {
-			const info = (await ajax({
-				url: string.encode`https://api.redgifs.com/v1/gfycats/${id}`,
+			return ajax({
+				url: string.encode`https://api.redgifs.com/v2/gifs/${id}`,
 				type: 'json',
 				cacheFor: DAY,
-			})).gfyItem;
-
-			let height = info.height;
-			let width = info.width;
-			const ratio = width / height;
-			const maxSize = 600;
-
-			if (height > width) {
-				height = Math.min(height, maxSize);
-				width = parseInt(ratio * height, 10);
-			} else {
-				width = Math.min(width, maxSize);
-				height = parseInt(width / ratio, 10);
+				headers: {
+					Authorization: `Bearer ${token}`,
+				},
+			});
+		}
+		try {
+			let info;
+			try {
+				info = await _getInfo(id);
+			} catch (e) {
+				info = await _getInfo(id, true);
 			}
-
-			return {
-				type: 'IFRAME',
-				embed: `${embed}?autoplay=0`,
-				embedAutoplay: embed,
-				fixedRatio: false,
-				width: `${width}px`,
-				height: `${height}px`,
-				muted: true,
-			};
+			const gif = info.gif;
+			if (gif.type === 2) {
+				return {
+					type: 'IMAGE',
+					src: gif.urls.hd,
+					href,
+				};
+			} else if (gif.type === 1) {
+				return {
+					type: 'VIDEO',
+					muted: !gif.hasAudio,
+					credits: gif.userName,
+					href,
+					poster: gif.urls.poster,
+					loop: true,
+					time: gif.duration,
+					sources: [
+						{
+							source: gif.urls.hd,
+							type: 'video/mp4',
+						},
+						{
+							source: gif.urls.sd,
+							type: 'video/mp4',
+						},
+					],
+				};
+			}
+			throw new Error(`Could not handle content type(${gif.type}), href: ${href}`);
 		} catch (error) { // Fallback to a fixedRatio embed
+			const embed = `https://redgifs.com/ifr/${id}`;
 			return {
 				type: 'IFRAME',
 				embed: `${embed}?autoplay=0`,

--- a/lib/modules/hosts/redgifs.js
+++ b/lib/modules/hosts/redgifs.js
@@ -7,7 +7,7 @@ import { ajax } from '../../environment';
 export default new Host('redgifs', {
 	name: 'redgifs',
 	domains: ['redgifs.com'],
-	permissions: ['https://*.redgifs.com/*'],
+	permissions: ['https://api.redgifs.com/v2/*'],
 	logo: 'https://redgifs.com/assets/favicon.ico',
 	detect: ({ pathname }) => (/^\/(?:(?:ifr|watch|i)\/)(\w+)/i).exec(pathname),
 	async handleLink(href, [, id]) {


### PR DESCRIPTION
Don't have much js or extension development experience, I tried to stick to the general structure of the code as much as I could, tell me if I did anything wrong... The python developer inside me could have surfaced here and there and mixed conventions between the languages.

I couldn't make a request to redgif API without the permissions (CORS error) so based on project documentations I added it to "manifest.json", although the documentation gave "api.twitter.com" as an example which doesnt really appear in the manifest anymore, I think the documentations might need a little update. 

Relevant issue: fixes #5468  
Tested in browser: Firefox, Chrome, Vivaldi
