### PR TITLE
Switch to using "all" instead of "unread" as the default inbox page

### DIFF
--- a/lib/modules/orangered.js
+++ b/lib/modules/orangered.js
@@ -94,7 +94,7 @@ module.options = {
 		description: 'orangeredUnreadLinksToInboxDesc',
 		title: 'orangeredUnreadLinksToInboxTitle',
 		type: 'boolean',
-		value: false,
+		value: true,
 		advanced: true,
 	},
 	hideEmptyMail: {


### PR DESCRIPTION
Reddit broke the inbox by making every message be marked as read automatically, so the unread page is now useless. This PR makes the inbox button take you to the barely useful inbox page instead.