### PR TITLE
Firefox Mobile needs min 120 due to API support

### DIFF
--- a/build.js
+++ b/build.js
@@ -155,7 +155,7 @@ async function buildForBrowser(targetName, { manifest, noSourceMap, browserName,
 							__homepage__: homepageURL,
 							__author__: author,
 							__browser_min_version__: browserMinVersion,
-							__browser_mobile_min_version__: browserMobileMinVersion
+							__browser_mobile_min_version__: browserMobileMinVersion,
 						}
 						Object.keys(replace).forEach(v => {
 							text = text.replaceAll(v, replace[v]);

--- a/build.js
+++ b/build.js
@@ -38,6 +38,7 @@ const targets = {
 	firefox: {
 		browserName: 'firefox',
 		browserMinVersion: '115.0',
+		browserMobileMinVersion: '120.0',
 		manifest: './firefox/manifest.json',
 		noSourcemap: true,
 	},
@@ -73,7 +74,7 @@ const homepageURL /*: string */ = packageInfo.homepage;
 // production builds uses version number to keep the build reproducible
 const buildToken = isProduction ? version : devBuildToken;
 
-async function buildForBrowser(targetName, { manifest, noSourceMap, browserName, browserMinVersion }) {
+async function buildForBrowser(targetName, { manifest, noSourceMap, browserName, browserMinVersion, browserMobileMinVersion }) {
 	const context = {
 		entryPoints: {
 			'foreground.entry': './lib/foreground.entry.js',
@@ -154,6 +155,7 @@ async function buildForBrowser(targetName, { manifest, noSourceMap, browserName,
 							__homepage__: homepageURL,
 							__author__: author,
 							__browser_min_version__: browserMinVersion,
+							__browser_mobile_min_version__: browserMobileMinVersion
 						}
 						Object.keys(replace).forEach(v => {
 							text = text.replaceAll(v, replace[v]);

--- a/firefox/beta/manifest.json
+++ b/firefox/beta/manifest.json
@@ -11,7 +11,7 @@
 			"strict_min_version": "__browser_min_version__"
 		},
 		"gecko_android": {
-			"strict_min_version": "__browser_min_version__"
+			"strict_min_version": "__browser_mobile_min_version__"
 		}
 	},
 	"icons": {

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -11,7 +11,7 @@
 			"strict_min_version": "__browser_min_version__"
 		},
 		"gecko_android": {
-			"strict_min_version": "__browser_min_version__"
+			"strict_min_version": "__browser_mobile_min_version__"
 		}
 	},
 	"icons": {


### PR DESCRIPTION
Need 120 for https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions/request. Keeping main at 115 for ESR.