### PR TITLE
Feature: Add keyboard shortcut to toggle mute on expando videos

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -472,6 +472,14 @@ module.options = {
 		title: 'keyboardNavToggleViewImagesTitle',
 		callback() { ShowImages.viewImagesButton().click(); },
 	},
+	toggleMuteVideo: {
+		type: 'keycode',
+		requiresModules: [ShowImages],
+		value: [77, false, false, false, false], // m
+		description: 'keyboardNavToggleMuteVideoDesc',
+		title: 'keyboardNavToggleMuteVideoTitle',
+		callback() { videoToggleMute(); },
+	},
 	toggleChildren: {
 		type: 'keycode',
 		include: ['comments', 'inbox'/* mostly modmail */],
@@ -1170,6 +1178,11 @@ function imageResize({ factor = 1, removeHeightRestriction = false }: {| factor?
 function imageMove(deltaX, deltaY) {
 	const mostVisible = getMostVisibleElementInThingByQuery('.res-media-movable', ASSERT);
 	ShowImages.move(mostVisible, deltaX, deltaY);
+}
+
+function videoToggleMute() {
+	const mostVisible = getMostVisibleElementInThingByQuery('.res-video-container', ASSERT);
+	ShowImages.toggleMute(mostVisible);
 }
 
 function navigateGallery(direction: 'previous' | 'next') {

--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -2297,3 +2297,10 @@ export function resize(ele: HTMLElement, newWidth: number, newHeight?: number): 
 	ele.style.width = `${newWidth}px`;
 	ele.style.maxWidth = ele.style.maxHeight = 'none';
 }
+
+export function toggleMute(ele: HTMLElement): void {
+	const video = downcast(ele.querySelector('video'), HTMLVideoElement);
+	if (video) {
+		video.muted = !video.muted;
+	}
+}

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -735,6 +735,12 @@
 	"keyboardNavToggleViewImagesDesc": {
 		"message": "Toggle \"show images\" button."
 	},
+	"keyboardNavToggleMuteVideoTitle": {
+		"message": "Toggle Mute Video"
+	},
+	"keyboardNavToggleMuteVideoDesc": {
+		"message": "Toggle mute/unmute for a video."
+	},
 	"keyboardNavToggleChildrenTitle": {
 		"message": "Toggle Children"
 	},


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: N/A
Tested in browser: Chrome

This adds a keyboardNav bind (default 'o') to toggle mute/unmute on the current most visible video expando.