### PR TITLE
Move Geolocation to optional

### DIFF
--- a/chrome/beta/manifest.json
+++ b/chrome/beta/manifest.json
@@ -69,11 +69,11 @@
     "storage",
     "unlimitedStorage",
     "webRequest",
-    "scripting",
-    "geolocation"
+    "scripting"
   ],
   "optional_permissions": [
-    "downloads"
+    "downloads",
+    "geolocation"
   ],
   "host_permissions": [
     "https://*.reddit.com/*"

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -69,11 +69,11 @@
     "storage",
     "unlimitedStorage",
     "webRequest",
-    "scripting",
-    "geolocation"
+    "scripting"
   ],
   "optional_permissions": [
-    "downloads"
+    "downloads",
+    "geolocation"
   ],
   "host_permissions": [
     "https://*.reddit.com/*"


### PR DESCRIPTION
It says you cant, but testing says you can. Avoid disable and permission prompt. Will test in beta.
