### PR TITLE
Remove random subreddit link from navigation

### DIFF
--- a/lib/modules/neverEndingReddit.js
+++ b/lib/modules/neverEndingReddit.js
@@ -350,7 +350,6 @@ function endNER(text) {
 			<a href="${location.href.split('#')[0]}">start over</a>
 			<a href="${getNextPageUrl() || ''}">try again</a>
 			<a target="_blank" rel="noopener noreferer" href="/r/Enhancement/wiki/faq/never_ending_reddit">learn more</a>
-			<a href="/r/random">random subreddit</a>
 		</p>
 	</div>`);
 }


### PR DESCRIPTION
Removed link to random subreddit from Never Ending Reddit (NER) feature.
The feature of [random subreddit has been removed from Reddit](https://www.reddit.com/r/help/comments/1fojw02/cleaning_up_some_lowusage_features/).
<img width="538" height="59" alt="image" src="https://github.com/user-attachments/assets/fe665abc-b5d4-4715-a2c1-d0a145d5c16b" />

<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Relevant issue:  [What happened to the "random subreddit" feature?](https://www.reddit.com/r/help/comments/1h8auuw/what_happened_to_the_random_subreddit_feature/)

Tested in browser: **Not tested**
