### PR TITLE
upgrade to snudown-js 4.1.0 for updated spoiler tag handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "favico.js": "0.3.10",
     "jquery": "3.7.1",
     "lodash-es": "4.17.21",
-    "snudown-js": "4.0.1",
+    "snudown-js": "4.1.0",
     "sortablejs": "1.15.3",
     "suncalc": "1.9.0",
     "tinycolor2": "1.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5023,10 +5023,10 @@ smart-buffer@^4.2.0:
   resolved "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
-snudown-js@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/snudown-js/-/snudown-js-4.0.1.tgz"
-  integrity sha512-91ZrO9Uu4qSDCpswyK0laHX64B1IqO7bSOs6iPUvNxkvxvrnzlDZqBV7bnqSkUBxGFGdOLFS4PfahqDz+JLVZw==
+snudown-js@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/snudown-js/-/snudown-js-4.1.0.tgz#537beff2cf04d7ffe6712659a2bfc1701b907830"
+  integrity sha512-qoglcYnRHtx+cTeRqTH48hs34F0qFDMBSL7tmsPn7OVZ3Akf01BBwQ81bbcvfp+1ZX6/9eMGtt6XsbgSdFVGcg==
 
 socks-proxy-agent@5, socks-proxy-agent@^5.0.0:
   version "5.0.1"


### PR DESCRIPTION
Basically, sometimes in the fall of 2025, reddit updated how spoiler tags function on old reddit, and now, having a leading space like `>! this!<` now properly hides the spoiler text (whereas before it was not hidden). This updates RES's markdown processor so that the preview can also be right.

snudown-js PR is https://github.com/erikdesjardins/snudown-js/pull/39.

Tested in Chrome: 
<img width="585" height="417" alt="image" src="https://github.com/user-attachments/assets/ca10b03f-3661-433c-9980-5fedfe367add" />
