### PR TITLE
Remove twitter external script

### DIFF
--- a/lib/modules/hosts/twitter.js
+++ b/lib/modules/hosts/twitter.js
@@ -12,7 +12,7 @@ export default new Host('twitter', {
 	detect: ({ href }) => (/^https?:\/\/(?:mobile\.)?twitter\.com\/(?:#!\/)?[\w]+\/status\/?[\w]+/i).exec(href),
 	async handleLink(href, [url]) {
 		// we have to omit the script tag and all of the nice formatting it brings us in Firefox/Chrome
-		// because AMO does not permit externally hosted script tags being pulled in from
+		// because AMO/MV3 does not permit externally hosted script tags being pulled in from
 		// oEmbed like this and MV3 prevents it with CSP...
 		const { html } = await ajax({
 			url: 'https://publish.twitter.com/oembed',

--- a/lib/modules/hosts/twitter.js
+++ b/lib/modules/hosts/twitter.js
@@ -11,12 +11,12 @@ export default new Host('twitter', {
 	attribution: false,
 	detect: ({ href }) => (/^https?:\/\/(?:mobile\.)?twitter\.com\/(?:#!\/)?[\w]+\/status\/?[\w]+/i).exec(href),
 	async handleLink(href, [url]) {
-		// we have to omit the script tag and all of the nice formatting it brings us in Firefox
+		// we have to omit the script tag and all of the nice formatting it brings us in Firefox/Chrome
 		// because AMO does not permit externally hosted script tags being pulled in from
-		// oEmbed like this...
+		// oEmbed like this and MV3 prevents it with CSP...
 		const { html } = await ajax({
 			url: 'https://publish.twitter.com/oembed',
-			query: { url, omit_script: process.env.BUILD_TARGET === 'firefox' },
+			query: { url, omit_script: true },
 			type: 'json',
 		});
 


### PR DESCRIPTION
MV3 no longer allows remotely hosted code - https://developer.chrome.com/docs/extensions/develop/migrate/improve-security#remove-remote-code

This aligns with Firefox and fixes RHC error.