### PR TITLE
Fix duplicate posts in Never Ending Reddit

### DIFF
--- a/lib/utils/__tests__/thingFullname.js
+++ b/lib/utils/__tests__/thingFullname.js
@@ -1,0 +1,27 @@
+/* @flow */
+
+import test from 'ava';
+
+import { isValidThingFullname } from '../thingFullname.js';
+
+test('valid Reddit thing fullnames may have variable-length IDs', t => {
+	for (const fullname of [
+		't1_abcdef',
+		't3_abcdef',
+		't3_1ul533q',
+		't5_2qh0u',
+	]) {
+		t.true(isValidThingFullname(fullname), `${fullname} should be valid`);
+	}
+});
+
+test('invalid or placeholder thing fullnames are rejected', t => {
+	for (const fullname of [
+		'',
+		't3_',
+		't3_invalid-id',
+		'placeholder',
+	]) {
+		t.false(isValidThingFullname(fullname), `${fullname} should be invalid`);
+	}
+});

--- a/lib/utils/thingFullname.js
+++ b/lib/utils/thingFullname.js
@@ -1,0 +1,5 @@
+/* @flow */
+
+const thingFullname = /^t\d+_[a-z0-9]+$/i;
+
+export const isValidThingFullname = (fullname: string): boolean => thingFullname.test(fullname);

--- a/lib/utils/watchers.js
+++ b/lib/utils/watchers.js
@@ -5,6 +5,7 @@ import { Thing } from './Thing';
 import { isPageType } from './currentLocation';
 import { isLastNodeInDOM, watchForFutureChildren, watchForFutureDescendants, waitForAttach, waitForDescendantChange, waitForSelectorMatch, watchForChildren } from './dom';
 import { contentLoaded } from './pagePhases';
+import { isValidThingFullname } from './thingFullname';
 import { MINUTE } from './time';
 
 type WatcherOptions = {| immediate?: boolean, id?: mixed |};
@@ -77,7 +78,7 @@ function registerThing(element: HTMLElement) {
 	// Loading additional things ("load more comments", neverEndingReddit) may cause repeating posts; remove those
 	const id = thing.getFullname();
 	// Some posts may not have a have an id, e.g. those that are deleted or placeholders
-	if (id.length === 9) { // valid ids have 9 characters
+	if (isValidThingFullname(id)) {
 		const existing = dupeSet.get(id);
 		if (existing === element) return; // `registerThing` is being run on an already added thing
 		if (existing && document.contains(existing)) {


### PR DESCRIPTION
Relevant issue: N/A (no matching issue found)
Tested in browser: Firefox

## What changed

- Accept valid Reddit thing fullnames regardless of ID length when tracking duplicates.
- Add regression tests for legacy- and current-length IDs, plus malformed placeholders.

## Why

`registerThing()` only added IDs to `dupeSet` when the fullname was exactly 9 characters. Reddit post IDs have grown beyond six base-36 characters; for example, `t3_1ul533q` is 10 characters. Newer posts therefore bypassed duplicate detection, allowing a post returned on consecutive Never Ending Reddit pages to appear more than once.

## Validation

- 92 unit tests passed.
- ESLint passed for the changed files.
- Development builds completed for Firefox and Chrome.
- Manually verified Never Ending Reddit in Firefox on old Reddit.
