### PR TITLE
Search page Fixes

### DIFF
--- a/lib/utils/Thing.js
+++ b/lib/utils/Thing.js
@@ -70,6 +70,7 @@ export class Thing {
 		if (elementMap.has(thingElement)) return elementMap.get(thingElement);
 
 		const entry = thingElement.querySelector(Thing.entrySelector) || thingElement;
+		entry.classList.add('entry');
 		const thing = new Thing(SECRET_TOKEN, downcast(thingElement, HTMLElement), entry);
 
 		Thing.thingElements.cache.clear();
@@ -268,7 +269,9 @@ export class Thing {
 	}
 
 	getPostLink(): HTMLAnchorElement {
-		return downcast(this.entry.querySelector('a.title, a.search-link'), HTMLAnchorElement);
+		const element = this.entry.querySelector('a.title, a.search-link') || this.entry.querySelector('a.search-title');
+		// Text posts on search don't have title/search-link class
+		return downcast(element, HTMLAnchorElement);
 	}
 
 	getPostUrl(): string {


### PR DESCRIPTION
This PR addresses two issues on the search page:
1. **Grey highlight not visible on search results entries**
The grey highlight was not appearing on search results because the entries were missing the "entry" CSS class. This class has now been added manually.

2. **Shortcuts unable to open text links for text post entries**
Shortcuts couldn't open links for text postd because the anchor tags in the search results were missing the "title" and "search-link" classes.

Testing:
Tested in Chromium (Brave).

![image](https://github.com/user-attachments/assets/294e4546-a7ef-426a-b168-2dc9706a5442)
The image above demonstrates fixed search result highlights