### PR TITLE
Feature: Add support for nitter expandos

### DIFF
--- a/lib/modules/hosts/index.js
+++ b/lib/modules/hosts/index.js
@@ -39,6 +39,7 @@ import makeameme from './makeameme';
 import memecrunch from './memecrunch';
 import memedad from './memedad';
 import navertv from './navertv';
+import nitter from './nitter';
 import onedrive from './onedrive';
 import pastebin from './pastebin';
 import peertube from './peertube';
@@ -127,6 +128,7 @@ export {
 	memecrunch,
 	memedad,
 	navertv,
+	nitter,
 	onedrive,
 	pastebin,
 	peertube,

--- a/lib/modules/hosts/nitter.js
+++ b/lib/modules/hosts/nitter.js
@@ -1,0 +1,15 @@
+/* @flow */
+
+import { Host } from '../../core/host';
+
+export default new Host('nitter', {
+	name: 'Nitter instance',
+	domains: ['nitter.privacydev.net', 'nitter.poast.org'],
+	detect: ({ href }) => (/^https?:\/\/(nitter\.privacydev\.net|nitter\.poast\.org)\/(?:#!\/)?[\w]+\/status\/?([\w]+)/i).exec(href),
+	handleLink(href, [, host, post]) {
+		return {
+			type: 'IFRAME',
+			embed: `https://${host}/i/status/${post}/embed`,
+		};
+	},
+});


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue: 
Tested in browser: Chrome

This goes directly to the given nitter instance instead of using the existing twitter/x handling.
Only includes the 2 nitter instances that seem to allow embeds.

Remaining in draft until discussion on whether to even do this concludes.