### PR TITLE
widget edit cancel button fix

### DIFF
--- a/lib/css/modules/_dashboard.scss
+++ b/lib/css/modules/_dashboard.scss
@@ -208,14 +208,14 @@
 .cancelButton {
 	width: 50px;
 	text-align: center;
-	cursor: pointer;
+	cursor: pointer !important;
 	display: inline-block;
-	padding: 3px 5px;
+	padding: 3px 5px !important;
 	font-size: 11px;
-	color: #fff;
-	border: 1px solid #636363;
+	color: #fff !important;
+	border: 1px solid #636363 !important;
 	border-radius: 3px;
-	background-color: #d02020;
+	background-color: #d02020 !important;
 	margin-top: 3px;
 	margin-left: 5px;
 }

--- a/lib/modules/dashboard.js
+++ b/lib/modules/dashboard.js
@@ -195,13 +195,13 @@ function attachEditComponent() {
 				<input type="text" id="editReddit" placeholder="subreddit / multireddit">
 				<input type="text" id="editRedditDisplayName" placeholder="display name (e.g. stuff)">
 				<input type="submit" class="updateButton" value="save changes">
-				<input type="cancel" class="cancelButton" value="cancel">
+				<input type="button" class="cancelButton" value="cancel">
 			</form>
 			<form id="editSearchForm">
 				<input type="text" id="editSearch" placeholder="search terms">
 				<input type="text" id="editSearchDisplayName" placeholder="display name (e.g. stuff)">
 				<input type="submit" class="updateButton" value="save changes">
-				<input type="cancel" class="cancelButton" value="cancel">
+				<input type="button" class="cancelButton" value="cancel">
 			</form>
 		</div>
 	`);


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: 5557
Tested in browser: Firefox

Fix #5557 by changing input type to button