### PR TITLE
Fix firefox legacy favicon

### DIFF
--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -238,9 +238,14 @@ const setupFavicon = once(() => {
 	for (const f of favicons) {
 		if (f !== selectedFavicon) f.remove();
 	}
+
 	// browser should auto resolve to this if all get removed, but just in case, setting it explicitly
 	if (module.options.faviconUseLegacy.value) {
 		selectedFavicon.setAttribute('href', legacyFavicon);
+		// Ensure Firefox uses legacy favicon
+		window.addEventListener('load', () => {
+			selectedFavicon.setAttribute('href', legacyFavicon);
+		})
 	}
 
 	const favicon = new Favico({


### PR DESCRIPTION
Fixes a bug where the legacy favicon is not displayed in Firefox.

The issue stems from Firefox’s `FaviconLoader.sys.mjs` module, which automatically fetches favicons (favicon-16x16.png and android-icon-192x192.png).  It appears to be a race condition between the browser module and the RES extension, preventing the legacy favicon from being persistently loaded.

<details>
	<summary>FaviconLoader.sys.mjs in action</summary>
	<div>
		<img src="https://github.com/user-attachments/assets/1e9fdd00-2e9e-4eb1-826b-fa15c43c70d8">
	</div>
</details>

My workaround for this: an event listener that sets the `href` attribute of the link, forcing Firefox to use the correct favicon instead of the one fetched by `FaviconLoader.sys.mjs`.

Relevant issues: https://github.com/honestbleeps/Reddit-Enhancement-Suite/issues/5551, https://www.reddit.com/r/RESissues/comments/1k3zcoh/use_legacy_favicon_only_works_sometimes_firefox/
Tested in browser: Firefox 130