### PR TITLE
Fix: Change mute keybind to 'o' to avoid clash with modmail keybind

### DIFF
--- a/lib/modules/keyboardNav.js
+++ b/lib/modules/keyboardNav.js
@@ -475,7 +475,7 @@ module.options = {
 	toggleMuteVideo: {
 		type: 'keycode',
 		requiresModules: [ShowImages],
-		value: [77, false, false, false, false], // m
+		value: [79, false, false, false, false], // o
 		description: 'keyboardNavToggleMuteVideoDesc',
 		title: 'keyboardNavToggleMuteVideoTitle',
 		callback() { videoToggleMute(); },


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: #5500 
Tested in browser: n/a

As discussed in #5500 but not implemented, this helps avoid the clash with the modmail 'm' keybind if go-mode isn't enabled.