### PR TITLE
environment/permissions: Fix permission popup not showing

### DIFF
--- a/lib/environment/background/permissions.js
+++ b/lib/environment/background/permissions.js
@@ -24,9 +24,11 @@ async function makePromptWindow({ permissions, origins }) {
 
 	const width = 630;
 	const height = 255;
-	// Display popup on middle of screen
-	const left = Math.floor(screen.width / 2 - width / 2);
-	const top = Math.floor(screen.height / 2 - height / 2);
+
+	// Get the current window's dimensions and calculate center position
+	const { width: screenWidth, height: screenHeight } = await chrome.windows.getCurrent();
+	const left = Math.floor(screenWidth / 2 - width / 2);
+	const top = Math.floor(screenHeight / 2 - height / 2);
 
 	const { tabs: [{ id }] } = await apiToPromise(chrome.windows.create)({ url: url.href, type: 'popup', width, height, left, top });
 

--- a/lib/environment/background/permissions.js
+++ b/lib/environment/background/permissions.js
@@ -26,7 +26,7 @@ async function makePromptWindow({ permissions, origins }) {
 	const height = 255;
 
 	// Get the current window's dimensions and calculate center position
-	const { width: screenWidth, height: screenHeight } = await chrome.windows.getCurrent();
+	const { width: screenWidth, height: screenHeight } = await chrome.windows.getCurrent() || { width: 1920, height: 1080 };
 	const left = Math.floor(screenWidth / 2 - width / 2);
 	const top = Math.floor(screenHeight / 2 - height / 2);
 


### PR DESCRIPTION
`window.screen` is not available in manifest v3, causing the prompt window fallback method to fail. This uses the web extension API to find the coordinates to place the popup.

The fallback method is ordinarily not needed in Chrome, but other extensions may interfere (see #5531) Chrome's detection of user initiated permission requests.

Relevant issue: #5531 
Tested in browser: Firefox 130, Chrome 128