### PR TITLE
Add workaround for Firefox specific bug

### DIFF
--- a/lib/environment/background/permissions.js
+++ b/lib/environment/background/permissions.js
@@ -17,6 +17,19 @@ export function handleMessage({ operation, permissions, origins }: *) {
 	}
 }
 
+async function isFirefox() {
+	if (browser.runtime.getBrowserInfo != undefined) {
+		const browserInfo = await apiToPromise(browser.runtime.getBrowserInfo)();
+		if (browser.name == "firefox") {
+			return true;
+		} else {
+			return false;
+		}
+	} else {
+		return false;
+	}
+}
+
 async function makePromptWindow({ permissions, origins }) {
 	const url = new URL('prompt.html', location.origin);
 	url.searchParams.set('permissions', JSON.stringify(permissions));
@@ -30,7 +43,17 @@ async function makePromptWindow({ permissions, origins }) {
 	const left = Math.floor(screenWidth / 2 - width / 2);
 	const top = Math.floor(screenHeight / 2 - height / 2);
 
-	const { tabs: [{ id }] } = await apiToPromise(chrome.windows.create)({ url: url.href, type: 'popup', width, height, left, top });
+	let id = -1;
+	// Firefox specific workaround: For some versions of firefox, windows of type popup created via `chrome.windows.create`
+	// cannot request permissions. Weirdly enough popups created by `window.open` can. I assume this is because the former
+	// doesn't have a location bar, but the latter does. We work around this by just opening a new tab in firefox.
+	if (isFirefox()) {
+		const tab = await apiToPromise(chrome.tabs.create)({ url: url.href });
+		id = tab.id;
+	} else {
+		const { tabs: [tab] } = await apiToPromise(chrome.windows.create)({ url: url.href, type: 'popup', width, height, left, top });
+		id = tab.id;
+	}
 
 	return new Promise(resolve => {
 		function updateListener(tabId, updates) {


### PR DESCRIPTION
Firefox (at least versions 128.0 and 137.0) doesn't allow popup created by `chrome.windows.create` to request permissions. I've added a workaround that checks if the user is using Firefox, and opens a new tab instead of a new window.
For some reason, this allows us to request permissions.

Relevant issue: fixes #5530
Tested in browser: Firefox for Fedora (64-bit) version 137.0

## Speculation

I'm guessing the reason Firefox doesn't allow us to request permissions, is because it opens a popup (relative to the hamburger menu in the toolbar), but the popup windows don't have the location bar. If we could call `window.open` instead,
it does work, presumably since the location bar is present. In fact, a better/more permanent fix would be to call `window.open` from the reddit page (using the same URL), rather than calling `chrome.windows.create` from the background script.

I'll also be reporting this as a Firefox bug in their bugzilla, but we'll see what happens there. (Link: https://bugzilla.mozilla.org/show_bug.cgi?id=1957822)
