### PR TITLE
Added support for bluesky expandos

### DIFF
--- a/chrome/beta/manifest.json
+++ b/chrome/beta/manifest.json
@@ -91,7 +91,8 @@
     "https://redditenhancementsuite.com/oauth",
     "https://accounts.google.com/signin/oauth",
     "https://www.dropbox.com/oauth2/authorize",
-    "https://login.live.com/oauth20_authorize.srf"
+    "https://login.live.com/oauth20_authorize.srf",
+    "https://embed.bsky.app/oembed"
   ],
   "web_accessible_resources": [
     {

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -91,7 +91,8 @@
     "https://redditenhancementsuite.com/oauth",
     "https://accounts.google.com/signin/oauth",
     "https://www.dropbox.com/oauth2/authorize",
-    "https://login.live.com/oauth20_authorize.srf"
+    "https://login.live.com/oauth20_authorize.srf",
+    "https://embed.bsky.app/oembed"
   ],
   "web_accessible_resources": [
     {

--- a/firefox/beta/manifest.json
+++ b/firefox/beta/manifest.json
@@ -91,7 +91,8 @@
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
 		"https://www.googleapis.com/drive/v3/*",
 		"https://*.redd.it/*",
-		"https://www.flickr.com/services/oembed"
+		"https://www.flickr.com/services/oembed",
+		"https://embed.bsky.app/oembed"
 	],
 	"web_accessible_resources": [
 		"prompt.html",

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -91,7 +91,8 @@
 		"https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/*",
 		"https://www.googleapis.com/drive/v3/*",
 		"https://*.redd.it/*",
-		"https://www.flickr.com/services/oembed"
+		"https://www.flickr.com/services/oembed",
+		"https://embed.bsky.app/oembed"
 	],
 	"web_accessible_resources": [
 		"prompt.html",

--- a/lib/modules/hosts/bluesky.js
+++ b/lib/modules/hosts/bluesky.js
@@ -1,0 +1,31 @@
+/* @flow */
+
+import $ from 'jquery';
+import { Host } from '../../core/host';
+import { ajax } from '../../environment';
+
+export default new Host('bluesky', {
+	name: 'bluesky',
+	logo: 'https://bsky.app/static/favicon.png',
+	permissions: ['https://embed.bsky.app/oembed'],
+	domains: ['bsky.app'],
+	detect: ({ href }) => (/^^https?:\/\/(bsky)\.app\/profile\/[\w.-]+\/post+/i).exec(href),
+	async handleLink(href) {
+		const post = await ajax({
+			url: 'https://embed.bsky.app/oembed',
+			query: { url: href },
+			type:'json',
+		});
+
+		// Script requires element to be attached to document when starting
+		const $dummy = $('<div>');
+
+		return {
+			type: 'GENERIC_EXPANDO',
+			muted: true,
+			expandoClass: 'selftext',
+			generate: () => $dummy[0],
+			onAttach: () => { $dummy.html(post.html); },
+		};
+	},
+}); 

--- a/lib/modules/hosts/index.js
+++ b/lib/modules/hosts/index.js
@@ -4,6 +4,7 @@ import adultswim from './adultswim';
 import archilogic from './archilogic';
 import archiveis from './archiveis';
 import bime from './bime';
+import bluesky from './bluesky';
 import clyp from './clyp';
 import codepen from './codepen';
 import coub from './coub';
@@ -91,6 +92,7 @@ export {
 	archilogic,
 	archiveis,
 	bime,
+	bluesky,
 	clyp,
 	codepen,
 	coub,


### PR DESCRIPTION
Noticed a post in /r/hockey that had a bsky.app link but didn't have an expando. Wanted to be the change I wanted to see in the world so I added support for it. Implemented it similarly to the Twitter/X module. Here it is:

![image](https://github.com/user-attachments/assets/a70f356f-0e6c-4b2f-a4e0-a216a12c761a)

I believe any video playing is just related to what bluesky offers in the embed, so unfortunately you still need to navigate to the page to view the video player.

Relevant issue: N/A
Tested in browser:  Firefox
