### PR TITLE
Fix Pastebin embed returning 404

### DIFF
--- a/lib/modules/hosts/pastebin.js
+++ b/lib/modules/hosts/pastebin.js
@@ -12,7 +12,7 @@ export default new Host('pastebin', {
 			type: 'IFRAME',
 			expandoClass: 'selftext',
 			muted: true,
-			embed: `https://pastebin.com/embed_iframe.php?i=${id}`,
+			embed: `https://pastebin.com/embed_iframe/${id}`,
 			height: '500px',
 			width: '700px',
 		};


### PR DESCRIPTION
<!-- e.g. "fixes #1234", see https://github.com/blog/1506-closing-issues-via-pull-requests -->
Pastebin has removed the embed_iframe.php redirect, breaking any application that relied on the old URL. This PR fixes this functionality by replacing it with the new URL.
Relevant issue: N/A
Tested in browser: Firefox
