### PR TITLE
showImages/hosts: Update Imgur

### DIFF
--- a/lib/modules/hosts/imgur.js
+++ b/lib/modules/hosts/imgur.js
@@ -15,12 +15,6 @@ export default new Host('imgur', {
 			value: true,
 			type: 'boolean',
 		},
-		useGifOverGifv: {
-			title: 'imgurUseGifOverGifVTitle',
-			description: 'imgurUseGifOverGifVDesc',
-			value: false,
-			type: 'boolean',
-		},
 		preferredImgurLink: {
 			title: 'imgurPreferredImgurLinkTitle',
 			description: 'imgurPreferredImgurLinkDesc',
@@ -63,7 +57,7 @@ export default new Host('imgur', {
 		const apiId = '1d8d9b36339e0e2';
 		const hashRe = /^https?:\/\/(?:i\.|m\.|edge\.|www\.)*imgur\.com\/(r\/\w+\/)*(?!gallery)(?!removalrequest)(?!random)(?!memegen)((?:\w{5}|\w{7})(?:[&,](?:\w{5}|\w{7}))*)(?:#\d+)?[a-z]?(\.(?:jpe?g|gifv?|png))?(\?.*)?$/i;
 		const hostedHashRe = /^https?:(\/\/i\.\w+\.*imgur\.com\/)((?:\w{5}|\w{7})(?:[&,](?:\w{5}|\w{7}))*)(?:#\d+)?[a-z]?(\.(?:jpe?g|gif|png))?(\?.*)?$/i;
-		const galleryHashRe = /^https?:\/\/(?:m\.|www\.)?imgur\.com\/gallery\/(\w+)(?:[/#]|$)/i;
+		const galleryHashRe = /^https?:\/\/(?:m\.|www\.)?imgur\.com\/gallery\/(?:(\w+)|(?:.*-)(\w+$))(?:[/#]|$)/i;
 		const albumHashRe = /^https?:\/\/(?:m\.|www\.)?imgur\.com\/a\/(\w+)(?:[/#]|$)/i;
 
 		if (pathname === '/rules' || pathname === '/inbox') return null;
@@ -73,7 +67,7 @@ export default new Host('imgur', {
 		let groups;
 
 		if ((groups = galleryHashRe.exec(href))) {
-			const hash = groups[1];
+			const hash = groups[2];
 			return () => _api(string.encode`gallery/${hash}`)
 				// may have been removed from the gallery, try looking up the album
 				.catch(() => _api(string.encode`album/${hash}`));
@@ -136,7 +130,7 @@ export default new Host('imgur', {
 				looping: false,
 				has_sound: false,
 				link: `${thisCdnUrl}${hash}${extension}`,
-				gifv: undefined,
+				type: `image/${extension}`,
 				title: '',
 				description: '',
 			};
@@ -152,10 +146,10 @@ export default new Host('imgur', {
 				// We must hit the API for gif(v) even when the extension is given, to determine if it should loop
 				return _mockImageAPI(hash, url);
 			} else if (hostedHashRe.test(url)) {
-				// Hosted images do not support gifv or albums, so we never need to hit the API
+				// Hosted images do not support videos or albums, so we never need to hit the API
 				return _mockImageAPI(hash, url);
 			} else {
-				// Check if image is gifv
+				// Check if image is a video
 				return _api(`image/${hash}`);
 			}
 		}
@@ -166,6 +160,7 @@ export default new Host('imgur', {
 				images: hashes.map(hash => _mockImageAPI(hash, url)),
 				title: '',
 				description: '',
+				type: '',
 			};
 		}
 	},
@@ -173,14 +168,13 @@ export default new Host('imgur', {
 		const baseUrl = 'https://imgur.com/';
 		const shareLinkPreferred = this.options.preferredImgurLink.value === 'share';
 		const resolutionSuffix = this.options.imgurImageResolution.value;
-		const useGif = this.options.useGifOverGifv.value;
 
 		const info = await getInfo();
 
-		if (info.images && info.images.length) {
+		if (info.is_album) {
 			return _handleAlbum(href, info);
-		} else if (info.gifv && !useGif) {
-			return _handleGifv(info);
+		} else if (info.type.startsWith('video\/')) {
+			return _handleSingleVideo(info);
 		} else if (info.link) {
 			return _handleSingleImage(info);
 		}
@@ -193,8 +187,8 @@ export default new Host('imgur', {
 				title: info.title,
 				caption: info.description,
 				src: info.images.map(info => {
-					const media = info.gifv && !useGif ?
-						_handleGifv(info) :
+					const media = info.type.startsWith('video\/') ?
+						_handleSingleVideo(info) :
 						_handleSingleImage(info);
 					media.href = shareLinkPreferred ? `${href.split('#')[0]}#${info.id}` : `${info.link}`;
 					return media;
@@ -204,7 +198,6 @@ export default new Host('imgur', {
 
 		function _handleSingleImage(info) {
 			const src = info.link
-				.replace('http:', 'https:')
 				.replace(`/${info.id}.`, `/${info.id}${resolutionSuffix}.`);
 
 			return {
@@ -216,18 +209,18 @@ export default new Host('imgur', {
 			};
 		}
 
-		function _handleGifv(info) {
+		function _handleSingleVideo(info) {
 			return {
 				type: 'VIDEO',
 				href: shareLinkPreferred ? `${baseUrl}${info.id}` : `${info.link}`,
-				fallback: info.link.replace('http:', 'https:'),
+				fallback: info.link,
 				caption: info.description,
 				title: info.title,
 				loop: info.looping !== false, // may be missing from API responses (randomly), so explicitly check for false
 				muted: !info.has_sound,
 				sources: [{
-					source: info.mp4.replace('http:', 'https:'),
-					type: 'video/mp4',
+					source: info.link,
+					type: info.type,
 				}],
 			};
 		}

--- a/locales/locales/en.json
+++ b/locales/locales/en.json
@@ -4387,12 +4387,6 @@
 	"imgurPreferResAlbumsDesc": {
 		"message": "Prefer RES support for imgur albums rather than reddit's built in support."
 	},
-	"imgurUseGifOverGifVTitle": {
-		"message": "Use GIFs instead of GIFV"
-	},
-	"imgurUseGifOverGifVDesc": {
-		"message": "Use GIFs in place of GIFV for imgur links"
-	},
 	"imgurPreferredImgurLinkTitle": {
 		"message": "Preferred Imgur Link"
 	},


### PR DESCRIPTION
- Fixes video retrieval (the API no longer contains the property `gifv`)
- Removes option `useGifOverGifv` which seemingly is broken
- Removes redundant protocol replacement, as Imgur now always responds with https

Relevant issue:  https://www.reddit.com/r/RESissues/comments/1exm5b7/imgur_gifgifvmp4_expandos_broken/
Tested in browser: Chrome 128
