### PR TITLE
Fix: reddit poll expando redirects to comments

### DIFF
--- a/lib/modules/hosts/redditpoll.js
+++ b/lib/modules/hosts/redditpoll.js
@@ -11,7 +11,7 @@ export default new Host('redditpoll', {
 		return {
 			type: 'IFRAME',
 			expandoClass: 'selftext',
-			embed: `https://www.reddit.com/poll/${id}`,
+			embed: `https://www.reddit.com/poll/${id}/`,
 			height: '500px',
 			width: '700px',
 		};


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: Poll expandos currently redirect to the comments.
![image](https://github.com/user-attachments/assets/2d4979e0-6c0f-47cf-8c81-9fa9cb432907)


Tested in browser: Firefox
