### PR TITLE
Feature: option to move comments actions (permalink, save-RES, parent, report, reply, etc) to the top of the comment (comment header)

### DIFF
--- a/lib/modules/betteReddit.js
+++ b/lib/modules/betteReddit.js
@@ -203,6 +203,12 @@ module.options = {
 		title: 'betteRedditRestrictScrollEventsTitle',
 		advanced: true,
 	},
+	commentActionButtonsOnCommentHeader: {
+		type: 'boolean',
+		value: false,
+		description: 'betteRedditCommentActionButtonsOnCommentHeaderDesc',
+		title: 'betteRedditCommentActionButtonsOnCommentHeaderTitle',
+	},
 };
 
 module.exclude = [
@@ -295,6 +301,10 @@ module.contentStart = () => {
 				}
 			}
 		});
+	}
+
+	if (module.options.commentActionButtonsOnCommentHeader.value){
+		commentActionButtonsOnCommentHeader();
 	}
 
 	const user = loggedInUser();
@@ -576,4 +586,14 @@ function applyNoCtrlF(element) {
 	element.classList.add('noCtrlF');
 	element.dataset.text = element.textContent;
 	element.textContent = '';
+}
+
+function commentActionButtonsOnCommentHeader() {
+	$(document).ready(function () {
+		$('ul.flat-list.buttons')
+			.slice(1)
+			.each(function () {
+				$(this).parent().find('p.tagline').append($(this));
+			});
+	});
 }

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -2061,6 +2061,12 @@
 	"betteRedditVideoViewed": {
 		"message": "[Views: $1]"
 	},
+	"betteRedditCommentActionButtonsOnCommentHeaderTitle": {
+		"message": "Comment Action Buttons on Comment Header"
+	},
+	"betteRedditCommentActionButtonsOnCommentHeaderDesc": {
+		"message": "Moves the comment action buttons from the bottom of the comment to the top (comment header)."
+	},
 	"commentDepthDefaultCommentDepthTitle": {
 		"message": "Default Comment Depth"
 	},


### PR DESCRIPTION
Tested in browser: Firefox

This pull request introduces the `commentActionButtonsOnCommentHeader` feature to betteReddit. When enabled, it relocates the comment actions to the top of the comment section rather than the bottom.

Useful if you want to quickly access the action buttons without having to scroll all the way to the bottom of the comment (especially if the comment is a long one).