### PR TITLE
Update gallery expandos

### DIFF
--- a/lib/modules/showImages.js
+++ b/lib/modules/showImages.js
@@ -1137,7 +1137,7 @@ function generateMedia(options: ExpandoMedia, context: {| href: string |}): Medi
 	if (options.caption) options.caption = DOMPurify.sanitize(options.caption);
 
 	switch (options.type) {
-		case 'GALLERY': return new Gallery(options, context);
+		case 'GALLERY': return new Gallery(options);
 		case 'IMAGE': return new Image(options, context);
 		case 'TEXT': return new Text(options);
 		case 'IFRAME': return new Iframe(options);
@@ -1399,7 +1399,7 @@ class Gallery extends Media {
 	rememberResizeWidth: boolean;
 	lastResizedWidth: number;
 
-	constructor(options: GalleryMedia, context) {
+	constructor(options: GalleryMedia) {
 		super();
 
 		this.element = galleryTemplate({
@@ -1418,7 +1418,8 @@ class Gallery extends Media {
 		this.ctrlConcurrentIncrease = this.element.querySelector('.res-gallery-increase-concurrent');
 
 		this.pieces = options.src.map(src => ({
-			generateMedia: () => generateMedia(src, context),
+			// Use the piece's source, not the gallery's URL, as the context
+			generateMedia: () => generateMedia(src, { href: src.src }),
 			media: null,
 			wrapper: string.html`<div hidden></div>`,
 		}));


### PR DESCRIPTION
Each item in a gallery now refers to the item itself, not the entire gallery. Clicking e.g. an image will open the image in a new window instead of opening the gallery.

Tested in browser: Firefox 140.0.2, Chrome 137.0.7151.104
